### PR TITLE
Adding IRONIC_INSPECTOR_ENDPOINT

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -40,6 +40,7 @@ install the operator-sdk tools.
     export DEPLOY_KERNEL_URL=http://172.22.0.1/images/ironic-python-agent.kernel
     export DEPLOY_RAMDISK_URL=http://172.22.0.1/images/ironic-python-agent.initramfs
     export IRONIC_ENDPOINT=http://localhost:6385/v1/
+    export IRONIC_INSPECTOR_ENDPOINT=http://localhost:5050/v1
     operator-sdk up local --namespace=metal3
     ```
 


### PR DESCRIPTION
The operator did not load until I exported  IRONIC_INSPECTOR_ENDPOINT to fix

INFO[0000] Running the operator locally.
INFO[0000] Using namespace metal3.
Cannot start: No IRONIC_INSPECTOR_ENDPOINT variable setError: failed to run operator locally:
(failed to exec []string{"build/_output/bin/baremetal-operator-local"}: exit status 1)