### PR TITLE
remove debugging log statement in adoption

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -927,11 +927,6 @@ func (p *ironicProvisioner) Adopt() (result provisioner.Result, err error) {
 		return p.ValidateManagementAccess(true)
 	}
 
-	p.log.Info("waiting for adoption to complete",
-		"current", ironicNode.ProvisionState,
-		"target", ironicNode.TargetProvisionState,
-	)
-
 	switch nodes.ProvisionState(ironicNode.ProvisionState) {
 	case nodes.Enroll:
 		err = fmt.Errorf("Invalid state for adopt: %s",


### PR DESCRIPTION
The adoption flow logs a message that it is waiting for adoption to
complete, even when no adoption is actually happening. Remove the log
message entirely to avoid cluttering the logs and confusing users.