### PR TITLE
Fix typo in e2e testing in certificate test

### DIFF
--- a/test/e2e/baremetal_test.go
+++ b/test/e2e/baremetal_test.go
@@ -187,7 +187,7 @@ func TestManageHardwareDetails(t *testing.T) {
 			BMC: metal3v1alpha1.BMCDetails{
 				Address:                        "ipmi://192.168.122.1:6233",
 				CredentialsName:                "bmc-creds-valid",
-				disableCertificateVerification: true,
+				DisableCertificateVerification: true,
 			},
 		})
 


### PR DESCRIPTION
There is a typo for DisableCertificateVerification that
causes the e2e tests to fail.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>