### PR TITLE
Makefile: update operator-sdk command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,14 +99,14 @@ e2e-local:
 
 .PHONY: run
 run:
-	operator-sdk up local \
+	operator-sdk run --local \
 		--go-ldflags=$(LDFLAGS) \
 		--namespace=$(RUN_NAMESPACE) \
 		--operator-flags="-dev"
 
 .PHONY: demo
 demo:
-	operator-sdk up local \
+	operator-sdk run --local \
 		--go-ldflags=$(LDFLAGS) \
 		--namespace=$(RUN_NAMESPACE) \
 		--operator-flags="-dev -demo-mode"


### PR DESCRIPTION
operator-sdk  `up local` is now  `run --local` since v0.15.0.

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>