### PR TITLE
Enable fasttrack for ironic

### DIFF
--- a/deploy/ironic_bmo_configmap.env
+++ b/deploy/ironic_bmo_configmap.env
@@ -6,4 +6,4 @@ DEPLOY_RAMDISK_URL=http://172.22.0.2:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.2:6385/v1/
 IRONIC_INSPECTOR_ENDPOINT=http://172.22.0.2:5050/v1/
 CACHEURL=http://172.22.0.1/images
-IRONIC_FAST_TRACK=false
+IRONIC_FAST_TRACK=true

--- a/deploy/ironic_ci.env
+++ b/deploy/ironic_ci.env
@@ -6,4 +6,4 @@ DEPLOY_RAMDISK_URL=http://172.22.0.1:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.1:6385/v1/
 IRONIC_INSPECTOR_ENDPOINT=http://172.22.0.1:5050/v1/
 CACHEURL=http://172.22.0.1/images
-IRONIC_FAST_TRACK=false
+IRONIC_FAST_TRACK=true


### PR DESCRIPTION
the fix was merged upstream and is in the tripleO package:
https://opendev.org/openstack/ironic/commit/7f1f79ac25e270c3585dd23c042a037431b97718