### PR TITLE
Fix: Delete ironic-endpoint-keepalived container also while deleting other ironic containers

### DIFF
--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -23,7 +23,7 @@ pushd "$IRONIC_DATA_DIR/html/images"
 # By default, image directory points to dir having needed images when metal3-dev-env environment in use.
 # In other cases user has to store images beforehand.
 
-for name in ironic ironic-inspector dnsmasq httpd mariadb ipa-downloader; do
+for name in ironic ironic-inspector dnsmasq httpd mariadb ipa-downloader ironic-endpoint-keepalived; do
     sudo "${CONTAINER_RUNTIME}" ps | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" kill "$name"
     sudo "${CONTAINER_RUNTIME}" ps --all | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" rm "$name" -f
 done


### PR DESCRIPTION
Since `tools/run_local_ironic.sh `  installs  `ironic-endpoint-keepalived` , it should also delete this container while it deleted the other ironic containers, otherwise while doing iterations on this file, docker finds `ironic-endpoint-keepalived` already installed and throws an error. 