### PR TITLE
 Introduce gosec for security checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,11 @@ lint:
 	golint -set_exit_status pkg/... cmd/...
 	go vet ./pkg/... ./cmd/...
 
+.PHONY: test-sec
+test-sec:
+	@which gosec 2> /dev/null >&1 || { echo "gosec must be installed to lint code";  exit 1; }
+	gosec -severity medium --confidence medium -quiet ./...
+
 .PHONY: docs
 docs: $(patsubst %.dot,%.png,$(wildcard docs/*.dot))
 

--- a/cmd/make-virt-host/main.go
+++ b/cmd/make-virt-host/main.go
@@ -146,6 +146,7 @@ func main() {
 	}
 
 	// Figure out the MAC for the VM
+	// #nosec
 	virshOut, err := exec.Command("sudo", "virsh", "dumpxml", virshDomain).Output()
 	if err != nil {
 		fmt.Fprintf(os.Stderr,

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -589,6 +589,8 @@ func (p *ironicProvisioner) getImageChecksum() (string, error) {
 	}
 	if isURL {
 		p.log.Info("looking for checksum for image", "URL", checksum)
+		// #nosec
+		// TODO: Are there more ways to constraint the URL that's given here?
 		resp, err := http.Get(checksum)
 		if err != nil {
 			return "", errors.Wrap(err, "Could not fetch image checksum")


### PR DESCRIPTION
gosec does static code analysis and checks for common security issues in golang codebases.

This PR introduces the tool, and sets it up as a test target in the Makefile; it also ignores a couple of warnings that were found which are probably not very problematic.