### PR TITLE
Wait for power status to change

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1307,6 +1307,7 @@ func (p *ironicProvisioner) PowerOn() (result provisioner.Result, err error) {
 		if ironicNode.TargetPowerState == powerOn {
 			p.log.Info("waiting for power status to change")
 			result.RequeueAfter = powerRequeueDelay
+			result.Dirty = true
 			return result, nil
 		}
 		result, err = p.changePower(ironicNode, nodes.PowerOn)
@@ -1334,6 +1335,7 @@ func (p *ironicProvisioner) PowerOff() (result provisioner.Result, err error) {
 		if ironicNode.TargetPowerState == powerOff {
 			p.log.Info("waiting for power status to change")
 			result.RequeueAfter = powerRequeueDelay
+			result.Dirty = true
 			return result, nil
 		}
 		result, err = p.changePower(ironicNode, nodes.PowerOff)


### PR DESCRIPTION
When attempting to power a host on or off with Ironic, we were declaring
success (updating the power status and dropping back to polling only
every 60s) as soon as we saw the target power state change in Ironic
even if the host had not yet reached that state.

Ensure that the power state has actually changed before we consider the
change complete.

Fixes #290