### PR TITLE
WIP: fix the e2e tests

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,6 +12,12 @@ oc --as system:admin apply -f test/e2e/role_binding.yaml
 
 ### Run the e2e tests
 
+First, create the namespace to be used for the test:
+
+```
+$ kubectl create namespace operator-test
+```
+
 Run the tests using the operator-sdk command line tool
 
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,6 +18,21 @@ First, create the namespace to be used for the test:
 $ kubectl create namespace operator-test
 ```
 
+Next, delete hosts created by metal3-dev-env and set environment
+variables with the URL and credentials for its master node:
+
+```
+$ kubectl delete -n metal3 -f ../metal3-dev-env/bmhosts_crs.yaml
+$ export TEST_HOST_URL=$(yq -r '. |
+    select(.metadata.name == "master-0") |
+   .spec.bmc.address' \
+    ../metal3-dev-env/bmhosts_crs.yaml)
+$ export TEST_HOST_CREDS=$(yq  -r '. |
+    select(.metadata.name == "master-0-bmc-secret") |
+    .data.username + ":" + .data.password' \
+    ../metal3-dev-env/bmhosts_crs.yaml)
+```
+
 Run the tests using the operator-sdk command line tool
 
 ```

--- a/test/e2e/baremetal_test.go
+++ b/test/e2e/baremetal_test.go
@@ -176,24 +176,6 @@ func waitForHostStateChange(t *testing.T, host *metal3v1alpha1.BareMetalHost, is
 	return instance
 }
 
-func waitForOfflineStatus(t *testing.T, host *metal3v1alpha1.BareMetalHost) {
-	waitForHostStateChange(t, host, func(host *metal3v1alpha1.BareMetalHost) (done bool, err error) {
-		state := host.Labels[metal3v1alpha1.OperationalStatusLabel]
-		t.Logf("OperationalState: %s", state)
-		if state == metal3v1alpha1.OperationalStatusOffline {
-			return true, nil
-		}
-		return false, nil
-	})
-}
-
-func waitForError(t *testing.T, host *metal3v1alpha1.BareMetalHost) {
-	waitForHostStateChange(t, host, func(host *metal3v1alpha1.BareMetalHost) (done bool, err error) {
-		t.Logf("ErrorMessage: %q", host.Status.ErrorMessage)
-		return host.HasError(), nil
-	})
-}
-
 func TestManageHardwareDetails(t *testing.T) {
 	ctx := setup(t)
 	defer ctx.Cleanup()

--- a/test/e2e/baremetal_test.go
+++ b/test/e2e/baremetal_test.go
@@ -153,8 +153,8 @@ func makeSecret(t *testing.T, ctx *framework.TestCtx, name string, username stri
 	}
 
 	data := make(map[string][]byte)
-	data["username"] = []byte(base64.StdEncoding.EncodeToString([]byte(username)))
-	data["password"] = []byte(base64.StdEncoding.EncodeToString([]byte(password)))
+	data["username"] = []byte(username)
+	data["password"] = []byte(password)
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/baremetal_test.go
+++ b/test/e2e/baremetal_test.go
@@ -162,7 +162,7 @@ func waitForHostStateChange(t *testing.T, host *metal3v1alpha1.BareMetalHost, is
 
 	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		t.Log("polling host for updates")
-		refreshHost(instance)
+		err = refreshHost(instance)
 		if err != nil {
 			return false, err
 		}

--- a/test/e2e/baremetal_test.go
+++ b/test/e2e/baremetal_test.go
@@ -182,7 +182,7 @@ func TestManageHardwareDetails(t *testing.T) {
 
 	f := framework.Global
 
-	host := makeHost(t, ctx, "hardware-profile",
+	host := makeHost(t, ctx, "test-host",
 		&metal3v1alpha1.BareMetalHostSpec{
 			BMC: metal3v1alpha1.BMCDetails{
 				Address:         "ipmi://192.168.122.1:6233",

--- a/test/e2e/baremetal_test.go
+++ b/test/e2e/baremetal_test.go
@@ -33,7 +33,7 @@ import (
 
 var (
 	retryInterval        = time.Second * 5
-	timeout              = time.Second * 10
+	timeout              = time.Second * 480
 	cleanupRetryInterval = time.Second * 1
 	cleanupTimeout       = time.Second * 5
 )

--- a/test/e2e/baremetal_test.go
+++ b/test/e2e/baremetal_test.go
@@ -60,8 +60,6 @@ func setup(t *testing.T) *framework.TestCtx {
 	t.Log("Initialized cluster resources")
 
 	makeSecret(t, ctx, "bmc-creds-valid", "User", "Pass")
-	makeSecret(t, ctx, "bmc-creds-no-user", "", "Pass")
-	makeSecret(t, ctx, "bmc-creds-no-pass", "User", "")
 
 	return ctx
 }


### PR DESCRIPTION
It looks like these tests have gone stale - perhaps they have less importance now that many of the tests are moved to the unit tests, but I got sucked into trying to fix them ...

Notes:

* The single test still doesn't actually pass - it times out waiting for inspection to complete
* I never figured out why the secret data is getting double-encoded (i.e. why the `base64.StdEncoding.EncodeToString()` appears not to be needed)
* I added a way to use the virtual nodes created by metal3-dev-env - not terribly easy to use though