### PR TITLE
add ilo5-redfish alias

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -41,6 +41,10 @@ mainly, but not only, provisioning details.
       * `irmc://<host>:<port>`, where `<port>` is optional if using the default.
     * HUAWEI ibmc
       * `ibmc://<host>:<port>` (or `ibmc+http://<host>:<port>` to disable TLS)
+    * iLO 5 Redfish
+      * `ilo5-redfish://` (or `ilo5-redfish+http://` to disable TLS), the hostname
+        or IP address, and the path to the system ID are required,
+        for example `ilo5-redfish://myhost.example/redfish/v1/Systems/MySystemExample`
     * Redfish
       * `redfish://` (or `redfish+http://` to disable TLS)
       * `redfish-virtualmedia://` to use virtual media instead of PXE

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -9,6 +9,7 @@ func init() {
 	schemes := []string{"http", "https"}
 	registerFactory("redfish", newRedfishAccessDetails, schemes)
 	registerFactory("redfish-virtualmedia", newRedfishVirtualMediaAccessDetails, schemes)
+	registerFactory("ilo5-redfish", newRedfishAccessDetails, schemes)
 	registerFactory("ilo5-virtualmedia", newRedfishVirtualMediaAccessDetails, schemes)
 	registerFactory("idrac-virtualmedia", newRedfishiDracVirtualMediaAccessDetails, schemes)
 }


### PR DESCRIPTION
The "redfish" type implies generic support for the Redfish
protocol. If a hardware vendor ever needs customization, we will want
an alias in place. This patch adds such an alias for iLO 5 gear,
without adding any customization.