### PR TITLE
Unify the image reference in operator deployments

### DIFF
--- a/deploy/operator/no_ironic/operator.yaml
+++ b/deploy/operator/no_ironic/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: metal3-baremetal-operator
       containers:
         - name: baremetal-operator
-          image: quay.io/metal3-io/baremetal-operator:master
+          image: quay.io/metal3-io/baremetal-operator
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
Kustomizing the image in metal3-dev-env requires the image to
be specific. This unifies the BMO image across different
deployments so that the image kustomization works in all cases