### PR TITLE
symlink role file used by operator-sdk

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,0 +1,1 @@
+rbac/role.yaml


### PR DESCRIPTION
Create a symlink from deploy/role.yaml to deploy/rbac/role.yaml so
that the operator-sdk will find the role file it needs for the `add
api` command.

We cannot make the link in the opposite direction because kustomize
refuses to follow symlinks outside of the directory where its
configuration is.

Replaces #501
Fixes #500
Related to #434