### PR TITLE
Use new interface to ironic containers.

### DIFF
--- a/deploy/ironic_bmo_configmap.yaml
+++ b/deploy/ironic_bmo_configmap.yaml
@@ -4,10 +4,12 @@ metadata:
   name: ironic-bmo-configmap
 data:
   http_port: "6180"
-  http_ip: "172.22.0.1"
-  interface: "ens3"
+  provisioning_interface: "ens3"
+  provisioning_ip: "172.22.0.3/24"
   dhcp_range: "172.22.0.10,172.22.0.100"
-  deploy_kernel_url: "http://172.22.0.1/images/ironic-python-agent.kernel"
-  deploy_ramdisk_url: "http://172.22.0.1/images/ironic-python-agent.initramfs"
-  ironic_endpoint: "http://localhost:6385/v1/"
-  ironic_inspector_endpoint: "http://localhost:5050/v1/"
+  deploy_kernel_url: "http://172.22.0.3:6180/images/ironic-python-agent.kernel"
+  deploy_ramdisk_url: "http://172.22.0.3:6180/images/ironic-python-agent.initramfs"
+  ironic_endpoint: "http://172.22.0.3:6385/v1/"
+  ironic_inspector_endpoint: "http://172.22.0.3:5050/v1/"
+  cache_url: "http://192.168.111.1/images"
+  rhcos_image_url: "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/ootpa/410.8.20190520.0/"

--- a/deploy/operator_ironic.yaml
+++ b/deploy/operator_ironic.yaml
@@ -14,6 +14,62 @@ spec:
     spec:
       serviceAccountName: metal3-baremetal-operator
       hostNetwork: true
+      initContainers:
+        - name: ipa-downloader
+          image: quay.io/metal3-io/ironic-ipa-downloader:master
+          command:
+            - /usr/local/bin/get-resource.sh
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /shared
+              name: ironic-data-volume
+          env:
+            - name: CACHEURL
+              valueFrom:
+                configMapKeyRef:
+                  name: ironic-bmo-configmap
+                  key: cache_url
+        - name: rhcos-downloader
+          image: quay.io/openshift-metal3/rhcos-downloader:master
+          command:
+            - /usr/local/bin/get-resource.sh
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /shared
+              name: ironic-data-volume
+          env:
+            - name: RHCOS_IMAGE_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: ironic-bmo-configmap
+                  key: rhcos_image_url
+            - name: CACHEURL
+              valueFrom:
+                configMapKeyRef:
+                  name: ironic-bmo-configmap
+                  key: cache_url
+        - name: static-ip-set
+          image: quay.io/metal3-io/static-ip-manager:latest
+          command:
+            - /set-static-ip
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          env:
+            - name: PROVISIONING_IP
+              valueFrom:
+                configMapKeyRef:
+                  name: ironic-bmo-configmap
+                  key: provisioning_ip
+            - name: PROVISIONING_INTERFACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ironic-bmo-configmap
+                  key: provisioning_interface
       containers:
         - name: baremetal-operator
           image: quay.io/metal3-io/baremetal-operator:master
@@ -55,7 +111,7 @@ spec:
                   name: ironic-bmo-configmap
                   key: ironic_inspector_endpoint
         - name: ironic-dnsmasq
-          image: quay.io/metalkube/metalkube-ironic
+          image: quay.io/metal3-io/ironic:master
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -70,23 +126,18 @@ spec:
                 configMapKeyRef:
                   name: ironic-bmo-configmap
                   key: http_port
-            - name: IP
+            - name: PROVISIONING_INTERFACE
               valueFrom:
                 configMapKeyRef:
                   name: ironic-bmo-configmap
-                  key: http_ip
+                  key: provisioning_interface
             - name: DHCP_RANGE
               valueFrom:
                 configMapKeyRef:
                   name: ironic-bmo-configmap
                   key: dhcp_range
-            - name: INTERFACE
-              valueFrom:
-                configMapKeyRef:
-                  name: ironic-bmo-configmap
-                  key: interface
         - name: mariadb
-          image: quay.io/metalkube/metalkube-ironic
+          image: quay.io/metal3-io/ironic:master
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -102,7 +153,7 @@ spec:
                   name: mariadb-password
                   key: password
         - name: ironic-httpd
-          image: quay.io/metalkube/metalkube-ironic
+          image: quay.io/metal3-io/ironic:master
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -117,18 +168,18 @@ spec:
                 configMapKeyRef:
                   name: ironic-bmo-configmap
                   key: http_port
-            - name: IP
+            - name: PROVISIONING_INTERFACE
               valueFrom:
                 configMapKeyRef:
                   name: ironic-bmo-configmap
-                  key: http_ip
-        - name: ironic
-          image: quay.io/metalkube/metalkube-ironic
+                  key: provisioning_interface
+        - name: ironic-conductor
+          image: quay.io/metal3-io/ironic:master
           imagePullPolicy: Always
           securityContext:
             privileged: true
           command:
-            - /bin/runironic
+            - /bin/runironic-conductor
           volumeMounts:
             - mountPath: /shared
               name: ironic-data-volume
@@ -143,27 +194,95 @@ spec:
                 configMapKeyRef:
                   name: ironic-bmo-configmap
                   key: http_port
-            - name: IP
+            - name: PROVISIONING_INTERFACE
               valueFrom:
                 configMapKeyRef:
                   name: ironic-bmo-configmap
-                  key: http_ip
-            - name: INTERFACE
+                  key: provisioning_interface
+        - name: ironic-api
+          image: quay.io/metal3-io/ironic:master
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          command:
+            - /bin/runironic-api
+          volumeMounts:
+            - mountPath: /shared
+              name: ironic-data-volume
+          env:
+            - name: MARIADB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mariadb-password
+                  key: password
+            - name: HTTP_PORT
               valueFrom:
                 configMapKeyRef:
                   name: ironic-bmo-configmap
-                  key: interface
+                  key: http_port
+            - name: PROVISIONING_INTERFACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ironic-bmo-configmap
+                  key: provisioning_interface
+        - name: ironic-exporter
+          image: quay.io/metal3-io/ironic:master
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          command:
+            - /bin/runironic-exporter
+          volumeMounts:
+            - mountPath: /shared
+              name: ironic-data-volume
+          env:
+            - name: MARIADB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mariadb-password
+                  key: password
+            - name: HTTP_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: ironic-bmo-configmap
+                  key: http_port
+            - name: PROVISIONING_INTERFACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ironic-bmo-configmap
+                  key: provisioning_interface
         - name: ironic-inspector
-          image: quay.io/metalkube/metalkube-ironic-inspector
+          image: quay.io/metal3-io/ironic-inspector:master
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /shared
+              name: ironic-data-volume
+          env:
+            - name: PROVISIONING_INTERFACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ironic-bmo-configmap
+                  key: provisioning_interface
+        - name: static-ip-refresh
+          image: quay.io/metal3-io/static-ip-manager:latest
+          command:
+            - /refresh-static-ip
           imagePullPolicy: Always
           securityContext:
             privileged: true
           env:
-            - name: INTERFACE
+            - name: PROVISIONING_IP
               valueFrom:
                 configMapKeyRef:
                   name: ironic-bmo-configmap
-                  key: interface
+                  key: provisioning_ip
+            - name: PROVISIONING_INTERFACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ironic-bmo-configmap
+                  key: provisioning_interface
       volumes:
         - name: ironic-data-volume
           emptyDir: {}


### PR DESCRIPTION
We now set a static IP with a 'lifetime' on the provisioning interface.
We also now determine this IP from the interface itself in the containers
using the new interface.