### PR TITLE
set up check to ensure operator-sdk generation is done

### DIFF
--- a/hack/Dockerfile.operator-sdk
+++ b/hack/Dockerfile.operator-sdk
@@ -1,0 +1,17 @@
+FROM registry.hub.docker.com/library/golang:1.13
+
+ENV SDK_VERSION=v0.17.0
+ENV SDK_BIN=/sdkbin
+ENV PATH="${SDK_BIN}:${PATH}"
+
+RUN mkdir -p ${SDK_BIN}
+
+# Install a stable build of operator-sdk
+ADD https://github.com/operator-framework/operator-sdk/releases/download/${SDK_VERSION}/operator-sdk-${SDK_VERSION}-x86_64-linux-gnu ${SDK_BIN}/operator-sdk
+RUN chmod 0755 ${SDK_BIN}/operator-sdk
+
+# Install kube-openapi from source
+RUN mkdir -p ${GOPATH}/src/github.com/kubernetes && cd ${GOPATH}/src/github.com/kubernetes && git clone https://github.com/kubernetes/kube-openapi && cd kube-openapi && go install ./cmd/...
+
+LABEL io.k8s.display-name="Metal3 operator-sdk test image" \
+      io.k8s.description="This image is for running tests requiring the operator-sdk"

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# Ignore the rule that says we should always quote variables, because
+# in this script we *do* want globbing.
+# shellcheck disable=SC2086
+
+set -eux
+
+IS_CONTAINER=${IS_CONTAINER:-false}
+ARTIFACTS=${ARTIFACTS:-/tmp}
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+  eval "$(go env)"
+  cd "${GOPATH}"/src/github.com/metal3-io/baremetal-operator
+  export XDG_CACHE_HOME="/tmp/.cache"
+
+  operator-sdk version
+
+  INPUT_FILES="deploy/crds/*.yaml pkg/apis/metal3/v1alpha1/zz_generated.*.go"
+  cksum $INPUT_FILES > "$ARTIFACTS/lint.cksums.before"
+  export VERBOSE="--verbose"
+  make generate
+  cksum $INPUT_FILES > "$ARTIFACTS/lint.cksums.after"
+  diff "$ARTIFACTS/lint.cksums.before" "$ARTIFACTS/lint.cksums.after"
+
+else
+  "${CONTAINER_RUNTIME}" run --rm \
+    --env IS_CONTAINER=TRUE \
+    --env DEPLOY_KERNEL_URL=http://172.22.0.1/images/ironic-python-agent.kernel \
+    --env DEPLOY_RAMDISK_URL=http://172.22.0.1/images/ironic-python-agent.initramfs \
+    --env IRONIC_ENDPOINT=http://localhost:6385/v1/ \
+    --env IRONIC_INSPECTOR_ENDPOINT=http://localhost:5050/v1/ \
+    --volume "${PWD}:/go/src/github.com/metal3-io/baremetal-operator:rw,z" \
+    --entrypoint sh \
+    --workdir /go/src/github.com/metal3-io/baremetal-operator \
+    quay.io/metal3-io/operator-sdk:latest \
+    /go/src/github.com/metal3-io/baremetal-operator/hack/generate.sh "${@}"
+fi;


### PR DESCRIPTION
Add a make target 'generate-check' to ensure that both the code and
CRDs have been regenerated for any change.

Add hack/Dockerfile.operator-sdk to build an image containing the
operator-sdk and other dependencies for the generator check.

Add hack/generate.sh to run the check in a container using the image
built by the new Dockerfile.

Addresses #434