### PR TITLE
clear error when credentials are recognized as good

### DIFF
--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -475,9 +475,12 @@ func (r *ReconcileBareMetalHost) actionRegistering(prov provisioner.Provisioner,
 	}
 
 	// Reaching this point means the credentials are valid and worked,
-	// so record that in the status block.
+	// so clear any previous error and record the success in the
+	// status block.
 	info.log.Info("updating credentials success status fields")
 	info.host.UpdateGoodCredentials(*info.bmcCredsSecret)
+	info.log.Info("clearing previous error message")
+	info.host.ClearError()
 
 	info.publishEvent("BMCAccessValidated", "Verified access to BMC")
 

--- a/pkg/controller/baremetalhost/baremetalhost_controller_test.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller_test.go
@@ -446,6 +446,67 @@ func TestFixSecret(t *testing.T) {
 	waitForNoError(t, r, host)
 }
 
+// TestBreakThenFixSecret ensures that when the secret for a known host
+// is updated to be broken, and then correct, the status of the host
+// moves out of the error state.
+func TestBreakThenFixSecret(t *testing.T) {
+
+	logger := log.WithValues("Test", "TestBreakThenFixSecret")
+
+	// Create the host without any errors and wait for it to be
+	// registered and get a provisioning ID.
+	secret := newSecret("bmc-creds-toggle-user", "User", "Pass")
+	host := newHost("break-then-fix-secret",
+		&metal3v1alpha1.BareMetalHostSpec{
+			BMC: metal3v1alpha1.BMCDetails{
+				Address:         "ipmi://192.168.122.1:6233",
+				CredentialsName: "bmc-creds-toggle-user",
+			},
+		})
+	r := newTestReconciler(host, secret)
+	tryReconcile(t, r, host,
+		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
+			id := host.Status.Provisioning.ID
+			logger.Info("WAIT FOR PROVISIONING ID", "ID", id)
+			return id != ""
+		},
+	)
+
+	// Modify the secret to be bad by removing the username. Wait for
+	// the host to show the error.
+	secret = &corev1.Secret{}
+	secretName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      "bmc-creds-toggle-user",
+	}
+	err := r.client.Get(goctx.TODO(), secretName, secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldUsername := secret.Data["username"]
+	secret.Data["username"] = []byte{}
+	err = r.client.Update(goctx.TODO(), secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForError(t, r, host)
+
+	// Modify the secret to be correct again. Wait for the error to be
+	// cleared from the host.
+	secret = &corev1.Secret{}
+	err = r.client.Get(goctx.TODO(), secretName, secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret.Data["username"] = oldUsername
+	err = r.client.Update(goctx.TODO(), secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForNoError(t, r, host)
+
+}
+
 // TestSetHardwareProfile ensures that the host has a label with
 // the hardware profile name.
 func TestSetHardwareProfile(t *testing.T) {

--- a/pkg/controller/baremetalhost/baremetalhost_controller_test.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller_test.go
@@ -145,28 +145,31 @@ func tryReconcile(t *testing.T, r *ReconcileBareMetalHost, host *metal3v1alpha1.
 }
 
 func waitForStatus(t *testing.T, r *ReconcileBareMetalHost, host *metal3v1alpha1.BareMetalHost, desiredStatus metal3v1alpha1.OperationalStatus) {
+	logger := log.WithValues("host", host.ObjectMeta.Name, "desiredStatus", desiredStatus)
 	tryReconcile(t, r, host,
 		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
 			state := host.OperationalStatus()
-			t.Logf("OperationalState of %s: %s", host.ObjectMeta.Name, state)
+			logger.Info("WAIT FOR STATUS", "State", state)
 			return state == desiredStatus
 		},
 	)
 }
 
 func waitForError(t *testing.T, r *ReconcileBareMetalHost, host *metal3v1alpha1.BareMetalHost) {
+	logger := log.WithValues("host", host.ObjectMeta.Name)
 	tryReconcile(t, r, host,
 		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
-			t.Logf("ErrorMessage of %s: %q", host.ObjectMeta.Name, host.Status.ErrorMessage)
+			logger.Info("WAIT FOR ERROR", "ErrorMessage", host.Status.ErrorMessage)
 			return host.HasError()
 		},
 	)
 }
 
 func waitForNoError(t *testing.T, r *ReconcileBareMetalHost, host *metal3v1alpha1.BareMetalHost) {
+	logger := log.WithValues("host", host.ObjectMeta.Name)
 	tryReconcile(t, r, host,
 		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
-			t.Logf("ErrorMessage of %s: %q", host.ObjectMeta.Name, host.Status.ErrorMessage)
+			logger.Info("WAIT FOR NO ERROR", "ErrorMessage", host.Status.ErrorMessage)
 			return !host.HasError()
 		},
 	)

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -55,9 +55,6 @@ func (p *fixtureProvisioner) ValidateManagementAccess() (result provisioner.Resu
 		return result, nil
 	}
 
-	// Clear any error
-	result.Dirty = p.host.ClearError()
-
 	return result, nil
 }
 


### PR DESCRIPTION
This change fixes a bug in which an existing host could be updated to have
bad credentials and then that mistake could be corrected but the host
status would not be fixed. Always clear any existing error messages when
the credentials are recognized as changed and good.

Also adds a unit test for that case.

Fixes #195