### PR TITLE
Expose error types through the CRD Status

### DIFF
--- a/deploy/crds/metal3.io_baremetalhosts_crd.yaml
+++ b/deploy/crds/metal3.io_baremetalhosts_crd.yaml
@@ -453,6 +453,11 @@ spec:
               type: object
             operationalStatus:
               description: OperationalStatus holds the status of the host
+              enum:
+              - ""
+              - OK
+              - discovered
+              - error
               type: string
             poweredOn:
               description: indicator for whether or not the host is powered on

--- a/deploy/crds/metal3.io_baremetalhosts_crd.yaml
+++ b/deploy/crds/metal3.io_baremetalhosts_crd.yaml
@@ -204,6 +204,15 @@ spec:
             errorMessage:
               description: the last error message reported by the provisioning subsystem
               type: string
+            errorType:
+              description: ErrorType indicates the type of failure encountered when
+                the OperationalStatus is OperationalStatusError
+              enum:
+              - registration error
+              - inspection error
+              - provisioning error
+              - power management error
+              type: string
             goodCredentials:
               description: the last credentials we were able to validate as working
               properties:

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -388,6 +388,7 @@ type BareMetalHostStatus struct {
 	// after modifying this file
 
 	// OperationalStatus holds the status of the host
+	// +kubebuilder:validation:Enum=,OK,discovered,error
 	OperationalStatus OperationalStatus `json:"operationalStatus"`
 
 	// ErrorType indicates the type of failure encountered when the

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -38,6 +38,26 @@ const (
 	OperationalStatusError OperationalStatus = "error"
 )
 
+// ErrorType indicates the class of problem that has caused the Host resource
+// to enter an error state.
+type ErrorType string
+
+const (
+	// RegistrationError is an error condition occurring when the
+	// controller is unable to connect to the Host's baseboard management
+	// controller.
+	RegistrationError ErrorType = "registration error"
+	// InspectionError is an error condition occurring when an attempt to
+	// obtain hardware details from the Host fails.
+	InspectionError ErrorType = "inspection error"
+	// ProvisioningError is an error condition occuring when the controller
+	// fails to provision or deprovision the Host.
+	ProvisioningError ErrorType = "provisioning error"
+	// PowerManagementError is an error condition occurring when the
+	// controller is unable to modify the power state of the Host.
+	PowerManagementError ErrorType = "power management error"
+)
+
 // ProvisioningState defines the states the provisioner will report
 // the host has having.
 type ProvisioningState string

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types_test.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types_test.go
@@ -15,7 +15,7 @@ func TestHostAvailable(t *testing.T) {
 			Namespace: "myns",
 		},
 	}
-	hostWithError.SetErrorMessage("oops something went wrong")
+	hostWithError.SetErrorMessage(RegistrationError, "oops something went wrong")
 
 	testCases := []struct {
 		Host        BareMetalHost

--- a/pkg/controller/baremetalhost/action_result.go
+++ b/pkg/controller/baremetalhost/action_result.go
@@ -1,6 +1,8 @@
 package baremetalhost
 
 import (
+	metal3 "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
+
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"time"
 )
@@ -77,7 +79,8 @@ func (r actionError) Dirty() bool {
 // actionFailed is a result indicating that the current action has failed,
 // and that the resource should be marked as in error.
 type actionFailed struct {
-	dirty bool
+	dirty     bool
+	ErrorType metal3.ErrorType
 }
 
 func (r actionFailed) Result() (result reconcile.Result, err error) {

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -683,6 +683,10 @@ func (r *ReconcileBareMetalHost) actionManageReady(prov provisioner.Provisioner,
 		return actionContinue{provResult.RequeueAfter}
 	}
 
+	if info.host.NeedsProvisioning() {
+		info.host.ClearError()
+		return actionComplete{}
+	}
 	return r.manageHostPower(prov, info)
 }
 

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -400,7 +400,6 @@ func (r *ReconcileBareMetalHost) actionRegistering(prov provisioner.Provisioner,
 	info.log.Info("response from validate", "provResult", provResult)
 
 	if provResult.ErrorMessage != "" {
-		info.host.Status.Provisioning.State = metal3v1alpha1.StateRegistrationError
 		return recordActionFailure(info, metal3v1alpha1.RegistrationError, provResult.ErrorMessage)
 	}
 
@@ -650,7 +649,6 @@ func (r *ReconcileBareMetalHost) actionManageSteadyState(prov provisioner.Provis
 		return actionError{err}
 	}
 	if provResult.ErrorMessage != "" {
-		info.host.Status.Provisioning.State = metal3v1alpha1.StateRegistrationError
 		return recordActionFailure(info, metal3v1alpha1.RegistrationError, provResult.ErrorMessage)
 	}
 	if provResult.Dirty {
@@ -677,7 +675,6 @@ func (r *ReconcileBareMetalHost) actionManageReady(prov provisioner.Provisioner,
 		return actionError{err}
 	}
 	if provResult.ErrorMessage != "" {
-		info.host.Status.Provisioning.State = metal3v1alpha1.StateRegistrationError
 		return recordActionFailure(info, metal3v1alpha1.RegistrationError, provResult.ErrorMessage)
 	}
 	if provResult.Dirty {

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -584,7 +584,6 @@ func (r *ReconcileBareMetalHost) manageHostPower(prov provisioner.Provisioner, i
 	}
 
 	if provResult.ErrorMessage != "" {
-		info.host.Status.Provisioning.State = metal3v1alpha1.StatePowerManagementError
 		return recordActionFailure(info, metal3v1alpha1.PowerManagementError, provResult.ErrorMessage)
 	}
 
@@ -615,7 +614,6 @@ func (r *ReconcileBareMetalHost) manageHostPower(prov provisioner.Provisioner, i
 	}
 
 	if provResult.ErrorMessage != "" {
-		info.host.Status.Provisioning.State = metal3v1alpha1.StatePowerManagementError
 		return recordActionFailure(info, metal3v1alpha1.PowerManagementError, provResult.ErrorMessage)
 	}
 

--- a/pkg/controller/baremetalhost/host_state_machine.go
+++ b/pkg/controller/baremetalhost/host_state_machine.go
@@ -237,24 +237,25 @@ func (hsm *hostStateMachine) handleExternallyProvisioned(info *reconcileInfo) ac
 }
 
 func (hsm *hostStateMachine) handleReady(info *reconcileInfo) actionResult {
-	switch {
-	case hsm.Host.Spec.ExternallyProvisioned:
+	if hsm.Host.Spec.ExternallyProvisioned {
 		hsm.NextState = metal3v1alpha1.StateExternallyProvisioned
-	case hsm.Host.NeedsProvisioning():
-		hsm.NextState = metal3v1alpha1.StateProvisioning
-	default:
-		actResult := hsm.Reconciler.actionManageReady(hsm.Provisioner, info)
-		if r, f := actResult.(actionFailed); f {
-			switch r.ErrorType {
-			case metal3v1alpha1.PowerManagementError:
-				hsm.NextState = metal3v1alpha1.StatePowerManagementError
-			case metal3v1alpha1.RegistrationError:
-				hsm.NextState = metal3v1alpha1.StateRegistrationError
-			}
-		}
-		return actResult
+		return actionComplete{}
 	}
-	return actionComplete{}
+
+	actResult := hsm.Reconciler.actionManageReady(hsm.Provisioner, info)
+
+	switch r := actResult.(type) {
+	case actionComplete:
+		hsm.NextState = metal3v1alpha1.StateProvisioning
+	case actionFailed:
+		switch r.ErrorType {
+		case metal3v1alpha1.PowerManagementError:
+			hsm.NextState = metal3v1alpha1.StatePowerManagementError
+		case metal3v1alpha1.RegistrationError:
+			hsm.NextState = metal3v1alpha1.StateRegistrationError
+		}
+	}
+	return actResult
 }
 
 func (hsm *hostStateMachine) handleProvisioning(info *reconcileInfo) actionResult {

--- a/pkg/controller/baremetalhost/host_state_machine.go
+++ b/pkg/controller/baremetalhost/host_state_machine.go
@@ -180,6 +180,8 @@ func (hsm *hostStateMachine) handleRegistering(info *reconcileInfo) actionResult
 		default:
 			hsm.NextState = metal3v1alpha1.StateReady
 		}
+	case actionFailed:
+		hsm.NextState = metal3v1alpha1.StateRegistrationError
 	}
 	return actResult
 }
@@ -216,6 +218,8 @@ func (hsm *hostStateMachine) handleExternallyProvisioned(info *reconcileInfo) ac
 			switch r.ErrorType {
 			case metal3v1alpha1.PowerManagementError:
 				hsm.NextState = metal3v1alpha1.StatePowerManagementError
+			case metal3v1alpha1.RegistrationError:
+				hsm.NextState = metal3v1alpha1.StateRegistrationError
 			}
 		}
 		return actResult
@@ -244,6 +248,8 @@ func (hsm *hostStateMachine) handleReady(info *reconcileInfo) actionResult {
 			switch r.ErrorType {
 			case metal3v1alpha1.PowerManagementError:
 				hsm.NextState = metal3v1alpha1.StatePowerManagementError
+			case metal3v1alpha1.RegistrationError:
+				hsm.NextState = metal3v1alpha1.StateRegistrationError
 			}
 		}
 		return actResult
@@ -288,6 +294,8 @@ func (hsm *hostStateMachine) handleProvisioned(info *reconcileInfo) actionResult
 		switch r.ErrorType {
 		case metal3v1alpha1.PowerManagementError:
 			hsm.NextState = metal3v1alpha1.StatePowerManagementError
+		case metal3v1alpha1.RegistrationError:
+			hsm.NextState = metal3v1alpha1.StateRegistrationError
 		}
 	}
 	return actResult


### PR DESCRIPTION
Previously, external consumers (such as the OpenShift UI) could only rely on the provisioning status to determine the cause of an error in a structured way (i.e. without having a lookup table of the possible error strings). This requires us to perform a lot of gymnastics with the provisioning status, and still did not always yield the correct results. This PR adds a well-defined field for determining the type of an error that systems such as UIs can use to direct the user to debugging the relevant thing.