### PR TITLE
Add metadata to BMH and pass it to ironic

### DIFF
--- a/deploy/crds/metal3.io_baremetalhosts_crd.yaml
+++ b/deploy/crds/metal3.io_baremetalhosts_crd.yaml
@@ -156,6 +156,19 @@ spec:
               - checksum
               - url
               type: object
+            metaData:
+              description: MetaData holds the reference to the Secret containing metadata
+                which is passed to Config Drive
+              properties:
+                name:
+                  description: Name is unique within a namespace to reference a secret
+                    resource.
+                  type: string
+                namespace:
+                  description: Namespace defines the space within which the secret
+                    name must be unique.
+                  type: string
+              type: object
             networkData:
               description: NetworkData holds the reference to the Secret containing
                 content of network_data.json which is passed to Config Drive

--- a/docs/api.md
+++ b/docs/api.md
@@ -67,6 +67,10 @@ mainly, but not only, provisioning details.
   and its namespace, so it can be attached to the host before it boots
   for configuring different aspects of the OS (like networking, storage, ...).
 
+* *metaData* -- A reference to the Secret containing the cloudinit metadata
+  and its namespace, so it can be attached to the host before it boots to pass
+  metadata.
+
 * *networkData* -- A reference to the Secret containing the network
   configuration data (e.g. network\_data.json) and its namespace, so it can be
   attached to the host before it boots to set network up

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -183,6 +183,10 @@ type BareMetalHostSpec struct {
 	// of network_data.json which is passed to Config Drive
 	NetworkData *corev1.SecretReference `json:"networkData,omitempty"`
 
+	// MetaData holds the reference to the Secret containing metadata
+	// which is passed to Config Drive
+	MetaData *corev1.SecretReference `json:"metaData,omitempty"`
+
 	// Description is a human-entered text used to help identify the host
 	Description string `json:"description,omitempty"`
 

--- a/pkg/controller/baremetalhost/host_config_data.go
+++ b/pkg/controller/baremetalhost/host_config_data.go
@@ -67,6 +67,20 @@ func (hcd *hostConfigData) UserData() (string, error) {
 
 }
 
+// metaData get Operating System metadata
+func (hcd *hostConfigData) MetaData() (string, error) {
+	if hcd.host.Spec.MetaData == nil {
+		hcd.log.Info("MetaData is not set return empty string")
+		return "", nil
+	}
+	return hcd.getSecretData(
+		hcd.host.Spec.MetaData.Name,
+		hcd.host.Spec.MetaData.Namespace,
+		"metaData",
+	)
+
+}
+
 // NetworkData get network configuration
 func (hcd *hostConfigData) NetworkData() (string, error) {
 	if hcd.host.Spec.NetworkData == nil {

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -24,11 +24,13 @@ type HostConfigData interface {
 	// data for a host being provisioned.
 	UserData() (string, error)
 
-	// NetworkData is the interface for a function to retrieve netwok
+	// NetworkData is the interface for a function to retrieve network
 	// configuration for a host.
 	NetworkData() (string, error)
 
-	// TODO add MetaDataSource method
+	// MetaData is the interface for a function to retrieve metadata
+	// configuration for a host.
+	MetaData() (string, error)
 }
 
 // Provisioner holds the state information for talking to the


### PR DESCRIPTION
This PR adds a feature to pass metadata to Ironic the same way we pass userdata or network data

/cc @dhellmann 
/cc @dukov 
/cc @zaneb 

/hold to give time for review