### PR TITLE
handle missing image in GetImageChecksum

### DIFF
--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -771,6 +771,10 @@ func (host *BareMetalHost) OperationMetricForState(operation ProvisioningState) 
 
 // GetImageChecksum returns the hash value and its algo.
 func (host *BareMetalHost) GetImageChecksum() (string, string, bool) {
+	if host.Spec.Image == nil {
+		return "", "", false
+	}
+
 	checksum := host.Spec.Image.Checksum
 	checksumType := host.Spec.Image.ChecksumType
 

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types_test.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types_test.go
@@ -645,6 +645,17 @@ func TestGetImageChecksum(t *testing.T) {
 			},
 			Expected: false,
 		},
+		{
+			Scenario: "no image",
+			Host: BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myhost",
+					Namespace: "myns",
+				},
+				Spec: BareMetalHostSpec{},
+			},
+			Expected: false,
+		},
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			_, _, actual := tc.Host.GetImageChecksum()


### PR DESCRIPTION
The BareMetalHost.GetImageChecksum method must not assume there is any
image information present.