### PR TITLE
Postpone inspector start when running out of cluster

### DIFF
--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -81,6 +81,10 @@ sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name ironic \
      --env "MARIADB_PASSWORD=$mariadb_password" \
      -v "$IRONIC_DATA_DIR:/shared" "${IRONIC_IMAGE}"
 
+# Let Ironic start properly before starting inspector, to avoid inspector
+# failing to start properly because ironic is not ready
+sleep 30
+
 # Start Ironic Inspector
 # shellcheck disable=SC2086
 sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name ironic-inspector \


### PR DESCRIPTION
To give some time for Ironic to start properly and avoid
inspector failing to start due to ironic not being ready