### PR TITLE
Re-enable Ironic Fast Track

### DIFF
--- a/deploy/default/ironic_bmo_configmap.env
+++ b/deploy/default/ironic_bmo_configmap.env
@@ -6,4 +6,4 @@ DEPLOY_RAMDISK_URL=http://172.22.0.2:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.2:6385/v1/
 IRONIC_INSPECTOR_ENDPOINT=http://172.22.0.2:5050/v1/
 CACHEURL=http://172.22.0.1/images
-IRONIC_FAST_TRACK=false
+IRONIC_FAST_TRACK=true

--- a/deploy/ironic_ci.env
+++ b/deploy/ironic_ci.env
@@ -8,4 +8,4 @@ DEPLOY_RAMDISK_URL=http://172.22.0.2:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.2:6385/v1/
 IRONIC_INSPECTOR_ENDPOINT=http://172.22.0.2:5050/v1/
 CACHEURL=http://172.22.0.1/images
-IRONIC_FAST_TRACK=false
+IRONIC_FAST_TRACK=true

--- a/ironic-deployment/default/ironic_bmo_configmap.env
+++ b/ironic-deployment/default/ironic_bmo_configmap.env
@@ -6,4 +6,4 @@ DEPLOY_RAMDISK_URL=http://172.22.0.2:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.2:6385/v1/
 IRONIC_INSPECTOR_ENDPOINT=http://172.22.0.2:5050/v1/
 CACHEURL=http://172.22.0.1/images
-IRONIC_FAST_TRACK=false
+IRONIC_FAST_TRACK=true

--- a/ironic-deployment/keepalived/ironic_bmo_configmap.env
+++ b/ironic-deployment/keepalived/ironic_bmo_configmap.env
@@ -8,4 +8,4 @@ DEPLOY_RAMDISK_URL=http://172.22.0.2:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.2:6385/v1/
 IRONIC_INSPECTOR_ENDPOINT=http://172.22.0.2:5050/v1/
 CACHEURL=http://172.22.0.1/images
-IRONIC_FAST_TRACK=false
+IRONIC_FAST_TRACK=true


### PR DESCRIPTION
This PR re-enables  Ironic Fast track.  It was disabled previously due to bug. 