### PR TITLE
Add hardware introspection support using ironic-inspector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ export OPERATOR_NAME=baremetal-operator
 export DEPLOY_KERNEL_URL=http://172.22.0.1/images/ironic-python-agent.kernel
 export DEPLOY_RAMDISK_URL=http://172.22.0.1/images/ironic-python-agent.initramfs
 export IRONIC_ENDPOINT=http://localhost:6385/v1/
+export IRONIC_INSPECTOR_ENDPOINT=http://localhost:5050/v1/
 
 .PHONY: help
 help:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -39,6 +39,8 @@ spec:
               value: "http://172.22.0.1/images/ironic-python-agent.initramfs"
             - name: IRONIC_ENDPOINT
               value: "http://localhost:6385/v1/"
+            - name: IRONIC_INSPECTOR_ENDPOINT
+              value: "http://localhost:5050/v1/"
         # Temporary workaround to talk to an external Ironic process until Ironic is running in this pod.
         - name: ironic-proxy
           image: alpine/socat

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -44,3 +44,7 @@ spec:
           image: alpine/socat
           command: ["socat", "tcp-listen:6385,fork,reuseaddr", "tcp-connect:172.22.0.1:6385"]
           imagePullPolicy: Always
+        - name: ironic-inspector-proxy
+          image: alpine/socat
+          command: ["socat", "tcp-listen:5050,fork,reuseaddr", "tcp-connect:172.22.0.1:5050"]
+          imagePullPolicy: Always

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,3 +12,6 @@ ramdisk.
 
 `IRONIC_ENDPOINT` -- The URL for the operator to use when talking to
 Ironic.
+
+`IRONIC_INSPECTOR_ENDPOINT` -- The URL for the operator to use when talking to
+Ironic Inspector.

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -154,10 +154,16 @@ type Image struct {
 // FIXME(dhellmann): We probably want some other module to own these
 // data structures.
 
+// GHz is a clock speed in GHz
+type GHz float64
+
+// GiB is a memory size in GiB
+type GiB int32
+
 // CPU describes one processor on the host.
 type CPU struct {
 	Type     string `json:"type"`
-	SpeedGHz int    `json:"speedGHz"`
+	SpeedGHz GHz    `json:"speedGHz"`
 }
 
 // Storage describes one storage device (disk, SSD, etc.) on the host.
@@ -168,8 +174,8 @@ type Storage struct {
 	// Type, e.g. SSD
 	Type string `json:"type"`
 
-	// The size of the disk in gigabyte
-	SizeGiB int `json:"sizeGiB"`
+	// The size of the disk in Gibibytes
+	SizeGiB GiB `json:"sizeGiB"`
 
 	// Hardware model
 	Model string `json:"model"`
@@ -199,7 +205,7 @@ type NIC struct {
 // HardwareDetails collects all of the information about hardware
 // discovered on the host.
 type HardwareDetails struct {
-	RAMGiB  int       `json:"ramGiB"`
+	RAMGiB  GiB       `json:"ramGiB"`
 	NIC     []NIC     `json:"nics"`
 	Storage []Storage `json:"storage"`
 	CPUs    []CPU     `json:"cpus"`

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -108,7 +108,6 @@ func (p *demoProvisioner) InspectHardware() (result provisioner.Result, err erro
 	hostName := p.host.ObjectMeta.Name
 
 	if hostName == InspectingHost {
-		p.host.Status.Provisioning.State = metal3v1alpha1.StateInspecting
 		// set dirty so we don't allow the host to progress past this
 		// state in Reconcile()
 		result.Dirty = true

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -102,7 +102,7 @@ func (p *demoProvisioner) ValidateManagementAccess() (result provisioner.Result,
 // details of devices discovered on the hardware. It may be called
 // multiple times, and should return true for its dirty flag until the
 // inspection is completed.
-func (p *demoProvisioner) InspectHardware() (result provisioner.Result, err error) {
+func (p *demoProvisioner) InspectHardware() (result provisioner.Result, details *metal3v1alpha1.HardwareDetails, err error) {
 	p.log.Info("inspecting hardware", "status", p.host.OperationalStatus())
 
 	hostName := p.host.ObjectMeta.Name
@@ -112,7 +112,7 @@ func (p *demoProvisioner) InspectHardware() (result provisioner.Result, err erro
 		// state in Reconcile()
 		result.Dirty = true
 		result.RequeueAfter = time.Second * 5
-		return result, nil
+		return
 	}
 
 	// The inspection is ongoing. We'll need to check the demo
@@ -121,7 +121,7 @@ func (p *demoProvisioner) InspectHardware() (result provisioner.Result, err erro
 	// hardware details struct as part of a second pass.
 	if p.host.Status.HardwareDetails == nil {
 		p.log.Info("continuing inspection by setting details")
-		p.host.Status.HardwareDetails =
+		details =
 			&metal3v1alpha1.HardwareDetails{
 				RAMGiB: 128,
 				NIC: []metal3v1alpha1.NIC{
@@ -165,11 +165,9 @@ func (p *demoProvisioner) InspectHardware() (result provisioner.Result, err erro
 			}
 		p.publisher("InspectionComplete", "Hardware inspection completed")
 		p.host.SetOperationalStatus(metal3v1alpha1.OperationalStatusOK)
-		result.Dirty = true
-		return result, nil
 	}
 
-	return result, nil
+	return
 }
 
 // UpdateHardwareState fetches the latest hardware state of the server

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -65,7 +65,7 @@ func (p *fixtureProvisioner) ValidateManagementAccess() (result provisioner.Resu
 // details of devices discovered on the hardware. It may be called
 // multiple times, and should return true for its dirty flag until the
 // inspection is completed.
-func (p *fixtureProvisioner) InspectHardware() (result provisioner.Result, err error) {
+func (p *fixtureProvisioner) InspectHardware() (result provisioner.Result, details *metal3v1alpha1.HardwareDetails, err error) {
 	p.log.Info("inspecting hardware", "status", p.host.OperationalStatus())
 
 	// The inspection is ongoing. We'll need to check the fixture
@@ -74,7 +74,7 @@ func (p *fixtureProvisioner) InspectHardware() (result provisioner.Result, err e
 	// hardware details struct as part of a second pass.
 	if p.host.Status.HardwareDetails == nil {
 		p.log.Info("continuing inspection by setting details")
-		p.host.Status.HardwareDetails =
+		details =
 			&metal3v1alpha1.HardwareDetails{
 				RAMGiB: 128,
 				NIC: []metal3v1alpha1.NIC{
@@ -117,11 +117,9 @@ func (p *fixtureProvisioner) InspectHardware() (result provisioner.Result, err e
 				},
 			}
 		p.publisher("InspectionComplete", "Hardware inspection completed")
-		result.Dirty = true
-		return result, nil
 	}
 
-	return result, nil
+	return
 }
 
 // UpdateHardwareState fetches the latest hardware state of the server

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/ports"
 	noauthintrospection "github.com/gophercloud/gophercloud/openstack/baremetalintrospection/noauth"
+	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/v1/introspection"
 
 	nodeutils "github.com/gophercloud/utils/openstack/baremetal/v1/nodes"
 
@@ -32,6 +33,7 @@ var log = logf.Log.WithName("baremetalhost_ironic")
 var deprovisionRequeueDelay = time.Second * 10
 var provisionRequeueDelay = time.Second * 10
 var powerRequeueDelay = time.Second * 10
+var introspectionRequeueDelay = time.Second * 15
 var deployKernelURL string
 var deployRamdiskURL string
 var ironicEndpoint string
@@ -380,10 +382,35 @@ func (p *ironicProvisioner) InspectHardware() (result provisioner.Result, err er
 		return result, fmt.Errorf("no ironic node for host")
 	}
 
-	// The inspection is ongoing. We'll need to check the ironic
-	// status for the server here until it is ready for us to get the
-	// inspection details. Simulate that for now by creating the
-	// hardware details struct as part of a second pass.
+	status, err := introspection.GetIntrospectionStatus(p.inspector, ironicNode.UUID).Extract()
+	if err != nil {
+		if _, isNotFound := err.(gophercloud.ErrDefault404); isNotFound {
+			p.log.Info("starting new hardware inspection")
+			manageBoot := true
+			start := introspection.StartIntrospection(p.inspector,
+				ironicNode.UUID,
+				introspection.StartOpts{ManageBoot: &manageBoot})
+			if err := start.ExtractErr(); err != nil {
+				return result, errors.Wrap(err, "failed to begin hardware inspection")
+			}
+			result.Dirty = true
+			return result, nil
+		}
+		return result, errors.Wrap(err, "failed to extract hardware inspection status")
+	}
+	if !status.Finished {
+		p.log.Info("inspection in progress", "started_at", status.StartedAt)
+		result.Dirty = true // make sure we check back
+		result.RequeueAfter = introspectionRequeueDelay
+		return result, nil
+	}
+	if status.Error != "" {
+		p.log.Info("inspection failed", "error", status.Error)
+		result.ErrorMessage = status.Error
+		return result, nil
+	}
+
+	// Introspection is ongoing
 	if p.host.Status.HardwareDetails == nil {
 		p.log.Info("continuing inspection by setting details")
 		p.host.Status.HardwareDetails =

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -386,15 +386,10 @@ func (p *ironicProvisioner) InspectHardware() (result provisioner.Result, err er
 	if err != nil {
 		if _, isNotFound := err.(gophercloud.ErrDefault404); isNotFound {
 			p.log.Info("starting new hardware inspection")
-			manageBoot := true
-			start := introspection.StartIntrospection(p.inspector,
-				ironicNode.UUID,
-				introspection.StartOpts{ManageBoot: &manageBoot})
-			if err := start.ExtractErr(); err != nil {
-				return result, errors.Wrap(err, "failed to begin hardware inspection")
-			}
-			result.Dirty = true
-			return result, nil
+			return p.changeNodeProvisionState(
+				ironicNode,
+				nodes.ProvisionStateOpts{Target: nodes.TargetInspect},
+			)
 		}
 		return result, errors.Wrap(err, "failed to extract hardware inspection status")
 	}

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -33,7 +33,7 @@ type Provisioner interface {
 	// details of devices discovered on the hardware. It may be called
 	// multiple times, and should return true for its dirty flag until the
 	// inspection is completed.
-	InspectHardware() (result Result, err error)
+	InspectHardware() (result Result, details *metal3v1alpha1.HardwareDetails, err error)
 
 	// UpdateHardwareState fetches the latest hardware state of the
 	// server and updates the HardwareDetails field of the host with


### PR DESCRIPTION
Note that https://github.com/metalkube/baremetal-operator/commit/fb54f2943004e7364cffd1f438768462adb1192e is a fix to the vendored gophercloud that is awaiting upstream acceptance in https://github.com/gophercloud/gophercloud/pull/1548