### PR TITLE
make the credential tracking fields optional

### DIFF
--- a/deploy/crds/metal3_v1alpha1_baremetalhost_crd.yaml
+++ b/deploy/crds/metal3_v1alpha1_baremetalhost_crd.yaml
@@ -368,8 +368,6 @@ spec:
           - operationalStatus
           - hardwareProfile
           - provisioning
-          - goodCredentials
-          - triedCredentials
           - errorMessage
           - poweredOn
           type: object

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -357,10 +357,10 @@ type BareMetalHostStatus struct {
 	Provisioning ProvisionStatus `json:"provisioning"`
 
 	// the last credentials we were able to validate as working
-	GoodCredentials CredentialsStatus `json:"goodCredentials"`
+	GoodCredentials CredentialsStatus `json:"goodCredentials,omitempty"`
 
 	// the last credentials we sent to the provisioning backend
-	TriedCredentials CredentialsStatus `json:"triedCredentials"`
+	TriedCredentials CredentialsStatus `json:"triedCredentials,omitempty"`
 
 	// the last error message reported by the provisioning subsystem
 	ErrorMessage string `json:"errorMessage"`


### PR DESCRIPTION
The status fields for tracking credentials will be empty when the host
is created, so make them optional.