### PR TITLE
Fix go-lint warning: "comment on exported type ChecksumType should be of the form "ChecksumType ...""

### DIFF
--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -201,7 +201,7 @@ type BareMetalHostSpec struct {
 	ExternallyProvisioned bool `json:"externallyProvisioned,omitempty"`
 }
 
-// Checksum Algorithm Type
+// ChecksumType Checksum Algorithm Type
 // +kubebuilder:validation:Enum=md5;sha256;sha512
 type ChecksumType string
 


### PR DESCRIPTION
Signed-off-by: ZouYu <zouy.fnst@cn.fujitsu.com>