### PR TITLE
Update Ironic image tag and Ironic-inspector shared folder

### DIFF
--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic"}
+IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic:master"}
 IRONIC_INSPECTOR_IMAGE=${IRONIC_INSPECTOR_IMAGE:-"quay.io/metal3-io/ironic-inspector"}
 IRONIC_DATA_DIR="$PWD/ironic"
 
@@ -56,4 +56,5 @@ sudo podman run -d --net host --privileged --name ironic --pod ironic-pod \
      -v $IRONIC_DATA_DIR:/shared ${IRONIC_IMAGE}
 
 # Start Ironic Inspector
-sudo podman run -d --net host --privileged --name ironic-inspector --pod ironic-pod "${IRONIC_INSPECTOR_IMAGE}"
+sudo podman run -d --net host --privileged --name ironic-inspector --pod ironic-pod \
+     -v $IRONIC_DATA_DIR:/shared "${IRONIC_INSPECTOR_IMAGE}"


### PR DESCRIPTION
Podman is trying to pull image with tag latest but there is no this tag at this moment here: https://quay.io/repository/metal3-io/ironic?tag=latest&tab=tags. Only **master** and **no-cleaning** are available.
This PR also configure a shared folder for ironic-inspector container

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>