### PR TITLE
Revert "Postpone inspector start when running out of cluster"

### DIFF
--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -81,10 +81,6 @@ sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name ironic \
      --env "MARIADB_PASSWORD=$mariadb_password" \
      -v "$IRONIC_DATA_DIR:/shared" "${IRONIC_IMAGE}"
 
-# Let Ironic start properly before starting inspector, to avoid inspector
-# failing to start properly because ironic is not ready
-sleep 30
-
 # Start Ironic Inspector
 # shellcheck disable=SC2086
 sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name ironic-inspector \


### PR DESCRIPTION
Reverts metal3-io/baremetal-operator#506 as it should not be needed once Ironic is fixed