### PR TITLE
Update dev documents by adding required env variables

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -37,6 +37,9 @@ install the operator-sdk tools.
 
     ```
     export OPERATOR_NAME=baremetal-operator
+    export DEPLOY_KERNEL_URL=http://172.22.0.1/images/ironic-python-agent.kernel
+    export DEPLOY_RAMDISK_URL=http://172.22.0.1/images/ironic-python-agent.initramfs
+    export IRONIC_ENDPOINT=http://localhost:6385/v1/
     operator-sdk up local --namespace=metal3
     ```
 


### PR DESCRIPTION
When we try to bring **baremetal-operator** up via **operator-sdk** CLI, it raises an error due to the missing of some environment variables to tell it where ironic is. This PR aims to update the doc by including these env variables.

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>