### PR TITLE
Add available ProvisioningState  , so CAPBM is aware of this state 

### DIFF
--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -80,6 +80,9 @@ const (
 	// StateReady means the host can be consumed
 	StateReady ProvisioningState = "ready"
 
+	// StateAvailable means the host can be consumed
+	StateAvailable ProvisioningState = "available"
+
 	// StateProvisioning means we are writing an image to the host's
 	// disk(s)
 	StateProvisioning ProvisioningState = "provisioning"


### PR DESCRIPTION
This is step 1 adding *stateAvailabel*  ProvisioningState to BMO, 
 Required  for the completion of  PR https://github.com/metal3-io/baremetal-operator/pull/340
Once this is merged the new bmh.StateAvailable will be available for CAPBM
step 2. Create a pull request for CAPBM to add stateAvailabel to case statement
[code to change](https://github.com/metal3-io/cluster-api-provider-baremetal/blob/7164d28f2e9c875ea7180eb8f315de322cf45512/baremetal/baremetalmachine_manager.go#L391)
Step 3. Merger BMO PR 340
Step 4 caret a PR to remove *stateReady* ProvisioningState from CAPBM