### PR TITLE
Default user and network data namespace to BMH namespace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
 	k8s.io/utils v0.0.0-20191030222137-2b95a09bc58d // indirect
 	sigs.k8s.io/controller-runtime v0.4.0
+	sigs.k8s.io/yaml v1.1.0
 )
 
 // Pinned to kubernetes-1.16.2

--- a/pkg/controller/baremetalhost/host_config_data.go
+++ b/pkg/controller/baremetalhost/host_config_data.go
@@ -59,9 +59,13 @@ func (hcd *hostConfigData) UserData() (string, error) {
 		hcd.log.Info("UserData is not set return empty string")
 		return "", nil
 	}
+	namespace := hcd.host.Spec.UserData.Namespace
+	if namespace == "" {
+		namespace = hcd.host.Namespace
+	}
 	return hcd.getSecretData(
 		hcd.host.Spec.UserData.Name,
-		hcd.host.Spec.UserData.Namespace,
+		namespace,
 		"userData",
 	)
 
@@ -73,9 +77,13 @@ func (hcd *hostConfigData) NetworkData() (string, error) {
 		hcd.log.Info("NetworkData is not set returning epmty(nil) data")
 		return "", nil
 	}
+	namespace := hcd.host.Spec.NetworkData.Namespace
+	if namespace == "" {
+		namespace = hcd.host.Namespace
+	}
 	return hcd.getSecretData(
 		hcd.host.Spec.NetworkData.Name,
-		hcd.host.Spec.NetworkData.Namespace,
+		namespace,
 		"networkData",
 	)
 }

--- a/pkg/controller/baremetalhost/host_config_data_test.go
+++ b/pkg/controller/baremetalhost/host_config_data_test.go
@@ -46,6 +46,24 @@ func TestProvisionWithHostConfig(t *testing.T) {
 			ErrNetworkData:      false,
 		},
 		{
+			Scenario: "host with user data only, no namespace",
+			Host: newHost("host-user-data",
+				&metal3v1alpha1.BareMetalHostSpec{
+					BMC: metal3v1alpha1.BMCDetails{
+						Address:         "ipmi://192.168.122.1:6233",
+						CredentialsName: defaultSecretName,
+					},
+					UserData: &corev1.SecretReference{
+						Name: "user-data",
+					},
+				}),
+			UserDataSecret:      newSecret("user-data", map[string]string{"userData": "somedata"}),
+			ExpectedUserData:    base64.StdEncoding.EncodeToString([]byte("somedata")),
+			ErrUserData:         false,
+			ExpectedNetworkData: "",
+			ErrNetworkData:      false,
+		},
+		{
 			Scenario: "host with network data only",
 			Host: newHost("host-user-data",
 				&metal3v1alpha1.BareMetalHostSpec{
@@ -56,6 +74,24 @@ func TestProvisionWithHostConfig(t *testing.T) {
 					NetworkData: &corev1.SecretReference{
 						Name:      "net-data",
 						Namespace: namespace,
+					},
+				}),
+			NetworkDataSecret:   newSecret("net-data", map[string]string{"networkData": "key: value"}),
+			ExpectedUserData:    "",
+			ErrUserData:         false,
+			ExpectedNetworkData: base64.StdEncoding.EncodeToString([]byte("key: value")),
+			ErrNetworkData:      false,
+		},
+		{
+			Scenario: "host with network data only, no namespace",
+			Host: newHost("host-user-data",
+				&metal3v1alpha1.BareMetalHostSpec{
+					BMC: metal3v1alpha1.BMCDetails{
+						Address:         "ipmi://192.168.122.1:6233",
+						CredentialsName: defaultSecretName,
+					},
+					NetworkData: &corev1.SecretReference{
+						Name: "net-data",
 					},
 				}),
 			NetworkDataSecret:   newSecret("net-data", map[string]string{"networkData": "key: value"}),


### PR DESCRIPTION
Empty namespaces in userdata and networkdata object references
now default to the baremetalhost namespace

Fixes #462 