### PR TITLE
Create an actionResult type to encapsulate the result of a reconcile action

### DIFF
--- a/pkg/controller/baremetalhost/action_result.go
+++ b/pkg/controller/baremetalhost/action_result.go
@@ -68,16 +68,6 @@ type actionFailed struct {
 }
 
 func (r actionFailed) Result() (result reconcile.Result, err error) {
-	// We don't actually want to requeue after a failure, but the Requeue
-	// field is overloaded since it's also used to determine whether the
-	// Host object needs to be written to the database.
-	// Once we've written the Host object, we ignore the Requeue flag when
-	// returning the final response if the Host is in an operational error
-	// state, unless it's needed to transition the Host out of that state
-	// despite the error (e.g. to delete it).
-	// We should be able to eliminate all of these extra layers of meaning
-	// in the future by using the Dirty() method at the top level.
-	result.Requeue = r.dirty
 	return
 }
 

--- a/pkg/controller/baremetalhost/action_result.go
+++ b/pkg/controller/baremetalhost/action_result.go
@@ -1,0 +1,73 @@
+package baremetalhost
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"time"
+)
+
+type actionResult interface {
+	Result() (reconcile.Result, error)
+	Dirty() bool
+}
+
+type actionContinue struct {
+	delay time.Duration
+}
+
+func (r actionContinue) Result() (result reconcile.Result, err error) {
+	result.RequeueAfter = r.delay
+	// Set Requeue true as well as RequeueAfter in case the delay is 0.
+	result.Requeue = true
+	return
+}
+
+func (r actionContinue) Dirty() bool {
+	return true
+}
+
+type actionComplete struct {
+}
+
+func (r actionComplete) Result() (result reconcile.Result, err error) {
+	result.Requeue = true
+	return
+}
+
+func (r actionComplete) Dirty() bool {
+	return true
+}
+
+type actionError struct {
+	err error
+}
+
+func (r actionError) Result() (result reconcile.Result, err error) {
+	err = r.err
+	return
+}
+
+func (r actionError) Dirty() bool {
+	return false
+}
+
+type actionFailed struct {
+	dirty bool
+}
+
+func (r actionFailed) Result() (result reconcile.Result, err error) {
+	// We don't actually want to requeue after a failure, but the Requeue
+	// field is overloaded since it's also used to determine whether the
+	// Host object needs to be written to the database.
+	// Once we've written the Host object, we ignore the Requeue flag when
+	// returning the final response if the Host is in an operational error
+	// state, unless it's needed to transition the Host out of that state
+	// despite the error (e.g. to delete it).
+	// We should be able to eliminate all of these extra layers of meaning
+	// in the future by using the Dirty() method at the top level.
+	result.Requeue = r.dirty
+	return
+}
+
+func (r actionFailed) Dirty() bool {
+	return r.dirty
+}

--- a/pkg/controller/baremetalhost/action_result.go
+++ b/pkg/controller/baremetalhost/action_result.go
@@ -37,6 +37,19 @@ func (r actionComplete) Dirty() bool {
 	return true
 }
 
+type deleteComplete struct {
+	actionComplete
+}
+
+func (r deleteComplete) Result() (result reconcile.Result, err error) {
+	// Don't requeue, since the CR has been successfully deleted
+	return
+}
+
+func (r deleteComplete) Dirty() bool {
+	return false
+}
+
 type actionError struct {
 	err error
 }

--- a/pkg/controller/baremetalhost/action_result.go
+++ b/pkg/controller/baremetalhost/action_result.go
@@ -5,11 +5,16 @@ import (
 	"time"
 )
 
+// actionResult is an interface that encapsulates the result of a Reconcile
+// call, as returned by the action corresponding to the current state.
 type actionResult interface {
 	Result() (reconcile.Result, error)
 	Dirty() bool
 }
 
+// actionContinue is a result indicating that the current action is still
+// in progress, and that the resource should remain in the same provisioning
+// state.
 type actionContinue struct {
 	delay time.Duration
 }
@@ -25,6 +30,8 @@ func (r actionContinue) Dirty() bool {
 	return true
 }
 
+// actionComplete is a result indicating that the current action has completed,
+// and that the resource should transition to the next state.
 type actionComplete struct {
 }
 
@@ -37,6 +44,8 @@ func (r actionComplete) Dirty() bool {
 	return true
 }
 
+// deleteComplete is a result indicating that the deletion action has
+// completed, and that the resource has now been deleted.
 type deleteComplete struct {
 	actionComplete
 }
@@ -50,6 +59,8 @@ func (r deleteComplete) Dirty() bool {
 	return false
 }
 
+// actionError is a result indicating that an error occurred while attempting
+// to advance the current action, and that reconciliation should be retried.
 type actionError struct {
 	err error
 }
@@ -63,6 +74,8 @@ func (r actionError) Dirty() bool {
 	return false
 }
 
+// actionFailed is a result indicating that the current action has failed,
+// and that the resource should be marked as in error.
 type actionFailed struct {
 	dirty bool
 }

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -132,19 +132,6 @@ func (info *reconcileInfo) publishEvent(reason, message string) {
 	info.events = append(info.events, info.host.NewEvent(reason, message))
 }
 
-// Action for one step of reconciliation.
-//
-// - Return a result if the host should be saved and requeued without error.
-// - Return error if there was an error.
-// - Return double nil if nothing was done and processing should continue.
-type reconcileAction func(info *reconcileInfo) (*reconcile.Result, error)
-
-// One step of reconciliation
-type reconcilePhase struct {
-	name   string
-	action reconcileAction
-}
-
 // Reconcile reads that state of the cluster for a BareMetalHost
 // object and makes changes based on the state read and what is in the
 // BareMetalHost.Spec TODO(user): Modify this Reconcile function to

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -248,6 +248,14 @@ func (r *ReconcileBareMetalHost) Reconcile(request reconcile.Request) (result re
 	return result, nil
 }
 
+func recordActionFailure(info *reconcileInfo, eventType string, errorMessage string) actionFailed {
+	dirty := info.host.SetErrorMessage(errorMessage)
+	if dirty {
+		info.publishEvent(eventType, errorMessage)
+	}
+	return actionFailed{dirty}
+}
+
 func (r *ReconcileBareMetalHost) credentialsErrorResult(err error, request reconcile.Request, host *metal3v1alpha1.BareMetalHost) (reconcile.Result, error) {
 	switch err.(type) {
 	// We treat an empty bmc address and empty bmc credentials fields as a

--- a/pkg/controller/baremetalhost/host_state_machine.go
+++ b/pkg/controller/baremetalhost/host_state_machine.go
@@ -223,13 +223,14 @@ func (hsm *hostStateMachine) handleProvisioning(info *reconcileInfo) (result rec
 		return
 	}
 
-	result, err = hsm.Reconciler.actionProvisioning(hsm.Provisioner, info)
-	if hsm.Host.Status.Provisioning.Image.URL != "" {
+	actResult := hsm.Reconciler.actionProvisioning(hsm.Provisioner, info)
+	switch actResult.(type) {
+	case actionComplete:
 		hsm.NextState = metal3v1alpha1.StateProvisioned
-	} else if hsm.Host.HasError() {
+	case actionFailed:
 		hsm.NextState = metal3v1alpha1.StateProvisioningError
 	}
-	return
+	return actResult.Result()
 }
 
 func (hsm *hostStateMachine) handleProvisioningError(info *reconcileInfo) (result reconcile.Result, err error) {

--- a/pkg/controller/baremetalhost/host_state_machine.go
+++ b/pkg/controller/baremetalhost/host_state_machine.go
@@ -140,9 +140,10 @@ func (hsm *hostStateMachine) handleNone(info *reconcileInfo) (result reconcile.R
 }
 
 func (hsm *hostStateMachine) handleRegistering(info *reconcileInfo) (result reconcile.Result, err error) {
-	result, err = hsm.Reconciler.actionRegistering(hsm.Provisioner, info)
+	actResult := hsm.Reconciler.actionRegistering(hsm.Provisioner, info)
 
-	if hsm.Host.Status.GoodCredentials.Match(*info.bmcCredsSecret) {
+	switch actResult.(type) {
+	case actionComplete:
 		// TODO: In future this state should only occur before the host is
 		// registered the first time (though we must always check and
 		// re-register the host regardless of the current state). That will
@@ -160,7 +161,7 @@ func (hsm *hostStateMachine) handleRegistering(info *reconcileInfo) (result reco
 			hsm.NextState = metal3v1alpha1.StateReady
 		}
 	}
-	return
+	return actResult.Result()
 }
 
 func (hsm *hostStateMachine) handleRegistrationError(info *reconcileInfo) (result reconcile.Result, err error) {

--- a/pkg/controller/baremetalhost/host_state_machine.go
+++ b/pkg/controller/baremetalhost/host_state_machine.go
@@ -212,7 +212,7 @@ func (hsm *hostStateMachine) handleReady(info *reconcileInfo) (result reconcile.
 	case hsm.Host.NeedsProvisioning():
 		hsm.NextState = metal3v1alpha1.StateProvisioning
 	default:
-		result, err = hsm.Reconciler.actionManageReady(hsm.Provisioner, info)
+		result, err = hsm.Reconciler.actionManageReady(hsm.Provisioner, info).Result()
 	}
 	return
 }

--- a/pkg/controller/baremetalhost/host_state_machine.go
+++ b/pkg/controller/baremetalhost/host_state_machine.go
@@ -293,6 +293,5 @@ func (hsm *hostStateMachine) handleDeprovisioning(info *reconcileInfo) (result r
 }
 
 func (hsm *hostStateMachine) handleDeleting(info *reconcileInfo) (result reconcile.Result, err error) {
-	result, err = hsm.Reconciler.actionDeleting(hsm.Provisioner, info)
-	return
+	return hsm.Reconciler.actionDeleting(hsm.Provisioner, info).Result()
 }

--- a/pkg/controller/baremetalhost/host_state_machine.go
+++ b/pkg/controller/baremetalhost/host_state_machine.go
@@ -174,11 +174,11 @@ func (hsm *hostStateMachine) handleRegistrationError(info *reconcileInfo) (resul
 }
 
 func (hsm *hostStateMachine) handleInspecting(info *reconcileInfo) (result reconcile.Result, err error) {
-	result, err = hsm.Reconciler.actionInspecting(hsm.Provisioner, info)
-	if hsm.Host.Status.HardwareDetails != nil {
+	actResult := hsm.Reconciler.actionInspecting(hsm.Provisioner, info)
+	if _, complete := actResult.(actionComplete); complete {
 		hsm.NextState = metal3v1alpha1.StateMatchProfile
 	}
-	return
+	return actResult.Result()
 }
 
 func (hsm *hostStateMachine) handleMatchProfile(info *reconcileInfo) (result reconcile.Result, err error) {

--- a/pkg/controller/baremetalhost/host_state_machine.go
+++ b/pkg/controller/baremetalhost/host_state_machine.go
@@ -191,7 +191,7 @@ func (hsm *hostStateMachine) handleMatchProfile(info *reconcileInfo) (result rec
 
 func (hsm *hostStateMachine) handleExternallyProvisioned(info *reconcileInfo) (result reconcile.Result, err error) {
 	if hsm.Host.Spec.ExternallyProvisioned {
-		result, err = hsm.Reconciler.actionManageSteadyState(hsm.Provisioner, info)
+		result, err = hsm.Reconciler.actionManageSteadyState(hsm.Provisioner, info).Result()
 	} else {
 		switch {
 		case hsm.Host.NeedsHardwareInspection():
@@ -248,7 +248,7 @@ func (hsm *hostStateMachine) handleProvisioned(info *reconcileInfo) (result reco
 	if hsm.Host.NeedsDeprovisioning() {
 		hsm.NextState = metal3v1alpha1.StateDeprovisioning
 	} else {
-		result, err = hsm.Reconciler.actionManageSteadyState(hsm.Provisioner, info)
+		result, err = hsm.Reconciler.actionManageSteadyState(hsm.Provisioner, info).Result()
 	}
 	return
 }

--- a/pkg/controller/baremetalhost/host_state_machine.go
+++ b/pkg/controller/baremetalhost/host_state_machine.go
@@ -182,11 +182,11 @@ func (hsm *hostStateMachine) handleInspecting(info *reconcileInfo) (result recon
 }
 
 func (hsm *hostStateMachine) handleMatchProfile(info *reconcileInfo) (result reconcile.Result, err error) {
-	result, err = hsm.Reconciler.actionMatchProfile(hsm.Provisioner, info)
-	if hsm.Host.Status.HardwareProfile != "" {
+	actResult := hsm.Reconciler.actionMatchProfile(hsm.Provisioner, info)
+	if _, complete := actResult.(actionComplete); complete {
 		hsm.NextState = metal3v1alpha1.StateReady
 	}
-	return
+	return actResult.Result()
 }
 
 func (hsm *hostStateMachine) handleExternallyProvisioned(info *reconcileInfo) (result reconcile.Result, err error) {


### PR DESCRIPTION
Add an actionResult interface with several implementations (for complete, in-progress, failed, and error). Each action (corresponding to a state in the state machine) now returns one of these results. An actionResult can produce the reconcile.Result that we ultimately need to return, but also transmit additional data to the intervening code, such as the state machine itself. This has several advantages:

* It removes a lot of duplicated code, some of which was buggy as a result of inconsistent updating.
* It makes the reason for returning a particular result from an action self-documenting.
* In future it will allow the state machine to infer the reason for a result.
* It allows us to stop overloading the meaning of the Requeue field in reconcile.Result.
* It allows us to distinguish new failures from those already recorded in the object's Status.

This PR should be a straight refactor with no behaviour changes.