### PR TITLE
Revert "Change CRD apiversion to apiextensions.k8s.io/v1"

### DIFF
--- a/deploy/crds/metal3.io_baremetalhosts_crd.yaml
+++ b/deploy/crds/metal3.io_baremetalhosts_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: baremetalhosts.metal3.io


### PR DESCRIPTION
Reverting the CRD version change as this broke the BMH CRD. Some changes to the CRD are required for the version bump and should be tested with /test-v1a1-integration