### PR TITLE
Makefile updates for docker build and push, and release manifests generation.

### DIFF
--- a/deploy/manager_image_patch.yaml
+++ b/deploy/manager_image_patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metal3-baremetal-operator
+spec:
+  template:
+    spec:
+      containers:
+      # Change the value of image field below to your controller image URL
+      - image: gcr.io/arvinders-1st-project/baremetal-operator-amd64:dev
+        name: baremetal-operator

--- a/deploy/manager_pull_policy.yaml
+++ b/deploy/manager_pull_policy.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metal3-baremetal-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: baremetal-operator
+        imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Changes introduced: 
 * Docker build and push commands that align with CAPI model.
 * Release manifests generation.

This is the first PR that brings us closer to having release model similar to that of CAPI. See Issue: https://github.com/metal3-io/baremetal-operator/issues/404