### PR TITLE
WIP: change default hardware profile to not set root device hints

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -102,13 +102,20 @@ mainly, but not only, provisioning details.
 
   | **hardwareProfile** | **Root Device** |
   |---------------------|-----------------|
-  | `unknown`           | /dev/sda        |
+  | `unknown`           | *none*          |
   | `libvirt`           | /dev/vda        |
   | `dell`              | HCTL: 0:0:0:0   |
   | `dell-raid`         | HCTL: 0:2:0:0   |
   | `openstack`         | /dev/vdb        |
 
   **NOTE:** These are subject to change.
+
+  When the hardware profile is not specified, and the `unknown`
+  profile is used, no root device hints are provided to the
+  provisioning tool. In that case, the tool tries to use the first
+  drive with more than 4GB of space. The actual device selected may
+  vary between hosts. For more deterministic behavior, use the
+  *rootDeviceHints* field to control the outcome.
 
 * *rootDeviceHints* -- Guidance for how to choose the device to
   receive the image being provisioned. The storage devices are

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -827,11 +827,21 @@ func saveHostProvisioningSettings(host *metal3v1alpha1.BareMetalHost) (dirty boo
 		if err != nil {
 			return false, errors.Wrap(err, "Could not update root device hints")
 		}
-		hintSource = &hwProf.RootDeviceHints
+		hintSource = hwProf.RootDeviceHints // might be nil if the profile provides no hints
 	}
-	if (hintSource != nil && host.Status.Provisioning.RootDeviceHints == nil) || *hintSource != *(host.Status.Provisioning.RootDeviceHints) {
+
+	if hintSource == nil {
+		if host.Status.Provisioning.RootDeviceHints != nil {
+			dirty = true
+		}
+	} else {
+		if host.Status.Provisioning.RootDeviceHints == nil || *hintSource != *(host.Status.Provisioning.RootDeviceHints) {
+			dirty = true
+		}
+	}
+
+	if dirty {
 		host.Status.Provisioning.RootDeviceHints = hintSource
-		dirty = true
 	}
 	return
 }

--- a/pkg/controller/baremetalhost/baremetalhost_controller_test.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller_test.go
@@ -1141,10 +1141,32 @@ func TestUpdateRootDeviceHints(t *testing.T) {
 					HardwareProfile: "unknown",
 				},
 			},
-			Dirty: true,
-			Expected: &metal3v1alpha1.RootDeviceHints{
-				DeviceName: "/dev/sda",
+			Dirty:    false,
+			Expected: nil,
+		},
+
+		{
+			Scenario: "clear profile hints",
+			Host: metal3v1alpha1.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myhost",
+					Namespace: "myns",
+					UID:       "27720611-e5d1-45d3-ba3a-222dcfaa4ca2",
+				},
+				Spec: metal3v1alpha1.BareMetalHostSpec{
+					HardwareProfile: "unknown",
+				},
+				Status: metal3v1alpha1.BareMetalHostStatus{
+					HardwareProfile: "unknown",
+					Provisioning: metal3v1alpha1.ProvisionStatus{
+						RootDeviceHints: &metal3v1alpha1.RootDeviceHints{
+							DeviceName: "/dev/vda",
+						},
+					},
+				},
 			},
+			Dirty:    true,
+			Expected: nil,
 		},
 	}
 

--- a/pkg/hardware/profile.go
+++ b/pkg/hardware/profile.go
@@ -19,7 +19,7 @@ type Profile struct {
 
 	// RootDeviceHints holds the suggestions for placing the storage
 	// for the root filesystem.
-	RootDeviceHints metal3v1alpha1.RootDeviceHints
+	RootDeviceHints *metal3v1alpha1.RootDeviceHints
 
 	// RootGB is the size of the root volume in GB
 	RootGB int
@@ -35,18 +35,16 @@ var profiles = make(map[string]Profile)
 
 func init() {
 	profiles[DefaultProfileName] = Profile{
-		Name: DefaultProfileName,
-		RootDeviceHints: metal3v1alpha1.RootDeviceHints{
-			DeviceName: "/dev/sda",
-		},
-		RootGB:  10,
-		LocalGB: 50,
-		CPUArch: "x86_64",
+		Name:            DefaultProfileName,
+		RootDeviceHints: nil, // ironic will find the first disk of size >=4GB
+		RootGB:          10,
+		LocalGB:         50,
+		CPUArch:         "x86_64",
 	}
 
 	profiles["libvirt"] = Profile{
 		Name: "libvirt",
-		RootDeviceHints: metal3v1alpha1.RootDeviceHints{
+		RootDeviceHints: &metal3v1alpha1.RootDeviceHints{
 			DeviceName: "/dev/vda",
 		},
 		RootGB:  10,
@@ -56,7 +54,7 @@ func init() {
 
 	profiles["dell"] = Profile{
 		Name: "dell",
-		RootDeviceHints: metal3v1alpha1.RootDeviceHints{
+		RootDeviceHints: &metal3v1alpha1.RootDeviceHints{
 			HCTL: "0:0:0:0",
 		},
 		RootGB:  10,
@@ -66,7 +64,7 @@ func init() {
 
 	profiles["dell-raid"] = Profile{
 		Name: "dell-raid",
-		RootDeviceHints: metal3v1alpha1.RootDeviceHints{
+		RootDeviceHints: &metal3v1alpha1.RootDeviceHints{
 			HCTL: "0:2:0:0",
 		},
 		RootGB:  10,
@@ -76,7 +74,7 @@ func init() {
 
 	profiles["openstack"] = Profile{
 		Name: "openstack",
-		RootDeviceHints: metal3v1alpha1.RootDeviceHints{
+		RootDeviceHints: &metal3v1alpha1.RootDeviceHints{
 			DeviceName: "/dev/vdb",
 		},
 		RootGB:  10,


### PR DESCRIPTION
Change the default behavior to not set an explicit root device hint
based on the hardware profile. This relies on Ironic's default
behavior of choosing the first disk that is bigger than 4GB to hold
the image, which can often bypass issues such as recovery drives or
other devices appearing as `/dev/sda`.