### PR TITLE
Add ValidateForAdmission function

### DIFF
--- a/pkg/bmc/access.go
+++ b/pkg/bmc/access.go
@@ -56,6 +56,11 @@ type AccessDetails interface {
 	PowerInterface() string
 	RAIDInterface() string
 	VendorInterface() string
+
+	// UniqueAccessPath returns a string that can be used to assert uniqueness
+	// among hosts with the same driver.  For example, when using redfish, we
+	// can return a combination of hostname and path.
+	UniqueAccessPath() string
 }
 
 func getParsedURL(address string) (parsedURL *url.URL, err error) {

--- a/pkg/bmc/ibmc.go
+++ b/pkg/bmc/ibmc.go
@@ -1,6 +1,7 @@
 package bmc
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
 )
@@ -96,4 +97,8 @@ func (a *ibmcAccessDetails) RAIDInterface() string {
 
 func (a *ibmcAccessDetails) VendorInterface() string {
 	return ""
+}
+
+func (a *ibmcAccessDetails) UniqueAccessPath() string {
+	return fmt.Sprintf("%s%s", a.host, a.path)
 }

--- a/pkg/bmc/idrac.go
+++ b/pkg/bmc/idrac.go
@@ -1,6 +1,7 @@
 package bmc
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
 )
@@ -92,4 +93,8 @@ func (a *iDracAccessDetails) RAIDInterface() string {
 
 func (a *iDracAccessDetails) VendorInterface() string {
 	return ""
+}
+
+func (a *iDracAccessDetails) UniqueAccessPath() string {
+	return fmt.Sprintf("%s:%s", a.hostname, a.portNum)
 }

--- a/pkg/bmc/idrac_virtualmedia.go
+++ b/pkg/bmc/idrac_virtualmedia.go
@@ -1,6 +1,7 @@
 package bmc
 
 import (
+	"fmt"
 	"net/url"
 )
 
@@ -85,4 +86,8 @@ func (a *redfishiDracVirtualMediaAccessDetails) RAIDInterface() string {
 
 func (a *redfishiDracVirtualMediaAccessDetails) VendorInterface() string {
 	return "no-vendor"
+}
+
+func (a *redfishiDracVirtualMediaAccessDetails) UniqueAccessPath() string {
+	return fmt.Sprintf("%s%s", a.host, a.path)
 }

--- a/pkg/bmc/ipmi.go
+++ b/pkg/bmc/ipmi.go
@@ -1,6 +1,7 @@
 package bmc
 
 import (
+	"fmt"
 	"net/url"
 )
 
@@ -91,4 +92,8 @@ func (a *ipmiAccessDetails) RAIDInterface() string {
 
 func (a *ipmiAccessDetails) VendorInterface() string {
 	return ""
+}
+
+func (a *ipmiAccessDetails) UniqueAccessPath() string {
+	return fmt.Sprintf("%s:%s", a.hostname, a.portNum)
 }

--- a/pkg/bmc/irmc.go
+++ b/pkg/bmc/irmc.go
@@ -1,6 +1,7 @@
 package bmc
 
 import (
+	"fmt"
 	"net/url"
 )
 
@@ -83,4 +84,8 @@ func (a *iRMCAccessDetails) RAIDInterface() string {
 
 func (a *iRMCAccessDetails) VendorInterface() string {
 	return ""
+}
+
+func (a *iRMCAccessDetails) UniqueAccessPath() string {
+	return fmt.Sprintf("%s:%s", a.hostname, a.portNum)
 }

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -1,6 +1,7 @@
 package bmc
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
 )
@@ -105,4 +106,8 @@ func (a *redfishAccessDetails) RAIDInterface() string {
 
 func (a *redfishAccessDetails) VendorInterface() string {
 	return ""
+}
+
+func (a *redfishAccessDetails) UniqueAccessPath() string {
+	return fmt.Sprintf("%s%s", a.host, a.path)
 }

--- a/pkg/bmc/redfish_virtualmedia.go
+++ b/pkg/bmc/redfish_virtualmedia.go
@@ -1,6 +1,7 @@
 package bmc
 
 import (
+	"fmt"
 	"net/url"
 )
 
@@ -84,4 +85,8 @@ func (a *redfishVirtualMediaAccessDetails) RAIDInterface() string {
 
 func (a *redfishVirtualMediaAccessDetails) VendorInterface() string {
 	return ""
+}
+
+func (a *redfishVirtualMediaAccessDetails) UniqueAccessPath() string {
+	return fmt.Sprintf("%s%s", a.host, a.path)
 }

--- a/pkg/validation/admission.go
+++ b/pkg/validation/admission.go
@@ -1,0 +1,70 @@
+package validation
+
+import (
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
+)
+
+// ValidateHostForAdmission takes a list of existing hosts, and a host we are
+// trying to add to the cluster.  It returns an error if the host fails
+// uniqueness validation, and cannot be added to the cluster.  The optional
+// third argument `old` denotes the previous version of `host` in the case of an
+// update.
+//
+// This is designed to be run by an admission webhook, `ValidateCreate`, and
+// `ValidateUpdate`.
+func ValidateHostForAdmission(existingHosts []metal3v1alpha1.BareMetalHost, host metal3v1alpha1.BareMetalHost, old *metal3v1alpha1.BareMetalHost) error {
+	if host.Spec.BMC.Address == "" && host.Spec.BootMACAddress == "" && host.Spec.BMC.CredentialsName == "" {
+		return nil
+	}
+
+	if len(existingHosts) == 0 {
+		return nil
+	}
+
+	var allErrs field.ErrorList
+
+	for _, existingHost := range existingHosts {
+		if old != nil && old.Namespace == existingHost.Namespace && old.Name == existingHost.Name {
+			continue
+		}
+
+		// The BMC address is optional so only validate it if it's set
+		if host.Spec.BMC.Address != "" && host.Spec.BMC.Address == existingHost.Spec.BMC.Address {
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("spec", "bmc", "address"),
+				host.Spec.BMC.Address,
+				"is not unique",
+			))
+		}
+
+		// The BootMACAddress is optional so only validate it if it's set
+		if host.Spec.BootMACAddress != "" && host.Spec.BootMACAddress == existingHost.Spec.BootMACAddress {
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("spec", "bootMACAddress"),
+				host.Spec.BootMACAddress,
+				"is not unique",
+			))
+		}
+
+		// The BMC credentials is optional so only validate it if it's set
+		if host.Spec.BMC.CredentialsName != "" && host.Spec.BMC.CredentialsName == existingHost.Spec.BMC.CredentialsName {
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("spec", "bmc", "credentialsName"),
+				host.Spec.BMC.CredentialsName,
+				"is not unique",
+			))
+		}
+	}
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(
+		metal3v1alpha1.SchemeGroupVersion.WithKind("BareMetalHost").GroupKind(),
+		host.Name,
+		allErrs)
+}

--- a/pkg/validation/admission_test.go
+++ b/pkg/validation/admission_test.go
@@ -70,8 +70,8 @@ func TestCanBeAdmitted(t *testing.T) {
 				defaultHostName,
 				field.ErrorList{
 					field.Invalid(
-						field.NewPath("spec", "bmc", "address"),
-						defaultBMCAddress,
+						field.NewPath("spec", "bmc"),
+						metal3v1alpha1.BMCDetails{Address: defaultBMCAddress},
 						"is not unique",
 					),
 				}),
@@ -79,44 +79,6 @@ func TestCanBeAdmitted(t *testing.T) {
 		{
 			Scenario: "BMC address is unique",
 			Host:     newHost(defaultHostName, "unique", "", ""),
-			Expected: nil,
-		},
-		{
-			Scenario: "BootMACAddress is not unique",
-			Host:     newHost(defaultHostName, "", "", defaultBootMACAddress),
-			Expected: apierrors.NewInvalid(
-				metal3v1alpha1.SchemeGroupVersion.WithKind("BareMetalHost").GroupKind(),
-				defaultHostName,
-				field.ErrorList{
-					field.Invalid(
-						field.NewPath("spec", "bootMACAddress"),
-						defaultBootMACAddress,
-						"is not unique",
-					),
-				}),
-		},
-		{
-			Scenario: "BootMACAddress is unique",
-			Host:     newHost(defaultHostName, "", "", "unique"),
-			Expected: nil,
-		},
-		{
-			Scenario: "BMC credentials name is not unique",
-			Host:     newHost(defaultHostName, "", defaultBMCCredentialsName, ""),
-			Expected: apierrors.NewInvalid(
-				metal3v1alpha1.SchemeGroupVersion.WithKind("BareMetalHost").GroupKind(),
-				defaultHostName,
-				field.ErrorList{
-					field.Invalid(
-						field.NewPath("spec", "bmc", "credentialsName"),
-						defaultBMCCredentialsName,
-						"is not unique",
-					),
-				}),
-		},
-		{
-			Scenario: "BMC credentials name is unique",
-			Host:     newHost(defaultHostName, "", "unique", ""),
 			Expected: nil,
 		},
 	}
@@ -128,19 +90,6 @@ func TestCanBeAdmitted(t *testing.T) {
 			assert.Equal(t, tc.Expected, err)
 		})
 	}
-}
-
-func TestCanBeAdmittedMultiple(t *testing.T) {
-	h1 := newHost("h1", "", "", "")
-	h2 := newHost("h2", "", "", "")
-	h3 := newHost("h3", "", "", "")
-	existingHosts := asList(h1, h2, h3)
-
-	err := ValidateHostForAdmission(existingHosts, newDefaultHost(), nil)
-	assert.Equal(t, nil, err)
-
-	err = ValidateHostForAdmission(existingHosts, newHost(defaultHostName, "", "", ""), nil)
-	assert.Equal(t, nil, err)
 }
 
 func TestCanBeAdmittedUpdate(t *testing.T) {
@@ -165,8 +114,8 @@ func TestCanBeAdmittedUpdate(t *testing.T) {
 		"h1",
 		field.ErrorList{
 			field.Invalid(
-				field.NewPath("spec", "bmc", "address"),
-				"2",
+				field.NewPath("spec", "bmc"),
+				metal3v1alpha1.BMCDetails{Address: "2"},
 				"is not unique",
 			),
 		})

--- a/pkg/validation/admission_test.go
+++ b/pkg/validation/admission_test.go
@@ -1,0 +1,175 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/kubernetes/scheme"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	metal3apis "github.com/metal3-io/baremetal-operator/pkg/apis"
+	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
+)
+
+const (
+	namespace                 string = "test-namespace"
+	defaultHostName           string = "default-host"
+	defaultBMCCredentialsName string = "bmc-creds-valid"
+	defaultBootMACAddress     string = "00:00:00:00:00"
+	defaultBMCAddress         string = "ipmi://192.168.122.1:6233"
+)
+
+func init() {
+	logf.SetLogger(logf.ZapLogger(true))
+	// Register our package types with the global scheme
+	metal3apis.AddToScheme(scheme.Scheme)
+}
+
+func newHost(name, bmcAddress, bmcCredentialsName, bootMACAddress string) metal3v1alpha1.BareMetalHost {
+	return metal3v1alpha1.BareMetalHost{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "BareMetalHost",
+			APIVersion: "metal3.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: metal3v1alpha1.BareMetalHostSpec{
+			BMC: metal3v1alpha1.BMCDetails{
+				Address:         bmcAddress,
+				CredentialsName: bmcCredentialsName,
+			},
+			BootMACAddress: bootMACAddress,
+		},
+	}
+}
+
+func newDefaultHost() metal3v1alpha1.BareMetalHost {
+	return newHost(defaultHostName, defaultBMCAddress, defaultBMCCredentialsName, defaultBootMACAddress)
+}
+
+func asList(hosts ...metal3v1alpha1.BareMetalHost) []metal3v1alpha1.BareMetalHost {
+	return hosts
+}
+
+func TestCanBeAdmitted(t *testing.T) {
+	testCases := []struct {
+		Scenario string
+		Host     metal3v1alpha1.BareMetalHost
+		Expected error
+	}{
+		{
+			Scenario: "BMC address is not unique",
+			Host:     newHost(defaultHostName, defaultBMCAddress, "", ""),
+			Expected: apierrors.NewInvalid(
+				metal3v1alpha1.SchemeGroupVersion.WithKind("BareMetalHost").GroupKind(),
+				defaultHostName,
+				field.ErrorList{
+					field.Invalid(
+						field.NewPath("spec", "bmc", "address"),
+						defaultBMCAddress,
+						"is not unique",
+					),
+				}),
+		},
+		{
+			Scenario: "BMC address is unique",
+			Host:     newHost(defaultHostName, "unique", "", ""),
+			Expected: nil,
+		},
+		{
+			Scenario: "BootMACAddress is not unique",
+			Host:     newHost(defaultHostName, "", "", defaultBootMACAddress),
+			Expected: apierrors.NewInvalid(
+				metal3v1alpha1.SchemeGroupVersion.WithKind("BareMetalHost").GroupKind(),
+				defaultHostName,
+				field.ErrorList{
+					field.Invalid(
+						field.NewPath("spec", "bootMACAddress"),
+						defaultBootMACAddress,
+						"is not unique",
+					),
+				}),
+		},
+		{
+			Scenario: "BootMACAddress is unique",
+			Host:     newHost(defaultHostName, "", "", "unique"),
+			Expected: nil,
+		},
+		{
+			Scenario: "BMC credentials name is not unique",
+			Host:     newHost(defaultHostName, "", defaultBMCCredentialsName, ""),
+			Expected: apierrors.NewInvalid(
+				metal3v1alpha1.SchemeGroupVersion.WithKind("BareMetalHost").GroupKind(),
+				defaultHostName,
+				field.ErrorList{
+					field.Invalid(
+						field.NewPath("spec", "bmc", "credentialsName"),
+						defaultBMCCredentialsName,
+						"is not unique",
+					),
+				}),
+		},
+		{
+			Scenario: "BMC credentials name is unique",
+			Host:     newHost(defaultHostName, "", "unique", ""),
+			Expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			existingHosts := asList(newDefaultHost())
+			err := ValidateHostForAdmission(existingHosts, tc.Host, nil)
+			assert.Equal(t, tc.Expected, err)
+		})
+	}
+}
+
+func TestCanBeAdmittedMultiple(t *testing.T) {
+	h1 := newHost("h1", "", "", "")
+	h2 := newHost("h2", "", "", "")
+	h3 := newHost("h3", "", "", "")
+	existingHosts := asList(h1, h2, h3)
+
+	err := ValidateHostForAdmission(existingHosts, newDefaultHost(), nil)
+	assert.Equal(t, nil, err)
+
+	err = ValidateHostForAdmission(existingHosts, newHost(defaultHostName, "", "", ""), nil)
+	assert.Equal(t, nil, err)
+}
+
+func TestCanBeAdmittedUpdate(t *testing.T) {
+	h1 := newHost("h1", "1", "", "")
+	h2 := newHost("h2", "2", "", "")
+	h3 := newHost("h3", "3", "", "")
+	existingHosts := asList(h1, h2, h3)
+
+	h1Updated := h1.DeepCopy()
+	h1Updated.Spec.HardwareProfile = "test"
+	err := ValidateHostForAdmission(existingHosts, *h1Updated, &h1)
+	assert.Equal(t, nil, err)
+
+	h1Updated.Spec.BMC.Address = "updated"
+	err = ValidateHostForAdmission(existingHosts, *h1Updated, &h1)
+	assert.Equal(t, nil, err)
+
+	h1Updated.Spec.BMC.Address = "2"
+	err = ValidateHostForAdmission(existingHosts, *h1Updated, &h1)
+	expected := apierrors.NewInvalid(
+		metal3v1alpha1.SchemeGroupVersion.WithKind("BareMetalHost").GroupKind(),
+		"h1",
+		field.ErrorList{
+			field.Invalid(
+				field.NewPath("spec", "bmc", "address"),
+				"2",
+				"is not unique",
+			),
+		})
+	assert.Equal(t, expected, err)
+
+}


### PR DESCRIPTION
This function determines if a new BareMetalHost can be added to the
cluster.  It's suitable to be run from a `ValidateCreate` admission
webhook.

Currently, it checks for BMC address uniquess, and BootMACAddress
uniqueness.