### PR TITLE
Return "redfish" as type

### DIFF
--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -28,7 +28,7 @@ type redfishAccessDetails struct {
 const redfishDefaultScheme = "https"
 
 func (a *redfishAccessDetails) Type() string {
-	return a.bmcType
+	return "redfish"
 }
 
 // NeedsMAC returns true when the host is going to need a separate


### PR DESCRIPTION
Ironic expects the type to be "redfish"(excluding the application protocol).

Closes: #352