### PR TITLE
InvolvedObject APIVersion is expected to be SchemeGroupVersion string

### DIFF
--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -689,7 +689,7 @@ func (host *BareMetalHost) NewEvent(reason, message string) corev1.Event {
 			Namespace:  host.Namespace,
 			Name:       host.Name,
 			UID:        host.UID,
-			APIVersion: SchemeGroupVersion.Version,
+			APIVersion: SchemeGroupVersion.String(),
 		},
 		Reason:  reason,
 		Message: message,


### PR DESCRIPTION
This propagates in UI which has broken (unclickable) links for bare metal host events. Since the APIGroup is not separately included event's InvolvedObject, it is expected to be included in APIVersion.

This change adds whole GroupVersion string as InvolvedObject's APIVersion.