### PR TITLE
Enable Pruning for BMH CRD

### DIFF
--- a/deploy/crds/metal3.io_baremetalhosts_crd.yaml
+++ b/deploy/crds/metal3.io_baremetalhosts_crd.yaml
@@ -42,6 +42,7 @@ spec:
     - bmhost
     singular: baremetalhost
   scope: Namespaced
+  preserveUnknownFields: false
   subresources:
     status: {}
   validation:


### PR DESCRIPTION
This causes stricter client-side validation against the schema
so that problems like typos in the user-provided BMH yaml can
be caught earlier and report a clear error message.

Fixes: #580