### PR TITLE
Avoid extra requeues when credentials missing

### DIFF
--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -307,12 +307,11 @@ func (r *ReconcileBareMetalHost) Reconcile(request reconcile.Request) (result re
 		info.log.Info("saving host status",
 			"operational status", host.OperationalStatus(),
 			"provisioning state", host.Status.Provisioning.State)
-		err := r.saveHostStatus(host)
+		err = r.saveHostStatus(host)
 		if err != nil {
 			return reconcile.Result{}, errors.Wrap(err,
 				fmt.Sprintf("failed to save host status after %q", initialState))
 		}
-		info.log.Info("Updated Status")
 
 		for _, cb := range info.postSaveCallbacks {
 			cb()
@@ -368,8 +367,6 @@ func (r *ReconcileBareMetalHost) credentialsErrorResult(err error, request recon
 		changed, saveErr := r.setErrorCondition(request, host, metal3v1alpha1.RegistrationError, err.Error())
 		if saveErr != nil {
 			return reconcile.Result{Requeue: true}, saveErr
-		} else if !changed {
-			return reconcile.Result{Requeue: true, RequeueAfter: hostErrorRetryDelay}, nil
 		}
 		if changed {
 			// Only publish the event if we do not have an error
@@ -386,16 +383,14 @@ func (r *ReconcileBareMetalHost) credentialsErrorResult(err error, request recon
 	case *EmptyBMCAddressError, *EmptyBMCSecretError,
 		*bmc.CredentialsValidationError, *bmc.UnknownBMCTypeError:
 		credentialsInvalid.Inc()
-		changed, saveErr := r.setErrorCondition(request, host, metal3v1alpha1.RegistrationError, err.Error())
+		_, saveErr := r.setErrorCondition(request, host, metal3v1alpha1.RegistrationError, err.Error())
 		if saveErr != nil {
 			return reconcile.Result{Requeue: true}, saveErr
-		} else if !changed {
-			return reconcile.Result{}, nil
 		}
 		// Only publish the event if we do not have an error
-		// after saving so that we only publish one time. Requeue immediately to save the status
+		// after saving so that we only publish one time.
 		r.publishEvent(request, host.NewEvent("BMCCredentialError", err.Error()))
-		return reconcile.Result{Requeue: true}, nil
+		return reconcile.Result{}, nil
 	default:
 		unhandledCredentialsError.Inc()
 		return reconcile.Result{}, errors.Wrap(err, "An unhandled failure occurred with the BMC secret")
@@ -880,7 +875,6 @@ func (r *ReconcileBareMetalHost) setErrorCondition(request reconcile.Request, ho
 			"adding error message",
 			"message", message,
 		)
-		// We might need to requeue if we failed to update the status
 		err = r.saveHostStatus(host)
 		if err != nil {
 			err = errors.Wrap(err, "failed to update error message")


### PR DESCRIPTION
The extra requeues added in 871926d407c4758f96a7fc011f254a57b2c0eaa1 to
ensure that the Status got written immediately after updating the status
annotation were incompletely reverted by
f1b81a06527cb41b2b7e0212e76fc86976b32324, after which they are no longer
required as we no longer write a status annotation and just write the
Status immediately. This reverts the remaining changes to prevent
unnecessary requeueing.