### PR TITLE
Change CRD apiversion to apiextensions.k8s.io/v1

### DIFF
--- a/deploy/crds/metal3.io_baremetalhosts_crd.yaml
+++ b/deploy/crds/metal3.io_baremetalhosts_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: baremetalhosts.metal3.io


### PR DESCRIPTION
This change will update the CRD apiversion from apiextensions.k8s.io/v1beta1 to v1, which is the default since k8s 1.16.
Address #327