### PR TITLE
update makefile to use hack scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,11 +95,8 @@ generate-check-local:
 	IS_CONTAINER=local ./hack/generate.sh
 
 .PHONY: test-sec
-test-sec: $GOPATH/bin/gosec
-	gosec -severity medium --confidence medium -quiet ./...
-
-$GOPATH/bin/gosec:
-	go get -u github.com/securego/gosec/cmd/gosec
+test-sec:
+	./hack/gosec.sh
 
 $GOPATH/bin/golint:
 	go get -u golang.org/x/lint/golint

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ help:
 	@echo "  unit             -- run the unit tests"
 	@echo "  unit-cover       -- run the unit tests and write code coverage statistics to console"
 	@echo "  unit-cover-html  -- run the unit tests and open code coverage statistics in a browser"
-	@echo "  unit-verbose     -- run unit tests with verbose flag enabled"
 	@echo "  lint             -- run the linter"
 	@echo "  e2e-local        -- run end-to-end tests locally"
 	@echo "  help             -- this help output"
@@ -58,10 +57,14 @@ bin:
 	mkdir -p bin
 
 .PHONY: travis
-travis: unit-verbose lint
+travis: unit lint
 
 .PHONY: unit
 unit:
+	./hack/unit.sh
+
+.PHONY: unit-local
+unit-local:
 	go test $(GO_TEST_FLAGS) ./cmd/... ./pkg/...
 
 .PHONY: unit-cover
@@ -73,10 +76,6 @@ unit-cover:
 unit-cover-html:
 	go test -coverprofile=cover.out $(GO_TEST_FLAGS) ./cmd/... ./pkg/...
 	go tool cover -html=cover.out
-
-.PHONY: unit-verbose
-unit-verbose:
-	VERBOSE=-v make unit
 
 .PHONY: lint
 lint: gosec-check golint-check generate-check gofmt-check govet-check markdownlint-check shellcheck-check

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ unit-verbose:
 	VERBOSE=-v make unit
 
 .PHONY: lint
-lint: gosec-check golint-check generate-check gofmt-check govet-check
+lint: gosec-check golint-check generate-check gofmt-check govet-check markdownlint-check
 
 .PHONY: golint-check
 golint-check:
@@ -108,6 +108,10 @@ gofmt-check:
 .PHONY: govet-check
 govet-check:
 	./hack/govet.sh
+
+.PHONY: markdownlint-check
+markdownlint-check:
+	./hack/markdownlint.sh
 
 .PHONY: docs
 docs: $(patsubst %.dot,%.png,$(wildcard docs/*.dot))

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ unit-verbose:
 	VERBOSE=-v make unit
 
 .PHONY: lint
-lint: gosec-check golint-check generate-check gofmt-check govet-check markdownlint-check
+lint: gosec-check golint-check generate-check gofmt-check govet-check markdownlint-check shellcheck-check
 
 .PHONY: golint-check
 golint-check:
@@ -112,6 +112,10 @@ govet-check:
 .PHONY: markdownlint-check
 markdownlint-check:
 	./hack/markdownlint.sh
+
+.PHONY: shellcheck-check
+shellcheck-check:
+	./hack/shellcheck.sh
 
 .PHONY: docs
 docs: $(patsubst %.dot,%.png,$(wildcard docs/*.dot))

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ unit-verbose:
 	VERBOSE=-v make unit
 
 .PHONY: lint
-lint: test-sec golint-check generate-check gofmt-check
+lint: gosec-check golint-check generate-check gofmt-check
 	go vet ./pkg/... ./cmd/...
 
 .PHONY: golint-check
@@ -94,8 +94,8 @@ generate-check:
 generate-check-local:
 	IS_CONTAINER=local ./hack/generate.sh
 
-.PHONY: test-sec
-test-sec:
+.PHONY: gosec-check
+gosec-check:
 	./hack/gosec.sh
 
 $GOPATH/bin/golint:

--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,6 @@ bin/operator-sdk: bin
 bin:
 	mkdir -p bin
 
-.PHONY: travis
-travis: unit lint
-
 .PHONY: unit
 unit:
 	./hack/unit.sh

--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,8 @@ lint: gosec-check golint-check generate-check gofmt-check
 	go vet ./pkg/... ./cmd/...
 
 .PHONY: golint-check
-golint-check: $GOPATH/bin/golint
-	find ./pkg ./cmd -type f -name \*.go  |grep -v zz_ | xargs -L1 golint -set_exit_status
+golint-check:
+	./hack/golint.sh
 
 .PHONY: generate-check
 generate-check:
@@ -97,9 +97,6 @@ generate-check-local:
 .PHONY: gosec-check
 gosec-check:
 	./hack/gosec.sh
-
-$GOPATH/bin/golint:
-	go get -u golang.org/x/lint/golint
 
 .PHONY: gofmt
 gofmt:

--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,7 @@ unit-verbose:
 	VERBOSE=-v make unit
 
 .PHONY: lint
-lint: gosec-check golint-check generate-check gofmt-check
-	go vet ./pkg/... ./cmd/...
+lint: gosec-check golint-check generate-check gofmt-check govet-check
 
 .PHONY: golint-check
 golint-check:
@@ -105,6 +104,10 @@ gofmt:
 .PHONY: gofmt-check
 gofmt-check:
 	./hack/gofmt.sh
+
+.PHONY: govet-check
+govet-check:
+	./hack/govet.sh
 
 .PHONY: docs
 docs: $(patsubst %.dot,%.png,$(wildcard docs/*.dot))

--- a/hack/Dockerfile.golint
+++ b/hack/Dockerfile.golint
@@ -1,0 +1,6 @@
+FROM registry.hub.docker.com/library/golang:1.13
+
+RUN go get -u golang.org/x/lint/golint
+
+LABEL io.k8s.display-name="Metal3 golint test image" \
+      io.k8s.description="This image is for running tests requiring golint"

--- a/hack/golint.sh
+++ b/hack/golint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -eux
+
+IS_CONTAINER=${IS_CONTAINER:-false}
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+  export XDG_CACHE_HOME="/tmp/.cache"
+
+  find ./pkg ./cmd -type f -name \*.go  \
+      | grep -v zz_ \
+      | xargs -I'{}' golint -set_exit_status '{}'
+else
+  "${CONTAINER_RUNTIME}" run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/go/src/github.com/metal3-io/baremetal-operator:ro,z" \
+    --entrypoint sh \
+    --workdir /go/src/github.com/metal3-io/baremetal-operator \
+    quay.io/metal3-io/golint:latest \
+    /go/src/github.com/metal3-io/baremetal-operator/hack/golint.sh "${@}"
+fi;

--- a/hack/govet.sh
+++ b/hack/govet.sh
@@ -6,15 +6,19 @@ IS_CONTAINER=${IS_CONTAINER:-false}
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
-  TOP_DIR="${1:-.}"
+  eval "$(go env)"
+  cd "${GOPATH}"/src/github.com/metal3-io/baremetal-operator
+
   export XDG_CACHE_HOME="/tmp/.cache"
-  go vet "${TOP_DIR}"/pkg/... "${TOP_DIR}"/cmd/...
+
+  go version
+  go vet ./pkg/... ./cmd/...
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/metal3-io/baremetal-operator:ro,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/baremetal-operator \
-    registry.hub.docker.com/library/golang:1.12 \
+    registry.hub.docker.com/library/golang:1.13 \
     /go/src/github.com/metal3-io/baremetal-operator/hack/govet.sh "${@}"
 fi;

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -21,6 +21,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/baremetal-operator:ro,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/baremetal-operator \
-    registry.hub.docker.com/library/golang:1.12 \
+    registry.hub.docker.com/library/golang:1.13 \
     /go/src/github.com/metal3-io/baremetal-operator/hack/unit.sh "${@}"
 fi;


### PR DESCRIPTION
This PR standarizes the make lint targets to use the same hack scripts
that are used in the CI system.

Fixes #505