### PR TITLE
Remove ironic workaround when running locally

### DIFF
--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -88,10 +88,6 @@ sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name ironic-endpoin
     ${POD} --env-file "${SCRIPTPATH}/../deploy/ironic_ci.env" \
     -v "$IRONIC_DATA_DIR:/shared" "${IRONIC_ENDPOINT_KEEPALIVED_IMAGE}"
 
-# Let Ironic start properly before starting inspector, to avoid inspector
-# failing to start properly because ironic is not ready
-sleep 30
-
 # Start Ironic Inspector
 # shellcheck disable=SC2086
 sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name ironic-inspector \


### PR DESCRIPTION
A sleep was added to give time for ironic to start properly before
starting inspector. It is not needed any more, the bug in
inspector was fixed