### PR TITLE
Avoid port conflict for metrics endpoint

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -31,7 +31,7 @@ func printVersion() {
 
 func main() {
 	devLogging := flag.Bool("dev", false, "enable dev logging")
-	metricsAddr := flag.String("metrics-addr", "127.0.0.1:8080", "The address the metric endpoint binds to.")
+	metricsAddr := flag.String("metrics-addr", "127.0.0.1:8085", "The address the metric endpoint binds to.")
 	flag.Parse()
 
 	// The logger instantiated here can be changed to any logger


### PR DESCRIPTION
In the OpenShift integrated case this conflicts with coredns which binds
to :::8080, switching to 8085 should avoid this conflict with the
default.

Fixes: #252