### PR TITLE
Persist firmware and bios data during introspection.

### DIFF
--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -262,10 +262,29 @@ type NIC struct {
 	PXE bool `json:"pxe"`
 }
 
+// Firmware describes the firmware on the host.
+type Firmware struct {
+	// The BIOS for this firmware
+	BIOS BIOS `json:"bios"`
+}
+
+// BIOS describes the BIOS version on the host.
+type BIOS struct {
+	// The release/build date for this BIOS
+	Date string `json:"date"`
+
+	// The vendor name for this BIOS
+	Vendor string `json:"vendor"`
+
+	// The version of the BIOS
+	Version string `json:"version"`
+}
+
 // HardwareDetails collects all of the information about hardware
 // discovered on the host.
 type HardwareDetails struct {
 	SystemVendor HardwareSystemVendor `json:"systemVendor"`
+	Firmware     Firmware             `json:"firmware"`
 	RAMMebibytes int                  `json:"ramMebibytes"`
 	NIC          []NIC                `json:"nics"`
 	Storage      []Storage            `json:"storage"`

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -465,8 +465,38 @@ func getCPUDetails(cpudata *introspection.CPUType) metal3v1alpha1.CPU {
 	return cpu
 }
 
+func getFirmwareDetails(firmwaredata introspection.ExtraHardwareDataSection) metal3v1alpha1.Firmware {
+
+	// handle bios optionally
+	var bios metal3v1alpha1.BIOS
+
+	if _, ok := firmwaredata["bios"]; ok {
+
+		// we do not know if all fields will be supplied
+		// as this is not a structured response
+		// so we must handle each field conditionally
+		if _, ok := firmwaredata["bios"]["vendor"]; ok {
+			bios.Vendor = firmwaredata["bios"]["vendor"].(string)
+		}
+
+		if _, ok := firmwaredata["bios"]["version"]; ok {
+			bios.Version = firmwaredata["bios"]["version"].(string)
+		}
+
+		if _, ok := firmwaredata["bios"]["date"]; ok {
+			bios.Date = firmwaredata["bios"]["date"].(string)
+		}
+	}
+
+	return metal3v1alpha1.Firmware{
+		BIOS: bios,
+	}
+
+}
+
 func getHardwareDetails(data *introspection.Data) *metal3v1alpha1.HardwareDetails {
 	details := new(metal3v1alpha1.HardwareDetails)
+	details.Firmware = getFirmwareDetails(data.Extra.Firmware)
 	details.SystemVendor = getSystemVendorDetails(data.Inventory.SystemVendor)
 	details.RAMMebibytes = data.MemoryMB
 	details.NIC = getNICDetails(data.Inventory.Interfaces, data.AllInterfaces, data.Extra.Network)

--- a/pkg/provisioner/ironic/ironic_test.go
+++ b/pkg/provisioner/ironic/ironic_test.go
@@ -422,3 +422,39 @@ func TestGetNICSpeedGbps(t *testing.T) {
 		t.Errorf("Expected speed 0, got %d", s4)
 	}
 }
+
+func TestGetFirmwareDetails(t *testing.T) {
+
+	// Test full (known) firmware payload
+	firmware := getFirmwareDetails(introspection.ExtraHardwareDataSection{
+		"bios": {
+			"vendor":  "foobar",
+			"version": "1.2.3",
+			"date":    "2019-07-10",
+		},
+	})
+
+	if firmware.BIOS.Vendor != "foobar" {
+		t.Errorf("Expected firmware BIOS vendor to be foobar, but got: %s", firmware)
+	}
+
+	// Ensure we can handle partial firmware/bios data
+	firmware = getFirmwareDetails(introspection.ExtraHardwareDataSection{
+		"bios": {
+			"vendor":  "foobar",
+			"version": "1.2.3",
+		},
+	})
+
+	if firmware.BIOS.Date != "" {
+		t.Errorf("Expected firmware BIOS date to be empty but got: %s", firmware)
+	}
+
+	// Finally, ensure we can handle completely empty firmware data
+	firmware = getFirmwareDetails(introspection.ExtraHardwareDataSection{})
+
+	if (firmware != metal3v1alpha1.Firmware{}) {
+		t.Errorf("Expected firmware data to be empty but got: %s", firmware)
+	}
+
+}


### PR DESCRIPTION
Introduce handling of the gophercloud's Firmware ExtraHardwareDataSection.  

Today, this only includes known BIOS fields.  If we are able to determine all likely data potentially within the Firmware section we can expand the data and fields handled.

Resolves: #220