### PR TITLE
update linter rules and test dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,10 @@ gofmt-check:
 	gofmt -l ./pkg ./cmd | sed -e 's/^/gofmt fails: /g'
 	test -z "`gofmt -l ./pkg ./cmd`"
 
+.PHONY: gofmt
+gofmt:
+	gofmt -w ./pkg ./cmd
+
 .PHONY: test-sec
 test-sec: $GOPATH/bin/gosec
 	gosec -severity medium --confidence medium -quiet ./...

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ crd_file=deploy/crds/metal3.io_baremetalhosts_crd.yaml
 crd_tmp=.crd.yaml.tmp
 
 .PHONY: lint
-lint: test-sec golint go-vet generate-check
+lint: test-sec golint go-vet generate-check gofmt-check
 
 # Ensure that generate does not produce changes
 .PHONY: generate-check
@@ -91,6 +91,14 @@ go-vet:
 .PHONY: golint
 golint:  $GOPATH/bin/golint
 	golint ./pkg ./cmd
+
+# Ensure that gofmt does not produce changes. First show a list of the
+# files that gofmt would rewrite, then build the same list and test
+# that it's empty.
+.PHONY: gofmt-check
+gofmt-check:
+	gofmt -l ./pkg ./cmd | sed -e 's/^/gofmt fails: /g'
+	test -z "`gofmt -l ./pkg ./cmd`"
 
 .PHONY: test-sec
 test-sec: $GOPATH/bin/gosec

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -21,8 +21,8 @@ import (
 )
 
 var (
-	log                     = logf.Log.WithName("cmd")
-	watchNamespace          string
+	log            = logf.Log.WithName("cmd")
+	watchNamespace string
 )
 
 func printVersion() {

--- a/go.mod
+++ b/go.mod
@@ -11,17 +11,16 @@ require (
 	github.com/gophercloud/gophercloud v0.6.0
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/imdario/mergo v0.3.8 // indirect
-	github.com/onsi/ginkgo v1.12.0 // indirect
-	github.com/onsi/gomega v1.9.0 // indirect
 	github.com/operator-framework/operator-sdk v0.17.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
+	github.com/securego/gosec v0.0.0-20200401082031-e946c8c39989 // indirect
 	github.com/spf13/cobra v0.0.6 // indirect
 	golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 // indirect
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
-	golang.org/x/tools v0.0.0-20200417140056-c07e33ef3290 // indirect
+	golang.org/x/tools v0.0.0-20200428211428-0c9eba77bc32 // indirect
 	k8s.io/api v0.17.4
 	k8s.io/apimachinery v0.17.4
 	k8s.io/client-go v12.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -521,6 +521,7 @@ github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
+github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kshvakov/clickhouse v1.3.5/go.mod h1:DMzX7FxRymoNkVgizH0DWAL8Cur7wHLgx3MUnGwJqpE=
@@ -528,6 +529,7 @@ github.com/kylelemons/godebug v0.0.0-20160406211939-eadb3ce320cb/go.mod h1:B69LE
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/leanovate/gopter v0.2.4/go.mod h1:gNcbPWNEWRe4lm+bycKqxUYoH5uoVje5SkOJ3uoLer8=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.0/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
@@ -597,6 +599,7 @@ github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
+github.com/mozilla/tls-observatory v0.0.0-20200317151703-4fa42e1c2dee/go.mod h1:SrKMQvPiws7F7iqYp8/TX+IhxCYhzr6N/1yb8cwHsGk=
 github.com/mozillazg/go-cos v0.13.0/go.mod h1:Zp6DvvXn0RUOXGJ2chmWt2bLEqRAnJnS3DnAZsJsoaE=
 github.com/mozillazg/go-httpheader v0.2.1/go.mod h1:jJ8xECTlalr6ValeXYdOF8fFUISeBAdw6E61aqQma60=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
@@ -605,6 +608,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/nakagami/firebirdsql v0.0.0-20190310045651-3c02a58cfed8/go.mod h1:86wM1zFnC6/uDBfZGNwB65O+pR2OFi5q/YQaEUid1qA=
+github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d h1:AREM5mwr4u1ORQBMvzfzBgpsctsbQikCVpvC+tX285E=
+github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v0.0.0-20170117200651-66bb6560562f/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -756,6 +761,8 @@ github.com/satori/go.uuid v0.0.0-20160603004225-b111a074d5ef/go.mod h1:dA0hQrYB0
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/securego/gosec v0.0.0-20200401082031-e946c8c39989 h1:rq2/kILQnPtq5oL4+IAjgVOjh5e2yj2aaCYi7squEvI=
+github.com/securego/gosec v0.0.0-20200401082031-e946c8c39989/go.mod h1:i9l/TNj+yDFh9SZXUTvspXTjbFXgZGP/UvhU1S65A4A=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
@@ -914,6 +921,7 @@ golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
@@ -1074,10 +1082,14 @@ golang.org/x/tools v0.0.0-20191111182352-50fa39b762bc/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191113191852-77e3bb0ad9e7/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
+golang.org/x/tools v0.0.0-20200331202046-9d5940d49312/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200417140056-c07e33ef3290 h1:NXNmtp0ToD36cui5IqWy95LC4Y6vT/4y3RnPxlQPinU=
 golang.org/x/tools v0.0.0-20200417140056-c07e33ef3290/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200428211428-0c9eba77bc32 h1:Xvf3ZQTm5bjXPxhI7g+dwqsCqadK1rcNtwtszuatetk=
+golang.org/x/tools v0.0.0-20200428211428-0c9eba77bc32/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -290,86 +290,86 @@ func TestParse(t *testing.T) {
 
 func TestStaticDriverInfo(t *testing.T) {
 	for _, tc := range []struct {
-		Scenario string
-		input    string
-		needsMac bool
-		driver   string
-		boot     string
+		Scenario   string
+		input      string
+		needsMac   bool
+		driver     string
+		boot       string
 		management string
-		power string
-		raid string
-		vendor string
+		power      string
+		raid       string
+		vendor     string
 	}{
 		{
-			Scenario: "ipmi",
-			input:    "ipmi://192.168.122.1:6233",
-			needsMac: false,
-			driver:   "ipmi",
-			boot:     "ipxe",
+			Scenario:   "ipmi",
+			input:      "ipmi://192.168.122.1:6233",
+			needsMac:   false,
+			driver:     "ipmi",
+			boot:       "ipxe",
 			management: "",
-			power: "",
-			raid: "",
-			vendor: "",
+			power:      "",
+			raid:       "",
+			vendor:     "",
 		},
 
 		{
-			Scenario: "libvirt",
-			input:    "libvirt://192.168.122.1",
-			needsMac: true,
-			driver:   "ipmi",
-			boot:     "ipxe",
+			Scenario:   "libvirt",
+			input:      "libvirt://192.168.122.1",
+			needsMac:   true,
+			driver:     "ipmi",
+			boot:       "ipxe",
 			management: "",
-			power: "",
-			raid: "",
-			vendor: "",
+			power:      "",
+			raid:       "",
+			vendor:     "",
 		},
 
 		{
-			Scenario: "idrac",
-			input:    "idrac://192.168.122.1",
-			needsMac: false,
-			driver:   "idrac",
-			boot:     "ipxe",
+			Scenario:   "idrac",
+			input:      "idrac://192.168.122.1",
+			needsMac:   false,
+			driver:     "idrac",
+			boot:       "ipxe",
 			management: "",
-			power: "",
-			raid: "",
-			vendor: "",
+			power:      "",
+			raid:       "",
+			vendor:     "",
 		},
 
 		{
-			Scenario: "irmc",
-			input:    "irmc://192.168.122.1",
-			needsMac: false,
-			driver:   "irmc",
-			boot:     "pxe",
+			Scenario:   "irmc",
+			input:      "irmc://192.168.122.1",
+			needsMac:   false,
+			driver:     "irmc",
+			boot:       "pxe",
 			management: "",
-			power: "",
-			raid: "irmc",
-			vendor: "",
+			power:      "",
+			raid:       "irmc",
+			vendor:     "",
 		},
 
 		{
-			Scenario: "redfish",
-			input:    "redfish://192.168.122.1",
-			needsMac: true,
-			driver:   "redfish",
-			boot:     "ipxe",
+			Scenario:   "redfish",
+			input:      "redfish://192.168.122.1",
+			needsMac:   true,
+			driver:     "redfish",
+			boot:       "ipxe",
 			management: "",
-			power: "",
-			raid: "",
-			vendor: "",
+			power:      "",
+			raid:       "",
+			vendor:     "",
 		},
 
 		{
-			Scenario: "redfish virtual media",
-			input:    "redfish-virtualmedia://192.168.122.1",
-			needsMac: true,
-			driver:   "redfish",
-			boot:     "redfish-virtual-media",
+			Scenario:   "redfish virtual media",
+			input:      "redfish-virtualmedia://192.168.122.1",
+			needsMac:   true,
+			driver:     "redfish",
+			boot:       "redfish-virtual-media",
 			management: "",
-			power: "",
-			raid: "",
-			vendor: "",
+			power:      "",
+			raid:       "",
+			vendor:     "",
 		},
 
 		{
@@ -381,15 +381,15 @@ func TestStaticDriverInfo(t *testing.T) {
 		},
 
 		{
-			Scenario: "idrac virtual media",
-			input:    "idrac-virtualmedia://192.168.122.1",
-			needsMac: true,
-			driver:   "idrac",
-			boot:     "idrac-redfish-virtual-media",
+			Scenario:   "idrac virtual media",
+			input:      "idrac-virtualmedia://192.168.122.1",
+			needsMac:   true,
+			driver:     "idrac",
+			boot:       "idrac-redfish-virtual-media",
 			management: "idrac-redfish",
-			power: "idrac-redfish",
-			raid: "no-raid",
-			vendor: "no-vendor",
+			power:      "idrac-redfish",
+			raid:       "no-raid",
+			vendor:     "no-vendor",
 		},
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {

--- a/pkg/controller/baremetalhost/action_result.go
+++ b/pkg/controller/baremetalhost/action_result.go
@@ -25,7 +25,6 @@ func (r actionContinueNoWrite) Dirty() bool {
 	return false
 }
 
-
 // actionContinue is a result indicating that the current action is still
 // in progress, and that the resource should remain in the same provisioning
 // state.

--- a/pkg/hardware/profile.go
+++ b/pkg/hardware/profile.go
@@ -85,7 +85,7 @@ func init() {
 		LocalGB: 50,
 		CPUArch: "x86_64",
 	}
-	
+
 	profiles["openstack"] = Profile{
 		Name: "openstack",
 		RootDeviceHints: RootDeviceHints{

--- a/pkg/provisioner/ironic/ironic_test.go
+++ b/pkg/provisioner/ironic/ironic_test.go
@@ -333,13 +333,13 @@ func TestGetNICDetails(t *testing.T) {
 	nics := getNICDetails(
 		[]introspection.InterfaceType{
 			introspection.InterfaceType{
-				Name: "eth0",
+				Name:        "eth0",
 				IPV4Address: "192.0.2.1",
-				MACAddress: "00:11:22:33:44:55"},
+				MACAddress:  "00:11:22:33:44:55"},
 			introspection.InterfaceType{
-				Name: "eth1",
+				Name:        "eth1",
 				IPV6Address: "2001:db8::1",
-				MACAddress: "66:77:88:99:aa:bb"},
+				MACAddress:  "66:77:88:99:aa:bb"},
 		},
 		map[string]introspection.BaseInterfaceType{
 			"eth0": introspection.BaseInterfaceType{


### PR DESCRIPTION
- Require a clean gofmt as part of the linter check.
- Update the linter dependencies.