### PR TITLE
Add short names for BareMetalHost.

### DIFF
--- a/deploy/crds/metal3_v1alpha1_baremetalhost_crd.yaml
+++ b/deploy/crds/metal3_v1alpha1_baremetalhost_crd.yaml
@@ -9,6 +9,9 @@ spec:
     listKind: BareMetalHostList
     plural: baremetalhosts
     singular: baremetalhost
+    shortNames:
+     - bmh
+     - bmhost
   scope: Namespaced
   version: v1alpha1
   subresources:


### PR DESCRIPTION
Add some short names for use at the command line that are a few less
keystrokes than "baremetalhost".