### PR TITLE
Check namespace when matching Secret references

### DIFF
--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -327,6 +327,8 @@ func (cs CredentialsStatus) Match(secret corev1.Secret) bool {
 		return false
 	case cs.Reference.Name != secret.ObjectMeta.Name:
 		return false
+	case cs.Reference.Namespace != secret.ObjectMeta.Namespace:
+		return false
 	case cs.Version != secret.ObjectMeta.ResourceVersion:
 		return false
 	}

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types_test.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types_test.go
@@ -495,10 +495,30 @@ func TestCredentialStatusMatch(t *testing.T) {
 			Secret: corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "match",
+					Namespace:       "namespace",
 					ResourceVersion: "1",
 				},
 			},
 			Expected: true,
+		},
+
+		{
+			Scenario: "wrong namespace",
+			CredStat: CredentialsStatus{
+				Reference: &corev1.SecretReference{
+					Name:      "match",
+					Namespace: "namespace",
+				},
+				Version: "1",
+			},
+			Secret: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "match",
+					Namespace:       "namespace2",
+					ResourceVersion: "1",
+				},
+			},
+			Expected: false,
 		},
 
 		{


### PR DESCRIPTION
Previously when checking if a Secret has changed we could have confused
two Secrets with the same name in different namespaces.