### PR TITLE
add local-hostname in ironic metadata

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -992,6 +992,8 @@ func (p *ironicProvisioner) Provision(getUserData provisioner.UserDataSource) (r
 					"uuid":             string(p.host.ObjectMeta.UID),
 					"metal3-namespace": p.host.ObjectMeta.Namespace,
 					"metal3-name":      p.host.ObjectMeta.Name,
+					"local-hostname":   p.host.ObjectMeta.Name,
+					"local_hostname":   p.host.ObjectMeta.Name,
 				},
 			}
 			if err != nil {


### PR DESCRIPTION
This is needed as a temporary fix for #439 

This adds a metadata key "local-hostname" set to the BMH name passed as metadata by Ironic.