### PR TITLE
handle deprovisioning in two phases

### DIFF
--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -520,6 +520,16 @@ func (host *BareMetalHost) WasProvisioned() bool {
 // WasExternallyProvisioned returns true when we think something else
 // is managing the image running on the host.
 func (host *BareMetalHost) WasExternallyProvisioned() bool {
+	// We do not want provisioned hosts to appear to be externally
+	// provisioned when we start deprovisioning them.
+	if host.Status.Provisioning.State == StateProvisioned {
+		return false
+	}
+	if host.Status.Provisioning.State == StateDeprovisioning {
+		return false
+	}
+	// Truly externally provisioned hosts have an image and no
+	// consumer.
 	if host.Spec.Image == nil && host.Spec.ConsumerRef != nil {
 		return true
 	}

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types_test.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types_test.go
@@ -374,6 +374,18 @@ func TestHostWasExternallyProvisioned(t *testing.T) {
 			},
 			Expected: false,
 		},
+
+		{
+			Scenario: "deprovisioning state",
+			Host: BareMetalHost{
+				Status: BareMetalHostStatus{
+					Provisioning: ProvisionStatus{
+						State: StateDeprovisioning,
+					},
+				},
+			},
+			Expected: false,
+		},
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			if tc.Expected && !tc.Host.WasExternallyProvisioned() {


### PR DESCRIPTION
The cluster-api-provider-baremetal implementation of deprovisioning
first removes the image reference and then removes the consumer
reference to ensure that a host is not grabbed and used while it is
being deprovisioned. This change fixes the state management to
understand that case and adds a test to demonstrate that the
reconciler logic works as expected.

Fixes #238