### PR TITLE
Handle conflicts consistently in ValidateManagementAccess()

### DIFF
--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -500,7 +500,6 @@ func (r *ReconcileBareMetalHost) actionRegistering(prov provisioner.Provisioner,
 	}
 
 	result.Requeue = true
-	result.RequeueAfter = provResult.RequeueAfter
 	return result, nil
 }
 

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -316,6 +316,7 @@ func (p *ironicProvisioner) ValidateManagementAccess(credentialsChanged bool) (r
 			case gophercloud.ErrDefault409:
 				p.log.Info("could not update host settings in ironic, busy")
 				result.Dirty = true
+				result.RequeueAfter = provisionRequeueDelay
 				return result, nil
 			default:
 				return result, errors.Wrap(err, "failed to update host settings in ironic")
@@ -349,6 +350,7 @@ func (p *ironicProvisioner) ValidateManagementAccess(credentialsChanged bool) (r
 			case nil:
 			case gophercloud.ErrDefault409:
 				p.log.Info("could not update host driver settings, busy")
+				result.Dirty = true
 				result.RequeueAfter = provisionRequeueDelay
 				return result, nil
 			default:


### PR DESCRIPTION
When we get an HTTP 409 response in ValidateManagementAccess, we should
retry after a delay. In one case we were not delaying (i.e. retrying
immediately), and in another we added a delay before moving to the next
state but reported that the management access was valid when that had
not been verified.

Handle both with a retry after a delay.

Since this was the only case where the provisioner would request a delay
while reporting success, this also removes the code handling that case
in actionRegistering(). Once the host is registered we always want to
requeue immediately so we can move to the next state.