### PR TITLE
Check provisioner ready status when applying reconcile logic

### DIFF
--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -303,3 +303,8 @@ func (p *demoProvisioner) PowerOff() (result provisioner.Result, err error) {
 
 	// return result, nil
 }
+
+// IsReady always returns true for the demo provisioner
+func (p *demoProvisioner) IsReady() (result bool, err error) {
+	return true, nil
+}

--- a/pkg/provisioner/ironic/dependencies.go
+++ b/pkg/provisioner/ironic/dependencies.go
@@ -1,0 +1,92 @@
+package ironic
+
+import (
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/drivers"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+const (
+	checkRequeueDelay = time.Second * 10
+)
+
+type ironicDependenciesChecker struct {
+	client    *gophercloud.ServiceClient
+	inspector *gophercloud.ServiceClient
+	log       logr.Logger
+}
+
+func newIronicDependenciesChecker(client *gophercloud.ServiceClient, inspector *gophercloud.ServiceClient, log logr.Logger) *ironicDependenciesChecker {
+	return &ironicDependenciesChecker{
+		client:    client,
+		inspector: inspector,
+		log:       log,
+	}
+}
+
+func (i *ironicDependenciesChecker) IsReady() (result bool, err error) {
+
+	ready, err := i.checkIronic()
+	if ready && err == nil {
+		ready = i.checkIronicInspector()
+	}
+
+	return ready, err
+}
+
+func (i *ironicDependenciesChecker) checkEndpoint(client *gophercloud.ServiceClient) (ready bool) {
+
+	// NOTE: Some versions of Ironic inspector returns 404 for /v1/ but 200 for /v1,
+	// which seems to be the default behavior for Flask. Remove the trailing slash
+	// from the client endpoint.
+	endpoint := strings.TrimSuffix(client.Endpoint, "/")
+
+	_, err := client.Get(endpoint, nil, nil)
+	if err != nil {
+		log.Info("error caught while checking endpoint", "endpoint", client.Endpoint, "error", err)
+	}
+
+	return err == nil
+}
+
+func (i *ironicDependenciesChecker) checkIronic() (ready bool, err error) {
+	ready = i.checkEndpoint(i.client)
+	if ready {
+		ready, err = i.checkIronicConductor()
+	}
+	return ready, err
+}
+
+func (i *ironicDependenciesChecker) checkIronicConductor() (ready bool, err error) {
+
+	pager := drivers.ListDrivers(i.client, drivers.ListDriversOpts{
+		Detail: false,
+	})
+	err = pager.Err
+
+	if err != nil {
+		return ready, err
+	}
+
+	driverCount := 0
+	pager.EachPage(func(page pagination.Page) (bool, error) {
+		actual, driverErr := drivers.ExtractDrivers(page)
+		if driverErr != nil {
+			return false, driverErr
+		}
+		driverCount += len(actual)
+		return true, nil
+	})
+	// If we have any drivers, conductor is up.
+	ready = driverCount > 0
+
+	return ready, err
+}
+
+func (i *ironicDependenciesChecker) checkIronicInspector() (ready bool) {
+	return i.checkEndpoint(i.inspector)
+}

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1394,3 +1394,11 @@ func (p *ironicProvisioner) softPowerOff() (result provisioner.Result, err error
 
 	return result, nil
 }
+
+// IsReady checks if the provisioning backend is available
+func (p *ironicProvisioner) IsReady() (result bool, err error) {
+	p.log.Info("verifying ironic provisioner dependencies")
+
+	checker := newIronicDependenciesChecker(p.client, p.inspector, p.log)
+	return checker.IsReady()
+}

--- a/pkg/provisioner/ironic/ironic_test.go
+++ b/pkg/provisioner/ironic/ironic_test.go
@@ -2,6 +2,11 @@ package ironic
 
 import (
 	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,58 +25,115 @@ func init() {
 	logf.SetLogger(logf.ZapLogger(true))
 }
 
-func TestGetUpdateOptsForNodeWithRootHints(t *testing.T) {
-	rotational := true
-	host := &metal3v1alpha1.BareMetalHost{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "myhost",
-			Namespace: "myns",
-			UID:       "27720611-e5d1-45d3-ba3a-222dcfaa4ca2",
+func TestProvisionerIsReady(t *testing.T) {
+
+	cases := []struct {
+		name      string
+		ironic    *mockServer
+		inspector *mockServer
+
+		expectedIronicCalls    string
+		expectedInspectorCalls string
+		expectedIsReady        bool
+		expectedError          string
+	}{
+		{
+			name:      "IsReady",
+			ironic:    newMockServer(6385).addDrivers(),
+			inspector: newMockServer(5050),
+
+			expectedIronicCalls:    "localhost:6385/v1;localhost:6385/v1/drivers;",
+			expectedInspectorCalls: "localhost:5050/v1;",
+			expectedIsReady:        true,
 		},
-		Spec: metal3v1alpha1.BareMetalHostSpec{
-			Image: &metal3v1alpha1.Image{
-				URL: "not-empty",
-			},
-			Online:          true,
-			HardwareProfile: "libvirt",
-			RootDeviceHints: &metal3v1alpha1.RootDeviceHints{
-				DeviceName:         "userd_devicename",
-				HCTL:               "1:2:3:4",
-				Model:              "userd_model",
-				Vendor:             "userd_vendor",
-				SerialNumber:       "userd_serial",
-				MinSizeGigabytes:   40,
-				WWN:                "userd_wwn",
-				WWNWithExtension:   "userd_with_extension",
-				WWNVendorExtension: "userd_vendor_extension",
-				Rotational:         &rotational,
-			},
+		{
+			name:      "NoDriversLoaded",
+			ironic:    newMockServer(6385),
+			inspector: newMockServer(5050),
+
+			expectedIronicCalls: "localhost:6385/v1;localhost:6385/v1/drivers;",
 		},
-		Status: metal3v1alpha1.BareMetalHostStatus{
-			Provisioning: metal3v1alpha1.ProvisionStatus{
-				ID: "provisioning-id",
-				// Place the hints in the status field to pretend the
-				// controller has already reconciled partially.
-				RootDeviceHints: &metal3v1alpha1.RootDeviceHints{
-					DeviceName:         "userd_devicename",
-					HCTL:               "1:2:3:4",
-					Model:              "userd_model",
-					Vendor:             "userd_vendor",
-					SerialNumber:       "userd_serial",
-					MinSizeGigabytes:   40,
-					WWN:                "userd_wwn",
-					WWNWithExtension:   "userd_with_extension",
-					WWNVendorExtension: "userd_vendor_extension",
-					Rotational:         &rotational,
-				},
-			},
-			HardwareProfile: "libvirt",
+		{
+			name:      "IronicDown",
+			inspector: newMockServer(5050),
+
+			expectedIsReady: false,
+		},
+		{
+			name:   "InspectorDown",
+			ironic: newMockServer(6385).addDrivers(),
+
+			expectedIronicCalls: "localhost:6385/v1;localhost:6385/v1/drivers;",
+
+			expectedIsReady: false,
+		},
+		{
+			name:      "IronicNotOk",
+			ironic:    newMockServer(6385).setErrorCode(http.StatusInternalServerError),
+			inspector: newMockServer(5050),
+
+			expectedIsReady: false,
+
+			expectedIronicCalls: "localhost:6385/v1;",
+		},
+		{
+			name:      "IronicNotOkAndNotExpected",
+			ironic:    newMockServer(6385).setErrorCode(http.StatusBadGateway),
+			inspector: newMockServer(5050),
+
+			expectedIsReady: false,
+
+			expectedIronicCalls: "localhost:6385/v1;",
+		},
+		{
+			name:      "InspectorNotOk",
+			ironic:    newMockServer(6385).addDrivers(),
+			inspector: newMockServer(5050).setErrorCode(http.StatusInternalServerError),
+
+			expectedIsReady: false,
+
+			expectedIronicCalls:    "localhost:6385/v1;localhost:6385/v1/drivers;",
+			expectedInspectorCalls: "localhost:5050/v1;",
 		},
 	}
 
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.ironic != nil {
+				tc.ironic.start()
+				defer tc.ironic.stop()
+			}
+
+			if tc.inspector != nil {
+				tc.inspector.start()
+				defer tc.inspector.stop()
+			}
+
+			prov, err := newProvisioner(makeHost(), bmc.Credentials{}, nil)
+			ready, err := prov.IsReady()
+
+			if tc.ironic != nil {
+				assert.Equal(t, tc.expectedIronicCalls, tc.ironic.requests)
+			}
+			if tc.inspector != nil {
+				assert.Equal(t, tc.expectedInspectorCalls, tc.inspector.requests)
+			}
+
+			if tc.expectedError != "" {
+				assert.Regexp(t, tc.expectedError, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tc.expectedIsReady, ready)
+			}
+		})
+	}
+}
+
+func TestGetUpdateOptsForNodeWithRootHints(t *testing.T) {
+
 	eventPublisher := func(reason, message string) {}
 
-	prov, err := newProvisioner(host, bmc.Credentials{}, eventPublisher)
+	prov, err := newProvisioner(makeHost(), bmc.Credentials{}, eventPublisher)
 	ironicNode := &nodes.Node{}
 
 	patches, err := prov.getUpdateOptsForNode(ironicNode)
@@ -431,4 +493,130 @@ func TestGetUpdateOptsForNodeBootMode(t *testing.T) {
 			)
 		})
 	}
+}
+
+func makeHost() *metal3v1alpha1.BareMetalHost {
+	rotational := true
+
+	return &metal3v1alpha1.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myhost",
+			Namespace: "myns",
+			UID:       "27720611-e5d1-45d3-ba3a-222dcfaa4ca2",
+		},
+		Spec: metal3v1alpha1.BareMetalHostSpec{
+			Image: &metal3v1alpha1.Image{
+				URL: "not-empty",
+			},
+			Online:          true,
+			HardwareProfile: "libvirt",
+			RootDeviceHints: &metal3v1alpha1.RootDeviceHints{
+				DeviceName:         "userd_devicename",
+				HCTL:               "1:2:3:4",
+				Model:              "userd_model",
+				Vendor:             "userd_vendor",
+				SerialNumber:       "userd_serial",
+				MinSizeGigabytes:   40,
+				WWN:                "userd_wwn",
+				WWNWithExtension:   "userd_with_extension",
+				WWNVendorExtension: "userd_vendor_extension",
+				Rotational:         &rotational,
+			},
+		},
+		Status: metal3v1alpha1.BareMetalHostStatus{
+			Provisioning: metal3v1alpha1.ProvisionStatus{
+				ID: "provisioning-id",
+				// Place the hints in the status field to pretend the
+				// controller has already reconciled partially.
+				RootDeviceHints: &metal3v1alpha1.RootDeviceHints{
+					DeviceName:         "userd_devicename",
+					HCTL:               "1:2:3:4",
+					Model:              "userd_model",
+					Vendor:             "userd_vendor",
+					SerialNumber:       "userd_serial",
+					MinSizeGigabytes:   40,
+					WWN:                "userd_wwn",
+					WWNWithExtension:   "userd_with_extension",
+					WWNVendorExtension: "userd_vendor_extension",
+					Rotational:         &rotational,
+				},
+			},
+			HardwareProfile: "libvirt",
+		},
+	}
+}
+
+func newMockServer(port int) *mockServer {
+	return &mockServer{
+		port: strconv.Itoa(port),
+	}
+}
+
+type mockServer struct {
+	port      string
+	requests  string
+	server    *httptest.Server
+	drivers   string
+	errorCode int
+}
+
+func (m *mockServer) setErrorCode(code int) *mockServer {
+	m.errorCode = code
+
+	return m
+}
+
+func (m *mockServer) addDrivers() *mockServer {
+	m.drivers = `
+	{
+		"drivers": [{
+			"hosts": [
+			  "master-2.ostest.test.metalkube.org"
+			],
+			"links": [
+			  {
+				"href": "http://[fd00:1101::3]:6385/v1/drivers/fake-hardware",
+				"rel": "self"
+			  },
+			  {
+				"href": "http://[fd00:1101::3]:6385/drivers/fake-hardware",
+				"rel": "bookmark"
+			  }
+			],
+			"name": "fake-hardware"
+		}]
+	}
+	`
+	return m
+}
+
+func (m *mockServer) start() *mockServer {
+	listener, err := net.Listen("tcp", "127.0.0.1:"+m.port)
+	if err != nil {
+		panic(err)
+	}
+
+	m.server = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.requests += r.Host + r.RequestURI + ";"
+
+		if m.errorCode != 0 {
+			http.Error(w, "An error", m.errorCode)
+			return
+		}
+
+		if strings.Contains(r.RequestURI, "/v1/drivers") {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, m.drivers)
+		}
+	}))
+
+	m.server.Listener.Close()
+	m.server.Listener = listener
+	m.server.Start()
+
+	return m
+}
+
+func (m *mockServer) stop() {
+	m.server.Close()
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -83,6 +83,10 @@ type Provisioner interface {
 	// PowerOff ensures the server is powered off independently of any image
 	// provisioning operation.
 	PowerOff() (result Result, err error)
+
+	// IsReady checks if the provisioning backend is available to accept
+	// all the incoming requests.
+	IsReady() (result bool, err error)
 }
 
 // Result holds the response from a call in the Provsioner API.


### PR DESCRIPTION
This PR aims to improve the reconcile loop by checking the status of the Provisioner dependencies before trying to reconcile the state: if the provisioner is not ready, the current request is requeued.
In particular, it checks the availability of the Ironic and Ironic Inspector services (thanks to @stbenjam for specific check logic, extracted from https://github.com/openshift-metal3/terraform-provider-ironic/blob/master/ironic/provider.go).
This approach should help especially during the bootstrap of those deployment scenarios where the Ironic services are launched at the same time of the operator - where the reconcile loop could start to operate before Ironic services were effectively up and running.