### PR TITLE
improve error handling in power state management code

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1176,9 +1176,15 @@ func (p *ironicProvisioner) Delete() (result provisioner.Result, err error) {
 func (p *ironicProvisioner) changePower(ironicNode *nodes.Node, target nodes.TargetPowerState) (result provisioner.Result, err error) {
 	p.log.Info("changing power state")
 
-	// If we're here, we're going to change the state and we should
-	// wait to try that again.
-	result.RequeueAfter = powerRequeueDelay
+	if ironicNode.TargetProvisionState != "" {
+		p.log.Info("host in state that does not allow power change, try again after delay",
+			"state", ironicNode.ProvisionState,
+			"target state", ironicNode.TargetProvisionState,
+		)
+		result.Dirty = true
+		result.RequeueAfter = powerRequeueDelay
+		return result, nil
+	}
 
 	changeResult := nodes.ChangePowerState(
 		p.client,
@@ -1193,10 +1199,12 @@ func (p *ironicProvisioner) changePower(ironicNode *nodes.Node, target nodes.Tar
 		p.log.Info("power change OK")
 	case gophercloud.ErrDefault409:
 		p.log.Info("host is locked, trying again after delay", "delay", powerRequeueDelay)
+		result.Dirty = true
+		result.RequeueAfter = powerRequeueDelay
 		return result, nil
 	default:
-		p.log.Info("power change error")
-		return result, errors.Wrap(err, "failed to change power state")
+		p.log.Info("power change error", "message", changeResult.Err)
+		return result, errors.Wrap(changeResult.Err, "failed to change power state")
 	}
 
 	return result, nil


### PR DESCRIPTION
When the host is in certain provisioning states we cannot change its
power status. Rather than erroring and trying over and over, report
the issue and delay retrying to give the host a chance to move into a
state where power can be changed.