### PR TITLE
Explicitly persistent boot mode setting with Redfish

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -71,6 +71,31 @@ Note that this script may need customizations to some of the `podman run`
 commands, to include environment variables that configure the containers for
 your environment.
 
+## Use with Redfish BMCs and UEFI
+
+Newer firmware versions being released by hardware vendors, starting in
+late 2019, are beginning to introducing changes which breaks the ability
+for a Redfish API consumer to assert a persistent boot behavior overrides
+utilizing a singular vendor-independnet field, at least when UEFI is also
+in use.
+
+Some, but not all, vendors have UEFI specific setting fields which are
+available, however the standard allows for it to be internally referential
+information. The end result being if these newer fields are even present,
+we need an extensive amount of vendor and hardware specific context, or even
+host specific internal information to be able to effectively leverage the
+UEFI specific fields.
+
+As a result, only one-time boot overrides can realistically be sent until
+vendors implement the latest fields and behavior specified in the early
+2020 Redfish schema documentation which calls for a easily relatable alias
+field to be implemented.
+
+The end result being that hardware *must* be set to persistently boot to
+a Hard Disk or other persistent storage medium prior to being deployed upon,
+if the desired end state is such and persistent settings are not asseted
+before the first reboot of the node after intiial deployment.
+
 ## Using libvirt VMs with Ironic
 
 In order to use VMs as hosts, they need to be connected to

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -557,6 +557,7 @@ func TestDriverInfo(t *testing.T) {
 				"redfish_password":  "",
 				"redfish_username":  "",
 				"redfish_verify_ca": false,
+				"force_persistent_boot_device": "Never",
 			},
 		},
 
@@ -569,6 +570,7 @@ func TestDriverInfo(t *testing.T) {
 				"redfish_password":  "",
 				"redfish_username":  "",
 				"redfish_verify_ca": false,
+				"force_persistent_boot_device": "Never",
 			},
 		},
 
@@ -581,6 +583,7 @@ func TestDriverInfo(t *testing.T) {
 				"redfish_password":  "",
 				"redfish_username":  "",
 				"redfish_verify_ca": false,
+				"force_persistent_boot_device": "Never",
 			},
 		},
 
@@ -593,6 +596,7 @@ func TestDriverInfo(t *testing.T) {
 				"redfish_password":  "",
 				"redfish_username":  "",
 				"redfish_verify_ca": false,
+				"force_persistent_boot_device": "Never",
 			},
 		},
 
@@ -605,6 +609,7 @@ func TestDriverInfo(t *testing.T) {
 				"redfish_password":  "",
 				"redfish_username":  "",
 				"redfish_verify_ca": false,
+				"force_persistent_boot_device": "Never",
 			},
 		},
 
@@ -617,6 +622,7 @@ func TestDriverInfo(t *testing.T) {
 				"redfish_password":  "",
 				"redfish_username":  "",
 				"redfish_verify_ca": false,
+				"force_persistent_boot_device": "Never",
 			},
 		},
 
@@ -629,6 +635,7 @@ func TestDriverInfo(t *testing.T) {
 				"redfish_password":  "",
 				"redfish_username":  "",
 				"redfish_verify_ca": false,
+				"force_persistent_boot_device": "Never",
 			},
 		},
 
@@ -641,6 +648,7 @@ func TestDriverInfo(t *testing.T) {
 				"redfish_password":  "",
 				"redfish_username":  "",
 				"redfish_verify_ca": false,
+				"force_persistent_boot_device": "Never",
 			},
 		},
 
@@ -653,6 +661,7 @@ func TestDriverInfo(t *testing.T) {
 				"redfish_password":  "",
 				"redfish_username":  "",
 				"redfish_verify_ca": false,
+				"force_persistent_boot_device": "Never",
 			},
 		},
 	} {

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -97,6 +97,7 @@ func (a *redfishAccessDetails) DriverInfo(bmcCreds Credentials) map[string]inter
 		"redfish_username":  bmcCreds.Username,
 		"redfish_password":  bmcCreds.Password,
 		"redfish_address":   strings.Join(redfishAddress, ""),
+		"force_persistent_boot_device": "Never",
 	}
 
 	if a.disableCertificateVerification {


### PR DESCRIPTION
Later versions of Redfish corresponding to the later 2019 Schema
documents and Redfish 1.9 have a breaking behavior change from
earlier Redfish versions where it was possible to explicitly
assert a continuously overridden boot device with UEFI.

The changes to the standard functionally removes the ability
for any reasonable override logic to assist until vendors possibly
implement the Redfish 1.10 Boot alias field and logic.

This is further compounded by API and schema version indicators
appearing to be an unreliable indicator as the implementations
are exhibiting different schema and API version numbers from
earlier versions from before the standard change was introduced.

The only clear option at this time seems to be disable assertion
of persistent overrides as vendors adapt their BMC implementations
to the newer Redfish schema/api, at least until we're able to find
a cross vendor or even set of vendor specific happy paths that can
be leveraged and implemented to reliably

The underlying ironic driver_info field
``force_persistent_boot_device`` enables us to disable the
persistent future boot device setting.

This change also adds contextual information to the dev-setup
documentation in order to help provide a complete context.

rhbz# 1828885