### PR TITLE
show which cleaning step is running during (de)provision operations

### DIFF
--- a/deploy/crds/metal3_v1alpha1_baremetalhost_crd.yaml
+++ b/deploy/crds/metal3_v1alpha1_baremetalhost_crd.yaml
@@ -50,7 +50,6 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: BareMetalHost is the Schema for the baremetalhosts API
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -65,7 +64,6 @@ spec:
         metadata:
           type: object
         spec:
-          description: BareMetalHostSpec defines the desired state of BareMetalHost
           properties:
             bmc:
               description: How do we connect to the BMC?
@@ -85,45 +83,12 @@ spec:
             bootMACAddress:
               description: Which MAC address will PXE boot? This is optional for some
                 types, but required for libvirt VMs driven by vbmc.
-              pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
+              pattern: '`[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}`'
               type: string
             consumerRef:
               description: ConsumerRef can be used to store information about something
                 that is using a host. When it is not empty, the host is considered
                 "in use".
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
               type: object
             description:
               description: Description is a human-entered text used to help identify
@@ -150,8 +115,8 @@ spec:
                   description: URL is a location of an image to deploy.
                   type: string
               required:
-              - checksum
               - url
+              - checksum
               type: object
             online:
               description: Should the server be online?
@@ -161,49 +126,16 @@ spec:
                 to the corresponding Machine. This list will overwrite any modifications
                 made to the Machine on an ongoing basis.
               items:
-                description: The node this Taint is attached to has the "effect" on
-                  any pod that does not tolerate the Taint.
-                properties:
-                  effect:
-                    description: Required. The effect of the taint on pods that do
-                      not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule
-                      and NoExecute.
-                    type: string
-                  key:
-                    description: Required. The taint key to be applied to a node.
-                    type: string
-                  timeAdded:
-                    description: TimeAdded represents the time at which the taint
-                      was added. It is only written for NoExecute taints.
-                    format: date-time
-                    type: string
-                  value:
-                    description: Required. The taint value corresponding to the taint
-                      key.
-                    type: string
-                required:
-                - effect
-                - key
                 type: object
               type: array
             userData:
               description: UserData holds the reference to the Secret containing the
                 user data to be passed to the host before it boots.
-              properties:
-                name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
-                  type: string
-                namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
-                  type: string
               type: object
           required:
           - online
           type: object
         status:
-          description: BareMetalHostStatus defines the observed state of BareMetalHost
           properties:
             errorMessage:
               description: the last error message reported by the provisioning subsystem
@@ -212,17 +144,6 @@ spec:
               description: the last credentials we were able to validate as working
               properties:
                 credentials:
-                  description: SecretReference represents a Secret Reference. It has
-                    enough information to retrieve secret in any namespace
-                  properties:
-                    name:
-                      description: Name is unique within a namespace to reference
-                        a secret resource.
-                      type: string
-                    namespace:
-                      description: Namespace defines the space within which the secret
-                        name must be unique.
-                      type: string
                   type: object
                 credentialsVersion:
                   type: string
@@ -231,13 +152,14 @@ spec:
               description: The hardware discovered to exist on the host.
               properties:
                 cpu:
-                  description: CPU describes one processor on the host.
                   properties:
                     arch:
                       type: string
                     clockMegahertz:
-                      description: ClockSpeed is a clock speed in MHz
+                      format: double
+                      type: number
                     count:
+                      format: int64
                       type: integer
                     flags:
                       items:
@@ -247,13 +169,12 @@ spec:
                       type: string
                   required:
                   - arch
-                  - clockMegahertz
-                  - count
-                  - flags
                   - model
+                  - clockMegahertz
+                  - flags
+                  - count
                   type: object
                 firmware:
-                  description: Firmware describes the firmware on the host.
                   properties:
                     bios:
                       description: The BIOS for this firmware
@@ -279,14 +200,13 @@ spec:
                   type: string
                 nics:
                   items:
-                    description: NIC describes one network interface on the host.
                     properties:
                       ip:
                         description: The IP address of the device
                         type: string
                       mac:
                         description: The device MAC addr
-                        pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
+                        pattern: '`[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}`'
                         type: string
                       model:
                         description: The name of the model, e.g. "virt-io"
@@ -299,19 +219,22 @@ spec:
                         type: boolean
                       speedGbps:
                         description: The speed of the device
+                        format: int64
                         type: integer
                       vlanId:
                         description: The untagged VLAN ID
                         format: int32
+                        maximum: 4094
+                        minimum: 0
                         type: integer
                       vlans:
                         description: The VLANs available
                         items:
-                          description: VLAN represents the name and ID of a VLAN
                           properties:
                             id:
-                              description: VLANID is a 12-bit 802.1Q VLAN identifier
                               format: int32
+                              maximum: 4094
+                              minimum: 0
                               type: integer
                             name:
                               type: string
@@ -320,21 +243,20 @@ spec:
                           type: object
                         type: array
                     required:
-                    - ip
-                    - mac
-                    - model
                     - name
-                    - pxe
+                    - model
+                    - mac
+                    - ip
                     - speedGbps
                     - vlanId
+                    - pxe
                     type: object
                   type: array
                 ramMebibytes:
+                  format: int64
                   type: integer
                 storage:
                   items:
-                    description: Storage describes one storage device (disk, SSD,
-                      etc.) on the host.
                     properties:
                       hctl:
                         description: The SCSI location of the device
@@ -370,13 +292,11 @@ spec:
                     required:
                     - name
                     - rotational
-                    - serialNumber
                     - sizeBytes
+                    - serialNumber
                     type: object
                   type: array
                 systemVendor:
-                  description: HardwareSystemVendor stores details about the whole
-                    hardware system.
                   properties:
                     manufacturer:
                       type: string
@@ -390,13 +310,13 @@ spec:
                   - serialNumber
                   type: object
               required:
-              - cpu
-              - firmware
-              - hostname
-              - nics
-              - ramMebibytes
-              - storage
               - systemVendor
+              - firmware
+              - ramMebibytes
+              - nics
+              - storage
+              - cpu
+              - hostname
               type: object
             hardwareProfile:
               description: The name of the profile matching the hardware details.
@@ -405,47 +325,6 @@ spec:
               description: LastUpdated identifies when this status was last observed.
               format: date-time
               type: string
-            operationHistory:
-              description: OperationHistory holds information about operations performed
-                on this host.
-              properties:
-                deprovision:
-                  properties:
-                    end:
-                      format: date-time
-                      type: string
-                    start:
-                      format: date-time
-                      type: string
-                  type: object
-                inspect:
-                  properties:
-                    end:
-                      format: date-time
-                      type: string
-                    start:
-                      format: date-time
-                      type: string
-                  type: object
-                provision:
-                  properties:
-                    end:
-                      format: date-time
-                      type: string
-                    start:
-                      format: date-time
-                      type: string
-                  type: object
-                register:
-                  properties:
-                    end:
-                      format: date-time
-                      type: string
-                    start:
-                      format: date-time
-                      type: string
-                  type: object
-              type: object
             operationalStatus:
               description: OperationalStatus holds the status of the host
               type: string
@@ -470,8 +349,8 @@ spec:
                       description: URL is a location of an image to deploy.
                       type: string
                   required:
-                  - checksum
                   - url
+                  - checksum
                   type: object
                 state:
                   description: An indicator for what the provisioner is doing with
@@ -482,38 +361,25 @@ spec:
                     State.
                   type: string
               required:
+              - state
               - step
               - ID
-              - state
               type: object
             triedCredentials:
               description: the last credentials we sent to the provisioning backend
               properties:
                 credentials:
-                  description: SecretReference represents a Secret Reference. It has
-                    enough information to retrieve secret in any namespace
-                  properties:
-                    name:
-                      description: Name is unique within a namespace to reference
-                        a secret resource.
-                      type: string
-                    namespace:
-                      description: Namespace defines the space within which the secret
-                        name must be unique.
-                      type: string
                   type: object
                 credentialsVersion:
                   type: string
               type: object
           required:
-          - errorMessage
-          - hardwareProfile
           - operationalStatus
-          - operationHistory
-          - poweredOn
+          - hardwareProfile
           - provisioning
+          - errorMessage
+          - poweredOn
           type: object
-      type: object
   version: v1alpha1
   versions:
   - name: v1alpha1

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -402,8 +402,11 @@ type BareMetalHostStatus struct {
 
 // ProvisionStatus holds the state information for a single target.
 type ProvisionStatus struct {
-	// An indiciator for what the provisioner is doing with the host.
+	// An indicator for what the provisioner is doing with the host.
 	State ProvisioningState `json:"state"`
+
+	// An indicator of the ongoing Step under the current State.
+	Step string `json:"step"`
 
 	// The machine's UUID from the underlying provisioning tool
 	ID string `json:"ID"`
@@ -421,6 +424,7 @@ type ProvisionStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.operationalStatus",description="Operational status"
 // +kubebuilder:printcolumn:name="Provisioning Status",type="string",JSONPath=".status.provisioning.state",description="Provisioning status"
+// +kubebuilder:printcolumn:name="Provisioning Step",type="string",JSONPath=".status.provisioning.step",description="Provisioning step"
 // +kubebuilder:printcolumn:name="Consumer",type="string",JSONPath=".spec.consumerRef.name",description="Consumer using this host"
 // +kubebuilder:printcolumn:name="BMC",type="string",JSONPath=".spec.bmc.address",description="Address of management controller"
 // +kubebuilder:printcolumn:name="Hardware Profile",type="string",JSONPath=".status.hardwareProfile",description="The type of hardware detected"

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -205,7 +205,7 @@ func (r *ReconcileBareMetalHost) Reconcile(request reconcile.Request) (result re
 
 	initialState := host.Status.Provisioning.State
 	info := &reconcileInfo{
-		log:            reqLogger.WithValues("provisioningState", initialState),
+		log:            reqLogger.WithValues("provisioningState", initialState, "provisioningStep", host.Status.Provisioning.Step),
 		host:           host,
 		request:        request,
 		bmcCredsSecret: bmcCredsSecret,
@@ -231,7 +231,8 @@ func (r *ReconcileBareMetalHost) Reconcile(request reconcile.Request) (result re
 	if actResult.Dirty() {
 		info.log.Info("saving host status",
 			"operational status", host.OperationalStatus(),
-			"provisioning state", host.Status.Provisioning.State)
+			"provisioning state", host.Status.Provisioning.State,
+			"provisioning step", host.Status.Provisioning.Step)
 		if err = r.saveStatus(host); err != nil {
 			return reconcile.Result{}, errors.Wrap(err,
 				fmt.Sprintf("failed to save host status after %q", initialState))


### PR DESCRIPTION
The cleaning step is set in the ironic client, running in bare metal operator. BMO fetches the host data which .i.a contains the step info.
The cleaning step field can be an empty/non-empty string.

Closes: #215