### PR TITLE
Support RAID and BIOS configuration for Baremetal Server

### DIFF
--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -104,6 +104,49 @@ type BMCDetails struct {
 	CredentialsName string `json:"credentialsName"`
 }
 
+type RAIDVolume struct {
+	// Size (Integer) of the logical disk to be created in GiB.  If unspecified, "MAX" will be used.
+	SizeGB *int `json:"sizeGB"`
+
+	// RAID level for the logical disk.
+	RAIDLevel string `json:"raidLevel" required:"true"`
+
+	// Name of the volume. Should be unique within the Node. If not specified, volume name will be auto-generated.
+	VolumeName string `json:"volumeName,omitempty"`
+
+	// Set to true if this logical disk can share physical disks with other logical disks.
+	SharePhysicalDisks *bool `json:"sharePhysicalDisks,omitempty"`
+
+	// If this is not specified, disk type will not be a criterion to find backing physical disks
+	DiskType string `json:"diskType,omitempty"`
+
+	// If this is not specified, interface type will not be a criterion to find backing physical disks.
+	InterfaceType string `json:"interfaceType,omitempty"`
+
+	// Integer, number of disks to use for the logical disk. Defaults to minimum number of disks required
+	// for the particular RAID level.
+	NumberOfPhysicalDisks int `json:"numberOfPhysicalDisks,omitempty"`
+
+	// The name of the controller as read by the RAID interface.
+	Controller string `json:"controller,omitempty"`
+
+	// A list of physical disks to use as read by the RAID interface.
+	PhysicalDisks []string `json:"physicalDisks,omitempty"`
+}
+
+// RAIDConfig contains the configuration that are required to config RAID in Bare Metal server
+type RAIDConfig struct {
+
+	// The logical disk that will be root volume
+	RootVolume *RAIDVolume `json:"rootVolume,omitempty"`
+
+	// The list of logical disks
+	Volumes []RAIDVolume `json:"volumes,omitempty"`
+}
+
+// BIOSConfig contains the configuration that are required to config BIOS in Bare Metal server
+type BIOSConfig map[string]interface{}
+
 // BareMetalHostSpec defines the desired state of BareMetalHost
 type BareMetalHostSpec struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code
@@ -117,6 +160,12 @@ type BareMetalHostSpec struct {
 
 	// How do we connect to the BMC?
 	BMC BMCDetails `json:"bmc,omitempty"`
+
+	// RAID configuration for bare metal server
+	RAID RAIDConfig `json:"raid,omitempty"`
+
+	// BIOS configurations for bare metal server
+	BIOS BIOSConfig `json:"bios,omitempty"`
 
 	// What is the name of the hardware profile for this host? It
 	// should only be necessary to set this when inspection cannot

--- a/pkg/bmc/access.go
+++ b/pkg/bmc/access.go
@@ -3,6 +3,7 @@ package bmc
 import (
 	"net"
 	"net/url"
+	"reflect"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -34,6 +35,28 @@ type AccessDetails interface {
 	
 	// Boot interface to set
 	BootInterface() string
+
+	// Return the map of supported BIOS configuration keys
+	GetBIOSConfigDetails() map[string]VendorBIOSConfigSpec
+}
+
+type VendorBIOSConfigSpec struct {
+	VendorKey string
+	ValueType reflect.Kind
+	SupportedValues []interface{}
+}
+
+func (v *VendorBIOSConfigSpec) IsSupportedConfigValue (value interface{}) (isSupport bool) {
+	if v.SupportedValues == nil {
+		return true
+	} else {
+		for _, supportedValue := range v.SupportedValues {
+			if value == supportedValue {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func getTypeHostPort(address string) (bmcType, host, port, path string, err error) {

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -1,6 +1,7 @@
 package bmc
 
 import (
+	"reflect"
 	"testing"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -211,6 +212,16 @@ func TestIPMIBootInterface(t *testing.T) {
 	}
 }
 
+func TestIPMIBiosConfigDetails(t *testing.T) {
+	acc, err := NewAccessDetails("ipmi://192.168.122.1:6233")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if acc.GetBIOSConfigDetails() != nil {
+		t.Fatal("expected BIOS configuration details to be nil")
+	}
+}
+
 func TestLibvirtNeedsMAC(t *testing.T) {
 	acc, err := NewAccessDetails("libvirt://192.168.122.1:6233/")
 	if err != nil {
@@ -239,6 +250,16 @@ func TestLibvirtBootInterface(t *testing.T) {
 	}
 	if acc.BootInterface() != "ipxe" {
 		t.Fatal("expected boot interface to be ipxe")
+	}
+}
+
+func TestLibvirtBiosConfigDetails(t *testing.T) {
+	acc, err := NewAccessDetails("libvirt://192.168.122.1:6233/")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if acc.GetBIOSConfigDetails() != nil {
+		t.Fatal("expected BIOS configuration details to be nil")
 	}
 }
 
@@ -469,6 +490,17 @@ func TestIDRACBootInterface(t *testing.T) {
 	}
 }
 
+func TestIRACBiosConfigDetails(t *testing.T) {
+	acc, err := NewAccessDetails("idrac://192.168.122.1")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if acc.GetBIOSConfigDetails() != nil {
+		t.Fatal("expected BIOS configuration details to be nil")
+	}
+}
+
+
 func TestParseIRMCURL(t *testing.T) {
 	T, H, P, A, err := getTypeHostPort("irmc://192.168.122.1")
 	if err != nil {
@@ -612,6 +644,17 @@ func TestIRMCBootInterface(t *testing.T) {
 		t.Fatal("expected boot interface to be pxe")
 	}
 }
+
+func TestIRMCBiosConfigDetails(t *testing.T) {
+	acc, err := NewAccessDetails("irmc://192.168.122.1")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if !reflect.DeepEqual(acc.GetBIOSConfigDetails(), iRMCBiosConfigDetails) {
+		t.Fatal("unexpected BIOS configuration details")
+	}
+}
+
 
 func TestUnknownType(t *testing.T) {
 	acc, err := NewAccessDetails("foo://192.168.122.1")

--- a/pkg/bmc/idrac.go
+++ b/pkg/bmc/idrac.go
@@ -54,3 +54,9 @@ func (a *iDracAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfa
 func (a *iDracAccessDetails) BootInterface() string {
 	return "ipxe"
 }
+
+// GetBIOSConfigDetails return the mapping of supported BIOS configuration keys between Metal3 and iDRAC.
+// If the user use the key that does not belong to this map, this key wil be marked as unsupported in iDRAC.
+func (a *iDracAccessDetails) GetBIOSConfigDetails() map[string]VendorBIOSConfigSpec {
+	return nil
+}

--- a/pkg/bmc/ipmi.go
+++ b/pkg/bmc/ipmi.go
@@ -49,3 +49,10 @@ func (a *ipmiAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 func (a *ipmiAccessDetails) BootInterface() string {
 	return "ipxe"
 }
+
+// GetBIOSConfigDetails return the mapping of supported BIOS configuration keys between Metal3 and IPMI.
+// If the user use the key that does not belong to this map, this key wil be marked as unsupported in IPMI.
+func (a *ipmiAccessDetails) GetBIOSConfigDetails() map[string] VendorBIOSConfigSpec {
+	return nil
+}
+

--- a/pkg/bmc/irmc.go
+++ b/pkg/bmc/irmc.go
@@ -1,5 +1,7 @@
 package bmc
 
+import "reflect"
+
 type iRMCAccessDetails struct {
 	bmcType  string
 	portNum  string
@@ -42,3 +44,90 @@ func (a *iRMCAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 func (a *iRMCAccessDetails) BootInterface() string {
 	return "pxe"
 }
+// GetBIOSConfigDetails return the mapping of supported BIOS configuration keys between Metal3 and iRMC.
+// If the user use the key that does not belong to this map, this key wil be marked as unsupported in iRMC
+func (a *iRMCAccessDetails) GetBIOSConfigDetails() map[string]VendorBIOSConfigSpec {
+	return iRMCBiosConfigDetails
+}
+
+var iRMCBiosConfigDetails = map[string]VendorBIOSConfigSpec {
+		// Specifies from which drives can be booted
+		"bootOptionFilter": {
+			VendorKey: "boot_option_filter",
+			ValueType: reflect.String,
+			SupportedValues: []interface{}{"UefiAndLegacy", "LegacyOnly", "UefiOnly"},
+		},
+		// The UEFI FW checks the controller health status.
+		"checkControllersHealthStatusEnabled": {
+			VendorKey: "check_controllers_health_status_enabled",
+			ValueType: reflect.Bool,
+		},
+		// The number of active processor cores 1…n. Option 0 indicates that all
+		// available processor cores are active.
+		"cpuActiveProcessorCores": {
+			VendorKey: "cpu_active_processor_cores",
+			ValueType: reflect.Int,
+		},
+		// The processor loads the requested cache line and the adjacent cache line
+		"cpuAdjacentCacheLinePrefetchEnabled": {
+			VendorKey: "cpu_adjacent_cache_line_prefetch_enabled",
+			ValueType: reflect.Bool,
+		},
+		// Supports the virtualization of platform hardware and several software
+		// environments, based on Virtual Machine Extensions to support the use of
+		// several software environments using virtual computers
+		"cpuVtEnabled": {
+			VendorKey: "cpu_vt_enabled",
+			ValueType: reflect.Bool,
+		},
+		// The system BIOS can be written. Flash BIOS update is possible
+		"flashWriteEnabled": {
+			VendorKey: "flash_write_enabled",
+			ValueType: reflect.Bool,
+		},
+		// Hyper-threading technology allows a single physical processor core to
+		// appear as several logical processors.
+		"hyperThreadingEnabled": {
+			VendorKey: "hyper_threading_enabled",
+			ValueType: reflect.Bool,
+		},
+		// Boot Options will not be removed from “Boot Option Priority” list
+		"keepVoidBootOptionsEnabled":{
+			VendorKey: "keep_void_boot_options_enabled",
+			ValueType: reflect.Bool,
+		},
+		// Specifies whether the Compatibility Support Module (CSM) is executed
+		"launchCsmEnabled": {
+			VendorKey: "launch_csm_enabled",
+			ValueType: reflect.Bool,
+		},
+		// Prevents the OS from overruling any energy efficiency policy setting of the setup
+		"osEnergyPerformanceOverrideEnabled":{
+			VendorKey: "os_energy_performance_override_enabled",
+			ValueType: reflect.Bool,
+		},
+		// Active State Power Management (ASPM) is used to power-manage the PCI
+		// Express links, thus consuming less power
+		"pciAspmSupport": {
+			VendorKey: "pci_aspm_support",
+			ValueType: reflect.String,
+			SupportedValues: []interface{}{"Disabled", "Auto", "L0Limited", "L1only", "L0Force"},
+		},
+		// Specifies if memory resources above the 4GB address boundary can be assigned to PCI devices
+		"pciAbove4gDecodingEnabled": {
+			VendorKey: "pci_above_4g_decoding_enabled",
+			ValueType: reflect.Bool,
+		},
+		// Specifies whether the switch on sources for the system are managed by
+		// the BIOS or the ACPI operating system
+		"powerOnSource": {
+			VendorKey: "power_on_source",
+			ValueType: reflect.String,
+			SupportedValues: []interface{}{"BiosControlled", "AcpiControlled"},
+		},
+		// Single Root IO Virtualization Support is active
+		"singleRootIoVirtualizationSupportEnabled": {
+			VendorKey: "single_root_io_virtualization_support_enabled",
+			ValueType: reflect.Bool,
+		},
+	}

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -1,6 +1,7 @@
 package provisioner
 
 import (
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
 	"time"
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
@@ -33,11 +34,17 @@ type Provisioner interface {
 	// credentials is correct.
 	ValidateManagementAccess(credentialsChanged bool) (result Result, err error)
 
+	// Get AccessDetails from provisioner
+	GetAccessDetails() (bmc.AccessDetails)
+
 	// InspectHardware updates the HardwareDetails field of the host with
 	// details of devices discovered on the hardware. It may be called
 	// multiple times, and should return true for its dirty flag until the
 	// inspection is completed.
 	InspectHardware() (result Result, details *metal3v1alpha1.HardwareDetails, err error)
+
+	// ManualCleaning execute the Clean Steps for extra configuration such as RAID, BIOS.
+	ManualCleaning(cleanSteps []nodes.CleanStep) (result Result, err error)
 
 	// UpdateHardwareState fetches the latest hardware state of the
 	// server and updates the HardwareDetails field of the host with


### PR DESCRIPTION
Currently, Metal3 does not support deploy baremetal server with RAID (#206 )and BIOS (#207) configuration. This commit aims to support RAID and BIOS configuration in Metal with the belows:
- Extend BaremetalHost CRD to suport RAID and BIOS configuration via **raid** and **bios** property
- Adding BIOS configuration detail to each vendor's driver
- Clean step builder and validator: It will check whether RAID and BIOS is supported by vendor's driver or not
- Introduce **cleaning** state as a new provisioning state to setup RAID/BIOS if needed. In this state, Metal3 can make Ironic enter Manual cleaning with clean steps to configure RAID/BIOS.