### PR TITLE
[metalkube] Make userdata work with cloud-init images.

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -775,6 +775,10 @@ func (p *ironicProvisioner) Provision(getUserData provisioner.UserDataSource) (r
 		if userData != "" {
 			configDrive := nodeutils.ConfigDrive{
 				UserData: nodeutils.UserDataString(userData),
+				// cloud-init requires that meta_data.json exists and
+				// that the "uuid" field is present to process
+				// any of the config drive contents.
+				MetaData: map[string]interface{}{"uuid":p.host.Status.Provisioning.ID},
 			}
 			configDriveData, err = configDrive.ToConfigDrive()
 			if err != nil {


### PR DESCRIPTION
cloud-init requires that the meta_data.json file exists and that it
contains at least the uuid key.  Add this to make provisioning of
cloud-init based images work and read user_data from the config drive.