### PR TITLE
Round clock frequency to integer when setting HW details

### DIFF
--- a/pkg/provisioner/ironic/hardwaredetails/hardwaredetails.go
+++ b/pkg/provisioner/ironic/hardwaredetails/hardwaredetails.go
@@ -2,6 +2,7 @@ package hardwaredetails
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 
@@ -110,6 +111,7 @@ func getSystemVendorDetails(vendor introspection.SystemVendorType) metal3v1alpha
 func getCPUDetails(cpudata *introspection.CPUType) metal3v1alpha1.CPU {
 	var freq float64
 	fmt.Sscanf(cpudata.Frequency, "%f", &freq)
+	freq = math.Round(freq) // Ensure freq has no fractional part
 	sort.Strings(cpudata.Flags)
 	cpu := metal3v1alpha1.CPU{
 		Arch:           cpudata.Architecture,


### PR DESCRIPTION
Since float is not considered a valid type we will eventually have to
convert this field to an integer. That's probably going to involve some
very not-fun contortions regardless (see metal3-io/metal3-docs#101), but
at the very least it's not helping anybody to continue creating Hosts
with fractional values that will be non-round-trippable later.