### PR TITLE
Limit BMO access to only BMH in all namespaces

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: metal3-baremetal-operator
@@ -7,30 +7,24 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
   - configmaps
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
   - secrets
   verbs:
-  - '*'
+  - get
+  - list
 - apiGroups:
   - ""
   resources:
   - namespaces
   verbs:
   - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - '*'
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -41,6 +35,20 @@ rules:
 - apiGroups:
   - metal3.io
   resources:
-  - '*'
+  - baremetalhosts
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - metal3.io
+  resources:
+  - baremetalhosts/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,14 +1,14 @@
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: metal3-baremetal-operator
-  namespace: metal3
 subjects:
 - kind: ServiceAccount
   name: metal3-baremetal-operator
+  namespace: metal3
 - kind: User
   name: developer
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: metal3-baremetal-operator
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This commit addresses two issues.
1. Currently, the BMO has access to all resources in the 'metal3.io' api-groups. Considering principle of least privilege as a good practice, It limits it to only the BareMetalHost resource.
2. It also allows it to see BareMetalHosts in all namespaces, much like the CAPBM controller does.