### PR TITLE
New BMH unhealthy annotation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -19,6 +19,15 @@ sure that you remove the annotation  **only if the value of the annotation is
 not `metal3.io/capm3`, but another value that you have provided**. Removing the
 annotation will enable the reconciliation again.
 
+### Unhealthy annotation
+
+It is possible to mark BareMetalHost object as unhealthy by adding an
+annotation `baremetalhost.metal3.io/unhealthy`. This annotation does not
+stop the reconciliation of the BMH. This annotation is used in the upper layers
+for coordination. For example **Metal³** provider should not provision BMH
+set as unhealthy. Removing the annotation will enable the normal operations
+on the provider layers.
+
 ### BareMetalHost spec
 
 The *BareMetalHost's* *spec* defines the desire state of the host. It contains

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -25,6 +25,9 @@ const (
 
 	// StatusAnnotation is the annotation that holds the Status of BMH
 	StatusAnnotation = "baremetalhost.metal3.io/status"
+
+	// UnhealthyAnnotation is the annotation that sets unhealthy status of BMH
+	UnhealthyAnnotation = "baremetalhost.metal3.io/unhealthy"
 )
 
 // OperationalStatus represents the state of the host


### PR DESCRIPTION
CAPM3 node remediation needs the simple way of coordinate the provisioning and remediation of the unhealthy BMH. We want the user to be able to mark an unhealthy BMH with an ```unhealthy``` annotation. That annotation is used to control provisioning and remediation at the CAPM3 level.

For example, use of current pause annotation prevents the deletion of the machine objects and blocks the remediation of the unhealthy nodes.  