### PR TITLE
Fix crash when cancelling provisioning

### DIFF
--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -644,11 +644,14 @@ func (host *BareMetalHost) NeedsDeprovisioning() bool {
 	if host.Spec.ExternallyProvisioned {
 		return false
 	}
-	if host.Status.Provisioning.Image.URL == "" {
-		return false
-	}
 	if host.Spec.Image == nil {
 		return true
+	}
+	if host.Spec.Image.URL == "" {
+		return true
+	}
+	if host.Status.Provisioning.Image.URL == "" {
+		return false
 	}
 	if host.Spec.Image.URL != host.Status.Provisioning.Image.URL {
 		return true

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -603,9 +603,6 @@ func (host *BareMetalHost) NeedsHardwareInspection() bool {
 // status and returns true when more work is needed or false
 // otherwise.
 func (host *BareMetalHost) NeedsProvisioning() bool {
-	if host.Spec.ExternallyProvisioned {
-		return false
-	}
 	if !host.Spec.Online {
 		// The host is not supposed to be powered on.
 		return false
@@ -641,9 +638,6 @@ func (host *BareMetalHost) WasProvisioned() bool {
 // NeedsDeprovisioning compares the settings with the provisioning
 // status and returns true when the host should be deprovisioned.
 func (host *BareMetalHost) NeedsDeprovisioning() bool {
-	if host.Spec.ExternallyProvisioned {
-		return false
-	}
 	if host.Spec.Image == nil {
 		return true
 	}

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types_test.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types_test.go
@@ -318,7 +318,7 @@ func TestHostNeedsDeprovisioning(t *testing.T) {
 					Online: true,
 				},
 			},
-			Expected: false,
+			Expected: true,
 		},
 
 		{
@@ -332,7 +332,7 @@ func TestHostNeedsDeprovisioning(t *testing.T) {
 					Online: true,
 				},
 			},
-			Expected: false,
+			Expected: true,
 		},
 
 		{
@@ -443,10 +443,10 @@ func TestHostNeedsDeprovisioning(t *testing.T) {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			actual := tc.Host.NeedsDeprovisioning()
 			if tc.Expected && !actual {
-				t.Error("expected to need provisioning")
+				t.Error("expected to need deprovisioning")
 			}
 			if !tc.Expected && actual {
-				t.Error("did not expect to need provisioning")
+				t.Error("did not expect to need deprovisioning")
 			}
 		})
 	}

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types_test.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types_test.go
@@ -377,24 +377,6 @@ func TestHostNeedsDeprovisioning(t *testing.T) {
 		},
 
 		{
-			Scenario: "externally provisioned",
-			Host: BareMetalHost{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "myhost",
-					Namespace: "myns",
-				},
-				Spec: BareMetalHostSpec{
-					ExternallyProvisioned: true,
-					Image: &Image{
-						URL: "same",
-					},
-					Online: true,
-				},
-			},
-			Expected: false,
-		},
-
-		{
 			Scenario: "removed image",
 			Host: BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
If you cancel provisioning before it has finished, both NeedsProvisioning() and NeedsDeprovisioning() return false because the latter assumes that provisioning has to be complete before the host needs to be deprovisioned.

Because the state machine remembers the state, it tries to continue provisioning (if it ever finished it would move on to deprovisioning, but it doesn't). This results in a crash because the Ironic provisioner assumes (quite reasonably) that the Image is non-null when we are trying to provision.