### PR TITLE
Add more privilege to BMO for configmap and secret resources

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -9,16 +9,14 @@ rules:
   resources:
   - configmaps
   verbs:
-  - get
-  - update
+  - "*"
 - apiGroups:
   - ""
   resources:
   - events
   - secrets
   verbs:
-  - get
-  - list
+  - "*"
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
The metal3-baremetal-operator pod does not start due to no able to perform operations on configmap and secret resources. 

This commit gives it the required privileges. 

Co-authored-by: Feruzjon Muyassarov feruzjon.muyassarov@est.tech