### PR TITLE
document openapi-gen dependency

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -6,6 +6,14 @@ Follow the instructions in the Quick Start section of
 <https://github.com/operator-framework/operator-sdk> to check out and
 install the operator-sdk tools.
 
+## Install openapi-gen
+
+Install the kube-api version of [openapi-gen](https://github.com/kubernetes/kube-openapi)
+
+```bash
+go get k8s.io/kube-openapi/cmd/openapi-gen
+```
+
 ## With minikube
 
 1. Install and launch minikube


### PR DESCRIPTION
Since we updated to operator-sdk 0.17.0 developers need to install
openapi-gen separately.