### PR TITLE
Attempt to power off BareMetalHost before delete

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -446,6 +446,9 @@ func (r *BareMetalHostReconciler) actionDeleting(prov provisioner.Provisioner, i
 	if provResult.Dirty {
 		return actionContinue{provResult.RequeueAfter}
 	}
+	if provResult.ErrorMessage != "" {
+		return recordActionFailure(info, metal3v1alpha1.PowerManagementError, provResult.ErrorMessage)
+	}
 
 	// Remove finalizer to allow deletion
 	info.host.Finalizers = utils.FilterStringFromList(

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -55,6 +55,10 @@ const (
 	powerOff     = "power off"
 	softPowerOff = "soft power off"
 	powerNone    = "None"
+
+	// Maximum number of times node Power off would be retried before
+	// it would be deleted.
+	maxPowerOffRetryCount = 3
 )
 
 var bootModeCapabilities = map[metal3v1alpha1.BootMode]string{
@@ -1611,6 +1615,20 @@ func (p *ironicProvisioner) Delete() (result provisioner.Result, err error) {
 		// Nova.
 		p.log.Info("setting host maintenance flag to force image delete")
 		return p.setMaintenanceFlag(ironicNode, true)
+	}
+
+	if ironicNode.PowerState == powerOn && p.host.Status.ErrorCount <= maxPowerOffRetryCount {
+		p.log.Info("host ready to be powered off")
+		_, err := p.hardPowerOff()
+		if err != nil {
+			switch err.(type) {
+			case HostLockedError:
+				p.log.Info("could not power off host, busy")
+				return retryAfterDelay(powerRequeueDelay)
+			default:
+				return operationFailed("failed to power off host")
+			}
+		}
 	}
 
 	p.log.Info("host ready to be removed")


### PR DESCRIPTION
When a BareMetalHost is deleted, power it off before performing
the delete operation.
Fixes #410