### PR TITLE
Add support for redfish virtual media

### DIFF
--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -333,7 +333,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:    "redfish://192.168.122.1",
 			needsMac: true,
 			driver:   "redfish",
-			boot:     "pxe",
+			boot:     "ipxe",
 		},
 
 		{

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -335,6 +335,14 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:   "redfish",
 			boot:     "pxe",
 		},
+
+		{
+			Scenario: "redfish virtual media",
+			input:    "redfish+virtualmedia://192.168.122.1",
+			needsMac: true,
+			driver:   "redfish",
+			boot:     "redfish-virtual-media",
+		},
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			acc, err := NewAccessDetails(tc.input)
@@ -542,6 +550,17 @@ func TestDriverInfo(t *testing.T) {
 			expects: map[string]string{
 				"redfish_address":   "https://[fe80::fc33:62ff:fe83:8a76]:8080",
 				"redfish_system_id": "/foo",
+				"redfish_password":  "",
+				"redfish_username":  "",
+			},
+		},
+
+		{
+			Scenario: "Redfish virtual media",
+			input:    "redfish+virtualmedia://192.168.122.1/foo/bar",
+			expects: map[string]string{
+				"redfish_address":   "https://192.168.122.1",
+				"redfish_system_id": "/foo/bar",
 				"redfish_password":  "",
 				"redfish_username":  "",
 			},

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -87,5 +87,5 @@ func (a *redfishAccessDetails) BootInterface() string {
 		return "redfish-virtual-media"
 	}
 
-	return "pxe"
+	return "ipxe"
 }

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -9,6 +9,7 @@ func init() {
 	registerFactory("redfish", newRedfishAccessDetails)
 	registerFactory("redfish+http", newRedfishAccessDetails)
 	registerFactory("redfish+https", newRedfishAccessDetails)
+	registerFactory("redfish+virtualmedia", newRedfishVirtualMediaAccessDetails)
 }
 
 func newRedfishAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
@@ -19,10 +20,21 @@ func newRedfishAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
 	}, nil
 }
 
+func newRedfishVirtualMediaAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
+	bmcType := strings.Replace(parsedURL.Scheme, "+virtualmedia", "", 1)
+	return &redfishAccessDetails{
+		bmcType:        bmcType,
+		host:           parsedURL.Host,
+		path:           parsedURL.Path,
+		isVirtualMedia: true,
+	}, nil
+}
+
 type redfishAccessDetails struct {
-	bmcType string
-	host    string
-	path    string
+	bmcType        string
+	host           string
+	path           string
+	isVirtualMedia bool
 }
 
 const redfishDefaultScheme = "https"
@@ -71,5 +83,9 @@ func (a *redfishAccessDetails) DriverInfo(bmcCreds Credentials) map[string]inter
 
 // That can be either pxe or redfish-virtual-media
 func (a *redfishAccessDetails) BootInterface() string {
+	if a.isVirtualMedia {
+		return "redfish-virtual-media"
+	}
+
 	return "pxe"
 }


### PR DESCRIPTION
Open questions:

* Are we happy with the `redfish+virtualmedia` prefix?
* Should we add another level to support both SSL and non-SSL schemes? `redfish+virtualmedia+https`?