### PR TITLE
Make BMCDetails optional

### DIFF
--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -204,6 +204,7 @@ type BareMetalHostSpec struct {
 	Taints []corev1.Taint `json:"taints,omitempty"`
 
 	// How do we connect to the BMC?
+	// +optional
 	BMC BMCDetails `json:"bmc,omitempty"`
 
 	// What is the name of the hardware profile for this host? It


### PR DESCRIPTION
Hosts with StateExternallyProvisioned may not have BMC details

Signed-off-by: Andrew Beekhof <andrew@beekhof.net>