### PR TITLE
Add a Pause annotation for pivoting

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -7,6 +7,12 @@ defines a physical host and its properties. The **BareMetalHost** embeds
 two well differentiated sections, the bare metal host specification
 and its current status.
 
+### Pausing reconciliation
+
+It is possible to pause the reconciliation of a BareMetalHost object by adding
+an annotation `baremetalhost.metal3.io/paused`. The value of the annotation does
+not matter. Removing the annotation will enable the reconciliation again.
+
 ### BareMetalHost spec
 
 The *BareMetalHost's* *spec* defines the desire state of the host. It contains

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -18,6 +18,10 @@ const (
 	// hosts to block delete operations until the physical host can be
 	// deprovisioned.
 	BareMetalHostFinalizer string = "baremetalhost.metal3.io"
+
+	// PausedAnnotation is the annotation that pauses the reconciliation (triggers
+	// an immediate requeue)
+	PausedAnnotation = "baremetalhost.metal3.io/paused"
 )
 
 // OperationalStatus represents the state of the host

--- a/pkg/controller/baremetalhost/baremetalhost_controller_test.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller_test.go
@@ -184,6 +184,25 @@ func waitForProvisioningState(t *testing.T, r *ReconcileBareMetalHost, host *met
 	)
 }
 
+// TestPause ensures that the requeue happens when the pause annotation is there.
+func TestPause(t *testing.T) {
+	host := newDefaultHost(t)
+	host.Annotations = map[string]string{
+		metal3v1alpha1.PausedAnnotation: "true",
+	}
+	r := newTestReconciler(host)
+
+	tryReconcile(t, r, host,
+		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
+			if result.Requeue && result.RequeueAfter == pauseRetryDelay &&
+				len(host.Finalizers) == 0 {
+				return true
+			}
+			return false
+		},
+	)
+}
+
 // TestAddFinalizers ensures that the finalizers for the host are
 // updated as part of reconciling it.
 func TestAddFinalizers(t *testing.T) {


### PR DESCRIPTION
When pivoting, we need a way to temporarily disable the reconciliation of objects while we are moving them. The BMH status needs to be moved along with the spec, and that is a two-step operation (create the BMH and update the status). If the reconciliation was happening in the meantime, this could trigger an introspection of a deployed host, hence messing up the host. Adding the annotation on the BMH would prevent such issues.