### PR TITLE
Allows boot interface to be customizable

### DIFF
--- a/pkg/bmc/access.go
+++ b/pkg/bmc/access.go
@@ -31,6 +31,9 @@ type AccessDetails interface {
 	// expected to add any other information that might be needed
 	// (such as the kernel and ramdisk locations).
 	DriverInfo(bmcCreds Credentials) map[string]interface{}
+	
+	// Boot interface to set
+	BootInterface() string
 }
 
 func getTypeHostPort(address string) (bmcType, host, port, path string, err error) {

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -201,6 +201,16 @@ func TestIPMIDriverInfoDefaultPort(t *testing.T) {
 	}
 }
 
+func TestIPMIBootInterface(t *testing.T) {
+	acc, err := NewAccessDetails("ipmi://192.168.122.1:6233")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if acc.BootInterface() != "ipxe" {
+		t.Fatal("expected boot interface to be ipxe")
+	}
+}
+
 func TestLibvirtNeedsMAC(t *testing.T) {
 	acc, err := NewAccessDetails("libvirt://192.168.122.1:6233/")
 	if err != nil {
@@ -219,6 +229,16 @@ func TestLibvirtDriver(t *testing.T) {
 	driver := acc.Driver()
 	if driver != "ipmi" {
 		t.Fatal("unexpected driver for libvirt")
+	}
+}
+
+func TestLibvirtBootInterface(t *testing.T) {
+	acc, err := NewAccessDetails("libvirt://192.168.122.1:6233/")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if acc.BootInterface() != "ipxe" {
+		t.Fatal("expected boot interface to be ipxe")
 	}
 }
 
@@ -436,6 +456,16 @@ func TestIDRACDriverInfoIPv6Port(t *testing.T) {
 	}
 	if di["drac_path"] != "/foo" {
 		t.Fatalf("unexpected path: %v", di["drac_path"])
+	}
+}
+
+func TestIDRACBootInterface(t *testing.T) {
+	acc, err := NewAccessDetails("idrac://192.168.122.1")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if acc.BootInterface() != "ipxe" {
+		t.Fatal("expected boot interface to be ipxe")
 	}
 }
 

--- a/pkg/bmc/idrac.go
+++ b/pkg/bmc/idrac.go
@@ -50,3 +50,7 @@ func (a *iDracAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfa
 
 	return result
 }
+
+func (a *iDracAccessDetails) BootInterface() string {
+	return "ipxe"
+}

--- a/pkg/bmc/ipmi.go
+++ b/pkg/bmc/ipmi.go
@@ -45,3 +45,7 @@ func (a *ipmiAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 	}
 	return result
 }
+
+func (a *ipmiAccessDetails) BootInterface() string {
+	return "ipxe"
+}

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -231,7 +231,7 @@ func (p *ironicProvisioner) ValidateManagementAccess() (result provisioner.Resul
 			p.client,
 			nodes.CreateOpts{
 				Driver:        p.bmcAccess.Driver(),
-				BootInterface: "ipxe",
+				BootInterface: p.bmcAccess.BootInterface(),
 				Name:          p.host.Name,
 				DriverInfo:    driverInfo,
 			}).Extract()


### PR DESCRIPTION
Currently boot interface is hard-code of 'ipxe'. This patch allows
boot interface to be set by vendor driver.

#230 
Signed-off-by: Dao Cong Tien <tiendc@vn.fujitsu.com>