### PR TITLE
Fix version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,11 +153,10 @@ docker-sdk:
 .PHONY: build
 build:
 	@echo LDFLAGS=$(LDFLAGS)
-	go build -o build/_output/bin/baremetal-operator cmd/manager/main.go
+	go build -ldflags $(LDFLAGS) -o build/_output/bin/baremetal-operator cmd/manager/main.go
 
 .PHONY: tools
 tools:
-	@echo LDFLAGS=$(LDFLAGS)
 	go build -o build/_output/bin/get-hardware-details cmd/get-hardware-details/main.go
 
 .PHONY: deploy


### PR DESCRIPTION
This PR adds the required build parameter to the `build` target to correctly display the baremetal-operator version string.

The echo has been removed for the `tools` targets since it was unused 