### PR TITLE
WIP: Add support for mutual TLS with ironic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/prometheus/client_golang v1.5.1
 	github.com/spf13/cobra v0.0.6 // indirect
 	github.com/stretchr/testify v1.4.0
+	go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738
 	golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 // indirect
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect

--- a/go.sum
+++ b/go.sum
@@ -845,6 +845,7 @@ go.elastic.co/apm/module/apmot v1.5.0/go.mod h1:d2KYwhJParTpyw2WnTNy8geNlHKKFX+4
 go.elastic.co/fastjson v1.0.0/go.mod h1:PmeUOMMtLHQr9ZS9J9owrAVg0FkaZDRZJEFTTGHtchs=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738 h1:VcrIfasaLFkyjk6KNlXQSzO+B0fZcnECiDrKJsfxka0=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.1.0/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=


### PR DESCRIPTION
Mutual TLS will be used to authenticate against ironic and
ironic-inspector. When the environment variables IRONIC_CERT_FILE,
IRONIC_KEY_FILE and IRONIC_TRUSTED_CA_FILE are all set, mutual TLS will
be used to communicate with the ironic endpoints.

The http.Client with the mTLS configuration will load the client
certificate from the disk every time a request is made. Therefore, it
allows to rotate the client certificate without a restart. The CA file
is only loaded when a new provisioner is created. This happens during
every reconciliation. Therefore, a rotation of the CA certificate
without restart is also supported.

**WIP:** Needs testing with all other mTLS components in place. Deployment needs to be adapted to include cert-manager.