### PR TITLE
ServiceMonitor for ironic-prometheus-exporter

### DIFF
--- a/deploy/baremetal-operator_servicemonitor.yaml
+++ b/deploy/baremetal-operator_servicemonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: baremetal-operator
+  namespace: openshift-machine-api
+spec:
+  endpoints:
+  - port: "5001-tcp"
+    scheme: http
+    path: /metrics
+    targetPort: 5001
+  namespaceSelector:
+    matchNames:
+    - openshift-machine-api
+  selector: {}


### PR DESCRIPTION
This PR adds the ServiceMonitor for the ironic-promeheus-exporter

We need a `yaml` to NameSpace deploy so we can add the label `openshift.io/cluster-monitoring=true`
like in [1]


[1] https://github.com/openshift/cluster-monitoring-operator/blob/master/manifests/01-namespace.yaml#L8
