### PR TITLE
Add redfish BMC support in baremetal operator

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -18,6 +18,10 @@ in place of `https://` in the iDRAC URL; only the hostname or IP address is
 required - `idrac://host.example` is equivalent to
 `idrac+https://host.example:443/wsman`. Fujitsu iRMC is also supported,
 by using the scheme `irmc://<host>:<port>` with `<port>` is optional.
+Redfish is also supported, by using the scheme `redfish://` (or
+`redfish+http://` to disable TLS) in place of `https://` in the Redfish URL;
+the hostname or IP address, and the path to the system ID are required -
+for example `redfish://myhost.example/redfish/v1/Systems/MySystemExample`
 
 *bmc.credentials* -- A reference to a Secret containing the connection
 data, at least username and password, for the BMC.

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -180,6 +180,57 @@ func TestParse(t *testing.T) {
 			Hostname: "192.168.122.1",
 			Path:     "",
 		},
+
+		{
+			Scenario: "redfish url",
+			Address:  "redfish://192.168.122.1",
+			Type:     "redfish",
+			Port:     "",
+			Host:     "192.168.122.1",
+			Hostname: "192.168.122.1",
+			Path:     "",
+		},
+
+		{
+			Scenario: "redfish url path",
+			Address:  "redfish://192.168.122.1:6233/foo",
+			Type:     "redfish",
+			Port:     "6233",
+			Host:     "192.168.122.1",
+			Hostname: "192.168.122.1:6233",
+			Path:     "/foo",
+		},
+
+		{
+			Scenario: "redfish url ipv6",
+			Address:  "redfish://[fe80::fc33:62ff:fe83:8a76]",
+			Type:     "redfish",
+			Port:     "",
+			Host:     "fe80::fc33:62ff:fe83:8a76",
+			Hostname: "[fe80::fc33:62ff:fe83:8a76]",
+			Path:     "",
+		},
+
+		{
+			Scenario: "redfish url path ipv6",
+			Address:  "redfish://[fe80::fc33:62ff:fe83:8a76]:6233/foo",
+			Type:     "redfish",
+			Port:     "6233",
+			Host:     "fe80::fc33:62ff:fe83:8a76",
+			Hostname: "[fe80::fc33:62ff:fe83:8a76]:6233",
+			Path:     "/foo",
+		},
+
+		{
+			Scenario: "redfish url no sep",
+			Address:  "redfish:192.168.122.1",
+			Type:     "redfish",
+			Port:     "",
+			Host:     "192.168.122.1",
+			Hostname: "192.168.122.1",
+			Path:     "",
+		},
+
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			url, err := getParsedURL(tc.Address)
@@ -277,6 +328,15 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:   "irmc",
 			boot:     "pxe",
 		},
+
+		{
+			Scenario: "redfish",
+			input:    "redfish://192.168.122.1",
+			needsMac: true,
+			driver:   "redfish",
+			boot:     "pxe",
+		},
+
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			acc, err := NewAccessDetails(tc.input)
@@ -422,6 +482,73 @@ func TestDriverInfo(t *testing.T) {
 				"irmc_username": "",
 			},
 		},
+
+		{
+			Scenario: "Redfish",
+			input: "redfish://192.168.122.1/foo/bar",
+			expects: map[string]string{
+				"redfish_address":  	"https://192.168.122.1",
+				"redfish_system_id":	"/foo/bar",
+				"redfish_password": "",
+				"redfish_username": "",
+			},
+		},
+
+		{
+			Scenario: "Redfish http",
+			input: "redfish+http://192.168.122.1/foo/bar",
+			expects: map[string]string{
+				"redfish_address":  	"http://192.168.122.1",
+				"redfish_system_id":	"/foo/bar",
+				"redfish_password": "",
+				"redfish_username": "",
+			},
+		},
+
+		{
+			Scenario: "Redfish https",
+			input: "redfish+https://192.168.122.1/foo/bar",
+			expects: map[string]string{
+				"redfish_address":  	"https://192.168.122.1",
+				"redfish_system_id":	"/foo/bar",
+				"redfish_password": "",
+				"redfish_username": "",
+			},
+		},
+
+		{
+			Scenario: "Redfish port",
+			input: "redfish://192.168.122.1:8080/foo/bar",
+			expects: map[string]string{
+				"redfish_address":  	"https://192.168.122.1:8080",
+				"redfish_system_id":	"/foo/bar",
+				"redfish_password": "",
+				"redfish_username": "",
+			},
+		},
+
+		{
+			Scenario: "Redfish ipv6",
+			input: "redfish://[fe80::fc33:62ff:fe83:8a76]/foo/bar",
+			expects: map[string]string{
+				"redfish_address":  	"https://[fe80::fc33:62ff:fe83:8a76]",
+				"redfish_system_id":	"/foo/bar",
+				"redfish_password": "",
+				"redfish_username": "",
+			},
+		},
+
+		{
+			Scenario: "Redfish ipv6 port",
+			input: "redfish://[fe80::fc33:62ff:fe83:8a76]:8080/foo",
+			expects: map[string]string{
+				"redfish_address":  	"https://[fe80::fc33:62ff:fe83:8a76]:8080",
+				"redfish_system_id":	"/foo",
+				"redfish_password": "",
+				"redfish_username": "",
+			},
+		},
+
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			acc, err := NewAccessDetails(tc.input)
@@ -444,6 +571,7 @@ func TestDriverInfo(t *testing.T) {
 		})
 	}
 }
+
 
 func TestUnknownType(t *testing.T) {
 	acc, err := NewAccessDetails("foo://192.168.122.1")

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -1,0 +1,75 @@
+package bmc
+
+import (
+	"net/url"
+	"strings"
+)
+
+func init() {
+	registerFactory("redfish", newRedfishAccessDetails)
+	registerFactory("redfish+http", newRedfishAccessDetails)
+	registerFactory("redfish+https", newRedfishAccessDetails)
+}
+
+func newRedfishAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
+	return &redfishAccessDetails{
+		bmcType:  parsedURL.Scheme,
+		host:     parsedURL.Host,
+		path:     parsedURL.Path,
+	}, nil
+}
+
+type redfishAccessDetails struct {
+	bmcType  string
+	host     string
+	path     string
+}
+
+const redfishDefaultScheme = "https"
+
+func (a *redfishAccessDetails) Type() string {
+	return a.bmcType
+}
+
+// NeedsMAC returns true when the host is going to need a separate
+// port created rather than having it discovered.
+func (a *redfishAccessDetails) NeedsMAC() bool {
+	// For the inspection to work, we need a MAC address
+	// https://github.com/metal3-io/baremetal-operator/pull/284#discussion_r317579040
+	return true
+}
+
+func (a *redfishAccessDetails) Driver() string {
+	return "redfish"
+}
+
+// DriverInfo returns a data structure to pass as the DriverInfo
+// parameter when creating a node in Ironic. The structure is
+// pre-populated with the access information, and the caller is
+// expected to add any other information that might be needed (such as
+// the kernel and ramdisk locations).
+func (a *redfishAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interface{} {
+	redfishAddress := []string{}
+	schemes := strings.Split(a.bmcType, "+")
+	if len(schemes) > 1 {
+		redfishAddress = append(redfishAddress, schemes[1])
+	} else {
+		redfishAddress = append(redfishAddress, redfishDefaultScheme)
+	}
+	redfishAddress = append(redfishAddress, "://")
+	redfishAddress = append(redfishAddress, a.host)
+
+	result := map[string]interface{}{
+		"redfish_system_id":     a.path,
+		"redfish_username": bmcCreds.Username,
+		"redfish_password": bmcCreds.Password,
+		"redfish_address": strings.Join(redfishAddress, ""),
+	}
+
+	return result
+}
+
+// That can be either pxe or redfish-virtual-media
+func (a *redfishAccessDetails) BootInterface() string {
+	return "pxe"
+}


### PR DESCRIPTION
accepts bmc address like
`redfish+https://my.host:8080/redfish/v1/Systems/MySystem`