### PR TITLE
Operational status cleanups

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -143,7 +143,7 @@ status:
   hardwareProfile: unknown
   image: ""
   lastUpdated: 2019-02-11T17:44:30Z
-  operationalStatus: online
+  operationalStatus: OK
   provisioningID: ""
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -77,8 +77,10 @@ host was updated.
 
 *operationalStatus* -- The status of the server. Value is one of the
 following:
-  * *online* -- The server is powered on and running.
-  * *offline* -- The server is powered off.
+  * *OK* -- The host is configured correctly and not actively being
+  managed.
+  * *discovered* -- The host is only partially configured, such as
+  when a few values are loaded from Ironic.
   * *error* -- There is an error with the configuration data for the
   host or there is a problem with the host itself. Refer to the
   *errorMessage* field in the status section for more details about

--- a/docs/api.md
+++ b/docs/api.md
@@ -75,6 +75,15 @@ spec:
 *lastUpdated* -- The timestamp of the last time the status for the
 host was updated.
 
+*operationalStatus* -- The status of the server. Value is one of the
+following:
+  * *online* -- The server is powered on and running.
+  * *offline* -- The server is powered off.
+  * *error* -- There is an error with the configuration data for the
+  host or there is a problem with the host itself. Refer to the
+  *errorMessage* field in the status section for more details about
+  the error condition.
+
 *hardware* -- The details for hardware capabilities discovered on the
 host. These are filled in by the provisioning agent when the host is
 registered.
@@ -99,6 +108,11 @@ the host.
 
 *hardware.cpus.speed* -- The speed in GHz of the CPU.
 
+*hardwareProfile* -- The name of the hardware profile that matches the
+hardware discovered on the host. Details about the hardware are saved
+to the *hardware* section of the status. If the hardware does not
+match a known profile, the value "unknown" is used.
+
 ```
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
@@ -107,9 +121,6 @@ metadata:
   finalizers:
   - baremetalhost.metal3.io
   generation: 9
-  labels:
-    metal3.io/hardware-profile: unknown
-    metal3.io/operational-status: online
   name: example-baremetalhost
   namespace: bmo-project
   resourceVersion: "1750818"
@@ -127,31 +138,12 @@ status:
     cpus: null
     nics: null
     storage: null
+  hardwareProfile: unknown
   image: ""
   lastUpdated: 2019-02-11T17:44:30Z
+  operationalStatus: online
   provisioningID: ""
 ```
-
-## Labels
-
-The BareMetalHost operator manages several labels with host status and
-settings to make it easier to find specific hosts.
-
-*metal3.io/hardware-profile* -- The name of the hardware profile
-that matches the hardware discovered on the host. Details about the
-hardware are saved to the *hardware* section of the status. If the
-hardware does not match a known profile, the value "unknown" is used.
-
-*metal3.io/operational-status* -- The status of the server.
-
-  *online* -- The server is powered on and running.
-
-  *offline* -- The server is powered off.
-
-  *error* -- There is an error with the configuration data for the
-  host or there is a problem with the host itself. Refer to the
-  *errorMessage* field in the status section for more details about
-  the error condition.
 
 ## Triggering Provisioning
 

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -390,7 +390,7 @@ func (host *BareMetalHost) SetHardwareProfile(name string) (dirty bool) {
 	return dirty
 }
 
-// SetOperationalStatus updates the OperationalStatusLabel and returns
+// SetOperationalStatus updates the OperationalStatus field and returns
 // true when a change is made or false when no change is made.
 func (host *BareMetalHost) SetOperationalStatus(status OperationalStatus) bool {
 	if host.Status.OperationalStatus != status {

--- a/test/e2e/baremetal_test.go
+++ b/test/e2e/baremetal_test.go
@@ -176,24 +176,6 @@ func waitForHostStateChange(t *testing.T, host *metal3v1alpha1.BareMetalHost, is
 	return instance
 }
 
-func waitForOfflineStatus(t *testing.T, host *metal3v1alpha1.BareMetalHost) {
-	waitForHostStateChange(t, host, func(host *metal3v1alpha1.BareMetalHost) (done bool, err error) {
-		state := host.Labels[metal3v1alpha1.OperationalStatusLabel]
-		t.Logf("OperationalState: %s", state)
-		if state == metal3v1alpha1.OperationalStatusOffline {
-			return true, nil
-		}
-		return false, nil
-	})
-}
-
-func waitForError(t *testing.T, host *metal3v1alpha1.BareMetalHost) {
-	waitForHostStateChange(t, host, func(host *metal3v1alpha1.BareMetalHost) (done bool, err error) {
-		t.Logf("ErrorMessage: %q", host.Status.ErrorMessage)
-		return host.HasError(), nil
-	})
-}
-
 func TestManageHardwareDetails(t *testing.T) {
 	ctx := setup(t)
 	defer ctx.Cleanup()


### PR DESCRIPTION
It looks like there are some remnants from "stop using labels for status values" in #78 