### PR TITLE
Select boot mode automatically

### DIFF
--- a/deploy/crds/metal3.io_baremetalhosts_crd.yaml
+++ b/deploy/crds/metal3.io_baremetalhosts_crd.yaml
@@ -505,6 +505,13 @@ spec:
                   description: The machine's UUID from the underlying provisioning
                     tool
                   type: string
+                bootMode:
+                  description: BootMode indicates the boot mode used to provision
+                    the node
+                  enum:
+                  - UEFI
+                  - legacy
+                  type: string
                 image:
                   description: Image holds the details of the last image successfully
                     provisioned to the host.

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -446,6 +446,15 @@ type BareMetalHostStatus struct {
 	OperationHistory OperationHistory `json:"operationHistory"`
 }
 
+// BootMode is the boot mode of the system
+type BootMode string
+
+// Allowed boot mode from metal3
+const (
+	UEFI   BootMode = "UEFI"
+	Legacy BootMode = "legacy"
+)
+
 // ProvisionStatus holds the state information for a single target.
 type ProvisionStatus struct {
 	// An indiciator for what the provisioner is doing with the host.
@@ -457,6 +466,10 @@ type ProvisionStatus struct {
 	// Image holds the details of the last image successfully
 	// provisioned to the host.
 	Image Image `json:"image,omitempty"`
+
+	// BootMode indicates the boot mode used to provision the node
+	// +kubebuilder:validation:Enum=UEFI;legacy
+	BootMode BootMode `json:"bootMode,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/bmc/access.go
+++ b/pkg/bmc/access.go
@@ -44,6 +44,10 @@ type AccessDetails interface {
 	// (such as the kernel and ramdisk locations).
 	DriverInfo(bmcCreds Credentials) map[string]interface{}
 
+	// NodeProperties returns properties of a host, including the boot
+	// mode. This will depend on each interface
+	NodeProperties() map[string]interface{}
+
 	// Boot interface to set
 	BootInterface() string
 

--- a/pkg/bmc/idrac.go
+++ b/pkg/bmc/idrac.go
@@ -3,6 +3,8 @@ package bmc
 import (
 	"net/url"
 	"strings"
+
+	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
 )
 
 func init() {
@@ -73,6 +75,16 @@ func (a *iDracAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfa
 		result["drac_path"] = a.path
 	}
 
+	return result
+}
+
+// NodeProperties returns a data structure to return details of
+// the host, including the boot mode. This will be used later to
+// instruct ironic to use specific boot mode
+func (a *iDracAccessDetails) NodeProperties() map[string]interface{} {
+	result := map[string]interface{}{
+		"boot_mode": metal3v1alpha1.UEFI,
+	}
 	return result
 }
 

--- a/pkg/bmc/ipmi.go
+++ b/pkg/bmc/ipmi.go
@@ -2,6 +2,8 @@ package bmc
 
 import (
 	"net/url"
+
+	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
 )
 
 func init() {
@@ -69,6 +71,16 @@ func (a *ipmiAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 	}
 	if a.portNum == "" {
 		result["ipmi_port"] = ipmiDefaultPort
+	}
+	return result
+}
+
+// NodeProperties returns a data structure to return details of
+// the host, including the boot mode. This will be used later to
+// instruct ironic to use specific boot mode
+func (a *ipmiAccessDetails) NodeProperties() map[string]interface{} {
+	result := map[string]interface{}{
+		"boot_mode": metal3v1alpha1.Legacy,
 	}
 	return result
 }

--- a/pkg/bmc/irmc.go
+++ b/pkg/bmc/irmc.go
@@ -2,6 +2,8 @@ package bmc
 
 import (
 	"net/url"
+
+	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
 )
 
 func init() {
@@ -62,6 +64,16 @@ func (a *iRMCAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 		result["irmc_port"] = a.portNum
 	}
 
+	return result
+}
+
+// NodeProperties returns a data structure to return details of
+// the host, including the boot mode. This will be used later to
+// instruct ironic to use specific boot mode
+func (a *iRMCAccessDetails) NodeProperties() map[string]interface{} {
+	result := map[string]interface{}{
+		"boot_mode": metal3v1alpha1.UEFI,
+	}
 	return result
 }
 

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -3,6 +3,8 @@ package bmc
 import (
 	"net/url"
 	"strings"
+
+	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
 )
 
 func init() {
@@ -103,6 +105,16 @@ func (a *redfishAccessDetails) DriverInfo(bmcCreds Credentials) map[string]inter
 		result["redfish_verify_ca"] = false
 	}
 
+	return result
+}
+
+// NodeProperties returns a data structure to return details of
+// the host, including the boot mode. This will be used later to
+// instruct ironic to use specific boot mode
+func (a *redfishAccessDetails) NodeProperties() map[string]interface{} {
+	result := map[string]interface{}{
+		"boot_mode": metal3v1alpha1.UEFI,
+	}
 	return result
 }
 


### PR DESCRIPTION
Create a new method for AccessDetails interface, that
will hold the boot_mode property. This property will
be automatically set, depending on bmc type.
Then use this method on ironic provisioner, to
automatically set the boot mode capability for
the host.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>