### PR TITLE
Adding support for hardware type iLO

### DIFF
--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -311,6 +311,36 @@ func TestParse(t *testing.T) {
 			Hostname: "192.168.122.1",
 			Path:     "",
 		},
+
+		{
+                        Scenario: "ilo url",
+                        Address:  "ilo://192.168.122.1",
+                        Type:     "ilo",
+                        Port:     "",
+                        Host:     "192.168.122.1",
+                        Hostname: "192.168.122.1",
+                        Path:     "",
+                },
+
+		{
+                        Scenario: "ilo url, ipv6",
+                        Address:  "ilo://[fe80::fc33:62ff:fe83:8a76]",
+                        Type:     "ilo",
+                        Port:     "",
+                        Host:     "fe80::fc33:62ff:fe83:8a76",
+                        Hostname: "[fe80::fc33:62ff:fe83:8a76]",
+                        Path:     "",
+                },
+
+                {
+                        Scenario: "ilo url, no sep",
+                        Address:  "ilo:192.168.122.1",
+                        Type:     "ilo",
+                        Port:     "",
+                        Host:     "192.168.122.1",
+                        Hostname: "192.168.122.1",
+                        Path:     "",
+                },
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			url, err := getParsedURL(tc.Address)

--- a/pkg/bmc/ilo.go
+++ b/pkg/bmc/ilo.go
@@ -1,0 +1,82 @@
+package bmc
+
+import (
+	"net/url"
+)
+
+func init() {
+	registerFactory("ilo", newILOAccessDetails)
+}
+
+func newILOAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+	return &iLOAccessDetails{
+		bmcType:                        parsedURL.Scheme,
+		hostname:                       parsedURL.Hostname(),
+		disableCertificateVerification: disableCertificateVerification,
+	}, nil
+}
+
+type iLOAccessDetails struct {
+	bmcType                        string
+	hostname                       string
+	disableCertificateVerification bool
+}
+
+func (a *iLOAccessDetails) Type() string {
+	return a.bmcType
+}
+
+// NeedsMAC returns true when the host is going to need a separate
+// port created rather than having it discovered.
+func (a *iLOAccessDetails) NeedsMAC() bool {
+	// For the inspection to work, we need a MAC address
+        // https://github.com/metal3-io/baremetal-operator/pull/284#discussion_r317579040
+        return true
+}
+
+func (a *iLOAccessDetails) Driver() string {
+	return "ilo"
+}
+
+func (a *iLOAccessDetails) DisableCertificateVerification() bool {
+        return a.disableCertificateVerification
+}
+
+// DriverInfo returns a data structure to pass as the DriverInfo
+// parameter when creating a node in Ironic. The structure is
+// pre-populated with the access information, and the caller is
+// expected to add any other information that might be needed (such as
+// the kernel and ramdisk locations).
+func (a *iLOAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interface{} {
+	result := map[string]interface{}{
+		"ilo_username": bmcCreds.Username,
+		"ilo_password": bmcCreds.Password,
+		"ilo_address":  a.hostname,
+	}
+
+	if a.disableCertificateVerification {
+                result["ilo_verify_ca"] = false
+        }
+
+	return result
+}
+
+func (a *iLOAccessDetails) BootInterface() string {
+	return "ilo-ipxe"
+}
+
+func (a *iLOAccessDetails) ManagementInterface() string {
+	return ""
+}
+
+func (a *iLOAccessDetails) PowerInterface() string {
+	return ""
+}
+
+func (a *iLOAccessDetails) RAIDInterface() string {
+	return ""
+}
+
+func (a *iLOAccessDetails) VendorInterface() string {
+	return ""
+}


### PR DESCRIPTION
This commit add support for iLO hardware type to
deploy ilo based systems using BMO.

I haven't added the changes related to hardware type ilo in ironic.conf. Since it doesn't support boot_interface ipxe or pxe. So it was giving error **Boot interface ipxe not supported** when i was adding ilo in **enabled_hardware_types** and restarting the ironic service.

So i had to remove all the other hardware type to make ilo work.
