### PR TITLE
Make use of nodes.CreateOpts.Properties (#265)

### DIFF
--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -142,6 +142,9 @@ type BareMetalHostSpec struct {
 	// data to be passed to the host before it boots.
 	UserData *corev1.SecretReference `json:"userData,omitempty"`
 
+	// Whether or not use UEFI boot mode (efiboot ipmitool option)
+	BootUEFI bool `json:"bootUEFI,omitempty"`
+
 	// Description is a human-entered text used to help identify the host
 	Description string `json:"description"`
 


### PR DESCRIPTION
This may be useful when you need to pass `properties` when creating a node in ironic, e.g. `boot_mode:uefi`