### PR TITLE
Get rid of extra resource write during delete

### DIFF
--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -438,10 +438,6 @@ func (r *ReconcileBareMetalHost) actionDeleting(prov provisioner.Provisioner, in
 		return actionError{errors.Wrap(err, "failed to delete")}
 	}
 	if provResult.Dirty {
-		err = r.saveHostStatus(info.host)
-		if err != nil {
-			return actionError{errors.Wrap(err, "failed to save host after deleting")}
-		}
 		return actionContinue{provResult.RequeueAfter}
 	}
 


### PR DESCRIPTION
Now that 'deleting' is treated as its own provisioning status, returning
actionContinue is sufficient to ensure that the state gets written at
the conclusion of reconciliation. Doing an early write will cause an
error to be logged when we go to do the final write, since the object
generation will no longer match.