### PR TITLE
Run gosec with lint target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ go:
 
 before_install:
   - go get golang.org/x/lint/golint
+  - go get -u github.com/securego/gosec/cmd/gosec
 
 env:
   - TARGET=test-verbose

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test-verbose:
 	VERBOSE=-v make unit
 
 .PHONY: lint
-lint:
+lint: test-sec
 	golint -set_exit_status pkg/... cmd/...
 	go vet ./pkg/... ./cmd/...
 


### PR DESCRIPTION
This enables gosec to run as part of the lint target, therefore running
it as well as part of CI.

This also adds the needed command to install it as part of the CI run.