### PR TITLE
Fix dep check in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ help:
 	@echo "  DEBUG            -- debug flag, if any ($(DEBUG))"
 
 .PHONY: test
-test: generate unit lint dep-check
+test: generate unit lint dep
 
 .PHONY: generate
 generate:


### PR DESCRIPTION
There is no `dep-check` target in the Makefile. This PR changes the target to `dep`