### PR TITLE
Fix make test phony to remove dep-check call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ help:
 	@echo "  DEBUG            -- debug flag, if any ($(DEBUG))"
 
 .PHONY: test
-test: generate unit lint dep-check
+test: generate unit lint
 
 .PHONY: generate
 generate:
@@ -97,10 +97,6 @@ e2e-local:
 		--up-local $(SETUP) \
 		$(DEBUG) --go-test-flags "$(GO_TEST_FLAGS)"
 
-.PHONY: dep
-dep:
-	dep ensure -v
-
 .PHONY: run
 run:
 	operator-sdk up local \
@@ -129,10 +125,3 @@ deploy:
 	cd deploy && kustomize edit set namespace $(RUN_NAMESPACE) && cd ..
 	kustomize build deploy | kubectl apply -f -
 
-.PHONY: dep-status
-dep-status:
-	dep status
-
-.PHONY: dep-prune
-dep-prune:
-	dep prune -v


### PR DESCRIPTION
The `make test`  still calls for dep-check which was removed previously. The call to dep-check in Makefile was accidentally left-behind. 