### PR TITLE
🏃 Change configMapGenerator behavior in kustomization and typo fixes

### DIFF
--- a/deploy/default/kustomization.yaml
+++ b/deploy/default/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 - ../crds
 - ../operator
 configMapGenerator:
-- behavior: merge
+- behavior: create
   envs:
   - ironic_bmo_configmap.env
   name: ironic-bmo-configmap

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -99,7 +99,7 @@ useful as well. For example:
    a successful pivoting state was met and ironic being deployed.
 
 2. BMO and Ironic are deployed together, in a case when CAPM3 is not used and
-   those to be deployed as a bundle.
+   baremetal-operator and ironic containers to be deployed together.
 
 3. Only Ironic is deployed, in a case when BMO is deployed as part of CAPM3 and
    only Ironic setup is sufficient, e.g.
@@ -108,8 +108,8 @@ useful as well. For example:
    the BaremetalHost during the pivoting.
 
 **Important Note**
-When the baremetal-operator is deployed through metal3-dev-env, this container
-inherits the following environment variables through configmap:
+When the baremetal-operator is deployed through metal3-dev-env, baremetal-operator
+container inherits the following environment variables through configmap:
 
 ```ini
 
@@ -119,5 +119,5 @@ $PROVISIONING_INTERFACE
 
 ```
 
-In case you are deploying baremetak-operator locally, make sure to populate and
+In case you are deploying baremetal-operator locally, make sure to populate and
 export these environment variables before deploying.


### PR DESCRIPTION
**What this PR does / why we need it:**
This patch fixes configMapGenerator behavior so that when BMO is deployed as part of CAPM3 it needs to be able to `create` configmap rather than `merge` and also addresses few fixes to some comments (typo and rephrasing) in #541 

Logs:
`Error: accumulating resources: accumulateFile "accumulating resources from '../deploy/default': '/home/****/go/src/github.com/metal3-io/baremetal-operator/deploy/default' must resolve to a file", accumulateDirector: "recursed accumulation of path '/home/****/go/src/github.com/metal3-io/baremetal-operator/deploy/default': merging from generator &{0xc0007bb230 { } {{ ironic-bmo-configmap merge {[] [] [ironic_bmo_configmap.env]} <nil>}}}: id resid.ResId{Gvk:resid.Gvk{Group:\"\", Version:\"v1\", Kind:\"ConfigMap\"}, Name:\"ironic-bmo-configmap\", Namespace:\"\"} does not exist; cannot merge or replace"
`

Related to: [/metal3-dev-env/pull/338](https://github.com/metal3-io/metal3-dev-env/pull/338)