### PR TITLE
add minimum validation for root device hint size

### DIFF
--- a/deploy/crds/metal3.io_baremetalhosts_crd.yaml
+++ b/deploy/crds/metal3.io_baremetalhosts_crd.yaml
@@ -217,6 +217,7 @@ spec:
                   type: string
                 minSizeGigabytes:
                   description: The minimum size of the device in Gigabytes.
+                  minimum: 0
                   type: integer
                 model:
                   description: A vendor-specific device identifier. The hint can be
@@ -629,6 +630,7 @@ spec:
                       type: string
                     minSizeGigabytes:
                       description: The minimum size of the device in Gigabytes.
+                      minimum: 0
                       type: integer
                     model:
                       description: A vendor-specific device identifier. The hint can

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -54,6 +54,7 @@ type RootDeviceHints struct {
 	SerialNumber string `json:"serialNumber,omitempty"`
 
 	// The minimum size of the device in Gigabytes.
+	// +kubebuilder:validation:Minimum=0
 	MinSizeGigabytes int `json:"minSizeGigabytes,omitempty"`
 
 	// Unique storage identifier. The hint must match the actual value


### PR DESCRIPTION
Disk sizes less than zero do not make sense.