### PR TITLE
simplify bmc access tests

### DIFF
--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -10,163 +10,188 @@ func init() {
 	logf.SetLogger(logf.ZapLogger(true))
 }
 
-func TestParseLibvirtURL(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("libvirt://192.168.122.1:6233/")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if T != "libvirt" {
-		t.Fatalf("unexpected type: %q", T)
-	}
-	if P != "6233" {
-		t.Fatalf("unexpected port: %q", P)
-	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
-	}
-	if A != "/" {
-		t.Fatalf("unexpected path: %q", A)
-	}
-}
+func TestParse(t *testing.T) {
+	for _, tc := range []struct {
+		Scenario    string
+		Address     string
+		Type        string
+		Host        string
+		Port        string
+		Path        string
+		ExpectError bool
+	}{
+		{
+			Scenario: "libvirt url",
+			Address:  "libvirt://192.168.122.1:6233/",
+			Type:     "libvirt",
+			Port:     "6233",
+			Host:     "192.168.122.1",
+			Path:     "/",
+		},
 
-func TestParseIPMIDefaultSchemeAndPort(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("192.168.122.1")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if T != "ipmi" {
-		t.Fatalf("unexpected type: %q", T)
-	}
-	if P != "" { // default is set in DriverInfo() method
-		t.Fatalf("unexpected port: %q", P)
-	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
-	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
-	}
-}
+		{
+			Scenario: "ipmi default scheme and port",
+			Address:  "192.168.122.1",
+			Type:     "ipmi",
+			Port:     "",
+			Host:     "192.168.122.1",
+			Path:     "",
+		},
 
-func TestParseIPMIDefaultSchemeAndPortHostname(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("my.favoritebmc.com")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if T != "ipmi" {
-		t.Fatalf("unexpected type: %q", T)
-	}
-	if P != "" { // default is set in DriverInfo() method
-		t.Fatalf("unexpected port: %q", P)
-	}
-	if H != "my.favoritebmc.com" {
-		t.Fatalf("unexpected hostname: %q", H)
-	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
-	}
-}
+		{
+			Scenario: "ipmi default scheme and port, hostname",
+			Address:  "my.favoritebmc.com",
+			Type:     "ipmi",
+			Port:     "",
+			Host:     "my.favoritebmc.com",
+			Path:     "",
+		},
 
-func TestParseHostPort(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("192.168.122.1:6233")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if T != "ipmi" {
-		t.Fatalf("unexpected type: %q", T)
-	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
-	}
-	if P != "6233" {
-		t.Fatalf("unexpected port: %q", P)
-	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
-	}
-}
+		{
+			Scenario: "host and port",
+			Address:  "192.168.122.1:6233",
+			Type:     "ipmi",
+			Port:     "6233",
+			Host:     "192.168.122.1",
+			Path:     "",
+		},
 
-func TestParseHostPortIPv6(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("[fe80::fc33:62ff:fe83:8a76]:6233")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if T != "ipmi" {
-		t.Fatalf("unexpected type: %q", T)
-	}
-	if H != "fe80::fc33:62ff:fe83:8a76" {
-		t.Fatalf("unexpected hostname: %q", H)
-	}
-	if P != "6233" {
-		t.Fatalf("unexpected port: %q", P)
-	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
-	}
-}
+		{
+			Scenario: "host and port, ipv6",
+			Address:  "[fe80::fc33:62ff:fe83:8a76]:6233",
+			Type:     "ipmi",
+			Port:     "6233",
+			Host:     "fe80::fc33:62ff:fe83:8a76",
+			Path:     "",
+		},
 
-func TestParseHostNoPortIPv6(t *testing.T) {
-	// They either have to give us a port or a URL scheme with IPv6.
-	_, _, _, _, err := getTypeHostPort("[fe80::fc33:62ff:fe83:8a76]")
-	if err == nil {
-		t.Fatal("expected parse error")
-	}
-}
+		{
+			Scenario:    "host and no port, ipv6",
+			Address:     "[fe80::fc33:62ff:fe83:8a76]",
+			ExpectError: true,
+		},
 
-func TestParseIPMIURL(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("ipmi://192.168.122.1:6233")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if T != "ipmi" {
-		t.Fatalf("unexpected type: %q", T)
-	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
-	}
-	if P != "6233" {
-		t.Fatalf("unexpected port: %q", P)
-	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
-	}
-}
+		{
+			Scenario: "ipmi full url",
+			Address:  "ipmi://192.168.122.1:6233",
+			Type:     "ipmi",
+			Port:     "6233",
+			Host:     "192.168.122.1",
+			Path:     "",
+		},
 
-func TestParseIPMIURLNoSep(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("ipmi:192.168.122.1")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if T != "ipmi" {
-		t.Fatalf("unexpected type: %q", T)
-	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
-	}
-	if P != "" {
-		t.Fatalf("unexpected port: %q", P)
-	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
-	}
-}
+		{
+			Scenario: "ipmi url, no sep",
+			Address:  "ipmi:192.168.122.1",
+			Type:     "ipmi",
+			Port:     "",
+			Host:     "192.168.122.1",
+			Path:     "",
+		},
 
-func TestParseIPMIURLNoSepPort(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("ipmi:192.168.122.1:6233")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if T != "ipmi" {
-		t.Fatalf("unexpected type: %q", T)
-	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
-	}
-	if P != "6233" {
-		t.Fatalf("unexpected port: %q", P)
-	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
+		{
+			Scenario: "ipmi url with port, no sep",
+			Address:  "ipmi:192.168.122.1:6233",
+			Type:     "ipmi",
+			Port:     "6233",
+			Host:     "192.168.122.1",
+			Path:     "",
+		},
+
+		{
+			Scenario: "idrac url",
+			Address:  "idrac://192.168.122.1",
+			Type:     "idrac",
+			Port:     "",
+			Host:     "192.168.122.1",
+			Path:     "",
+		},
+
+		{
+			Scenario: "idrac url with path",
+			Address:  "idrac://192.168.122.1:6233/foo",
+			Type:     "idrac",
+			Port:     "6233",
+			Host:     "192.168.122.1",
+			Path:     "/foo",
+		},
+
+		{
+			Scenario: "idrac url ipv6",
+			Address:  "idrac://[fe80::fc33:62ff:fe83:8a76]",
+			Type:     "idrac",
+			Port:     "",
+			Host:     "fe80::fc33:62ff:fe83:8a76",
+			Path:     "",
+		},
+
+		{
+			Scenario: "idrac url, no sep",
+			Address:  "idrac:192.168.122.1",
+			Type:     "idrac",
+			Port:     "",
+			Host:     "192.168.122.1",
+			Path:     "",
+		},
+
+		{
+			Scenario: "irmc url",
+			Address:  "irmc://192.168.122.1",
+			Type:     "irmc",
+			Port:     "",
+			Host:     "192.168.122.1",
+			Path:     "",
+		},
+
+		{
+			Scenario: "irmc url, ipv6",
+			Address:  "irmc://[fe80::fc33:62ff:fe83:8a76]",
+			Type:     "irmc",
+			Port:     "",
+			Host:     "fe80::fc33:62ff:fe83:8a76",
+			Path:     "",
+		},
+
+		{
+			Scenario: "irmc url, no sep",
+			Address:  "irmc:192.168.122.1",
+			Type:     "irmc",
+			Port:     "",
+			Host:     "192.168.122.1",
+			Path:     "",
+		},
+	} {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			T, H, P, A, err := getTypeHostPort(tc.Address)
+
+			if tc.ExpectError {
+				if err == nil {
+					t.Fatal("Expected error, did not get one")
+				}
+				// Expected an error and did get one, so no need to
+				// test anything else.
+				return
+			}
+			if !tc.ExpectError && err != nil {
+				t.Fatalf("unexpected parse error: %v", err)
+			}
+
+			if T != tc.Type {
+				t.Fatalf("expected type %q but got %q", tc.Type, T)
+			}
+
+			if P != tc.Port {
+				t.Fatalf("expected port %q but got %q", tc.Port, P)
+			}
+
+			if H != tc.Host {
+				t.Fatalf("expected host %q but got %q", tc.Host, H)
+			}
+
+			if A != tc.Path {
+				t.Fatalf("expected path %q but got %q", tc.Path, A)
+			}
+		})
 	}
 }
 
@@ -239,82 +264,6 @@ func TestLibvirtBootInterface(t *testing.T) {
 	}
 	if acc.BootInterface() != "ipxe" {
 		t.Fatal("expected boot interface to be ipxe")
-	}
-}
-
-func TestParseIDRACURL(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("idrac://192.168.122.1")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if T != "idrac" {
-		t.Fatalf("unexpected type: %q", T)
-	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
-	}
-	if P != "" {
-		t.Fatalf("unexpected port: %q", P)
-	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
-	}
-}
-
-func TestParseIDRACURLPath(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("idrac://192.168.122.1:6233/foo")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if T != "idrac" {
-		t.Fatalf("unexpected type: %q", T)
-	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
-	}
-	if P != "6233" {
-		t.Fatalf("unexpected port: %q", P)
-	}
-	if A != "/foo" {
-		t.Fatalf("unexpected path: %q", A)
-	}
-}
-
-func TestParseIDRACURLIPv6(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("idrac://[fe80::fc33:62ff:fe83:8a76]")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if T != "idrac" {
-		t.Fatalf("unexpected type: %q", T)
-	}
-	if H != "fe80::fc33:62ff:fe83:8a76" {
-		t.Fatalf("unexpected hostname: %q", H)
-	}
-	if P != "" {
-		t.Fatalf("unexpected port: %q", P)
-	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
-	}
-}
-
-func TestParseIDRACURLNoSep(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("idrac:192.168.122.1")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if T != "idrac" {
-		t.Fatalf("unexpected type: %q", T)
-	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
-	}
-	if P != "" {
-		t.Fatalf("unexpected port: %q", P)
-	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
 	}
 }
 
@@ -466,63 +415,6 @@ func TestIDRACBootInterface(t *testing.T) {
 	}
 	if acc.BootInterface() != "ipxe" {
 		t.Fatal("expected boot interface to be ipxe")
-	}
-}
-
-func TestParseIRMCURL(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("irmc://192.168.122.1")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if T != "irmc" {
-		t.Fatalf("unexpected type: %q", T)
-	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
-	}
-	if P != "" {
-		t.Fatalf("unexpected port: %q", P)
-	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
-	}
-}
-
-func TestParseIRMCURLIPv6(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("irmc://[fe80::fc33:62ff:fe83:8a76]")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if T != "irmc" {
-		t.Fatalf("unexpected type: %q", T)
-	}
-	if H != "fe80::fc33:62ff:fe83:8a76" {
-		t.Fatalf("unexpected hostname: %q", H)
-	}
-	if P != "" {
-		t.Fatalf("unexpected port: %q", P)
-	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
-	}
-}
-
-func TestParseIRMCURLNoSep(t *testing.T) {
-	T, H, P, A, err := getTypeHostPort("irmc:192.168.122.1")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if T != "irmc" {
-		t.Fatalf("unexpected type: %q", T)
-	}
-	if H != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", H)
-	}
-	if P != "" {
-		t.Fatalf("unexpected port: %q", P)
-	}
-	if A != "" {
-		t.Fatalf("unexpected path: %q", A)
 	}
 }
 


### PR DESCRIPTION
Convert the separate test functions for parsing BMC URLs to a table
test to cut down on the repetition.