### PR TITLE
Register host config data error metric

### DIFF
--- a/pkg/controller/baremetalhost/metrics.go
+++ b/pkg/controller/baremetalhost/metrics.go
@@ -117,7 +117,8 @@ func init() {
 		credentialsInvalid,
 		unhandledCredentialsError,
 		updatedCredentials,
-		noManagementAccess)
+		noManagementAccess,
+		hostConfigDataError)
 
 	metrics.Registry.MustRegister(
 		stateChanges,


### PR DESCRIPTION
The prometheus metric metal3_host_config_data_error_total added in
004fc7a72f95ba7130c5ddf658de309c11e9bafa (#348) was not registered.