### PR TITLE
Fix Ironic fast-track for local BMO deployment

### DIFF
--- a/deploy/ironic_ci.env
+++ b/deploy/ironic_ci.env
@@ -6,4 +6,4 @@ DEPLOY_RAMDISK_URL=http://172.22.0.1:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.1:6385/v1/
 IRONIC_INSPECTOR_ENDPOINT=http://172.22.0.1:5050/v1/
 CACHEURL=http://172.22.0.1/images
-IRONIC_FAST_TRACK=true
+IRONIC_FAST_TRACK=false


### PR DESCRIPTION
Ironic fast-track is not working properly yet. Setting it to false for local BMO deployment. 