### PR TITLE
Update ironic deployment to latest requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,9 @@ deploy:
 	kubectl apply -f deploy/role.yaml -n $(RUN_NAMESPACE)
 	kubectl apply -f deploy/role_binding.yaml
 	kubectl apply -f deploy/crds/metal3_v1alpha1_baremetalhost_crd.yaml
-	kubectl apply -f deploy/operator.yaml -n $(RUN_NAMESPACE)
+	kubectl apply -f deploy/ironic_bmo_configmap.yaml -n $(RUN_NAMESPACE)
+	kubectl apply -f deploy/mariadb-password.yaml -n $(RUN_NAMESPACE)
+	kubectl apply -f deploy/operator_ironic.yaml -n $(RUN_NAMESPACE)
 
 .PHONY: dep-check
 dep-check:

--- a/deploy/ironic_bmo_configmap.yaml
+++ b/deploy/ironic_bmo_configmap.yaml
@@ -4,10 +4,10 @@ metadata:
   name: ironic-bmo-configmap
 data:
   http_port: "6180"
-  http_ip: "172.22.0.1"
-  interface: "ens3"
+  interface: "eth2"
   dhcp_range: "172.22.0.10,172.22.0.100"
-  deploy_kernel_url: "http://172.22.0.1/images/ironic-python-agent.kernel"
-  deploy_ramdisk_url: "http://172.22.0.1/images/ironic-python-agent.initramfs"
-  ironic_endpoint: "http://localhost:6385/v1/"
-  ironic_inspector_endpoint: "http://localhost:5050/v1/"
+  deploy_kernel_url: "http://172.22.0.2:6180/images/ironic-python-agent.kernel"
+  deploy_ramdisk_url: "http://172.22.0.2:6180/images/ironic-python-agent.initramfs"
+  ironic_endpoint: "http://172.22.0.2:6385/v1/"
+  ironic_inspector_endpoint: "http://172.22.0.2:5050/v1/"
+  cacheurl: "http://172.22.0.1/images"

--- a/deploy/mariadb-password.yaml
+++ b/deploy/mariadb-password.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  password: cGFzc3dvcmQ=
+kind: Secret
+metadata:
+  name: mariadb-password
+  namespace: metal3
+type: Opaque

--- a/deploy/operator_ironic.yaml
+++ b/deploy/operator_ironic.yaml
@@ -70,17 +70,12 @@ spec:
                 configMapKeyRef:
                   name: ironic-bmo-configmap
                   key: http_port
-            - name: IP
-              valueFrom:
-                configMapKeyRef:
-                  name: ironic-bmo-configmap
-                  key: http_ip
             - name: DHCP_RANGE
               valueFrom:
                 configMapKeyRef:
                   name: ironic-bmo-configmap
                   key: dhcp_range
-            - name: INTERFACE
+            - name: PROVISIONING_INTERFACE
               valueFrom:
                 configMapKeyRef:
                   name: ironic-bmo-configmap
@@ -112,16 +107,16 @@ spec:
             - mountPath: /shared
               name: ironic-data-volume
           env:
+            - name: PROVISIONING_INTERFACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ironic-bmo-configmap
+                  key: interface
             - name: HTTP_PORT
               valueFrom:
                 configMapKeyRef:
                   name: ironic-bmo-configmap
                   key: http_port
-            - name: IP
-              valueFrom:
-                configMapKeyRef:
-                  name: ironic-bmo-configmap
-                  key: http_ip
         - name: ironic
           image: quay.io/metal3-io/ironic
           imagePullPolicy: Always
@@ -143,12 +138,7 @@ spec:
                 configMapKeyRef:
                   name: ironic-bmo-configmap
                   key: http_port
-            - name: IP
-              valueFrom:
-                configMapKeyRef:
-                  name: ironic-bmo-configmap
-                  key: http_ip
-            - name: INTERFACE
+            - name: PROVISIONING_INTERFACE
               valueFrom:
                 configMapKeyRef:
                   name: ironic-bmo-configmap
@@ -159,11 +149,28 @@ spec:
           securityContext:
             privileged: true
           env:
-            - name: INTERFACE
+            - name: PROVISIONING_INTERFACE
               valueFrom:
                 configMapKeyRef:
                   name: ironic-bmo-configmap
                   key: interface
+      initContainers:
+        - name: ironic-ipa-downloader
+          image: quay.io/metal3-io/ironic-ipa-downloader
+          imagePullPolicy: Always
+          command:
+            - /usr/local/bin/get-resource.sh
+          securityContext:
+            privileged: true
+          env:
+            - name: CACHEURL
+              valueFrom:
+                configMapKeyRef:
+                  name: ironic-bmo-configmap
+                  key: cacheurl
+          volumeMounts:
+            - mountPath: /shared
+              name: ironic-data-volume
       volumes:
         - name: ironic-data-volume
           emptyDir: {}


### PR DESCRIPTION
This creates a mariadb scret, deploys the bmo configmap, and creates the
IPA downloader as an init container.