### PR TITLE
Handle enroll/verifying states on node delete

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -953,7 +953,7 @@ func (p *ironicProvisioner) Deprovision() (result provisioner.Result, err error)
 		result.RequeueAfter = deprovisionRequeueDelay
 		return result, nil
 
-	case nodes.Manageable:
+	case nodes.Manageable, string(nodes.Enroll), nodes.Verifying:
 		p.publisher("DeprovisioningComplete", "Image deprovisioning completed")
 		return result, nil
 


### PR DESCRIPTION
This allows nodes to be deleted when the IPMI details are wrong,
otherwise you can get stuck with an undeletable BaremetalHost.

Closes: #170