### PR TITLE
add test for operator-sdk docker file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,15 @@ demo:
 		--operator-flags="-dev -demo-mode"
 
 .PHONY: docker
-docker:
+docker: docker-operator docker-sdk
+
+.PHONY: docker-operator
+docker-operator:
 	docker build . -f build/Dockerfile
+
+.PHONY: docker-sdk
+docker-sdk:
+	docker build . -f hack/Dockerfile.operator-sdk
 
 .PHONY: build
 build:
@@ -135,4 +142,3 @@ build:
 deploy:
 	cd deploy && kustomize edit set namespace $(RUN_NAMESPACE) && cd ..
 	kustomize build deploy | kubectl apply -f -
-


### PR DESCRIPTION
Expand the docker make target to test both docker files that appear in
the repo. The existing travis-ci job will try to build both images.