### PR TITLE
add tests for make-bm-worker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ travis: test-verbose lint
 
 .PHONY: unit
 unit:
-	go test $(GO_TEST_FLAGS) ./pkg/...
+	go test $(GO_TEST_FLAGS) ./cmd/... ./pkg/...
 
 .PHONY: unit-verbose
 test-verbose:

--- a/cmd/make-bm-worker/main.go
+++ b/cmd/make-bm-worker/main.go
@@ -1,60 +1,13 @@
 package main
 
 import (
-	"encoding/base64"
 	"flag"
 	"fmt"
 	"os"
 	"strings"
-	"text/template"
+
+	"github.com/metal3-io/baremetal-operator/cmd/make-bm-worker/templates"
 )
-
-var templateBody = `---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ .Name }}-bmc-secret
-type: Opaque
-data:
-  username: {{ .EncodedUsername }}
-  password: {{ .EncodedPassword }}
-
----
-apiVersion: metal3.io/v1alpha1
-kind: BareMetalHost
-metadata:
-  name: {{ .Name }}
-spec:
-  online: true
-{{- if .WithHardwareProfile }}
-  hardwareProfile: {{ .HardwareProfile }}
-{{- end }}
-  bmc:
-    address: {{ .BMCAddress }}
-    credentialsName: {{ .Name }}-bmc-secret
-{{- if .WithMachine }}
-  machineRef:
-    name: {{ .Machine }}
-    namespace: {{ .MachineNamespace }}
-{{- end }}
-`
-
-// TemplateArgs holds the arguments to pass to the template.
-type TemplateArgs struct {
-	Name                string
-	BMCAddress          string
-	EncodedUsername     string
-	EncodedPassword     string
-	WithHardwareProfile bool
-	HardwareProfile     string
-	WithMachine         bool
-	Machine             string
-	MachineNamespace    string
-}
-
-func encodeToSecret(input string) string {
-	return base64.StdEncoding.EncodeToString([]byte(input))
-}
 
 func main() {
 	var username = flag.String("user", "", "username for BMC")
@@ -87,28 +40,24 @@ func main() {
 		os.Exit(1)
 	}
 
-	args := TemplateArgs{
+	template := templates.Template{
 		Name:             strings.Replace(hostName, "_", "-", -1),
 		BMCAddress:       *bmcAddress,
-		EncodedUsername:  encodeToSecret(*username),
-		EncodedPassword:  encodeToSecret(*password),
+		Username:         *username,
+		Password:         *password,
 		HardwareProfile:  *hardwareProfile,
 		Machine:          strings.TrimSpace(*machine),
 		MachineNamespace: strings.TrimSpace(*machineNamespace),
 	}
-	if args.Machine != "" {
-		args.WithMachine = true
-	}
-	if args.HardwareProfile != "" {
-		args.WithHardwareProfile = true
-	}
 	if *verbose {
-		fmt.Fprintf(os.Stderr, "%v", args)
+		fmt.Fprintf(os.Stderr, "%v", template)
 	}
 
-	t := template.Must(template.New("yaml_out").Parse(templateBody))
-	err := t.Execute(os.Stdout, args)
+	result, err := template.Render()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+		os.Exit(1)
+	} else {
+		fmt.Fprintf(os.Stdout, result)
 	}
 }

--- a/cmd/make-bm-worker/templates/templates.go
+++ b/cmd/make-bm-worker/templates/templates.go
@@ -1,0 +1,73 @@
+package templates
+
+import (
+	"bytes"
+	"encoding/base64"
+	"text/template"
+)
+
+var templateBody = `---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Name }}-bmc-secret
+type: Opaque
+data:
+  username: {{ .EncodedUsername }}
+  password: {{ .EncodedPassword }}
+
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: {{ .Name }}
+spec:
+  online: true
+{{- if .HardwareProfile }}
+  hardwareProfile: {{ .HardwareProfile }}
+{{- end }}
+  bmc:
+    address: {{ .BMCAddress }}
+    credentialsName: {{ .Name }}-bmc-secret
+{{- if .Machine }}
+  machineRef:
+    name: {{ .Machine }}
+    namespace: {{ .MachineNamespace }}
+{{- end }}
+`
+
+// Template holds the arguments to pass to the template.
+type Template struct {
+	Name             string
+	BMCAddress       string
+	Username         string
+	Password         string
+	HardwareProfile  string
+	Machine          string
+	MachineNamespace string
+}
+
+// EncodedUsername returns the username in the format needed to store
+// it in a Secret.
+func (t Template) EncodedUsername() string {
+	return encodeToSecret(t.Username)
+}
+
+// EncodedPassword returns the password in the format needed to store
+// it in a Secret.
+func (t Template) EncodedPassword() string {
+	return encodeToSecret(t.Password)
+}
+
+func encodeToSecret(input string) string {
+	return base64.StdEncoding.EncodeToString([]byte(input))
+}
+
+// Render returns the string from the template or an error if there
+// was a problem rendering it.
+func (t Template) Render() (string, error) {
+	buf := new(bytes.Buffer)
+	tmpl := template.Must(template.New("yaml_out").Parse(templateBody))
+	err := tmpl.Execute(buf, t)
+	return buf.String(), err
+}

--- a/cmd/make-bm-worker/templates/templates_test.go
+++ b/cmd/make-bm-worker/templates/templates_test.go
@@ -1,0 +1,136 @@
+package templates
+
+import (
+	"strings"
+	"testing"
+)
+
+func compareStrings(t *testing.T, s1, s2 string) bool {
+	if s1 == s2 {
+		return true
+	}
+
+	s1Lines := strings.Split(s1, "\n")
+	s2Lines := strings.Split(s2, "\n")
+
+	max := len(s1Lines)
+	if len(s2Lines) < max {
+		max = len(s2Lines)
+	}
+
+	for i := 0; i < max; i++ {
+		if s1Lines[i] != s2Lines[i] {
+			t.Logf("line %d differ: %q != %q", i, s1Lines[i], s2Lines[i])
+		}
+	}
+	return false
+}
+
+func TestWithHardwareProfile(t *testing.T) {
+	template := Template{
+		Name:            "hostname",
+		BMCAddress:      "bmcAddress",
+		Username:        "username",
+		Password:        "password",
+		HardwareProfile: "hardware profile",
+	}
+	actual, _ := template.Render()
+	expected := `---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hostname-bmc-secret
+type: Opaque
+data:
+  username: dXNlcm5hbWU=
+  password: cGFzc3dvcmQ=
+
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: hostname
+spec:
+  online: true
+  hardwareProfile: hardware profile
+  bmc:
+    address: bmcAddress
+    credentialsName: hostname-bmc-secret
+`
+	if !compareStrings(t, expected, actual) {
+		t.Fail()
+	}
+}
+
+func TestWithoutHardwareProfile(t *testing.T) {
+	template := Template{
+		Name:       "hostname",
+		BMCAddress: "bmcAddress",
+		Username:   "username",
+		Password:   "password",
+	}
+	actual, _ := template.Render()
+	expected := `---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hostname-bmc-secret
+type: Opaque
+data:
+  username: dXNlcm5hbWU=
+  password: cGFzc3dvcmQ=
+
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: hostname
+spec:
+  online: true
+  bmc:
+    address: bmcAddress
+    credentialsName: hostname-bmc-secret
+`
+	if !compareStrings(t, expected, actual) {
+		t.Fail()
+	}
+}
+
+func TestWithMachine(t *testing.T) {
+	template := Template{
+		Name:             "hostname",
+		BMCAddress:       "bmcAddress",
+		Username:         "username",
+		Password:         "password",
+		Machine:          "machine",
+		MachineNamespace: "machineNamespace",
+	}
+	actual, _ := template.Render()
+	expected := `---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hostname-bmc-secret
+type: Opaque
+data:
+  username: dXNlcm5hbWU=
+  password: cGFzc3dvcmQ=
+
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: hostname
+spec:
+  online: true
+  bmc:
+    address: bmcAddress
+    credentialsName: hostname-bmc-secret
+  machineRef:
+    name: machine
+    namespace: machineNamespace
+`
+	if !compareStrings(t, expected, actual) {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Add unit tests for the template rendering in make-bm-worker.

In the process, restructure the code so it is testable and so the
template type does not need the separate boolean fields and so the
caller does not need to provide username and password as base64
encoded values.

Fixes #160