### PR TITLE
Modify BMC drivers to handle url.URL instead of separate arguments and refactor BMC tests

### DIFF
--- a/pkg/bmc/access.go
+++ b/pkg/bmc/access.go
@@ -10,7 +10,7 @@ import (
 
 // AccessDetailsFactory describes a callable that returns a new
 // AccessDetails based on the input parameters.
-type AccessDetailsFactory func(bmcType, portNum, hostname, path string) (AccessDetails, error)
+type AccessDetailsFactory func(parsedURL *url.URL) (AccessDetails, error)
 
 var factories = map[string]AccessDetailsFactory{}
 
@@ -48,9 +48,9 @@ type AccessDetails interface {
 	BootInterface() string
 }
 
-func getTypeHostPort(address string) (bmcType, host, port, path string, err error) {
+func getParsedURL(address string) (parsedURL *url.URL, err error) {
 	// Start by assuming "type://host:port"
-	parsedURL, err := url.Parse(address)
+	parsedURL, err = url.Parse(address)
 	if err != nil {
 		// We failed to parse the URL, but it may just be a host or
 		// host:port string (which the URL parser rejects because ":"
@@ -60,55 +60,51 @@ func getTypeHostPort(address string) (bmcType, host, port, path string, err erro
 		if strings.Contains(address, ":") {
 			// If we can parse host:port, carry on with those
 			// values. Otherwise, report the original parser error.
-			var err2 error
-			host, port, err2 = net.SplitHostPort(address)
+			_, _, err2 := net.SplitHostPort(address)
 			if err2 != nil {
-				return "", "", "", "", errors.Wrap(err, "failed to parse BMC address information")
+				return nil, errors.Wrap(err, "failed to parse BMC address information")
 			}
-			bmcType = "ipmi"
-		} else {
-			bmcType = "ipmi"
-			host = address
+		}
+		parsedURL = &url.URL{
+			Scheme: "ipmi",
+			Host: address,
 		}
 	} else {
 		// Successfully parsed the URL
-		bmcType = parsedURL.Scheme
 		if parsedURL.Opaque != "" {
 			parsedURL, err = url.Parse(strings.Replace(address, ":", "://", 1))
 			if err != nil {
-				return "", "", "", "", errors.Wrap(err, "failed to parse BMC address information")
+				return nil, errors.Wrap(err, "failed to parse BMC address information")
 
 			}
 		}
-		port = parsedURL.Port()
-		host = parsedURL.Hostname()
 		if parsedURL.Scheme == "" {
-			bmcType = "ipmi"
-			if host == "" {
+			if parsedURL.Hostname() == "" {
 				// If there was no scheme at all, the hostname was
 				// interpreted as a path.
-				host = parsedURL.Path
+				parsedURL, err = url.Parse(strings.Join([]string{"ipmi://", address}, ""))
+				if err != nil {
+					return nil, errors.Wrap(err, "failed to parse BMC address information")
+				}
 			}
-		} else {
-			path = parsedURL.Path
 		}
 	}
-	return bmcType, host, port, path, nil
+	return parsedURL, nil
 }
 
 // NewAccessDetails creates an AccessDetails structure from the URL
 // for a BMC.
 func NewAccessDetails(address string) (AccessDetails, error) {
 
-	bmcType, host, port, path, err := getTypeHostPort(address)
+	parsedURL, err := getParsedURL(address)
 	if err != nil {
 		return nil, err
 	}
 
-	factory, ok := factories[bmcType]
+	factory, ok := factories[parsedURL.Scheme]
 	if !ok {
-		return nil, &UnknownBMCTypeError{address, bmcType}
+		return nil, &UnknownBMCTypeError{address, parsedURL.Scheme}
 	}
 
-	return factory(bmcType, port, host, path)
+	return factory(parsedURL)
 }

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -16,17 +16,23 @@ func TestParse(t *testing.T) {
 		Address     string
 		Type        string
 		Host        string
+		Hostname    string
 		Port        string
 		Path        string
 		ExpectError bool
+		Query       map[string][]string
 	}{
 		{
 			Scenario: "libvirt url",
-			Address:  "libvirt://192.168.122.1:6233/",
+			Address:  "libvirt://192.168.122.1:6233/?abc=def",
 			Type:     "libvirt",
 			Port:     "6233",
 			Host:     "192.168.122.1",
+			Hostname: "192.168.122.1:6233",
 			Path:     "/",
+			Query: map[string][]string{
+				"abc": []string{"def"},
+			},
 		},
 
 		{
@@ -35,6 +41,7 @@ func TestParse(t *testing.T) {
 			Type:     "ipmi",
 			Port:     "",
 			Host:     "192.168.122.1",
+			Hostname: "192.168.122.1",
 			Path:     "",
 		},
 
@@ -44,6 +51,7 @@ func TestParse(t *testing.T) {
 			Type:     "ipmi",
 			Port:     "",
 			Host:     "my.favoritebmc.com",
+			Hostname: "my.favoritebmc.com",
 			Path:     "",
 		},
 
@@ -53,6 +61,7 @@ func TestParse(t *testing.T) {
 			Type:     "ipmi",
 			Port:     "6233",
 			Host:     "192.168.122.1",
+			Hostname: "192.168.122.1:6233",
 			Path:     "",
 		},
 
@@ -63,6 +72,7 @@ func TestParse(t *testing.T) {
 			Port:     "6233",
 			Host:     "fe80::fc33:62ff:fe83:8a76",
 			Path:     "",
+			Hostname: "[fe80::fc33:62ff:fe83:8a76]:6233",
 		},
 
 		{
@@ -78,6 +88,7 @@ func TestParse(t *testing.T) {
 			Port:     "6233",
 			Host:     "192.168.122.1",
 			Path:     "",
+			Hostname: "192.168.122.1:6233",
 		},
 
 		{
@@ -86,6 +97,7 @@ func TestParse(t *testing.T) {
 			Type:     "ipmi",
 			Port:     "",
 			Host:     "192.168.122.1",
+			Hostname: "192.168.122.1",
 			Path:     "",
 		},
 
@@ -95,6 +107,7 @@ func TestParse(t *testing.T) {
 			Type:     "ipmi",
 			Port:     "6233",
 			Host:     "192.168.122.1",
+			Hostname: "192.168.122.1:6233",
 			Path:     "",
 		},
 
@@ -104,6 +117,7 @@ func TestParse(t *testing.T) {
 			Type:     "idrac",
 			Port:     "",
 			Host:     "192.168.122.1",
+			Hostname: "192.168.122.1",
 			Path:     "",
 		},
 
@@ -113,6 +127,7 @@ func TestParse(t *testing.T) {
 			Type:     "idrac",
 			Port:     "6233",
 			Host:     "192.168.122.1",
+			Hostname: "192.168.122.1:6233",
 			Path:     "/foo",
 		},
 
@@ -122,6 +137,7 @@ func TestParse(t *testing.T) {
 			Type:     "idrac",
 			Port:     "",
 			Host:     "fe80::fc33:62ff:fe83:8a76",
+			Hostname: "[fe80::fc33:62ff:fe83:8a76]",
 			Path:     "",
 		},
 
@@ -131,6 +147,7 @@ func TestParse(t *testing.T) {
 			Type:     "idrac",
 			Port:     "",
 			Host:     "192.168.122.1",
+			Hostname: "192.168.122.1",
 			Path:     "",
 		},
 
@@ -140,6 +157,7 @@ func TestParse(t *testing.T) {
 			Type:     "irmc",
 			Port:     "",
 			Host:     "192.168.122.1",
+			Hostname: "192.168.122.1",
 			Path:     "",
 		},
 
@@ -149,6 +167,7 @@ func TestParse(t *testing.T) {
 			Type:     "irmc",
 			Port:     "",
 			Host:     "fe80::fc33:62ff:fe83:8a76",
+			Hostname: "[fe80::fc33:62ff:fe83:8a76]",
 			Path:     "",
 		},
 
@@ -158,11 +177,12 @@ func TestParse(t *testing.T) {
 			Type:     "irmc",
 			Port:     "",
 			Host:     "192.168.122.1",
+			Hostname: "192.168.122.1",
 			Path:     "",
 		},
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
-			T, H, P, A, err := getTypeHostPort(tc.Address)
+			url, err := getParsedURL(tc.Address)
 
 			if tc.ExpectError {
 				if err == nil {
@@ -176,338 +196,258 @@ func TestParse(t *testing.T) {
 				t.Fatalf("unexpected parse error: %v", err)
 			}
 
-			if T != tc.Type {
-				t.Fatalf("expected type %q but got %q", tc.Type, T)
+			if url.Scheme != tc.Type {
+				t.Fatalf("expected type %q but got %q", tc.Type, url.Scheme)
 			}
 
-			if P != tc.Port {
-				t.Fatalf("expected port %q but got %q", tc.Port, P)
+			if url.Port() != tc.Port {
+				t.Fatalf("expected port %q but got %q", tc.Port, url.Port())
 			}
 
-			if H != tc.Host {
-				t.Fatalf("expected host %q but got %q", tc.Host, H)
+			if url.Hostname() != tc.Host {
+				t.Fatalf("expected host %q but got %q", tc.Host, url.Hostname())
 			}
 
-			if A != tc.Path {
-				t.Fatalf("expected path %q but got %q", tc.Path, A)
+			if url.Host != tc.Hostname {
+				t.Fatalf("expected hostname %q but got %q", tc.Hostname, url.Host)
+			}
+
+			if url.Path != tc.Path {
+				t.Fatalf("expected path %q but got %q", tc.Path, url.Path)
+			}
+
+			if len(url.Query()) != len(tc.Query) {
+				t.Fatalf("unexpected query length: %q , expected %q",
+					len(url.Query()), len(tc.Query))
+			}
+
+			for queryKey, queryArg := range tc.Query {
+				if len(url.Query()[queryKey]) != len(queryArg) {
+					t.Fatalf("unexpected query length: %q , expected %q",
+						len(url.Query()[queryKey]), len(queryArg))
+				}
+
+				for queryArgPos := range queryArg {
+					if url.Query()[queryKey][queryArgPos] != queryArg[queryArgPos] {
+						t.Fatalf("unexpected query: %q=%q", queryArg[queryArgPos],
+							url.Query()[queryKey][queryArgPos])
+					}
+				}
 			}
 		})
 	}
 }
 
-func TestIPMINeedsMAC(t *testing.T) {
-	acc, err := NewAccessDetails("ipmi://192.168.122.1:6233")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if acc.NeedsMAC() {
-		t.Fatal("expected to not need a MAC")
+func TestStaticDriverInfo(t *testing.T) {
+	for _, tc := range []struct {
+		Scenario string
+		input    string
+		needsMac bool
+		driver   string
+		boot     string
+	}{
+		{
+			Scenario: "ipmi",
+			input:    "ipmi://192.168.122.1:6233",
+			needsMac: false,
+			driver:   "ipmi",
+			boot:     "ipxe",
+		},
+
+		{
+			Scenario: "libvirt",
+			input:    "libvirt://192.168.122.1",
+			needsMac: true,
+			driver:   "ipmi",
+			boot:     "ipxe",
+		},
+
+		{
+			Scenario: "idrac",
+			input:    "idrac://192.168.122.1",
+			needsMac: false,
+			driver:   "idrac",
+			boot:     "ipxe",
+		},
+
+		{
+			Scenario: "irmc",
+			input:    "irmc://192.168.122.1",
+			needsMac: false,
+			driver:   "irmc",
+			boot:     "pxe",
+		},
+	} {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			acc, err := NewAccessDetails(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected parse error: %v", err)
+			}
+			if acc.NeedsMAC() != tc.needsMac {
+				t.Fatalf("MAC needed: %v , expected %v", acc.NeedsMAC(), tc.needsMac)
+			}
+			if acc.Driver() != tc.driver {
+				t.Fatalf("Unexpected driver %q, expected %q", acc.Driver(), tc.driver)
+			}
+			if acc.BootInterface() != tc.boot {
+				t.Fatalf("Unexpected boot interface %q, expected %q",
+					acc.BootInterface(), tc.boot)
+			}
+		})
 	}
 }
 
-func TestIPMIDriver(t *testing.T) {
-	acc, err := NewAccessDetails("ipmi://192.168.122.1:6233")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if acc.Driver() != "ipmi" {
-		t.Fatal("unexpected driver for ipmi")
-	}
-}
+func TestDriverInfo(t *testing.T) {
+	for _, tc := range []struct {
+		Scenario	string
+		input   	string
+		expects 	map[string]string
+	}{
+		{
+			Scenario: "ipmi default port",
+			input: "ipmi://192.168.122.1",
+			expects: map[string]string{
+				"ipmi_port":     ipmiDefaultPort,
+				"ipmi_password": "",
+				"ipmi_username": "",
+				"ipmi_address":  "192.168.122.1",
+			},
+		},
 
-func TestIPMIDriverInfoDefaultPort(t *testing.T) {
-	acc, err := NewAccessDetails("ipmi://192.168.122.1")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	di := acc.DriverInfo(Credentials{})
-	if di["ipmi_port"] != ipmiDefaultPort {
-		t.Fatalf("unexpected port: %v", di["ipmi_port"])
-	}
-}
+		{
+			Scenario: "idrac",
+			input: "idrac://192.168.122.1",
+			expects: map[string]string{
+				"drac_address":  "192.168.122.1",
+				"drac_password": "",
+				"drac_username": "",
+			},
+		},
 
-func TestIPMIBootInterface(t *testing.T) {
-	acc, err := NewAccessDetails("ipmi://192.168.122.1:6233")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if acc.BootInterface() != "ipxe" {
-		t.Fatal("expected boot interface to be ipxe")
-	}
-}
+		{
+			Scenario: "idrac http",
+			input: "idrac+http://192.168.122.1",
+			expects: map[string]string{
+				"drac_address":  "192.168.122.1",
+				"drac_protocol": "http",
+				"drac_password": "",
+				"drac_username": "",
+			},
+		},
 
-func TestLibvirtNeedsMAC(t *testing.T) {
-	acc, err := NewAccessDetails("libvirt://192.168.122.1:6233/")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if !acc.NeedsMAC() {
-		t.Fatal("expected to need a MAC")
-	}
-}
+		{
+			Scenario: "idrac https",
+			input: "idrac+https://192.168.122.1",
+			expects: map[string]string{
+				"drac_address":  "192.168.122.1",
+				"drac_protocol": "https",
+				"drac_password": "",
+				"drac_username": "",
+			},
+		},
 
-func TestLibvirtDriver(t *testing.T) {
-	acc, err := NewAccessDetails("libvirt://192.168.122.1:6233/")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	driver := acc.Driver()
-	if driver != "ipmi" {
-		t.Fatal("unexpected driver for libvirt")
-	}
-}
+		{
+			Scenario: "idrac port and path http",
+			input: "idrac://192.168.122.1:8080/foo",
+			expects: map[string]string{
+				"drac_address":  "192.168.122.1",
+				"drac_port":     "8080",
+				"drac_path":     "/foo",
+				"drac_password": "",
+				"drac_username": "",
+			},
+		},
 
-func TestLibvirtBootInterface(t *testing.T) {
-	acc, err := NewAccessDetails("libvirt://192.168.122.1:6233/")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if acc.BootInterface() != "ipxe" {
-		t.Fatal("expected boot interface to be ipxe")
-	}
-}
+		{
+			Scenario: "idrac ipv6",
+			input: "idrac://[fe80::fc33:62ff:fe83:8a76]/foo",
+			expects: map[string]string{
+				"drac_address":  "fe80::fc33:62ff:fe83:8a76",
+				"drac_path":     "/foo",
+				"drac_password": "",
+				"drac_username": "",
+			},
+		},
 
-func TestIDRACNeedsMAC(t *testing.T) {
-	acc, err := NewAccessDetails("idrac://192.168.122.1")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if acc.NeedsMAC() {
-		t.Fatal("expected to not need a MAC")
-	}
-}
+		{
+			Scenario: "idrac ipv6 port and path",
+			input: "idrac://[fe80::fc33:62ff:fe83:8a76]:8080/foo",
+			expects: map[string]string{
+				"drac_address":  "fe80::fc33:62ff:fe83:8a76",
+				"drac_port":     "8080",
+				"drac_path":     "/foo",
+				"drac_password": "",
+				"drac_username": "",
+			},
+		},
 
-func TestIDRACDriver(t *testing.T) {
-	acc, err := NewAccessDetails("idrac://192.168.122.1")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	driver := acc.Driver()
-	if driver != "idrac" {
-		t.Fatal("unexpected driver for idrac")
-	}
-}
+		{
+			Scenario: "irmc",
+			input: "irmc://192.168.122.1",
+			expects: map[string]string{
+				"irmc_address":  "192.168.122.1",
+				"irmc_password": "",
+				"irmc_username": "",
+			},
+		},
 
-func TestIDRACDriverInfo(t *testing.T) {
-	acc, err := NewAccessDetails("idrac://192.168.122.1")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	di := acc.DriverInfo(Credentials{})
-	if di["drac_address"] != "192.168.122.1" {
-		t.Fatalf("unexpected address: %v", di["drac_address"])
-	}
-	if _, present := di["drac_port"]; present {
-		t.Fatalf("unexpected port: %v", di["drac_port"])
-	}
-	if _, present := di["drac_protocol"]; present {
-		t.Fatalf("unexpected protocol: %v", di["drac_protocol"])
-	}
-	if _, present := di["drac_path"]; present {
-		t.Fatalf("unexpected path: %v", di["drac_path"])
-	}
-}
+		{
+			Scenario: "irmc port",
+			input: "irmc://192.168.122.1:8080",
+			expects: map[string]string{
+				"irmc_address":  "192.168.122.1",
+				"irmc_port":     "8080",
+				"irmc_password": "",
+				"irmc_username": "",
+			},
+		},
 
-func TestIDRACDriverInfoHTTP(t *testing.T) {
-	acc, err := NewAccessDetails("idrac+http://192.168.122.1")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	di := acc.DriverInfo(Credentials{})
-	if di["drac_address"] != "192.168.122.1" {
-		t.Fatalf("unexpected address: %v", di["drac_address"])
-	}
-	if _, present := di["drac_port"]; present {
-		t.Fatalf("unexpected port: %v", di["drac_port"])
-	}
-	if di["drac_protocol"] != "http" {
-		t.Fatalf("unexpected protocol: %v", di["drac_protocol"])
-	}
-	if _, present := di["drac_path"]; present {
-		t.Fatalf("unexpected path: %v", di["drac_path"])
-	}
-}
+		{
+			Scenario: "irmc ipv6",
+			input: "irmc://[fe80::fc33:62ff:fe83:8a76]",
+			expects: map[string]string{
+				"irmc_address":  "fe80::fc33:62ff:fe83:8a76",
+				"irmc_password": "",
+				"irmc_username": "",
+			},
+		},
 
-func TestIDRACDriverInfoHTTPS(t *testing.T) {
-	acc, err := NewAccessDetails("idrac+https://192.168.122.1")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	di := acc.DriverInfo(Credentials{})
-	if di["drac_address"] != "192.168.122.1" {
-		t.Fatalf("unexpected address: %v", di["drac_address"])
-	}
-	if _, present := di["drac_port"]; present {
-		t.Fatalf("unexpected port: %v", di["drac_port"])
-	}
-	if di["drac_protocol"] != "https" {
-		t.Fatalf("unexpected protocol: %v", di["drac_protocol"])
-	}
-	if _, present := di["drac_path"]; present {
-		t.Fatalf("unexpected path: %v", di["drac_path"])
-	}
-}
-
-func TestIDRACDriverInfoPort(t *testing.T) {
-	acc, err := NewAccessDetails("idrac://192.168.122.1:8080/foo")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	di := acc.DriverInfo(Credentials{})
-	if di["drac_address"] != "192.168.122.1" {
-		t.Fatalf("unexpected address: %v", di["drac_address"])
-	}
-	if di["drac_port"] != "8080" {
-		t.Fatalf("unexpected port: %v", di["drac_port"])
-	}
-	if _, present := di["drac_protocol"]; present {
-		t.Fatalf("unexpected protocol: %v", di["drac_protocol"])
-	}
-	if di["drac_path"] != "/foo" {
-		t.Fatalf("unexpected path: %v", di["drac_path"])
-	}
-}
-
-func TestIDRACDriverInfoIPv6(t *testing.T) {
-	acc, err := NewAccessDetails("idrac://[fe80::fc33:62ff:fe83:8a76]/foo")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	di := acc.DriverInfo(Credentials{})
-	if di["drac_address"] != "fe80::fc33:62ff:fe83:8a76" {
-		t.Fatalf("unexpected address: %v", di["drac_address"])
-	}
-	if _, present := di["drac_port"]; present {
-		t.Fatalf("unexpected port: %v", di["drac_port"])
-	}
-	if _, present := di["drac_protocol"]; present {
-		t.Fatalf("unexpected protocol: %v", di["drac_protocol"])
-	}
-	if di["drac_path"] != "/foo" {
-		t.Fatalf("unexpected path: %v", di["drac_path"])
-	}
-}
-
-func TestIDRACDriverInfoIPv6Port(t *testing.T) {
-	acc, err := NewAccessDetails("idrac://[fe80::fc33:62ff:fe83:8a76]:8080/foo")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	di := acc.DriverInfo(Credentials{})
-	if di["drac_address"] != "fe80::fc33:62ff:fe83:8a76" {
-		t.Fatalf("unexpected address: %v", di["drac_address"])
-	}
-	if di["drac_port"] != "8080" {
-		t.Fatalf("unexpected port: %v", di["drac_port"])
-	}
-	if _, present := di["drac_protocol"]; present {
-		t.Fatalf("unexpected protocol: %v", di["drac_protocol"])
-	}
-	if di["drac_path"] != "/foo" {
-		t.Fatalf("unexpected path: %v", di["drac_path"])
-	}
-}
-
-func TestIDRACBootInterface(t *testing.T) {
-	acc, err := NewAccessDetails("idrac://192.168.122.1")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if acc.BootInterface() != "ipxe" {
-		t.Fatal("expected boot interface to be ipxe")
-	}
-}
-
-func TestIRMCNeedsMAC(t *testing.T) {
-	acc, err := NewAccessDetails("irmc://192.168.122.1")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if acc.NeedsMAC() {
-		t.Fatal("expected to not need a MAC")
-	}
-}
-
-func TestIRMCDriver(t *testing.T) {
-	acc, err := NewAccessDetails("irmc://192.168.122.1")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	driver := acc.Driver()
-	if driver != "irmc" {
-		t.Fatal("unexpected driver for irmc")
-	}
-}
-
-func TestIRMCDriverInfo(t *testing.T) {
-	acc, err := NewAccessDetails("irmc://192.168.122.1")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	di := acc.DriverInfo(Credentials{})
-	if di["irmc_address"] != "192.168.122.1" {
-		t.Fatalf("unexpected address: %v", di["irmc_address"])
-	}
-	if _, present := di["irmc_port"]; present {
-		t.Fatalf("unexpected port: %v", di["irmc_port"])
-	}
-}
-
-func TestIRMCDriverInfoPort(t *testing.T) {
-	acc, err := NewAccessDetails("irmc://192.168.122.1:8080")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	di := acc.DriverInfo(Credentials{})
-	if di["irmc_address"] != "192.168.122.1" {
-		t.Fatalf("unexpected address: %v", di["irmc_address"])
-	}
-	if di["irmc_port"] != "8080" {
-		t.Fatalf("unexpected port: %v", di["irmc_port"])
-	}
-}
-
-func TestIRMCDriverInfoIPv6(t *testing.T) {
-	acc, err := NewAccessDetails("irmc://[fe80::fc33:62ff:fe83:8a76]")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	di := acc.DriverInfo(Credentials{})
-	if di["irmc_address"] != "fe80::fc33:62ff:fe83:8a76" {
-		t.Fatalf("unexpected address: %v", di["irmc_address"])
-	}
-	if _, present := di["irmc_port"]; present {
-		t.Fatalf("unexpected port: %v", di["irmc_port"])
-	}
-}
-
-func TestIRMCDriverInfoIPv6Port(t *testing.T) {
-	acc, err := NewAccessDetails("irmc://[fe80::fc33:62ff:fe83:8a76]:8080")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	di := acc.DriverInfo(Credentials{})
-	if di["irmc_address"] != "fe80::fc33:62ff:fe83:8a76" {
-		t.Fatalf("unexpected address: %v", di["irmc_address"])
-	}
-	if di["irmc_port"] != "8080" {
-		t.Fatalf("unexpected port: %v", di["irmc_port"])
-	}
-}
-
-func TestIRMCBootInterface(t *testing.T) {
-	acc, err := NewAccessDetails("irmc://192.168.122.1")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if acc.BootInterface() != "pxe" {
-		t.Fatal("expected boot interface to be pxe")
+		{
+			Scenario: "irmc ipv6 port",
+			input: "irmc://[fe80::fc33:62ff:fe83:8a76]:8080",
+			expects: map[string]string{
+				"irmc_address":  "fe80::fc33:62ff:fe83:8a76",
+				"irmc_port":     "8080",
+				"irmc_password": "",
+				"irmc_username": "",
+			},
+		},
+	} {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			acc, err := NewAccessDetails(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected parse error: %v", err)
+			}
+			di := acc.DriverInfo(Credentials{})
+			//If a key is present when it should not, this will catch it
+			if len(di) != len(tc.expects) {
+				t.Fatalf("Number of items do not match: %v and %v, %#v", len(di),
+					len(tc.expects), di)
+			}
+			for expectKey, expectArg := range tc.expects {
+				value, ok := di[expectKey]
+				if value != expectArg && ok {
+					t.Fatalf("unexpected value for %v (key present: %v): %v, expected %v",
+						ok, expectKey, value, expectArg)
+				}
+			}
+		})
 	}
 }
 
 func TestUnknownType(t *testing.T) {
 	acc, err := NewAccessDetails("foo://192.168.122.1")
 	if err == nil || acc != nil {
-		t.Fatal("unexpected parse success")
+		t.Fatalf("unexpected parse success")
 	}
 }

--- a/pkg/bmc/idrac.go
+++ b/pkg/bmc/idrac.go
@@ -2,6 +2,7 @@ package bmc
 
 import (
 	"strings"
+	"net/url"
 )
 
 func init() {
@@ -10,12 +11,12 @@ func init() {
 	registerFactory("idrac+https", newIDRACAccessDetails)
 }
 
-func newIDRACAccessDetails(bmcType, portNum, hostname, path string) (AccessDetails, error) {
+func newIDRACAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
 	return &iDracAccessDetails{
-		bmcType:  bmcType,
-		portNum:  portNum,
-		hostname: hostname,
-		path:     path,
+		bmcType:  parsedURL.Scheme,
+		portNum:  parsedURL.Port(),
+		hostname: parsedURL.Hostname(),
+		path:     parsedURL.Path,
 	}, nil
 }
 

--- a/pkg/bmc/ipmi.go
+++ b/pkg/bmc/ipmi.go
@@ -1,15 +1,19 @@
 package bmc
 
+import (
+	"net/url"
+)
+
 func init() {
 	registerFactory("ipmi", newIPMIAccessDetails)
 	registerFactory("libvirt", newIPMIAccessDetails)
 }
 
-func newIPMIAccessDetails(bmcType, portNum, hostname, path string) (AccessDetails, error) {
+func newIPMIAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
 	return &ipmiAccessDetails{
-		bmcType:  bmcType,
-		portNum:  portNum,
-		hostname: hostname,
+		bmcType:  parsedURL.Scheme,
+		portNum:  parsedURL.Port(),
+		hostname: parsedURL.Hostname(),
 	}, nil
 }
 

--- a/pkg/bmc/irmc.go
+++ b/pkg/bmc/irmc.go
@@ -1,14 +1,18 @@
 package bmc
 
+import (
+	"net/url"
+)
+
 func init() {
 	registerFactory("irmc", newIRMCAccessDetails)
 }
 
-func newIRMCAccessDetails(bmcType, portNum, hostname, path string) (AccessDetails, error) {
+func newIRMCAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
 	return &iRMCAccessDetails{
-		bmcType:  bmcType,
-		portNum:  portNum,
-		hostname: hostname,
+		bmcType:  parsedURL.Scheme,
+		portNum:  parsedURL.Port(),
+		hostname: parsedURL.Hostname(),
 	}, nil
 }
 


### PR DESCRIPTION
This enhancements changes the BMC drivers factory method to accept a url.URL object instead of separate string arguments, allowing more flexibility in passing information to the BMC drivers.