### PR TITLE
add explicit boot mode field to baremetal host

### DIFF
--- a/deploy/crds/metal3.io_baremetalhosts_crd.yaml
+++ b/deploy/crds/metal3.io_baremetalhosts_crd.yaml
@@ -90,6 +90,13 @@ spec:
                 types, but required for libvirt VMs driven by vbmc.
               pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
               type: string
+            bootMode:
+              description: Select the method of initializing the hardware during boot
+                to override the value based on the BMC driver.
+              enum:
+              - UEFI
+              - legacy
+              type: string
             consumerRef:
               description: ConsumerRef can be used to store information about something
                 that is using a host. When it is not empty, the host is considered
@@ -585,6 +592,13 @@ spec:
                 ID:
                   description: The machine's UUID from the underlying provisioning
                     tool
+                  type: string
+                bootMode:
+                  description: BootMode indicates the boot mode used to provision
+                    the node
+                  enum:
+                  - UEFI
+                  - legacy
                   type: string
                 image:
                   description: Image holds the details of the last image successfully

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -73,6 +73,16 @@ type RootDeviceHints struct {
 	Rotational *bool `json:"rotational,omitempty"`
 }
 
+// BootMode is the boot mode of the system
+// +kubebuilder:validation:Enum=UEFI;legacy
+type BootMode string
+
+// Allowed boot mode from metal3
+const (
+	UEFI   BootMode = "UEFI"
+	Legacy BootMode = "legacy"
+)
+
 // OperationalStatus represents the state of the host
 type OperationalStatus string
 
@@ -215,6 +225,11 @@ type BareMetalHostSpec struct {
 	// Provide guidance about how to choose the device for the image
 	// being provisioned.
 	RootDeviceHints *RootDeviceHints `json:"rootDeviceHints,omitempty"`
+
+	// Select the method of initializing the hardware during boot to
+	// override the value based on the BMC driver.
+	// +optional
+	BootMode BootMode `json:"bootMode,omitempty"`
 
 	// Which MAC address will PXE boot? This is optional for some
 	// types, but required for libvirt VMs driven by vbmc.
@@ -545,6 +560,9 @@ type ProvisionStatus struct {
 
 	// The RootDevicehints set by the user
 	RootDeviceHints *RootDeviceHints `json:"rootDeviceHints,omitempty"`
+
+	// BootMode indicates the boot mode used to provision the node
+	BootMode BootMode `json:"bootMode,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
This PR extends the API to include the new field described in
https://github.com/metal3-io/metal3-docs/blob/master/design/baremetal-operator/implicit-boot-mode.md
without using it, so we can update the cluster API providers to avoid
overwriting the user-provided value when provisioning a host.

We need this before approving #586