### PR TITLE
Fix error generating CRDs with operator-sdk v0.12.0

### DIFF
--- a/deploy/crds/metal3.io_baremetalhosts_crd.yaml
+++ b/deploy/crds/metal3.io_baremetalhosts_crd.yaml
@@ -470,6 +470,7 @@ spec:
             operationalStatus:
               description: OperationalStatus holds the status of the host
               enum:
+              - ""
               - OK
               - discovered
               - error

--- a/deploy/crds/metal3.io_baremetalhosts_crd.yaml
+++ b/deploy/crds/metal3.io_baremetalhosts_crd.yaml
@@ -470,7 +470,6 @@ spec:
             operationalStatus:
               description: OperationalStatus holds the status of the host
               enum:
-              - ""
               - OK
               - discovered
               - error

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -390,12 +390,12 @@ type BareMetalHostStatus struct {
 	// after modifying this file
 
 	// OperationalStatus holds the status of the host
-	// +kubebuilder:validation:Enum=,OK,discovered,error
+	// +kubebuilder:validation:Enum=OK;discovered;error
 	OperationalStatus OperationalStatus `json:"operationalStatus"`
 
 	// ErrorType indicates the type of failure encountered when the
 	// OperationalStatus is OperationalStatusError
-	// +kubebuilder:validation:Enum=registration error,inspection error,provisioning error,power management error
+	// +kubebuilder:validation:Enum=registration error;inspection error;provisioning error;power management error
 	ErrorType ErrorType `json:"errorType,omitempty"`
 
 	// LastUpdated identifies when this status was last observed.

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -390,7 +390,7 @@ type BareMetalHostStatus struct {
 	// after modifying this file
 
 	// OperationalStatus holds the status of the host
-	// +kubebuilder:validation:Enum=OK;discovered;error
+	// +kubebuilder:validation:Enum="";OK;discovered;error
 	OperationalStatus OperationalStatus `json:"operationalStatus"`
 
 	// ErrorType indicates the type of failure encountered when the


### PR DESCRIPTION
Using operator-sdk v0.12.0, CRD generation part fails with an unspecified error. Digging further reveals a slight format change in validation pragma for enums (';' replaces ',').

Address #360 