### PR TITLE
Set error message on inspection error 

### DIFF
--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -516,9 +516,10 @@ func (r *ReconcileBareMetalHost) actionInspecting(prov provisioner.Provisioner, 
 	}
 
 	if provResult.ErrorMessage != "" {
-		info.host.Status.Provisioning.State = metal3v1alpha1.StateRegistrationError
-		info.host.SetErrorMessage(provResult.ErrorMessage)
-		info.publishEvent("RegistrationError", provResult.ErrorMessage)
+		if info.host.SetErrorMessage(provResult.ErrorMessage) {
+			info.publishEvent("InspectionError", provResult.ErrorMessage)
+			result.Requeue = true
+		}
 		return result, nil
 	}
 


### PR DESCRIPTION
When an error occurred during inspection, we weren't setting the Requeue
flag, which is required for the event to actually be published and the
CR to be updated (although it doesn't actually cause the reconcile to be
requeued, because of the error).

Had we published the event, it would have wrongly stated that it was a
registration error.

Finally, we weren't actually changing the Host's ProvisionState to
RegistrationError (since changes weren't written), so don't start now.