### PR TITLE
Add a set of hack scripts and fix corresponding warnings

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -154,7 +154,8 @@ details, etc.
     * *validation error* -- The provisioning steps found an error.
     * *provisioning* -- An image is being written to the host's disk(s).
     * *provisioning error* -- The image could not be written to the host.
-    * *provisioned* -- An image has been completely written to the host's disk(s). 
+    * *provisioned* -- An image has been completely written to the host's
+      disk(s).
     * *externally provisioned* -- Metal³ does not manage the image on the host.
     * *deprovisioning* -- The image is being wiped from the host's disk(s).
     * *inspecting* -- The hardware details for the host are being collected

--- a/docs/baremetalhost-states.md
+++ b/docs/baremetalhost-states.md
@@ -1,6 +1,7 @@
 # BaremetalHost Provisioning States
 
-The following diagram shows the possible Provisioning State transitions for the BaremetalHost object:
+The following diagram shows the possible Provisioning State transitions for the
+BaremetalHost object:
 
 ![BaremetalHost ProvisioningState transitions](BaremetalHost_ProvisioningState.png)
 

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,27 +1,26 @@
-Setup Development Environment
-=============================
+# Setup Development Environment
 
 ## Install the operator-sdk
 
 Follow the instructions in the Quick Start section of
-https://github.com/operator-framework/operator-sdk to check out and
+<https://github.com/operator-framework/operator-sdk> to check out and
 install the operator-sdk tools.
 
 ## With minikube
 
 1. Install and launch minikube
 
-   https://kubernetes.io/docs/setup/minikube/
+   <https://kubernetes.io/docs/setup/minikube/>
 
-3. Create a namespace to host the operator
+1. Create a namespace to host the operator
 
-    ```
+    ```bash
     kubectl create namespace metal3
     ```
 
-4. Install operator-sdk
+1. Install operator-sdk
 
-    ```
+    ```bash
     eval $(go env)
     mkdir -p $GOPATH/src/github.com/metal3-io
     cd $GOPATH/src/github.com/metal3-io
@@ -33,9 +32,9 @@ install the operator-sdk tools.
     kubectl apply -f deploy/crds/metal3_v1alpha1_baremetalhost_crd.yaml
     ```
 
-5. Launch the operator locally
+1. Launch the operator locally
 
-    ```
+    ```bash
     export OPERATOR_NAME=baremetal-operator
     export DEPLOY_KERNEL_URL=http://172.22.0.1/images/ironic-python-agent.kernel
     export DEPLOY_RAMDISK_URL=http://172.22.0.1/images/ironic-python-agent.initramfs
@@ -44,9 +43,9 @@ install the operator-sdk tools.
     operator-sdk up local --namespace=metal3
     ```
 
-6. Create the CR
+1. Create the CR
 
-    ```
+    ```bash
     kubectl apply -f deploy/crds/example-host.yaml -n metal3
     ```
 
@@ -57,7 +56,7 @@ is to be able to have some test data, use the test fixture provisioner
 instead of the real Ironic provisioner by passing `-test-mode` to the
 operator when launching it.
 
-```
+```bash
 operator-sdk up local --operator-flags "-test-mode"
 ```
 
@@ -74,8 +73,9 @@ your environment.
 
 ## Using libvirt VMs with Ironic
 
-In order to use VMs as hosts, they need to be connected to [vbmc](https://docs.openstack.org/tripleo-docs/latest/install/environments/virtualbmc.html) and
-the `bootMACAddress` field needs to be set to the MAC address of the
+In order to use VMs as hosts, they need to be connected to
+[vbmc](https://docs.openstack.org/tripleo-docs/latest/install/environments/virtualbmc.html)
+and the `bootMACAddress` field needs to be set to the MAC address of the
 network interface that will PXE boot.
 
 For example:
@@ -98,7 +98,7 @@ registering a host. It takes as input the name of the `virsh` domain
 and produces as output the basic YAML to register that host properly,
 with the boot MAC address and BMC address filled in.
 
-```
+```bash
 $ go run cmd/make-virt-host/main.go openshift_worker_1
 ---
 apiVersion: v1
@@ -125,16 +125,17 @@ spec:
 
 The output can be passed directly to `oc apply` like this:
 
-```
-$ go run cmd/make-virt-host/main.go openshift_worker_1 | oc apply -f -
+```bash
+go run cmd/make-virt-host/main.go openshift_worker_1 | oc apply -f -
 ```
 
 When the host is a *master*, include the `-consumer` and
 `-consumer-namespace` options to associate the host with the existing
 `Machine` object.
 
-```
-$ go run cmd/make-virt-host/main.go -consumer ostest-master-1 -consumer-namespace openshift-machine-api  openshift_master_1
+```bash
+$ go run cmd/make-virt-host/main.go -consumer ostest-master-1 \
+  -consumer-namespace openshift-machine-api  openshift_master_1
 ---
 apiVersion: v1
 kind: Secret
@@ -166,8 +167,9 @@ spec:
 The `make-bm-worker` tool may be a more convenient way of creating
 YAML definitions for workers than editing the files directly.
 
-```
-$ go run cmd/make-bm-worker/main.go -address 1.2.3.4 -password password -user admin worker-99
+```bash
+$ go run cmd/make-bm-worker/main.go -address 1.2.3.4 \
+  -password password -user admin worker-99
 ---
 apiVersion: v1
 kind: Secret

--- a/docs/publishing-images.md
+++ b/docs/publishing-images.md
@@ -11,7 +11,7 @@ your development fork.
 2. Set up your account on [quay.io](https://quay.io).
 3. Link your repository from step 1 to quay.io by following the
    instructions to "Create New Repository" from
-   https://quay.io/repository/
+   <https://quay.io/repository/>
 
    1. Enter the quay.io repository name. It is good practice to use
       the same name as the github repo.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,7 +6,7 @@ The user running the tests must have permission on the cluster to
 create CRDs. An example role binding setting for configuring the
 "developer" user is provided in test/e2e/role_binding.yaml
 
-```
+```bash
 oc --as system:admin apply -f test/e2e/role_binding.yaml
 ```
 
@@ -14,24 +14,25 @@ oc --as system:admin apply -f test/e2e/role_binding.yaml
 
 Run the tests using the operator-sdk command line tool
 
-```
+```bash
 operator-sdk test local ./test/e2e --namespace operator-test --up-local --debug
 ```
 
 If the setup steps above have already been run, causing "X already
 exists" errors, use the --no-setup option to skip that step in the test.
 
-```
+```bash
 operator-sdk test local ./test/e2e --namespace operator-test --up-local --debug --no-setup
 ```
 
 The tests can also be run via `make`
 
-```
+```bash
 make test
 ```
 
 Run linters test before pushing your commit
-```
+
+```bash
 make lint
 ```

--- a/hack/gofmt.sh
+++ b/hack/gofmt.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -eux
+
+IS_CONTAINER=${IS_CONTAINER:-false}
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+  TOP_DIR="${1:-.}"
+  go fmt "${TOP_DIR}"/pkg/... "${TOP_DIR}"/cmd/...
+else
+  podman run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/workdir:rw,z" \
+    --entrypoint sh \
+    --workdir /workdir \
+    registry.hub.docker.com/library/golang:1.12 \
+    /workdir/hack/gofmt.sh "${@}"
+fi;

--- a/hack/gosec.sh
+++ b/hack/gosec.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -eux
+
+IS_CONTAINER=${IS_CONTAINER:-false}
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+  export XDG_CACHE_HOME="/tmp/.cache"
+  gosec -severity medium --confidence medium -quiet ./...
+else
+  podman run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/go/src/github.com/metal3-io/baremetal-operator:ro,z" \
+    --entrypoint sh \
+    --workdir /go/src/github.com/metal3-io/baremetal-operator \
+    registry.hub.docker.com/securego/gosec:latest \
+    /go/src/github.com/metal3-io/baremetal-operator/hack/gosec.sh "${@}"
+fi;

--- a/hack/govet.sh
+++ b/hack/govet.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eux
+
+IS_CONTAINER=${IS_CONTAINER:-false}
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+  TOP_DIR="${1:-.}"
+  export XDG_CACHE_HOME="/tmp/.cache"
+  go vet "${TOP_DIR}"/pkg/... "${TOP_DIR}"/cmd/...
+else
+  podman run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/go/src/github.com/metal3-io/baremetal-operator:ro,z" \
+    --entrypoint sh \
+    --workdir /go/src/github.com/metal3-io/baremetal-operator \
+    registry.hub.docker.com/library/golang:1.12 \
+    /go/src/github.com/metal3-io/baremetal-operator/hack/govet.sh "${@}"
+fi;

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -eux
+
+IS_CONTAINER=${IS_CONTAINER:-false}
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+  TOP_DIR="${1:-.}"
+  find "${TOP_DIR}" -path ./vendor -prune -o -name '*.md' -exec \
+      mdl --style all --warnings \
+      --rules "MD001,MD002,MD003,MD004,MD005,MD006,MD007,MD009,MD010,MD011,MD012,MD013,MD014,MD018,MD019,MD020,MD021,MD022,MD023,MD024,MD025,MD026,MD027,MD028,MD030,MD031,MD032,MD033,MD034,MD035,MD036,MD037,MD038,MD039,MD040,MD041" \
+      {} \+
+else
+  podman run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/workdir:ro,z" \
+    --entrypoint sh \
+    --workdir /workdir \
+    registry.hub.docker.com/pipelinecomponents/markdownlint:latest \
+    /workdir/hack/markdownlint.sh "${@}"
+fi;
+
+# $ mdl --style all -l
+# MD001 - Header levels should only increment by one level at a time
+# MD002 - First header should be a top level header
+# MD003 - Header style
+# MD004 - Unordered list style
+# MD005 - Inconsistent indentation for list items at the same level
+# MD006 - Consider starting bulleted lists at the beginning of the line
+# MD007 - Unordered list indentation
+# MD009 - Trailing spaces
+# MD010 - Hard tabs
+# MD011 - Reversed link syntax
+# MD012 - Multiple consecutive blank lines
+# MD013 - Line length
+# MD014 - Dollar signs used before commands without showing output
+# MD018 - No space after hash on atx style header
+# MD019 - Multiple spaces after hash on atx style header
+# MD020 - No space inside hashes on closed atx style header
+# MD021 - Multiple spaces inside hashes on closed atx style header
+# MD022 - Headers should be surrounded by blank lines
+# MD023 - Headers must start at the beginning of the line
+# MD024 - Multiple headers with the same content
+# MD025 - Multiple top level headers in the same document
+# MD026 - Trailing punctuation in header
+# MD027 - Multiple spaces after blockquote symbol
+# MD028 - Blank line inside blockquote
+# MD029 - Ordered list item prefix - DISABLED
+# MD030 - Spaces after list markers
+# MD031 - Fenced code blocks should be surrounded by blank lines
+# MD032 - Lists should be surrounded by blank lines
+# MD033 - Inline HTML
+# MD034 - Bare URL used
+# MD035 - Horizontal rule style
+# MD036 - Emphasis used instead of a header
+# MD037 - Spaces inside emphasis markers
+# MD038 - Spaces inside code span elements
+# MD039 - Spaces inside link text
+# MD040 - Fenced code blocks should have a language specified
+# MD041 - First line in file should be a top level header
+# MD046 - Code block style - DISABLED

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -eux
+
+IS_CONTAINER=${IS_CONTAINER:-false}
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+  TOP_DIR="${1:-.}"
+  find "${TOP_DIR}" -path ./vendor -prune -o -name '*.sh' -exec shellcheck -s bash {} \+
+else
+  podman run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/workdir:ro,z" \
+    --entrypoint sh \
+    --workdir /workdir \
+    registry.hub.docker.com/koalaman/shellcheck-alpine:stable \
+    /workdir/hack/shellcheck.sh "${@}"
+fi;

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -eux
+
+IS_CONTAINER=${IS_CONTAINER:-false}
+ARTIFACTS=${ARTIFACTS:-/tmp}
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+  eval "$(go env)"
+  cd "${GOPATH}"/src/github.com/metal3-io/baremetal-operator
+  export XDG_CACHE_HOME="/tmp/.cache"
+  go test -v ./pkg/... ./cmd/... -coverprofile "${ARTIFACTS}"/cover.out
+else
+  podman run --rm \
+    --env IS_CONTAINER=TRUE \
+    --env DEPLOY_KERNEL_URL=http://172.22.0.1/images/ironic-python-agent.kernel \
+    --env DEPLOY_RAMDISK_URL=http://172.22.0.1/images/ironic-python-agent.initramfs \
+    --env IRONIC_ENDPOINT=http://localhost:6385/v1/ \
+    --env IRONIC_INSPECTOR_ENDPOINT=http://localhost:5050/v1/ \
+    --volume "${PWD}:/go/src/github.com/metal3-io/baremetal-operator:ro,z" \
+    --entrypoint sh \
+    --workdir /go/src/github.com/metal3-io/baremetal-operator \
+    registry.hub.docker.com/library/golang:1.12 \
+    /go/src/github.com/metal3-io/baremetal-operator/hack/unit.sh "${@}"
+fi;

--- a/pkg/bmc/access.go
+++ b/pkg/bmc/access.go
@@ -67,7 +67,7 @@ func getParsedURL(address string) (parsedURL *url.URL, err error) {
 		}
 		parsedURL = &url.URL{
 			Scheme: "ipmi",
-			Host: address,
+			Host:   address,
 		}
 	} else {
 		// Successfully parsed the URL

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -230,7 +230,6 @@ func TestParse(t *testing.T) {
 			Hostname: "192.168.122.1",
 			Path:     "",
 		},
-
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			url, err := getParsedURL(tc.Address)
@@ -336,7 +335,6 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:   "redfish",
 			boot:     "pxe",
 		},
-
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			acc, err := NewAccessDetails(tc.input)
@@ -359,13 +357,13 @@ func TestStaticDriverInfo(t *testing.T) {
 
 func TestDriverInfo(t *testing.T) {
 	for _, tc := range []struct {
-		Scenario	string
-		input   	string
-		expects 	map[string]string
+		Scenario string
+		input    string
+		expects  map[string]string
 	}{
 		{
 			Scenario: "ipmi default port",
-			input: "ipmi://192.168.122.1",
+			input:    "ipmi://192.168.122.1",
 			expects: map[string]string{
 				"ipmi_port":     ipmiDefaultPort,
 				"ipmi_password": "",
@@ -376,7 +374,7 @@ func TestDriverInfo(t *testing.T) {
 
 		{
 			Scenario: "idrac",
-			input: "idrac://192.168.122.1",
+			input:    "idrac://192.168.122.1",
 			expects: map[string]string{
 				"drac_address":  "192.168.122.1",
 				"drac_password": "",
@@ -386,7 +384,7 @@ func TestDriverInfo(t *testing.T) {
 
 		{
 			Scenario: "idrac http",
-			input: "idrac+http://192.168.122.1",
+			input:    "idrac+http://192.168.122.1",
 			expects: map[string]string{
 				"drac_address":  "192.168.122.1",
 				"drac_protocol": "http",
@@ -397,7 +395,7 @@ func TestDriverInfo(t *testing.T) {
 
 		{
 			Scenario: "idrac https",
-			input: "idrac+https://192.168.122.1",
+			input:    "idrac+https://192.168.122.1",
 			expects: map[string]string{
 				"drac_address":  "192.168.122.1",
 				"drac_protocol": "https",
@@ -408,7 +406,7 @@ func TestDriverInfo(t *testing.T) {
 
 		{
 			Scenario: "idrac port and path http",
-			input: "idrac://192.168.122.1:8080/foo",
+			input:    "idrac://192.168.122.1:8080/foo",
 			expects: map[string]string{
 				"drac_address":  "192.168.122.1",
 				"drac_port":     "8080",
@@ -420,7 +418,7 @@ func TestDriverInfo(t *testing.T) {
 
 		{
 			Scenario: "idrac ipv6",
-			input: "idrac://[fe80::fc33:62ff:fe83:8a76]/foo",
+			input:    "idrac://[fe80::fc33:62ff:fe83:8a76]/foo",
 			expects: map[string]string{
 				"drac_address":  "fe80::fc33:62ff:fe83:8a76",
 				"drac_path":     "/foo",
@@ -431,7 +429,7 @@ func TestDriverInfo(t *testing.T) {
 
 		{
 			Scenario: "idrac ipv6 port and path",
-			input: "idrac://[fe80::fc33:62ff:fe83:8a76]:8080/foo",
+			input:    "idrac://[fe80::fc33:62ff:fe83:8a76]:8080/foo",
 			expects: map[string]string{
 				"drac_address":  "fe80::fc33:62ff:fe83:8a76",
 				"drac_port":     "8080",
@@ -443,7 +441,7 @@ func TestDriverInfo(t *testing.T) {
 
 		{
 			Scenario: "irmc",
-			input: "irmc://192.168.122.1",
+			input:    "irmc://192.168.122.1",
 			expects: map[string]string{
 				"irmc_address":  "192.168.122.1",
 				"irmc_password": "",
@@ -453,7 +451,7 @@ func TestDriverInfo(t *testing.T) {
 
 		{
 			Scenario: "irmc port",
-			input: "irmc://192.168.122.1:8080",
+			input:    "irmc://192.168.122.1:8080",
 			expects: map[string]string{
 				"irmc_address":  "192.168.122.1",
 				"irmc_port":     "8080",
@@ -464,7 +462,7 @@ func TestDriverInfo(t *testing.T) {
 
 		{
 			Scenario: "irmc ipv6",
-			input: "irmc://[fe80::fc33:62ff:fe83:8a76]",
+			input:    "irmc://[fe80::fc33:62ff:fe83:8a76]",
 			expects: map[string]string{
 				"irmc_address":  "fe80::fc33:62ff:fe83:8a76",
 				"irmc_password": "",
@@ -474,7 +472,7 @@ func TestDriverInfo(t *testing.T) {
 
 		{
 			Scenario: "irmc ipv6 port",
-			input: "irmc://[fe80::fc33:62ff:fe83:8a76]:8080",
+			input:    "irmc://[fe80::fc33:62ff:fe83:8a76]:8080",
 			expects: map[string]string{
 				"irmc_address":  "fe80::fc33:62ff:fe83:8a76",
 				"irmc_port":     "8080",
@@ -485,70 +483,69 @@ func TestDriverInfo(t *testing.T) {
 
 		{
 			Scenario: "Redfish",
-			input: "redfish://192.168.122.1/foo/bar",
+			input:    "redfish://192.168.122.1/foo/bar",
 			expects: map[string]string{
-				"redfish_address":  	"https://192.168.122.1",
-				"redfish_system_id":	"/foo/bar",
-				"redfish_password": "",
-				"redfish_username": "",
+				"redfish_address":   "https://192.168.122.1",
+				"redfish_system_id": "/foo/bar",
+				"redfish_password":  "",
+				"redfish_username":  "",
 			},
 		},
 
 		{
 			Scenario: "Redfish http",
-			input: "redfish+http://192.168.122.1/foo/bar",
+			input:    "redfish+http://192.168.122.1/foo/bar",
 			expects: map[string]string{
-				"redfish_address":  	"http://192.168.122.1",
-				"redfish_system_id":	"/foo/bar",
-				"redfish_password": "",
-				"redfish_username": "",
+				"redfish_address":   "http://192.168.122.1",
+				"redfish_system_id": "/foo/bar",
+				"redfish_password":  "",
+				"redfish_username":  "",
 			},
 		},
 
 		{
 			Scenario: "Redfish https",
-			input: "redfish+https://192.168.122.1/foo/bar",
+			input:    "redfish+https://192.168.122.1/foo/bar",
 			expects: map[string]string{
-				"redfish_address":  	"https://192.168.122.1",
-				"redfish_system_id":	"/foo/bar",
-				"redfish_password": "",
-				"redfish_username": "",
+				"redfish_address":   "https://192.168.122.1",
+				"redfish_system_id": "/foo/bar",
+				"redfish_password":  "",
+				"redfish_username":  "",
 			},
 		},
 
 		{
 			Scenario: "Redfish port",
-			input: "redfish://192.168.122.1:8080/foo/bar",
+			input:    "redfish://192.168.122.1:8080/foo/bar",
 			expects: map[string]string{
-				"redfish_address":  	"https://192.168.122.1:8080",
-				"redfish_system_id":	"/foo/bar",
-				"redfish_password": "",
-				"redfish_username": "",
+				"redfish_address":   "https://192.168.122.1:8080",
+				"redfish_system_id": "/foo/bar",
+				"redfish_password":  "",
+				"redfish_username":  "",
 			},
 		},
 
 		{
 			Scenario: "Redfish ipv6",
-			input: "redfish://[fe80::fc33:62ff:fe83:8a76]/foo/bar",
+			input:    "redfish://[fe80::fc33:62ff:fe83:8a76]/foo/bar",
 			expects: map[string]string{
-				"redfish_address":  	"https://[fe80::fc33:62ff:fe83:8a76]",
-				"redfish_system_id":	"/foo/bar",
-				"redfish_password": "",
-				"redfish_username": "",
+				"redfish_address":   "https://[fe80::fc33:62ff:fe83:8a76]",
+				"redfish_system_id": "/foo/bar",
+				"redfish_password":  "",
+				"redfish_username":  "",
 			},
 		},
 
 		{
 			Scenario: "Redfish ipv6 port",
-			input: "redfish://[fe80::fc33:62ff:fe83:8a76]:8080/foo",
+			input:    "redfish://[fe80::fc33:62ff:fe83:8a76]:8080/foo",
 			expects: map[string]string{
-				"redfish_address":  	"https://[fe80::fc33:62ff:fe83:8a76]:8080",
-				"redfish_system_id":	"/foo",
-				"redfish_password": "",
-				"redfish_username": "",
+				"redfish_address":   "https://[fe80::fc33:62ff:fe83:8a76]:8080",
+				"redfish_system_id": "/foo",
+				"redfish_password":  "",
+				"redfish_username":  "",
 			},
 		},
-
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			acc, err := NewAccessDetails(tc.input)
@@ -571,7 +568,6 @@ func TestDriverInfo(t *testing.T) {
 		})
 	}
 }
-
 
 func TestUnknownType(t *testing.T) {
 	acc, err := NewAccessDetails("foo://192.168.122.1")

--- a/pkg/bmc/idrac.go
+++ b/pkg/bmc/idrac.go
@@ -1,8 +1,8 @@
 package bmc
 
 import (
-	"strings"
 	"net/url"
+	"strings"
 )
 
 func init() {

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -13,16 +13,16 @@ func init() {
 
 func newRedfishAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
 	return &redfishAccessDetails{
-		bmcType:  parsedURL.Scheme,
-		host:     parsedURL.Host,
-		path:     parsedURL.Path,
+		bmcType: parsedURL.Scheme,
+		host:    parsedURL.Host,
+		path:    parsedURL.Path,
 	}, nil
 }
 
 type redfishAccessDetails struct {
-	bmcType  string
-	host     string
-	path     string
+	bmcType string
+	host    string
+	path    string
 }
 
 const redfishDefaultScheme = "https"
@@ -60,10 +60,10 @@ func (a *redfishAccessDetails) DriverInfo(bmcCreds Credentials) map[string]inter
 	redfishAddress = append(redfishAddress, a.host)
 
 	result := map[string]interface{}{
-		"redfish_system_id":     a.path,
-		"redfish_username": bmcCreds.Username,
-		"redfish_password": bmcCreds.Password,
-		"redfish_address": strings.Join(redfishAddress, ""),
+		"redfish_system_id": a.path,
+		"redfish_username":  bmcCreds.Username,
+		"redfish_password":  bmcCreds.Password,
+		"redfish_address":   strings.Join(redfishAddress, ""),
 	}
 
 	return result

--- a/tools/clean_host.sh
+++ b/tools/clean_host.sh
@@ -6,7 +6,7 @@ openstack baremetal node list
 sudo virsh list --all
 oc get baremetalhosts
 
-openstack baremetal node maintenance set openshift-worker-${num}
-openstack baremetal node delete openshift-worker-${num}
-sudo virsh shutdown openshift_worker_${num}
-oc delete baremetalhost openshift-worker-${num}
+openstack baremetal node maintenance set "openshift-worker-${num}"
+openstack baremetal node delete "openshift-worker-${num}"
+sudo virsh shutdown "openshift_worker_${num}"
+oc delete baremetalhost "openshift-worker-${num}"

--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -6,19 +6,19 @@ IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic:master"}
 IRONIC_INSPECTOR_IMAGE=${IRONIC_INSPECTOR_IMAGE:-"quay.io/metal3-io/ironic-inspector"}
 IRONIC_DATA_DIR="$PWD/ironic"
 
-sudo podman pull $IRONIC_IMAGE
-sudo podman pull $IRONIC_INSPECTOR_IMAGE
+sudo podman pull "$IRONIC_IMAGE"
+sudo podman pull "$IRONIC_INSPECTOR_IMAGE"
 
 mkdir -p "$IRONIC_DATA_DIR/html/images"
-pushd $IRONIC_DATA_DIR/html/images
+pushd "$IRONIC_DATA_DIR/html/images"
 
 # The images directory should contain images and an associated md5sum.
 #   - image.qcow2
 #   - image.qcow2.md5sum
 
 for name in ironic ironic-inspector dnsmasq httpd mariadb; do
-    sudo podman ps | grep -w "$name$" && sudo podman kill $name
-    sudo podman ps --all | grep -w "$name$" && sudo podman rm $name -f
+    sudo podman ps | grep -w "$name$" && sudo podman kill "$name"
+    sudo podman ps --all | grep -w "$name$" && sudo podman rm "$name" -f
 done
 
 # Remove existing pod
@@ -27,7 +27,7 @@ if  sudo podman pod exists ironic-pod ; then
 fi
 
 # set password for mariadb
-mariadb_password=$(echo $(date;hostname)|sha256sum |cut -c-20)
+mariadb_password=$(echo "$(date;hostname)"|sha256sum |cut -c-20)
 
 # Create pod
 sudo podman pod create -n ironic-pod
@@ -37,24 +37,24 @@ sudo podman pod create -n ironic-pod
 # See this file for env vars you can set, like IP, DHCP_RANGE, INTERFACE
 # https://github.com/metal3-io/ironic/blob/master/rundnsmasq.sh
 sudo podman run -d --net host --privileged --name dnsmasq  --pod ironic-pod \
-     -v $IRONIC_DATA_DIR:/shared --entrypoint /bin/rundnsmasq ${IRONIC_IMAGE}
+     -v "$IRONIC_DATA_DIR:/shared" --entrypoint /bin/rundnsmasq "${IRONIC_IMAGE}"
 
 # For available env vars, see:
 # https://github.com/metal3-io/ironic/blob/master/runhttpd.sh
 sudo podman run -d --net host --privileged --name httpd --pod ironic-pod \
-     -v $IRONIC_DATA_DIR:/shared --entrypoint /bin/runhttpd ${IRONIC_IMAGE}
+     -v "$IRONIC_DATA_DIR:/shared" --entrypoint /bin/runhttpd "${IRONIC_IMAGE}"
 
 # https://github.com/metal3-io/ironic/blob/master/runmariadb.sh
 sudo podman run -d --net host --privileged --name mariadb --pod ironic-pod \
-     -v $IRONIC_DATA_DIR:/shared --entrypoint /bin/runmariadb \
-     --env MARIADB_PASSWORD=$mariadb_password ${IRONIC_IMAGE}
+     -v "$IRONIC_DATA_DIR:/shared" --entrypoint /bin/runmariadb \
+     --env "MARIADB_PASSWORD=$mariadb_password" "${IRONIC_IMAGE}"
 
 # See this file for additional env vars you may want to pass, like IP and INTERFACE
 # https://github.com/metal3-io/ironic/blob/master/runironic.sh
 sudo podman run -d --net host --privileged --name ironic --pod ironic-pod \
-     --env MARIADB_PASSWORD=$mariadb_password \
-     -v $IRONIC_DATA_DIR:/shared ${IRONIC_IMAGE}
+     --env "MARIADB_PASSWORD=$mariadb_password" \
+     -v "$IRONIC_DATA_DIR:/shared" "${IRONIC_IMAGE}"
 
 # Start Ironic Inspector
 sudo podman run -d --net host --privileged --name ironic-inspector --pod ironic-pod \
-     -v $IRONIC_DATA_DIR:/shared "${IRONIC_INSPECTOR_IMAGE}"
+     -v "$IRONIC_DATA_DIR:/shared" "${IRONIC_INSPECTOR_IMAGE}"


### PR DESCRIPTION
This PR adds a series of scripts in the hack/ directory that can be used to run various tests or linters in containers.  The scripts can be run directly, and they'll launch a container env to run the test in.  When the scripts are run from prow, prow will run this script in a Pod, using the same image that the script is using.

This same pattern is being used in capbm and metal3-dev-env.