### PR TITLE
Add support for http_basic auth for ironic and inspector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ export LDFLAGS="-X github.com/metal3-io/baremetal-operator/pkg/version.Raw=$(she
 export OPERATOR_NAME=baremetal-operator
 export DEPLOY_KERNEL_URL=http://172.22.0.1:6180/images/ironic-python-agent.kernel
 export DEPLOY_RAMDISK_URL=http://172.22.0.1:6180/images/ironic-python-agent.initramfs
-export IRONIC_AUTH_STRATEGY=noauth
 export IRONIC_ENDPOINT=http://localhost:6385/v1/
 export IRONIC_INSPECTOR_ENDPOINT=http://localhost:5050/v1/
 export GO111MODULE=on

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ export LDFLAGS="-X github.com/metal3-io/baremetal-operator/pkg/version.Raw=$(she
 export OPERATOR_NAME=baremetal-operator
 export DEPLOY_KERNEL_URL=http://172.22.0.1:6180/images/ironic-python-agent.kernel
 export DEPLOY_RAMDISK_URL=http://172.22.0.1:6180/images/ironic-python-agent.initramfs
+export IRONIC_AUTH_STRATEGY=noauth
 export IRONIC_ENDPOINT=http://localhost:6385/v1/
 export IRONIC_INSPECTOR_ENDPOINT=http://localhost:5050/v1/
 export GO111MODULE=on

--- a/cmd/get-hardware-details/main.go
+++ b/cmd/get-hardware-details/main.go
@@ -12,36 +12,22 @@ import (
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/hardwaredetails"
 )
 
-func main() {
-	var nodeID string
-	authConfig := clients.AuthConfig{
-		Type: clients.AuthType(os.Getenv("IRONIC_AUTH_STRATEGY")),
-	}
+type options struct {
+	Endpoint   string
+	AuthConfig clients.AuthConfig
+	NodeID     string
+}
 
-	switch authConfig.Type {
-	case clients.HTTPBasicAuth:
-		if len(os.Args) != 5 {
-			fmt.Println("Usage: get-hardware-details <inspector URI> <inspector User> <inspector Password> <node UUID>")
-			os.Exit(1)
-		}
-		authConfig.Username = os.Args[2]
-		authConfig.Password = os.Args[3]
-		nodeID = os.Args[4]
-	default:
-		if len(os.Args) != 3 {
-			fmt.Println("Usage: get-hardware-details <inspector URI> <node UUID>")
-			os.Exit(1)
-		}
-		nodeID = os.Args[2]
-	}
-	inspectorEndpoint := os.Args[1]
-	inspector, err := clients.InspectorClient(inspectorEndpoint, authConfig)
+func main() {
+	opts := getOptions()
+
+	inspector, err := clients.InspectorClient(opts.Endpoint, opts.AuthConfig)
 	if err != nil {
 		fmt.Printf("could not get inspector client: %s", err)
 		os.Exit(1)
 	}
 
-	introData := introspection.GetIntrospectionData(inspector, nodeID)
+	introData := introspection.GetIntrospectionData(inspector, opts.NodeID)
 	data, err := introData.Extract()
 	if err != nil {
 		fmt.Printf("could not get introspection data: %s", err)
@@ -55,4 +41,27 @@ func main() {
 	}
 
 	fmt.Println(string(json))
+}
+
+func getOptions() (o options) {
+	o.AuthConfig.Type = clients.AuthType(os.Getenv("IRONIC_AUTH_STRATEGY"))
+
+	switch o.AuthConfig.Type {
+	case clients.HTTPBasicAuth:
+		if len(os.Args) != 5 {
+			fmt.Println("Usage: get-hardware-details <inspector URI> <inspector User> <inspector Password> <node UUID>")
+			os.Exit(1)
+		}
+		o.AuthConfig.Username = os.Args[2]
+		o.AuthConfig.Password = os.Args[3]
+		o.NodeID = os.Args[4]
+	default:
+		if len(os.Args) != 3 {
+			fmt.Println("Usage: get-hardware-details <inspector URI> <node UUID>")
+			os.Exit(1)
+		}
+		o.NodeID = os.Args[2]
+	}
+	o.Endpoint = os.Args[1]
+	return
 }

--- a/cmd/get-hardware-details/main.go
+++ b/cmd/get-hardware-details/main.go
@@ -44,24 +44,17 @@ func main() {
 }
 
 func getOptions() (o options) {
-	o.AuthConfig.Type = clients.AuthType(os.Getenv("IRONIC_AUTH_STRATEGY"))
-
-	switch o.AuthConfig.Type {
-	case clients.HTTPBasicAuth:
-		if len(os.Args) != 5 {
-			fmt.Println("Usage: get-hardware-details <inspector URI> <inspector User> <inspector Password> <node UUID>")
-			os.Exit(1)
-		}
-		o.AuthConfig.Username = os.Args[2]
-		o.AuthConfig.Password = os.Args[3]
-		o.NodeID = os.Args[4]
-	default:
-		if len(os.Args) != 3 {
-			fmt.Println("Usage: get-hardware-details <inspector URI> <node UUID>")
-			os.Exit(1)
-		}
-		o.NodeID = os.Args[2]
+	if len(os.Args) != 3 {
+		fmt.Println("Usage: get-hardware-details <inspector URI> <node UUID>")
+		os.Exit(1)
 	}
-	o.Endpoint = os.Args[1]
+
+	var err error
+	o.Endpoint, o.AuthConfig, err = clients.ConfigFromEndpointURL(os.Args[1])
+	if err != nil {
+		fmt.Printf("Error: %s\n", err)
+		os.Exit(1)
+	}
+	o.NodeID = os.Args[2]
 	return
 }

--- a/cmd/get-hardware-details/main.go
+++ b/cmd/get-hardware-details/main.go
@@ -7,27 +7,55 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/httpbasic"
 	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/noauth"
 	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/v1/introspection"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/hardwaredetails"
 )
 
 func main() {
-	if len(os.Args) != 3 {
-		fmt.Println("Usage: get-hardware-details <inspector URI> <node UUID>")
-		return
+	authStrategy := os.Getenv("IRONIC_AUTH_STRATEGY")
+	if authStrategy == "http_basic" {
+		if len(os.Args) != 5 {
+			fmt.Println("Usage: get-hardware-details <inspector URI> <inspector User> <inspector Password> <node UUID>")
+			return
+		}
+	} else {
+		if len(os.Args) != 3 {
+			fmt.Println("Usage: get-hardware-details <inspector URI> <node UUID>")
+			return
+		}
 	}
 
-	inspector, err := noauth.NewBareMetalIntrospectionNoAuth(
-		noauth.EndpointOpts{
-			IronicInspectorEndpoint: os.Args[1],
+	var inspector *gophercloud.ServiceClient
+	var nodeID string
+	if authStrategy == "http_basic" {
+		client, err := httpbasic.NewBareMetalIntrospectionHTTPBasic(httpbasic.EndpointOpts{
+			IronicInspectorEndpoint:     os.Args[1],
+			IronicInspectorUser:         os.Args[2],
+			IronicInspectorUserPassword: os.Args[3],
 		})
-	if err != nil {
-		fmt.Printf("could not get inspector client: %s", err)
-		os.Exit(1)
+		if err != nil {
+			fmt.Printf("could not get inspector client: %s", err)
+			os.Exit(1)
+		}
+		inspector = client
+		nodeID = os.Args[4]
+	} else {
+		client, err := noauth.NewBareMetalIntrospectionNoAuth(
+			noauth.EndpointOpts{
+				IronicInspectorEndpoint: os.Args[1],
+			})
+		if err != nil {
+			fmt.Printf("could not get inspector client: %s", err)
+			os.Exit(1)
+		}
+		inspector = client
+		nodeID = os.Args[2]
 	}
 
-	introData := introspection.GetIntrospectionData(inspector, os.Args[2])
+	introData := introspection.GetIntrospectionData(inspector, nodeID)
 	data, err := introData.Extract()
 	if err != nil {
 		fmt.Printf("could not get introspection data: %s", err)

--- a/docs/ironic-authentication.md
+++ b/docs/ironic-authentication.md
@@ -1,0 +1,37 @@
+# Authenticating to Ironic
+
+Because hosts under the control of Metal³ need to contact the Ironic and Ironic
+Inspector APIs during inspection and provisioning, it is highly advisable to
+require authentication on those APIs, since the provisioned hosts running user
+workloads will remain connected to the provisioning network.
+
+## Configuration
+
+The `baremetal-operator` supports connecting to Ironic and Ironic Inspector
+configured with the following `auth_strategy` modes:
+
+* `noauth` (no authentication)
+* `http_basic` (HTTP [Basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication))
+
+Note that Keystone authentication methods are not yet supported.
+
+Authentication configuration is read from the filesystem, beginning at the root
+directory specified in the environment variable `METAL3_AUTH_ROOT_DIR`. If this
+variable is empty or not specified, the default is `/opt/metal3/auth`.
+
+Within the root directory there are separate subdirectories, `ironic` for
+Ironic client configuration, and `ironic-inspector` for Ironic Inspector client
+configuration. (This allows the data to be populated from separate secrets when
+deploying in Kubernetes.)
+
+### `noauth`
+
+This is the default, and will be chosen if the auth root directory does not
+exist. In this mode, the baremetal-operator does not attempt to do any
+authentication against the Ironic APIs.
+
+### `http_basic`
+
+This mode is configured by files in each authentication subdirectory named
+`username` and `password`, and containing the Basic auth username and password,
+respectively.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gobuffalo/envy v1.7.1 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
-	github.com/gophercloud/gophercloud v0.6.0
+	github.com/gophercloud/gophercloud v0.12.0
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/onsi/ginkgo v1.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -406,6 +406,8 @@ github.com/gophercloud/gophercloud v0.2.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEo
 github.com/gophercloud/gophercloud v0.3.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/gophercloud v0.6.0 h1:Xb2lcqZtml1XjgYZxbeayEemq7ASbeTp09m36gQFpEU=
 github.com/gophercloud/gophercloud v0.6.0/go.mod h1:GICNByuaEBibcjmjvI7QvYJSZEbGkcYwAR7EZK2WMqM=
+github.com/gophercloud/gophercloud v0.12.0 h1:mZrie07npp6ODiwHZolTicr5jV8Ogn43AvAsSMm6Ork=
+github.com/gophercloud/gophercloud v0.12.0/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20191106031601-ce3c9ade29de/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
@@ -893,6 +895,7 @@ golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 h1:xMPOj6Pz6UipU1wXLkrtqpHbR0AVFnyPEQq/wRWz9lM=
@@ -959,6 +962,7 @@ golang.org/x/net v0.0.0-20191002035440-2ec189313ef0/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191112182307-2180aed22343/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3obCJtX9IJhpXkvY7kzk0=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -1019,6 +1023,7 @@ golang.org/x/sys v0.0.0-20191112214154-59a1497f0cea/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e h1:N7DeIrjYszNmSW409R3frPPwglRwMkXSBzwVbkOjLLA=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgmDSfjglYZ3vStQ/gSCU=
@@ -1074,6 +1079,7 @@ golang.org/x/tools v0.0.0-20191111182352-50fa39b762bc/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191113191852-77e3bb0ad9e7/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191203134012-c197fd4bf371/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200430192856-2840dafb9ee1 h1:OlmCHPqCyX+EpIpxG55cfMJuINAFd7HHTdWwA3yyelQ=

--- a/pkg/provisioner/ironic/clients/auth.go
+++ b/pkg/provisioner/ironic/clients/auth.go
@@ -15,40 +15,39 @@ const (
 	HTTPBasicAuth AuthType = "http_basic"
 )
 
-var authStrategy AuthType
-
-// Variables for http_basic
-var ironicUser string
-var ironicPassword string
-var inspectorUser string
-var inspectorPassword string
+// AuthConfig contains data needed to configure authentication in the client
+type AuthConfig struct {
+	Type     AuthType
+	Username string
+	Password string
+}
 
 // LoadAuth loads the Ironic and Inspector configuration from the environment
-func LoadAuth() error {
-	authStrategy = AuthType(os.Getenv("IRONIC_AUTH_STRATEGY"))
-	switch authStrategy {
+func LoadAuth() (ironicAuth, inspectorAuth AuthConfig, err error) {
+	strategy := AuthType(os.Getenv("IRONIC_AUTH_STRATEGY"))
+	ironicAuth.Type = strategy
+	inspectorAuth.Type = strategy
+	switch strategy {
 	case "":
-		return fmt.Errorf("No IRONIC_AUTH_STRATEGY variable set")
+		err = fmt.Errorf("No IRONIC_AUTH_STRATEGY variable set")
 	case NoAuth:
 	case HTTPBasicAuth:
-		ironicUser = os.Getenv("IRONIC_HTTP_BASIC_USERNAME")
-		ironicPassword = os.Getenv("IRONIC_HTTP_BASIC_PASSWORD")
-		inspectorUser = os.Getenv("INSPECTOR_HTTP_BASIC_USERNAME")
-		inspectorPassword = os.Getenv("INSPECTOR_HTTP_BASIC_PASSWORD")
-		if ironicUser == "" {
-			return fmt.Errorf("No IRONIC_HTTP_BASIC_USERNAME variable set")
-		}
-		if ironicPassword == "" {
-			return fmt.Errorf("No IRONIC_HTTP_BASIC_PASSWORD variable set")
-		}
-		if inspectorUser == "" {
-			return fmt.Errorf("No INSPECTOR_HTTP_BASIC_USERNAME variable set")
-		}
-		if inspectorPassword == "" {
-			return fmt.Errorf("No INSPECTOR_HTTP_BASIC_PASSWORD variable set")
+		ironicAuth.Username = os.Getenv("IRONIC_HTTP_BASIC_USERNAME")
+		ironicAuth.Password = os.Getenv("IRONIC_HTTP_BASIC_PASSWORD")
+		inspectorAuth.Username = os.Getenv("INSPECTOR_HTTP_BASIC_USERNAME")
+		inspectorAuth.Password = os.Getenv("INSPECTOR_HTTP_BASIC_PASSWORD")
+		switch {
+		case ironicAuth.Username == "":
+			err = fmt.Errorf("No IRONIC_HTTP_BASIC_USERNAME variable set")
+		case ironicAuth.Password == "":
+			err = fmt.Errorf("No IRONIC_HTTP_BASIC_PASSWORD variable set")
+		case inspectorAuth.Username == "":
+			err = fmt.Errorf("No INSPECTOR_HTTP_BASIC_USERNAME variable set")
+		case inspectorAuth.Password == "":
+			err = fmt.Errorf("No INSPECTOR_HTTP_BASIC_PASSWORD variable set")
 		}
 	default:
-		return fmt.Errorf("IRONIC_AUTH_STRATEGY does not have a valid value. Set to %s or %s", NoAuth, HTTPBasicAuth)
+		err = fmt.Errorf("IRONIC_AUTH_STRATEGY does not have a valid value. Set to %s or %s", NoAuth, HTTPBasicAuth)
 	}
-	return nil
+	return
 }

--- a/pkg/provisioner/ironic/clients/auth.go
+++ b/pkg/provisioner/ironic/clients/auth.go
@@ -26,13 +26,21 @@ type AuthConfig struct {
 	Password string
 }
 
+func authRoot() string {
+	env := os.Getenv("METAL3_AUTH_ROOT_DIR")
+	if env != "" {
+		return filepath.Clean(env)
+	}
+	return "/opt/metal3/auth"
+}
+
 func readAuthFile(filename string) (string, error) {
 	content, err := ioutil.ReadFile(filepath.Clean(filename))
 	return strings.TrimSpace(string(content)), err
 }
 
 func load(clientType string) (auth AuthConfig, err error) {
-	authPath := path.Join("/opt/metal3/auth", clientType)
+	authPath := path.Join(authRoot(), clientType)
 
 	if _, err := os.Stat(authPath); err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/provisioner/ironic/clients/auth.go
+++ b/pkg/provisioner/ironic/clients/auth.go
@@ -1,0 +1,54 @@
+package clients
+
+import (
+	"fmt"
+	"os"
+)
+
+// AuthType is the method of authenticating requests to the server
+type AuthType string
+
+const (
+	// NoAuth uses no authentication
+	NoAuth AuthType = "noauth"
+	// HTTPBasicAuth uses HTTP Basic Authentication
+	HTTPBasicAuth AuthType = "http_basic"
+)
+
+var authStrategy AuthType
+
+// Variables for http_basic
+var ironicUser string
+var ironicPassword string
+var inspectorUser string
+var inspectorPassword string
+
+// LoadAuth loads the Ironic and Inspector configuration from the environment
+func LoadAuth() error {
+	authStrategy = AuthType(os.Getenv("IRONIC_AUTH_STRATEGY"))
+	switch authStrategy {
+	case "":
+		return fmt.Errorf("No IRONIC_AUTH_STRATEGY variable set")
+	case NoAuth:
+	case HTTPBasicAuth:
+		ironicUser = os.Getenv("IRONIC_HTTP_BASIC_USERNAME")
+		ironicPassword = os.Getenv("IRONIC_HTTP_BASIC_PASSWORD")
+		inspectorUser = os.Getenv("INSPECTOR_HTTP_BASIC_USERNAME")
+		inspectorPassword = os.Getenv("INSPECTOR_HTTP_BASIC_PASSWORD")
+		if ironicUser == "" {
+			return fmt.Errorf("No IRONIC_HTTP_BASIC_USERNAME variable set")
+		}
+		if ironicPassword == "" {
+			return fmt.Errorf("No IRONIC_HTTP_BASIC_PASSWORD variable set")
+		}
+		if inspectorUser == "" {
+			return fmt.Errorf("No INSPECTOR_HTTP_BASIC_USERNAME variable set")
+		}
+		if inspectorPassword == "" {
+			return fmt.Errorf("No INSPECTOR_HTTP_BASIC_PASSWORD variable set")
+		}
+	default:
+		return fmt.Errorf("IRONIC_AUTH_STRATEGY does not have a valid value. Set to %s or %s", NoAuth, HTTPBasicAuth)
+	}
+	return nil
+}

--- a/pkg/provisioner/ironic/clients/auth_test.go
+++ b/pkg/provisioner/ironic/clients/auth_test.go
@@ -1,0 +1,99 @@
+package clients
+
+import (
+	"testing"
+)
+
+func TestConfigFromEndpointURL(t *testing.T) {
+	testCases := []struct {
+		Scenario         string
+		URL              string
+		ExpectedEndpoint string
+		ExpectedAuth     AuthConfig
+		ExpectErr        bool
+	}{
+		{
+			Scenario:  "garbage",
+			URL:       "@foo::bar",
+			ExpectErr: true,
+		},
+		{
+			Scenario:         "no auth",
+			URL:              "https://example.test/v1",
+			ExpectedEndpoint: "https://example.test/v1",
+			ExpectedAuth: AuthConfig{
+				Type: NoAuth,
+			},
+		},
+		{
+			Scenario:         "username-only",
+			URL:              "https://user@example.test/v1",
+			ExpectedEndpoint: "https://example.test/v1",
+			ExpectedAuth: AuthConfig{
+				Type:     HTTPBasicAuth,
+				Username: "user",
+			},
+			ExpectErr: true,
+		},
+		{
+			Scenario:         "empty password",
+			URL:              "https://user:@example.test/v1",
+			ExpectedEndpoint: "https://example.test/v1",
+			ExpectedAuth: AuthConfig{
+				Type:     HTTPBasicAuth,
+				Username: "user",
+				Password: "",
+			},
+		},
+		{
+			Scenario:         "basic auth",
+			URL:              "https://user:pass@example.test/v1",
+			ExpectedEndpoint: "https://example.test/v1",
+			ExpectedAuth: AuthConfig{
+				Type:     HTTPBasicAuth,
+				Username: "user",
+				Password: "pass",
+			},
+		},
+		{
+			Scenario:         "IPv6 no auth",
+			URL:              "https://[::1]/v1",
+			ExpectedEndpoint: "https://[::1]/v1",
+			ExpectedAuth: AuthConfig{
+				Type: NoAuth,
+			},
+		},
+		{
+			Scenario:         "IPv6 basic auth",
+			URL:              "https://user:pass@[::1]/v1",
+			ExpectedEndpoint: "https://[::1]/v1",
+			ExpectedAuth: AuthConfig{
+				Type:     HTTPBasicAuth,
+				Username: "user",
+				Password: "pass",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			ep, auth, err := ConfigFromEndpointURL(tc.URL)
+			if ep != tc.ExpectedEndpoint {
+				t.Errorf("Expected endpoint '%s', got '%s'",
+					tc.ExpectedEndpoint, ep)
+			}
+			if auth.Type != tc.ExpectedAuth.Type {
+				t.Errorf("Unexpected auth type %s", auth.Type)
+			}
+			if auth.Username != tc.ExpectedAuth.Username {
+				t.Errorf("Unexpected username '%s'", auth.Username)
+			}
+			if auth.Password != tc.ExpectedAuth.Password {
+				t.Errorf("Unexpected password '%s'", auth.Password)
+			}
+			if (err != nil) != tc.ExpectErr {
+				t.Errorf("Unexpected error %s", err)
+			}
+		})
+	}
+}

--- a/pkg/provisioner/ironic/clients/client.go
+++ b/pkg/provisioner/ironic/clients/client.go
@@ -11,8 +11,8 @@ import (
 )
 
 // IronicClient creates a client for Ironic
-func IronicClient(ironicEndpoint string) (client *gophercloud.ServiceClient, err error) {
-	switch authStrategy {
+func IronicClient(ironicEndpoint string, auth AuthConfig) (client *gophercloud.ServiceClient, err error) {
+	switch auth.Type {
 	case NoAuth:
 		client, err = noauth.NewBareMetalNoAuth(noauth.EndpointOpts{
 			IronicEndpoint: ironicEndpoint,
@@ -20,8 +20,8 @@ func IronicClient(ironicEndpoint string) (client *gophercloud.ServiceClient, err
 	case HTTPBasicAuth:
 		client, err = httpbasic.NewBareMetalHTTPBasic(httpbasic.EndpointOpts{
 			IronicEndpoint:     ironicEndpoint,
-			IronicUser:         ironicUser,
-			IronicUserPassword: ironicPassword,
+			IronicUser:         auth.Username,
+			IronicUserPassword: auth.Password,
 		})
 	default:
 		err = fmt.Errorf("Unknown auth type %s", auth.Type)
@@ -30,8 +30,8 @@ func IronicClient(ironicEndpoint string) (client *gophercloud.ServiceClient, err
 }
 
 // InspectorClient creates a client for Ironic Inspector
-func InspectorClient(inspectorEndpoint string) (client *gophercloud.ServiceClient, err error) {
-	switch authStrategy {
+func InspectorClient(inspectorEndpoint string, auth AuthConfig) (client *gophercloud.ServiceClient, err error) {
+	switch auth.Type {
 	case NoAuth:
 		client, err = noauthintrospection.NewBareMetalIntrospectionNoAuth(
 			noauthintrospection.EndpointOpts{
@@ -40,8 +40,8 @@ func InspectorClient(inspectorEndpoint string) (client *gophercloud.ServiceClien
 	case HTTPBasicAuth:
 		client, err = httpbasicintrospection.NewBareMetalIntrospectionHTTPBasic(httpbasicintrospection.EndpointOpts{
 			IronicInspectorEndpoint:     inspectorEndpoint,
-			IronicInspectorUser:         inspectorUser,
-			IronicInspectorUserPassword: inspectorPassword,
+			IronicInspectorUser:         auth.Username,
+			IronicInspectorUserPassword: auth.Password,
 		})
 	default:
 		err = fmt.Errorf("Unknown auth type %s", auth.Type)

--- a/pkg/provisioner/ironic/clients/client.go
+++ b/pkg/provisioner/ironic/clients/client.go
@@ -1,0 +1,50 @@
+package clients
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/httpbasic"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/noauth"
+	httpbasicintrospection "github.com/gophercloud/gophercloud/openstack/baremetalintrospection/httpbasic"
+	noauthintrospection "github.com/gophercloud/gophercloud/openstack/baremetalintrospection/noauth"
+)
+
+// IronicClient creates a client for Ironic
+func IronicClient(ironicEndpoint string) (client *gophercloud.ServiceClient, err error) {
+	switch authStrategy {
+	case NoAuth:
+		client, err = noauth.NewBareMetalNoAuth(noauth.EndpointOpts{
+			IronicEndpoint: ironicEndpoint,
+		})
+	case HTTPBasicAuth:
+		client, err = httpbasic.NewBareMetalHTTPBasic(httpbasic.EndpointOpts{
+			IronicEndpoint:     ironicEndpoint,
+			IronicUser:         ironicUser,
+			IronicUserPassword: ironicPassword,
+		})
+	default:
+		err = fmt.Errorf("Unknown auth type %s", auth.Type)
+	}
+	return
+}
+
+// InspectorClient creates a client for Ironic Inspector
+func InspectorClient(inspectorEndpoint string) (client *gophercloud.ServiceClient, err error) {
+	switch authStrategy {
+	case NoAuth:
+		client, err = noauthintrospection.NewBareMetalIntrospectionNoAuth(
+			noauthintrospection.EndpointOpts{
+				IronicInspectorEndpoint: inspectorEndpoint,
+			})
+	case HTTPBasicAuth:
+		client, err = httpbasicintrospection.NewBareMetalIntrospectionHTTPBasic(httpbasicintrospection.EndpointOpts{
+			IronicInspectorEndpoint:     inspectorEndpoint,
+			IronicInspectorUser:         inspectorUser,
+			IronicInspectorUserPassword: inspectorPassword,
+		})
+	default:
+		err = fmt.Errorf("Unknown auth type %s", auth.Type)
+	}
+	return
+}


### PR DESCRIPTION
This commit adds the support for BMO to interact with ironic when
using http_basic.

requires gophercloud 0.12.0