### PR TITLE
rename git repository in metalkube branch

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,11 +1,11 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
-WORKDIR /go/src/github.com/metalkube/baremetal-operator
+WORKDIR /go/src/github.com/metal3-io/baremetal-operator
 COPY . .
 RUN go build -o build/_output/bin/baremetal-operator cmd/manager/main.go
 
 FROM quay.io/metalkube/base-image
 
-COPY --from=builder /go/src/github.com/metalkube/baremetal-operator/build/_output/bin/baremetal-operator /
+COPY --from=builder /go/src/github.com/metal3-io/baremetal-operator/build/_output/bin/baremetal-operator /
 
 RUN if ! rpm -q genisoimage; \
     then yum install -y genisoimage && \

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/metalkube/baremetal-operator/pkg/apis"
-	"github.com/metalkube/baremetal-operator/pkg/controller"
+	"github.com/metal3-io/baremetal-operator/pkg/apis"
+	"github.com/metal3-io/baremetal-operator/pkg/controller"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: metalkube-baremetal-operator
       containers:
         - name: baremetal-operator
-          image: quay.io/metalkube/baremetal-operator
+          image: quay.io/metalkube/baremetal-operator:metalkube
           ports:
           - containerPort: 60000
             name: metrics

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -23,9 +23,10 @@ install the operator-sdk tools.
 
     ```
     eval $(go env)
-    mkdir -p $GOPATH/src/github.com/metalkube
-    cd $GOPATH/src/github.com/metalkube
-    git clone https://github.com/metalkube/baremetal-operator.git
+    mkdir -p $GOPATH/src/github.com/metal3-io
+    cd $GOPATH/src/github.com/metal3-io
+    git clone https://github.com/metal3-io/baremetal-operator.git
+    git checkout origin/metalkube
     cd baremetal-operator
     kubectl apply -f deploy/service_account.yaml
     kubectl apply -f deploy/role.yaml

--- a/docs/publishing-images.md
+++ b/docs/publishing-images.md
@@ -2,12 +2,12 @@ Publishing Images
 =================
 
 Images for changes merged into master are automatically built through
-the [MetalKube org on
-quay.io](https://quay.io/repository/metalkube/baremetal-operator). It
+the [Metal3 org on
+quay.io](https://quay.io/repository/metal3-io/baremetal-operator). It
 is also easy to set up your own builds to test images from branches in
 your development fork.
 
-1. Fork `metalkube/baremetal-operator` on GitHub.
+1. Fork `metal3-io/baremetal-operator` on GitHub.
 2. Set up your account on [quay.io](https://quay.io).
 3. Link your repository from step 1 to quay.io by following the
    instructions to "Create New Repository" from
@@ -49,7 +49,7 @@ your development fork.
       build because the UI seems to cache pretty aggressively.
 
 5. Create a dev deployment file that uses your image instead of the
-   one from the metalkube organization.
+   one from the metal3 organization.
 
    1. Copy `deploy/operator.yaml` to `deploy/dev-operator.yaml`.
    2. Edit `deploy/dev-operator.yaml` and change the `image` setting

--- a/pkg/apis/addtoscheme_metalkube_v1alpha1.go
+++ b/pkg/apis/addtoscheme_metalkube_v1alpha1.go
@@ -1,7 +1,7 @@
 package apis
 
 import (
-	"github.com/metalkube/baremetal-operator/pkg/apis/metalkube/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/apis/metalkube/v1alpha1"
 )
 
 func init() {

--- a/pkg/controller/add_baremetalhost.go
+++ b/pkg/controller/add_baremetalhost.go
@@ -1,7 +1,7 @@
 package controller
 
 import (
-	"github.com/metalkube/baremetal-operator/pkg/controller/baremetalhost"
+	"github.com/metal3-io/baremetal-operator/pkg/controller/baremetalhost"
 )
 
 func init() {

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -9,14 +9,14 @@ import (
 
 	"github.com/pkg/errors"
 
-	metalkubev1alpha1 "github.com/metalkube/baremetal-operator/pkg/apis/metalkube/v1alpha1"
-	"github.com/metalkube/baremetal-operator/pkg/bmc"
-	"github.com/metalkube/baremetal-operator/pkg/hardware"
-	"github.com/metalkube/baremetal-operator/pkg/provisioner"
-	"github.com/metalkube/baremetal-operator/pkg/provisioner/demo"
-	"github.com/metalkube/baremetal-operator/pkg/provisioner/fixture"
-	"github.com/metalkube/baremetal-operator/pkg/provisioner/ironic"
-	"github.com/metalkube/baremetal-operator/pkg/utils"
+	metalkubev1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metalkube/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/hardware"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner/demo"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner/fixture"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic"
+	"github.com/metal3-io/baremetal-operator/pkg/utils"
 
 	"github.com/go-logr/logr"
 

--- a/pkg/controller/baremetalhost/baremetalhost_controller_test.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller_test.go
@@ -18,10 +18,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
-	metalkubeapis "github.com/metalkube/baremetal-operator/pkg/apis"
-	metalkubev1alpha1 "github.com/metalkube/baremetal-operator/pkg/apis/metalkube/v1alpha1"
-	"github.com/metalkube/baremetal-operator/pkg/provisioner/fixture"
-	"github.com/metalkube/baremetal-operator/pkg/utils"
+	metalkubeapis "github.com/metal3-io/baremetal-operator/pkg/apis"
+	metalkubev1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metalkube/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner/fixture"
+	"github.com/metal3-io/baremetal-operator/pkg/utils"
 )
 
 const (

--- a/pkg/controller/baremetalhost/demo_test.go
+++ b/pkg/controller/baremetalhost/demo_test.go
@@ -12,9 +12,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
-	metalkubeapis "github.com/metalkube/baremetal-operator/pkg/apis"
-	metalkubev1alpha1 "github.com/metalkube/baremetal-operator/pkg/apis/metalkube/v1alpha1"
-	"github.com/metalkube/baremetal-operator/pkg/provisioner/demo"
+	metalkubeapis "github.com/metal3-io/baremetal-operator/pkg/apis"
+	metalkubev1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metalkube/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner/demo"
 )
 
 func init() {

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -6,9 +6,9 @@ import (
 	"github.com/go-logr/logr"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
-	metalkubev1alpha1 "github.com/metalkube/baremetal-operator/pkg/apis/metalkube/v1alpha1"
-	"github.com/metalkube/baremetal-operator/pkg/bmc"
-	"github.com/metalkube/baremetal-operator/pkg/provisioner"
+	metalkubev1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metalkube/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 )
 
 var log = logf.Log.WithName("demo")

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -6,9 +6,9 @@ import (
 	"github.com/go-logr/logr"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
-	metalkubev1alpha1 "github.com/metalkube/baremetal-operator/pkg/apis/metalkube/v1alpha1"
-	"github.com/metalkube/baremetal-operator/pkg/bmc"
-	"github.com/metalkube/baremetal-operator/pkg/provisioner"
+	metalkubev1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metalkube/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 )
 
 var log = logf.Log.WithName("fixture")

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -21,10 +21,10 @@ import (
 	"github.com/go-logr/logr"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
-	metalkubev1alpha1 "github.com/metalkube/baremetal-operator/pkg/apis/metalkube/v1alpha1"
-	"github.com/metalkube/baremetal-operator/pkg/bmc"
-	"github.com/metalkube/baremetal-operator/pkg/hardware"
-	"github.com/metalkube/baremetal-operator/pkg/provisioner"
+	metalkubev1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metalkube/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/hardware"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 )
 
 var log = logf.Log.WithName("baremetalhost_ironic")

--- a/pkg/provisioner/ironic/ironic_test.go
+++ b/pkg/provisioner/ironic/ironic_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
 
-	metalkubev1alpha1 "github.com/metalkube/baremetal-operator/pkg/apis/metalkube/v1alpha1"
-	"github.com/metalkube/baremetal-operator/pkg/bmc"
+	metalkubev1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metalkube/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/bmc"
 )
 
 func init() {

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -3,8 +3,8 @@ package provisioner
 import (
 	"time"
 
-	metalkubev1alpha1 "github.com/metalkube/baremetal-operator/pkg/apis/metalkube/v1alpha1"
-	"github.com/metalkube/baremetal-operator/pkg/bmc"
+	metalkubev1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metalkube/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/bmc"
 )
 
 /*

--- a/test/e2e/baremetal_test.go
+++ b/test/e2e/baremetal_test.go
@@ -19,8 +19,8 @@ import (
 	"testing"
 	"time"
 
-	apis "github.com/metalkube/baremetal-operator/pkg/apis"
-	metalkubev1alpha1 "github.com/metalkube/baremetal-operator/pkg/apis/metalkube/v1alpha1"
+	apis "github.com/metal3-io/baremetal-operator/pkg/apis"
+	metalkubev1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metalkube/v1alpha1"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
This change is part of renaming metalkube to metal3. We have renamed
the git repository, so in order to build this repo in its new location
it needs to have the imports updated. We do not want the full rename
in this branch, though, to minimize changes in a "stable" branch.