### PR TITLE
refactor redfish driver hierarchy

### DIFF
--- a/pkg/bmc/idrac_virtualmedia.go
+++ b/pkg/bmc/idrac_virtualmedia.go
@@ -2,7 +2,6 @@ package bmc
 
 import (
 	"net/url"
-	"strings"
 )
 
 func init() {
@@ -48,21 +47,11 @@ func (a *redfishiDracVirtualMediaAccessDetails) DisableCertificateVerification()
 // expected to add any other information that might be needed (such as
 // the kernel and ramdisk locations).
 func (a *redfishiDracVirtualMediaAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interface{} {
-	redfishAddress := []string{}
-	schemes := strings.Split(a.bmcType, "+")
-	if len(schemes) > 1 {
-		redfishAddress = append(redfishAddress, schemes[1])
-	} else {
-		redfishAddress = append(redfishAddress, redfishDefaultScheme)
-	}
-	redfishAddress = append(redfishAddress, "://")
-	redfishAddress = append(redfishAddress, a.host)
-
 	result := map[string]interface{}{
 		"redfish_system_id": a.path,
 		"redfish_username":  bmcCreds.Username,
 		"redfish_password":  bmcCreds.Password,
-		"redfish_address":   strings.Join(redfishAddress, ""),
+		"redfish_address":   getRedfishAddress(a.bmcType, a.host),
 	}
 
 	if a.disableCertificateVerification {

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -8,9 +8,7 @@ import (
 func init() {
 	schemes := []string{"http", "https"}
 	registerFactory("redfish", newRedfishAccessDetails, schemes)
-	registerFactory("redfish-virtualmedia", newRedfishVirtualMediaAccessDetails, schemes)
 	registerFactory("ilo5-redfish", newRedfishAccessDetails, schemes)
-	registerFactory("ilo5-virtualmedia", newRedfishVirtualMediaAccessDetails, schemes)
 	registerFactory("idrac-virtualmedia", newRedfishiDracVirtualMediaAccessDetails, schemes)
 }
 
@@ -27,12 +25,6 @@ func newRedfishAccessDetails(parsedURL *url.URL, disableCertificateVerification 
 	return redfishDetails(parsedURL, disableCertificateVerification), nil
 }
 
-func newRedfishVirtualMediaAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
-	return &redfishVirtualMediaAccessDetails{
-		*redfishDetails(parsedURL, disableCertificateVerification),
-	}, nil
-}
-
 func newRedfishiDracVirtualMediaAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
 	return &redfishiDracVirtualMediaAccessDetails{
 		*redfishDetails(parsedURL, disableCertificateVerification),
@@ -44,10 +36,6 @@ type redfishAccessDetails struct {
 	host                           string
 	path                           string
 	disableCertificateVerification bool
-}
-
-type redfishVirtualMediaAccessDetails struct {
-	redfishAccessDetails
 }
 
 type redfishiDracVirtualMediaAccessDetails struct {
@@ -125,12 +113,6 @@ func (a *redfishAccessDetails) RAIDInterface() string {
 
 func (a *redfishAccessDetails) VendorInterface() string {
 	return ""
-}
-
-// Virtual Media Overrides
-
-func (a *redfishVirtualMediaAccessDetails) BootInterface() string {
-	return "redfish-virtual-media"
 }
 
 // iDrac Virtual Media Overrides

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -53,27 +53,30 @@ func (a *redfishAccessDetails) DisableCertificateVerification() bool {
 	return a.disableCertificateVerification
 }
 
-// DriverInfo returns a data structure to pass as the DriverInfo
-// parameter when creating a node in Ironic. The structure is
-// pre-populated with the access information, and the caller is
-// expected to add any other information that might be needed (such as
-// the kernel and ramdisk locations).
-func (a *redfishAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interface{} {
+func getRedfishAddress(bmcType, host string) string {
 	redfishAddress := []string{}
-	schemes := strings.Split(a.bmcType, "+")
+	schemes := strings.Split(bmcType, "+")
 	if len(schemes) > 1 {
 		redfishAddress = append(redfishAddress, schemes[1])
 	} else {
 		redfishAddress = append(redfishAddress, redfishDefaultScheme)
 	}
 	redfishAddress = append(redfishAddress, "://")
-	redfishAddress = append(redfishAddress, a.host)
+	redfishAddress = append(redfishAddress, host)
+	return strings.Join(redfishAddress, "")
+}
 
+// DriverInfo returns a data structure to pass as the DriverInfo
+// parameter when creating a node in Ironic. The structure is
+// pre-populated with the access information, and the caller is
+// expected to add any other information that might be needed (such as
+// the kernel and ramdisk locations).
+func (a *redfishAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interface{} {
 	result := map[string]interface{}{
 		"redfish_system_id": a.path,
 		"redfish_username":  bmcCreds.Username,
 		"redfish_password":  bmcCreds.Password,
-		"redfish_address":   strings.Join(redfishAddress, ""),
+		"redfish_address":   getRedfishAddress(a.bmcType, a.host),
 	}
 
 	if a.disableCertificateVerification {

--- a/pkg/bmc/redfish_virtualmedia.go
+++ b/pkg/bmc/redfish_virtualmedia.go
@@ -1,0 +1,98 @@
+package bmc
+
+import (
+	"net/url"
+	"strings"
+)
+
+func init() {
+	schemes := []string{"http", "https"}
+	registerFactory("redfish-virtualmedia", newRedfishVirtualMediaAccessDetails, schemes)
+	registerFactory("ilo5-virtualmedia", newRedfishVirtualMediaAccessDetails, schemes)
+}
+
+func newRedfishVirtualMediaAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+	return &redfishVirtualMediaAccessDetails{
+		bmcType:                        parsedURL.Scheme,
+		host:                           parsedURL.Host,
+		path:                           parsedURL.Path,
+		disableCertificateVerification: disableCertificateVerification,
+	}, nil
+}
+
+type redfishVirtualMediaAccessDetails struct {
+	bmcType                        string
+	host                           string
+	path                           string
+	disableCertificateVerification bool
+}
+
+func (a *redfishVirtualMediaAccessDetails) Type() string {
+	return a.bmcType
+}
+
+// NeedsMAC returns true when the host is going to need a separate
+// port created rather than having it discovered.
+func (a *redfishVirtualMediaAccessDetails) NeedsMAC() bool {
+	// For the inspection to work, we need a MAC address
+	// https://github.com/metal3-io/baremetal-operator/pull/284#discussion_r317579040
+	return true
+}
+
+func (a *redfishVirtualMediaAccessDetails) Driver() string {
+	return "redfish"
+}
+
+func (a *redfishVirtualMediaAccessDetails) DisableCertificateVerification() bool {
+	return a.disableCertificateVerification
+}
+
+// DriverInfo returns a data structure to pass as the DriverInfo
+// parameter when creating a node in Ironic. The structure is
+// pre-populated with the access information, and the caller is
+// expected to add any other information that might be needed (such as
+// the kernel and ramdisk locations).
+func (a *redfishVirtualMediaAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interface{} {
+	redfishAddress := []string{}
+	schemes := strings.Split(a.bmcType, "+")
+	if len(schemes) > 1 {
+		redfishAddress = append(redfishAddress, schemes[1])
+	} else {
+		redfishAddress = append(redfishAddress, redfishDefaultScheme)
+	}
+	redfishAddress = append(redfishAddress, "://")
+	redfishAddress = append(redfishAddress, a.host)
+
+	result := map[string]interface{}{
+		"redfish_system_id": a.path,
+		"redfish_username":  bmcCreds.Username,
+		"redfish_password":  bmcCreds.Password,
+		"redfish_address":   strings.Join(redfishAddress, ""),
+	}
+
+	if a.disableCertificateVerification {
+		result["redfish_verify_ca"] = false
+	}
+
+	return result
+}
+
+func (a *redfishVirtualMediaAccessDetails) BootInterface() string {
+	return "redfish-virtual-media"
+}
+
+func (a *redfishVirtualMediaAccessDetails) ManagementInterface() string {
+	return ""
+}
+
+func (a *redfishVirtualMediaAccessDetails) PowerInterface() string {
+	return ""
+}
+
+func (a *redfishVirtualMediaAccessDetails) RAIDInterface() string {
+	return ""
+}
+
+func (a *redfishVirtualMediaAccessDetails) VendorInterface() string {
+	return ""
+}

--- a/pkg/bmc/redfish_virtualmedia.go
+++ b/pkg/bmc/redfish_virtualmedia.go
@@ -2,7 +2,6 @@ package bmc
 
 import (
 	"net/url"
-	"strings"
 )
 
 func init() {
@@ -53,21 +52,11 @@ func (a *redfishVirtualMediaAccessDetails) DisableCertificateVerification() bool
 // expected to add any other information that might be needed (such as
 // the kernel and ramdisk locations).
 func (a *redfishVirtualMediaAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interface{} {
-	redfishAddress := []string{}
-	schemes := strings.Split(a.bmcType, "+")
-	if len(schemes) > 1 {
-		redfishAddress = append(redfishAddress, schemes[1])
-	} else {
-		redfishAddress = append(redfishAddress, redfishDefaultScheme)
-	}
-	redfishAddress = append(redfishAddress, "://")
-	redfishAddress = append(redfishAddress, a.host)
-
 	result := map[string]interface{}{
 		"redfish_system_id": a.path,
 		"redfish_username":  bmcCreds.Username,
 		"redfish_password":  bmcCreds.Password,
-		"redfish_address":   strings.Join(redfishAddress, ""),
+		"redfish_address":   getRedfishAddress(a.bmcType, a.host),
 	}
 
 	if a.disableCertificateVerification {


### PR DESCRIPTION
The redfish drivers were mixed together in one file and relied
on inheritance. The point of the BMC types is that they're very
simple, so a little repetition isn't a bad thing. This PR moves the
redfish-virtualmedia and idrac-virtualmedia drivers out to their own
files and removes the inheritance to make them easier to understand.