### PR TITLE
Configure RAID Interface for iRMC driver 

### DIFF
--- a/pkg/bmc/irmc.go
+++ b/pkg/bmc/irmc.go
@@ -68,7 +68,7 @@ func (a *iRMCAccessDetails) PowerInterface() string {
 }
 
 func (a *iRMCAccessDetails) RAIDInterface() string {
-	return ""
+	return "irmc"
 }
 
 func (a *iRMCAccessDetails) VendorInterface() string {


### PR DESCRIPTION
Currently, RAID interface is not set when we create Ironic node(#320). This PR aims to make RAID interface to be set by vendor driver.

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>
Co-Authored-By: Dao Cong Tien <tiendc@vn.fujitsu.com>