### PR TITLE
Clear *provisionNet* to get MAC address

### DIFF
--- a/cmd/make-virt-host/main.go
+++ b/cmd/make-virt-host/main.go
@@ -118,7 +118,7 @@ type VBMC struct {
 
 func main() {
 	var provisionNet = flag.String(
-		"provision-net", "provisioning", "use the MAC on this network")
+		"provision-net", "", "use the MAC on this network")
 	var machine = flag.String(
 		"machine", "", "specify name of a related, existing, machine to link")
 	var machineNamespace = flag.String(


### PR DESCRIPTION
Current, *provisionNet* is set to *provisioning* as default values that makes the our *main.go* cannot get the MAC address [1] of virt-host. This PR intends to clear this default to make our tool work smoothly.

[1] https://github.com/metal3-io/baremetal-operator/blob/master/cmd/make-virt-host/main.go#L161-L163

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>