### PR TITLE
Use leader election mechanism from controller-runtime library

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -11,9 +10,10 @@ import (
 	"github.com/metal3-io/baremetal-operator/pkg/controller"
 	"github.com/metal3-io/baremetal-operator/pkg/version"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	"github.com/operator-framework/operator-sdk/pkg/leader"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
+
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -55,16 +55,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Become the leader before proceeding
-	err = leader.Become(context.TODO(), "baremetal-operator-lock")
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
-
 	opts := manager.Options{
-		Namespace:          namespace,
-		MetricsBindAddress: *metricsAddr,
+		LeaderElection:          true,
+		LeaderElectionID:        "baremetal-operator",
+		LeaderElectionNamespace: namespace,
+		Namespace:               namespace,
+		MetricsBindAddress:      *metricsAddr,
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components


### PR DESCRIPTION
There are[ two options for the leader election](https://docs.openshift.com/container-platform/4.1/applications/operator_sdk/osdk-leader-election.html). The SDK defaults to the simpler one ("Leader for life") which trades off slower failover (5 minutes by default - the pod-eviction-timeout) for a guarantee that there can never be two leaders. The other one (used here) fails over faster, but there may be two leaders if one node is running a clock 50% faster(!) than the others unless you tweak the default timeouts to accommodate the clock skew rate you expect.

The controller-runtime library provides a way to set leader among pods via config map annotation, that includes leader lease. In case when the pod fails to update the lease under the config map, the other pod will acquire the leader.

Otherwise, the operator-SDK do not provide the lease feature and just creates the
config map, so until the config map exists, another pod can not acquire the leader,
but the config map will exist as long as pod exists(also in terminating state),
so it will prevent HA in cases when node not responsive for some reason(network, kernel panic, ...).

Fixes #295