### PR TITLE
Parameterize the BMC address

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -18,6 +18,10 @@ in place of `https://` in the iDRAC URL; only the hostname or IP address is
 required - `idrac://host.example` is equivalent to
 `idrac+https://host.example:443/wsman`. Fujitsu iRMC is also supported,
 by using the scheme `irmc://<host>:<port>` with `<port>` is optional.
+Redfish is also supported, by using the scheme `redfish://` (or
+`redfish+http://` to disable TLS) in place of `https://` in the Redfish URL;
+the hostname or IP address, and the path to the system ID are required -
+for example `redfish://myhost.example/redfish/v1/Systems/MySystemExample`
 
 *bmc.credentials* -- A reference to a Secret containing the connection
 data, at least username and password, for the BMC.

--- a/pkg/bmc/access.go
+++ b/pkg/bmc/access.go
@@ -10,7 +10,7 @@ import (
 
 // AccessDetailsFactory describes a callable that returns a new
 // AccessDetails based on the input parameters.
-type AccessDetailsFactory func(bmcType, portNum, hostname, path string) (AccessDetails, error)
+type AccessDetailsFactory func(parsedURL *url.URL) (AccessDetails, error)
 
 var factories = map[string]AccessDetailsFactory{}
 
@@ -48,9 +48,9 @@ type AccessDetails interface {
 	BootInterface() string
 }
 
-func getTypeHostPort(address string) (bmcType, host, port, path string, err error) {
+func getParsedURL(address string) (parsedURL *url.URL, err error) {
 	// Start by assuming "type://host:port"
-	parsedURL, err := url.Parse(address)
+	parsedURL, err = url.Parse(address)
 	if err != nil {
 		// We failed to parse the URL, but it may just be a host or
 		// host:port string (which the URL parser rejects because ":"
@@ -60,55 +60,51 @@ func getTypeHostPort(address string) (bmcType, host, port, path string, err erro
 		if strings.Contains(address, ":") {
 			// If we can parse host:port, carry on with those
 			// values. Otherwise, report the original parser error.
-			var err2 error
-			host, port, err2 = net.SplitHostPort(address)
+			_, _, err2 := net.SplitHostPort(address)
 			if err2 != nil {
-				return "", "", "", "", errors.Wrap(err, "failed to parse BMC address information")
+				return nil, errors.Wrap(err, "failed to parse BMC address information")
 			}
-			bmcType = "ipmi"
-		} else {
-			bmcType = "ipmi"
-			host = address
+		}
+		parsedURL = &url.URL{
+			Scheme: "ipmi",
+			Host: address,
 		}
 	} else {
 		// Successfully parsed the URL
-		bmcType = parsedURL.Scheme
 		if parsedURL.Opaque != "" {
 			parsedURL, err = url.Parse(strings.Replace(address, ":", "://", 1))
 			if err != nil {
-				return "", "", "", "", errors.Wrap(err, "failed to parse BMC address information")
+				return nil, errors.Wrap(err, "failed to parse BMC address information")
 
 			}
 		}
-		port = parsedURL.Port()
-		host = parsedURL.Hostname()
 		if parsedURL.Scheme == "" {
-			bmcType = "ipmi"
-			if host == "" {
+			if parsedURL.Hostname() == "" {
 				// If there was no scheme at all, the hostname was
 				// interpreted as a path.
-				host = parsedURL.Path
+				parsedURL, err = url.Parse(strings.Join([]string{"ipmi://", address}, ""))
+				if err != nil {
+					return nil, errors.Wrap(err, "failed to parse BMC address information")
+				}
 			}
-		} else {
-			path = parsedURL.Path
 		}
 	}
-	return bmcType, host, port, path, nil
+	return parsedURL, nil
 }
 
 // NewAccessDetails creates an AccessDetails structure from the URL
 // for a BMC.
 func NewAccessDetails(address string) (AccessDetails, error) {
 
-	bmcType, host, port, path, err := getTypeHostPort(address)
+	parsedURL, err := getParsedURL(address)
 	if err != nil {
 		return nil, err
 	}
 
-	factory, ok := factories[bmcType]
+	factory, ok := factories[parsedURL.Scheme]
 	if !ok {
-		return nil, &UnknownBMCTypeError{address, bmcType}
+		return nil, &UnknownBMCTypeError{address, parsedURL.Scheme}
 	}
 
-	return factory(bmcType, port, host, path)
+	return factory(parsedURL)
 }

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -11,162 +11,192 @@ func init() {
 }
 
 func TestParseLibvirtURL(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("libvirt://192.168.122.1:6233/")
+	url, err := getParsedURL("libvirt://192.168.122.1:6233/?abc=def")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if T != "libvirt" {
-		t.Fatalf("unexpected type: %q", T)
+	if url.Scheme != "libvirt" {
+		t.Fatalf("unexpected type: %q", url.Scheme)
 	}
-	if P != "6233" {
-		t.Fatalf("unexpected port: %q", P)
+	if url.Port() != "6233" {
+		t.Fatalf("unexpected port: %q", url.Port())
 	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
+	if url.Hostname() != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", url.Hostname())
 	}
-	if A != "/" {
-		t.Fatalf("unexpected path: %q", A)
+	if url.Path != "/" {
+		t.Fatalf("unexpected path: %q", url.Path)
+	}
+	if len(url.Query()) != 1 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()))
+	}
+	if len(url.Query()["abc"]) != 1 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()["abc"]))
+	}
+	if url.Query()["abc"][0] != "def" {
+		t.Fatalf("unexpected query: %q=%q", "abc", url.Query()["abc"])
 	}
 }
 
 func TestParseIPMIDefaultSchemeAndPort(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("192.168.122.1")
+	url, err := getParsedURL("192.168.122.1")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if T != "ipmi" {
-		t.Fatalf("unexpected type: %q", T)
+	if url.Scheme != "ipmi" {
+		t.Fatalf("unexpected type: %q", url.Scheme)
 	}
-	if P != "" { // default is set in DriverInfo() method
-		t.Fatalf("unexpected port: %q", P)
+	if url.Port() != "" { // default is set in DriverInfo() method
+		t.Fatalf("unexpected port: %q", url.Port())
 	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
+	if url.Hostname() != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", url.Hostname())
 	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
+	if url.Path != "" {
+		t.Fatalf("unexpected path: %q", url.Path)
+	}
+	if len(url.Query()) != 0 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()))
 	}
 }
 
 func TestParseIPMIDefaultSchemeAndPortHostname(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("my.favoritebmc.com")
+	url, err := getParsedURL("my.favoritebmc.com")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if T != "ipmi" {
-		t.Fatalf("unexpected type: %q", T)
+	if url.Scheme != "ipmi" {
+		t.Fatalf("unexpected type: %q", url.Scheme)
 	}
-	if P != "" { // default is set in DriverInfo() method
-		t.Fatalf("unexpected port: %q", P)
+	if url.Port() != "" { // default is set in DriverInfo() method
+		t.Fatalf("unexpected port: %q", url.Port())
 	}
-	if H != "my.favoritebmc.com" {
-		t.Fatalf("unexpected hostname: %q", H)
+	if url.Hostname() != "my.favoritebmc.com" {
+		t.Fatalf("unexpected hostname: %q", url.Hostname())
 	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
+	if url.Path != "" {
+		t.Fatalf("unexpected path: %q", url.Path)
+	}
+	if len(url.Query()) != 0 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()))
 	}
 }
 
 func TestParseHostPort(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("192.168.122.1:6233")
+	url, err := getParsedURL("192.168.122.1:6233")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if T != "ipmi" {
-		t.Fatalf("unexpected type: %q", T)
+	if url.Scheme != "ipmi" {
+		t.Fatalf("unexpected type: %q", url.Scheme)
 	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
+	if url.Hostname() != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", url.Hostname())
 	}
-	if P != "6233" {
-		t.Fatalf("unexpected port: %q", P)
+	if url.Port() != "6233" {
+		t.Fatalf("unexpected port: %q", url.Port())
 	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
+	if url.Path != "" {
+		t.Fatalf("unexpected path: %q", url.Path)
+	}
+	if len(url.Query()) != 0 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()))
 	}
 }
 
 func TestParseHostPortIPv6(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("[fe80::fc33:62ff:fe83:8a76]:6233")
+	url, err := getParsedURL("[fe80::fc33:62ff:fe83:8a76]:6233")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if T != "ipmi" {
-		t.Fatalf("unexpected type: %q", T)
+	if url.Scheme != "ipmi" {
+		t.Fatalf("unexpected type: %q", url.Scheme)
 	}
-	if H != "fe80::fc33:62ff:fe83:8a76" {
-		t.Fatalf("unexpected hostname: %q", H)
+	if url.Hostname() != "fe80::fc33:62ff:fe83:8a76" {
+		t.Fatalf("unexpected hostname: %q", url.Hostname())
 	}
-	if P != "6233" {
-		t.Fatalf("unexpected port: %q", P)
+	if url.Port() != "6233" {
+		t.Fatalf("unexpected port: %q", url.Port())
 	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
+	if url.Path != "" {
+		t.Fatalf("unexpected path: %q", url.Path)
+	}
+	if len(url.Query()) != 0 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()))
 	}
 }
 
 func TestParseHostNoPortIPv6(t *testing.T) {
-	// They either have to give us a port or a URL scheme with IPv6.
-	_, _, _, _, err := getTypeHostPort("[fe80::fc33:62ff:fe83:8a76]")
+	// TBy default we fallback to IPMI, also with IPv6.
+	_, err := getParsedURL("[fe80::fc33:62ff:fe83:8a76]")
 	if err == nil {
 		t.Fatal("expected parse error")
 	}
 }
 
 func TestParseIPMIURL(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("ipmi://192.168.122.1:6233")
+	url, err := getParsedURL("ipmi://192.168.122.1:6233")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if T != "ipmi" {
-		t.Fatalf("unexpected type: %q", T)
+	if url.Scheme != "ipmi" {
+		t.Fatalf("unexpected type: %q", url.Scheme)
 	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
+	if url.Hostname() != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", url.Hostname())
 	}
-	if P != "6233" {
-		t.Fatalf("unexpected port: %q", P)
+	if url.Port() != "6233" {
+		t.Fatalf("unexpected port: %q", url.Port())
 	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
+	if url.Path != "" {
+		t.Fatalf("unexpected path: %q", url.Path)
+	}
+	if len(url.Query()) != 0 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()))
 	}
 }
 
 func TestParseIPMIURLNoSep(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("ipmi:192.168.122.1")
+	url, err := getParsedURL("ipmi:192.168.122.1")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if T != "ipmi" {
-		t.Fatalf("unexpected type: %q", T)
+	if url.Scheme != "ipmi" {
+		t.Fatalf("unexpected type: %q", url.Scheme)
 	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
+	if url.Hostname() != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", url.Hostname())
 	}
-	if P != "" {
-		t.Fatalf("unexpected port: %q", P)
+	if url.Port() != "" {
+		t.Fatalf("unexpected port: %q", url.Port())
 	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
+	if url.Path != "" {
+		t.Fatalf("unexpected path: %q", url.Path)
+	}
+	if len(url.Query()) != 0 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()))
 	}
 }
 
 func TestParseIPMIURLNoSepPort(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("ipmi:192.168.122.1:6233")
+	url, err := getParsedURL("ipmi:192.168.122.1:6233")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if T != "ipmi" {
-		t.Fatalf("unexpected type: %q", T)
+	if url.Scheme != "ipmi" {
+		t.Fatalf("unexpected type: %q", url.Scheme)
 	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
+	if url.Hostname() != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", url.Hostname())
 	}
-	if P != "6233" {
-		t.Fatalf("unexpected port: %q", P)
+	if url.Port() != "6233" {
+		t.Fatalf("unexpected port: %q", url.Port())
 	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
+	if url.Path != "" {
+		t.Fatalf("unexpected path: %q", url.Path)
+	}
+	if len(url.Query()) != 0 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()))
 	}
 }
 
@@ -243,78 +273,90 @@ func TestLibvirtBootInterface(t *testing.T) {
 }
 
 func TestParseIDRACURL(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("idrac://192.168.122.1")
+	url, err := getParsedURL("idrac://192.168.122.1")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if T != "idrac" {
-		t.Fatalf("unexpected type: %q", T)
+	if url.Scheme != "idrac" {
+		t.Fatalf("unexpected type: %q", url.Scheme)
 	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
+	if url.Hostname() != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", url.Hostname())
 	}
-	if P != "" {
-		t.Fatalf("unexpected port: %q", P)
+	if url.Port() != "" {
+		t.Fatalf("unexpected port: %q", url.Port())
 	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
+	if url.Path != "" {
+		t.Fatalf("unexpected path: %q", url.Path)
+	}
+	if len(url.Query()) != 0 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()))
 	}
 }
 
 func TestParseIDRACURLPath(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("idrac://192.168.122.1:6233/foo")
+	url, err := getParsedURL("idrac://192.168.122.1:6233/foo")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if T != "idrac" {
-		t.Fatalf("unexpected type: %q", T)
+	if url.Scheme != "idrac" {
+		t.Fatalf("unexpected type: %q", url.Scheme)
 	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
+	if url.Hostname() != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", url.Hostname())
 	}
-	if P != "6233" {
-		t.Fatalf("unexpected port: %q", P)
+	if url.Port() != "6233" {
+		t.Fatalf("unexpected port: %q", url.Port())
 	}
-	if A != "/foo" {
-		t.Fatalf("unexpected path: %q", A)
+	if url.Path != "/foo" {
+		t.Fatalf("unexpected path: %q", url.Path)
+	}
+	if len(url.Query()) != 0 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()))
 	}
 }
 
 func TestParseIDRACURLIPv6(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("idrac://[fe80::fc33:62ff:fe83:8a76]")
+	url, err := getParsedURL("idrac://[fe80::fc33:62ff:fe83:8a76]")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if T != "idrac" {
-		t.Fatalf("unexpected type: %q", T)
+	if url.Scheme != "idrac" {
+		t.Fatalf("unexpected type: %q", url.Scheme)
 	}
-	if H != "fe80::fc33:62ff:fe83:8a76" {
-		t.Fatalf("unexpected hostname: %q", H)
+	if url.Hostname() != "fe80::fc33:62ff:fe83:8a76" {
+		t.Fatalf("unexpected hostname: %q", url.Hostname())
 	}
-	if P != "" {
-		t.Fatalf("unexpected port: %q", P)
+	if url.Port() != "" {
+		t.Fatalf("unexpected port: %q", url.Port())
 	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
+	if url.Path != "" {
+		t.Fatalf("unexpected path: %q", url.Path)
+	}
+	if len(url.Query()) != 0 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()))
 	}
 }
 
 func TestParseIDRACURLNoSep(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("idrac:192.168.122.1")
+	url, err := getParsedURL("idrac:192.168.122.1")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if T != "idrac" {
-		t.Fatalf("unexpected type: %q", T)
+	if url.Scheme != "idrac" {
+		t.Fatalf("unexpected type: %q", url.Scheme)
 	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
+	if url.Hostname() != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", url.Hostname())
 	}
-	if P != "" {
-		t.Fatalf("unexpected port: %q", P)
+	if url.Port() != "" {
+		t.Fatalf("unexpected port: %q", url.Port())
 	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
+	if url.Path != "" {
+		t.Fatalf("unexpected path: %q", url.Path)
+	}
+	if len(url.Query()) != 0 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()))
 	}
 }
 
@@ -470,59 +512,68 @@ func TestIDRACBootInterface(t *testing.T) {
 }
 
 func TestParseIRMCURL(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("irmc://192.168.122.1")
+	url, err := getParsedURL("irmc://192.168.122.1")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if T != "irmc" {
-		t.Fatalf("unexpected type: %q", T)
+	if url.Scheme != "irmc" {
+		t.Fatalf("unexpected type: %q", url.Scheme)
 	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
+	if url.Hostname() != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", url.Hostname())
 	}
-	if P != "" {
-		t.Fatalf("unexpected port: %q", P)
+	if url.Port() != "" {
+		t.Fatalf("unexpected port: %q", url.Port())
 	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
+	if url.Path != "" {
+		t.Fatalf("unexpected path: %q", url.Path)
+	}
+	if len(url.Query()) != 0 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()))
 	}
 }
 
 func TestParseIRMCURLIPv6(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("irmc://[fe80::fc33:62ff:fe83:8a76]")
+	url, err := getParsedURL("irmc://[fe80::fc33:62ff:fe83:8a76]")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if T != "irmc" {
-		t.Fatalf("unexpected type: %q", T)
+	if url.Scheme != "irmc" {
+		t.Fatalf("unexpected type: %q", url.Scheme)
 	}
-	if H != "fe80::fc33:62ff:fe83:8a76" {
-		t.Fatalf("unexpected hostname: %q", H)
+	if url.Hostname() != "fe80::fc33:62ff:fe83:8a76" {
+		t.Fatalf("unexpected hostname: %q", url.Hostname())
 	}
-	if P != "" {
-		t.Fatalf("unexpected port: %q", P)
+	if url.Port() != "" {
+		t.Fatalf("unexpected port: %q", url.Port())
 	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
+	if url.Path != "" {
+		t.Fatalf("unexpected path: %q", url.Path)
+	}
+	if len(url.Query()) != 0 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()))
 	}
 }
 
 func TestParseIRMCURLNoSep(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("irmc:192.168.122.1")
+	url, err := getParsedURL("irmc:192.168.122.1")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if T != "irmc" {
-		t.Fatalf("unexpected type: %q", T)
+	if url.Scheme != "irmc" {
+		t.Fatalf("unexpected type: %q", url.Scheme)
 	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
+	if url.Hostname() != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", url.Hostname())
 	}
-	if P != "" {
-		t.Fatalf("unexpected port: %q", P)
+	if url.Port() != "" {
+		t.Fatalf("unexpected port: %q", url.Port())
 	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
+	if url.Path != "" {
+		t.Fatalf("unexpected path: %q", url.Path)
+	}
+	if len(url.Query()) != 0 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()))
 	}
 }
 
@@ -614,78 +665,102 @@ func TestIRMCBootInterface(t *testing.T) {
 }
 
 func TestParserRedfishURL(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("redfish://192.168.122.1")
+	url, err := getParsedURL("redfish://192.168.122.1")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if T != "redfish" {
-		t.Fatalf("unexpected type: %q", T)
+	if url.Scheme != "redfish" {
+		t.Fatalf("unexpected type: %q", url.Scheme)
 	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
+	if url.Hostname() != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", url.Hostname())
 	}
-	if P != "" {
-		t.Fatalf("unexpected port: %q", P)
+	if url.Port() != "" {
+		t.Fatalf("unexpected port: %q", url.Port())
 	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
+	if url.Path != "" {
+		t.Fatalf("unexpected path: %q", url.Path)
+	}
+	if len(url.Query()) != 0 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()))
 	}
 }
 
 func TestParseRedfishURLPath(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("redfish://192.168.122.1:6233/foo")
+	url, err := getParsedURL("redfish://192.168.122.1:6233/foo?abc=def&ghi=jkl")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if T != "redfish" {
-		t.Fatalf("unexpected type: %q", T)
+	if url.Scheme != "redfish" {
+		t.Fatalf("unexpected type: %q", url.Scheme)
 	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
+	if url.Hostname() != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", url.Hostname())
 	}
-	if P != "6233" {
-		t.Fatalf("unexpected port: %q", P)
+	if url.Port() != "6233" {
+		t.Fatalf("unexpected port: %q", url.Port())
 	}
-	if A != "/foo" {
-		t.Fatalf("unexpected path: %q", A)
+	if url.Path != "/foo" {
+		t.Fatalf("unexpected path: %q", url.Path)
+	}
+	if len(url.Query()) != 2 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()))
+	}
+	if len(url.Query()["abc"]) != 1 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()["abc"]))
+	}
+	if url.Query()["abc"][0] != "def" {
+		t.Fatalf("unexpected query: %q=%q", "abc", url.Query()["abc"])
+	}
+	if len(url.Query()["ghi"]) != 1 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()["ghi"]))
+	}
+	if url.Query()["ghi"][0] != "jkl" {
+		t.Fatalf("unexpected query: %q=%q", "ghi", url.Query()["jkl"])
 	}
 }
 
 func TestParseRedfishURLIPv6(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("redfish://[fe80::fc33:62ff:fe83:8a76]")
+	url, err := getParsedURL("redfish://[fe80::fc33:62ff:fe83:8a76]")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if T != "redfish" {
-		t.Fatalf("unexpected type: %q", T)
+	if url.Scheme != "redfish" {
+		t.Fatalf("unexpected type: %q", url.Scheme)
 	}
-	if H != "fe80::fc33:62ff:fe83:8a76" {
-		t.Fatalf("unexpected hostname: %q", H)
+	if url.Hostname() != "fe80::fc33:62ff:fe83:8a76" {
+		t.Fatalf("unexpected hostname: %q", url.Hostname())
 	}
-	if P != "" {
-		t.Fatalf("unexpected port: %q", P)
+	if url.Port() != "" {
+		t.Fatalf("unexpected port: %q", url.Port())
 	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
+	if url.Path != "" {
+		t.Fatalf("unexpected path: %q", url.Path)
+	}
+	if len(url.Query()) != 0 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()))
 	}
 }
 
 func TestParseRedfishURLNoSep(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("redfish:192.168.122.1")
+	url, err := getParsedURL("redfish:192.168.122.1")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if T != "redfish" {
-		t.Fatalf("unexpected type: %q", T)
+	if url.Scheme != "redfish" {
+		t.Fatalf("unexpected type: %q", url.Scheme)
 	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
+	if url.Hostname() != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", url.Hostname())
 	}
-	if P != "" {
-		t.Fatalf("unexpected port: %q", P)
+	if url.Port() != "" {
+		t.Fatalf("unexpected port: %q", url.Port())
 	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
+	if url.Path != "" {
+		t.Fatalf("unexpected path: %q", url.Path)
+	}
+	if len(url.Query()) != 0 {
+		t.Fatalf("unexpected query length: %q", len(url.Query()))
 	}
 }
 

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -786,7 +786,7 @@ func TestRedfishDriver(t *testing.T) {
 }
 
 func TestRedfishDriverInfo(t *testing.T) {
-	acc, err := NewAccessDetails("redfish://192.168.122.1/foo/bar")
+	acc, err := NewAccessDetails("redfish://192.168.122.1/foo/bar?abc=def&ghi=jkl")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
@@ -797,10 +797,16 @@ func TestRedfishDriverInfo(t *testing.T) {
 	if di["redfish_system_id"] != "/foo/bar" {
 		t.Fatalf("unexpected system ID: %v", di["redfish_system_id"])
 	}
+	if di["abc"] != "def" {
+		t.Fatalf("unexpected query parameter: %v=%v", "abc", di["abc"])
+	}
+	if di["ghi"] != "jkl" {
+		t.Fatalf("unexpected query parameter: %v=%v", "ghi", di["jkl"])
+	}
 }
 
 func TestRedfishDriverInfoHTTP(t *testing.T) {
-	acc, err := NewAccessDetails("redfish+http://192.168.122.1/foo/bar")
+	acc, err := NewAccessDetails("redfish+http://192.168.122.1/foo/bar?abc=def&ghi=jkl")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
@@ -811,10 +817,16 @@ func TestRedfishDriverInfoHTTP(t *testing.T) {
 	if di["redfish_system_id"] != "/foo/bar" {
 		t.Fatalf("unexpected system ID: %v", di["redfish_system_id"])
 	}
+	if di["abc"] != "def" {
+		t.Fatalf("unexpected query parameter: %v=%v", "abc", di["abc"])
+	}
+	if di["ghi"] != "jkl" {
+		t.Fatalf("unexpected query parameter: %v=%v", "ghi", di["jkl"])
+	}
 }
 
 func TestRedfishDriverInfoHTTPS(t *testing.T) {
-	acc, err := NewAccessDetails("redfish+https://192.168.122.1/foo/bar")
+	acc, err := NewAccessDetails("redfish+https://192.168.122.1/foo/bar?abc=def&ghi=jkl")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
@@ -825,10 +837,16 @@ func TestRedfishDriverInfoHTTPS(t *testing.T) {
 	if di["redfish_system_id"] != "/foo/bar" {
 		t.Fatalf("unexpected system ID: %v", di["redfish_system_id"])
 	}
+	if di["abc"] != "def" {
+		t.Fatalf("unexpected query parameter: %v=%v", "abc", di["abc"])
+	}
+	if di["ghi"] != "jkl" {
+		t.Fatalf("unexpected query parameter: %v=%v", "ghi", di["jkl"])
+	}
 }
 
 func TestRedfishDriverInfoPort(t *testing.T) {
-	acc, err := NewAccessDetails("redfish://192.168.122.1:8080/foo/bar")
+	acc, err := NewAccessDetails("redfish://192.168.122.1:8080/foo/bar?abc=def&ghi=jkl")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
@@ -839,10 +857,16 @@ func TestRedfishDriverInfoPort(t *testing.T) {
 	if di["redfish_system_id"] != "/foo/bar" {
 		t.Fatalf("unexpected system ID: %v", di["redfish_system_id"])
 	}
+	if di["abc"] != "def" {
+		t.Fatalf("unexpected query parameter: %v=%v", "abc", di["abc"])
+	}
+	if di["ghi"] != "jkl" {
+		t.Fatalf("unexpected query parameter: %v=%v", "ghi", di["jkl"])
+	}
 }
 
 func TestRedfishDriverInfoIPv6(t *testing.T) {
-	acc, err := NewAccessDetails("redfish://[fe80::fc33:62ff:fe83:8a76]/foo/bar")
+	acc, err := NewAccessDetails("redfish://[fe80::fc33:62ff:fe83:8a76]/foo/bar?abc=def&ghi=jkl")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
@@ -853,10 +877,16 @@ func TestRedfishDriverInfoIPv6(t *testing.T) {
 	if di["redfish_system_id"] != "/foo/bar" {
 		t.Fatalf("unexpected system ID: %v", di["redfish_system_id"])
 	}
+	if di["abc"] != "def" {
+		t.Fatalf("unexpected query parameter: %v=%v", "abc", di["abc"])
+	}
+	if di["ghi"] != "jkl" {
+		t.Fatalf("unexpected query parameter: %v=%v", "ghi", di["jkl"])
+	}
 }
 
 func TestRedfishDriverInfoIPv6Port(t *testing.T) {
-	acc, err := NewAccessDetails("redfish://[fe80::fc33:62ff:fe83:8a76]:8080/foo")
+	acc, err := NewAccessDetails("redfish://[fe80::fc33:62ff:fe83:8a76]:8080/foo?abc=def&ghi=jkl")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
@@ -866,6 +896,12 @@ func TestRedfishDriverInfoIPv6Port(t *testing.T) {
 	}
 	if di["redfish_system_id"] != "/foo" {
 		t.Fatalf("unexpected system ID: %v", di["redfish_system_id"])
+	}
+	if di["abc"] != "def" {
+		t.Fatalf("unexpected query parameter: %v=%v", "abc", di["abc"])
+	}
+	if di["ghi"] != "jkl" {
+		t.Fatalf("unexpected query parameter: %v=%v", "ghi", di["jkl"])
 	}
 }
 

--- a/pkg/bmc/idrac.go
+++ b/pkg/bmc/idrac.go
@@ -2,6 +2,7 @@ package bmc
 
 import (
 	"strings"
+	"net/url"
 )
 
 func init() {
@@ -10,12 +11,12 @@ func init() {
 	registerFactory("idrac+https", newIDRACAccessDetails)
 }
 
-func newIDRACAccessDetails(bmcType, portNum, hostname, path string) (AccessDetails, error) {
+func newIDRACAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
 	return &iDracAccessDetails{
-		bmcType:  bmcType,
-		portNum:  portNum,
-		hostname: hostname,
-		path:     path,
+		bmcType:  parsedURL.Scheme,
+		portNum:  parsedURL.Port(),
+		hostname: parsedURL.Hostname(),
+		path:     parsedURL.Path,
 	}, nil
 }
 

--- a/pkg/bmc/ipmi.go
+++ b/pkg/bmc/ipmi.go
@@ -1,15 +1,19 @@
 package bmc
 
+import (
+	"net/url"
+)
+
 func init() {
 	registerFactory("ipmi", newIPMIAccessDetails)
 	registerFactory("libvirt", newIPMIAccessDetails)
 }
 
-func newIPMIAccessDetails(bmcType, portNum, hostname, path string) (AccessDetails, error) {
+func newIPMIAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
 	return &ipmiAccessDetails{
-		bmcType:  bmcType,
-		portNum:  portNum,
-		hostname: hostname,
+		bmcType:  parsedURL.Scheme,
+		portNum:  parsedURL.Port(),
+		hostname: parsedURL.Hostname(),
 	}, nil
 }
 

--- a/pkg/bmc/irmc.go
+++ b/pkg/bmc/irmc.go
@@ -1,14 +1,18 @@
 package bmc
 
+import (
+	"net/url"
+)
+
 func init() {
 	registerFactory("irmc", newIRMCAccessDetails)
 }
 
-func newIRMCAccessDetails(bmcType, portNum, hostname, path string) (AccessDetails, error) {
+func newIRMCAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
 	return &iRMCAccessDetails{
-		bmcType:  bmcType,
-		portNum:  portNum,
-		hostname: hostname,
+		bmcType:  parsedURL.Scheme,
+		portNum:  parsedURL.Port(),
+		hostname: parsedURL.Hostname(),
 	}, nil
 }
 

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -2,8 +2,8 @@ package bmc
 
 import (
 	"net"
-	"strings"
 	"net/url"
+	"strings"
 )
 
 func init() {
@@ -41,6 +41,7 @@ func newRedfishAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
 		bmcType:  parsedURL.Scheme,
 		address:  strings.Join(redfishAddress, ""),
 		path:     parsedURL.Path,
+		query:    parsedURL.Query(),
 	}, nil
 }
 
@@ -48,6 +49,7 @@ type redfishAccessDetails struct {
 	bmcType  string
 	address  string
 	path     string
+	query    url.Values
 }
 
 func (a *redfishAccessDetails) Type() string {
@@ -79,6 +81,12 @@ func (a *redfishAccessDetails) DriverInfo(bmcCreds Credentials) map[string]inter
 		"redfish_username": bmcCreds.Username,
 		"redfish_password": bmcCreds.Password,
 		"redfish_address": a.address,
+	}
+
+	for k, v := range a.query {
+		for _, queryValue := range v {
+			result[k] = queryValue
+		}
 	}
 
 	return result

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -1,0 +1,92 @@
+package bmc
+
+import (
+	"net"
+	"strings"
+)
+
+func init() {
+	registerFactory("redfish", newRedfishAccessDetails)
+	registerFactory("redfish+http", newRedfishAccessDetails)
+	registerFactory("redfish+https", newRedfishAccessDetails)
+}
+
+func newRedfishAccessDetails(bmcType, portNum, hostname, path string) (AccessDetails, error) {
+	// If the hostname is an ipv6 address, it needs to be in square brackets
+	// as we are forming a URL out of it.
+	addresses, err := net.LookupIP(hostname)
+	if err == nil {
+		for _, address := range addresses {
+			if address.String() == hostname && address.To4() == nil {
+				hostname = strings.Join([]string{"[",hostname,"]"}, "")
+			}
+		}
+	}
+	return &redfishAccessDetails{
+		bmcType:  bmcType,
+		portNum:  portNum,
+		hostname: hostname,
+		path: path,
+	}, nil
+}
+
+type redfishAccessDetails struct {
+	bmcType  string
+	portNum  string
+	hostname string
+	path     string
+}
+
+const redfishDefaultScheme = "https"
+
+func (a *redfishAccessDetails) Type() string {
+	return a.bmcType
+}
+
+// NeedsMAC returns true when the host is going to need a separate
+// port created rather than having it discovered.
+func (a *redfishAccessDetails) NeedsMAC() bool {
+	// For the inspection to work, we need a MAC address
+	// https://github.com/metal3-io/baremetal-operator/pull/284#discussion_r317579040
+	return true
+}
+
+func (a *redfishAccessDetails) Driver() string {
+	return "redfish"
+}
+
+// DriverInfo returns a data structure to pass as the DriverInfo
+// parameter when creating a node in Ironic. The structure is
+// pre-populated with the access information, and the caller is
+// expected to add any other information that might be needed (such as
+// the kernel and ramdisk locations).
+func (a *redfishAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interface{} {
+	redfishAddress := []string{}
+	schemes := strings.Split(a.bmcType, "+")
+	if len(schemes) > 1 {
+		redfishAddress = append(redfishAddress, schemes[1])
+	} else {
+		redfishAddress = append(redfishAddress, redfishDefaultScheme)
+	}
+	redfishAddress = append(redfishAddress, "://")
+	redfishAddress = append(redfishAddress, a.hostname)
+
+	if a.portNum != "" {
+		redfishAddress = append(redfishAddress, ":")
+		redfishAddress = append(redfishAddress, a.portNum)
+	}
+
+	result := map[string]interface{}{
+		"redfish_system_id":     a.path,
+		"redfish_username": bmcCreds.Username,
+		"redfish_password": bmcCreds.Password,
+		"redfish_address": strings.Join(redfishAddress, ""),
+	}
+
+	return result
+}
+
+// That can be either pxe or redfish-virtual-media
+func (a *redfishAccessDetails) BootInterface() string {
+	return "pxe"
+}


### PR DESCRIPTION
Retrieve the query elements if any from the BMC address and pass them to the BMC drivers.
For redfish, add the URL parameters to the ironic options.

This is built on and depends on https://github.com/metal3-io/baremetal-operator/pull/284