### PR TITLE
Use actionContinueNoWrite when power State == desired

### DIFF
--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -720,7 +720,7 @@ func (r *ReconcileBareMetalHost) manageHostPower(prov provisioner.Provisioner, i
 	// a delay.
 	steadyStateResult := actionContinue{time.Second * 60}
 	if info.host.Status.PoweredOn == desiredPowerOnState {
-		return steadyStateResult
+		return actionContinueNoWrite{steadyStateResult}
 	}
 
 	info.log.Info("power state change needed",


### PR DESCRIPTION
If the power state is correct then we don't need to
save host status.