### PR TITLE
fix the broken link to vbmc doc

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -82,7 +82,7 @@ your environment.
 ## Using libvirt VMs with Ironic
 
 In order to use VMs as hosts, they need to be connected to
-[vbmc](https://docs.openstack.org/tripleo-docs/latest/install/environments/virtualbmc.html)
+[vbmc](https://docs.openstack.org/project-deploy-guide/tripleo-docs/latest/environments/virtualbmc.html)
 and the `bootMACAddress` field needs to be set to the MAC address of the
 network interface that will PXE boot.
 


### PR DESCRIPTION
This PR fixes the broken link to vBMC docs in docs/dev-setup.md. It's just one line.

Addresses: #507 