### PR TITLE
define the Unmanaged state

### DIFF
--- a/docs/baremetalhost-states.md
+++ b/docs/baremetalhost-states.md
@@ -11,10 +11,10 @@ Newly created hosts move immediately to Discovered or Registering. No
 host stays in the Created state while the operator is working
 properly.
 
-## Discovered
+## Unmanaged
 
-A Discovered host is missing either the BMC address or credentials
-secret name, and does not have enough information to access the BMC
+An Unmanaged host is missing both the BMC address and credentials
+secret name, and does not have any information to access the BMC
 for registration.
 
 ## Externally Provisioned

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -119,6 +119,10 @@ const (
 	// StateNone means the state is unknown
 	StateNone ProvisioningState = ""
 
+	// StateUnmanaged means there is insufficient information available to
+	// register the host
+	StateUnmanaged ProvisioningState = "unmanaged"
+
 	// StateRegistrationError means there was an error registering the
 	// host with the backend
 	StateRegistrationError ProvisioningState = "registration error"


### PR DESCRIPTION
Define a new state for newly-created Hosts with no BMC details.

We need the state definition so we can add it to CAPM3 so that does
not break when #569 merges.

See https://github.com/metal3-io/metal3-docs/pull/120 for more
details.