### PR TITLE
implement explicit boot mode api field

### DIFF
--- a/deploy/crds/metal3.io_baremetalhosts_crd.yaml
+++ b/deploy/crds/metal3.io_baremetalhosts_crd.yaml
@@ -92,7 +92,7 @@ spec:
                 type: string
               bootMode:
                 description: Select the method of initializing the hardware during
-                  boot to override the value based on the BMC driver.
+                  boot. Defaults to UEFI.
                 enum:
                 - UEFI
                 - legacy

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -79,8 +79,9 @@ type BootMode string
 
 // Allowed boot mode from metal3
 const (
-	UEFI   BootMode = "UEFI"
-	Legacy BootMode = "legacy"
+	UEFI            BootMode = "UEFI"
+	Legacy          BootMode = "legacy"
+	DefaultBootMode BootMode = UEFI
 )
 
 // OperationalStatus represents the state of the host
@@ -226,8 +227,8 @@ type BareMetalHostSpec struct {
 	// being provisioned.
 	RootDeviceHints *RootDeviceHints `json:"rootDeviceHints,omitempty"`
 
-	// Select the method of initializing the hardware during boot to
-	// override the value based on the BMC driver.
+	// Select the method of initializing the hardware during
+	// boot. Defaults to UEFI.
 	// +optional
 	BootMode BootMode `json:"bootMode,omitempty"`
 

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -798,7 +798,7 @@ func (r *ReconcileBareMetalHost) actionManageReady(prov provisioner.Provisioner,
 	}
 
 	if info.host.NeedsProvisioning() {
-		// Ensure the root device hints we're going to use are stored.
+		// Ensure the provisioning settings we're going to use are stored.
 		dirty, err := saveHostProvisioningSettings(info.host)
 		if err != nil {
 			return actionError{errors.Wrap(err, "Could not save the host provisioning settings")}
@@ -833,6 +833,18 @@ func saveHostProvisioningSettings(host *metal3v1alpha1.BareMetalHost) (dirty boo
 		host.Status.Provisioning.RootDeviceHints = hintSource
 		dirty = true
 	}
+
+	// Make sure we have saved the current boot mode value, using a
+	// default if the spec does not include a value.
+	bootMode := host.Spec.BootMode
+	if bootMode == "" {
+		bootMode = metal3v1alpha1.DefaultBootMode
+	}
+	if bootMode != host.Status.Provisioning.BootMode {
+		host.Status.Provisioning.BootMode = bootMode
+		dirty = true
+	}
+
 	return
 }
 

--- a/pkg/provisioner/ironic/ironic_test.go
+++ b/pkg/provisioner/ironic/ironic_test.go
@@ -313,3 +313,122 @@ func TestGetUpdateOptsForNodeDell(t *testing.T) {
 		})
 	}
 }
+
+func TestGetUpdateOptsForNodeBootMode(t *testing.T) {
+
+	testCases := []struct {
+		Scenario string
+		BootMode metal3v1alpha1.BootMode
+		Node     nodes.Node
+		Expected nodes.UpdateOperation
+	}{
+		{
+			Scenario: "add uefi",
+			BootMode: metal3v1alpha1.UEFI,
+			Node:     nodes.Node{},
+			Expected: nodes.UpdateOperation{
+				Op:    nodes.AddOp,
+				Path:  "/instance_info/deploy_boot_mode",
+				Value: "uefi",
+			},
+		},
+		{
+			Scenario: "add uefi",
+			BootMode: metal3v1alpha1.Legacy,
+			Node:     nodes.Node{},
+			Expected: nodes.UpdateOperation{
+				Op:    nodes.AddOp,
+				Path:  "/instance_info/deploy_boot_mode",
+				Value: "bios",
+			},
+		},
+		{
+			Scenario: "replace uefi",
+			BootMode: metal3v1alpha1.UEFI,
+			Node: nodes.Node{
+				InstanceInfo: map[string]interface{}{
+					"deploy_boot_mode": "legacy",
+				},
+			},
+			Expected: nodes.UpdateOperation{
+				Op:    nodes.ReplaceOp,
+				Path:  "/instance_info/deploy_boot_mode",
+				Value: "uefi",
+			},
+		},
+		{
+			Scenario: "replace legacy",
+			BootMode: metal3v1alpha1.Legacy,
+			Node: nodes.Node{
+				InstanceInfo: map[string]interface{}{
+					"deploy_boot_mode": "legacy",
+				},
+			},
+			Expected: nodes.UpdateOperation{
+				Op:    nodes.ReplaceOp,
+				Path:  "/instance_info/deploy_boot_mode",
+				Value: "bios",
+			},
+		},
+	}
+
+	eventPublisher := func(reason, message string) {}
+
+	for _, tc := range testCases {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			t.Logf("expected: %v", tc.Expected)
+
+			// Create a host with the boot mode in the status set to
+			// the test value. getUpdateOptsForNode() doesn't care
+			// where that value came from before it ended up in the
+			// status.
+			host := metal3v1alpha1.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myhost",
+					Namespace: "myns",
+					UID:       "27720611-e5d1-45d3-ba3a-222dcfaa4ca2",
+				},
+				Spec: metal3v1alpha1.BareMetalHostSpec{
+					Image: &metal3v1alpha1.Image{
+						URL:          "not-empty",
+						Checksum:     "checksum",
+						ChecksumType: metal3v1alpha1.MD5,
+						DiskFormat:   pointer.StringPtr("raw"),
+					},
+					Online: true,
+				},
+				Status: metal3v1alpha1.BareMetalHostStatus{
+					HardwareProfile: "libvirt",
+					Provisioning: metal3v1alpha1.ProvisionStatus{
+						BootMode: tc.BootMode,
+					},
+				},
+			}
+
+			prov, err := newProvisioner(&host, bmc.Credentials{}, eventPublisher)
+			patches, err := prov.getUpdateOptsForNode(&tc.Node)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			t.Logf("patches: %v", patches)
+
+			var update nodes.UpdateOperation
+			for _, patch := range patches {
+				update = patch.(nodes.UpdateOperation)
+				if update.Path == tc.Expected.Path {
+					break
+				}
+			}
+			if update.Path != tc.Expected.Path {
+				t.Errorf("did not find %q in updates", tc.Expected.Path)
+				return
+			}
+			t.Logf("update: %v", update)
+			assert.Equal(t,
+				tc.Expected, update,
+				fmt.Sprintf("%s does not match", tc.Expected.Path),
+			)
+		})
+	}
+}


### PR DESCRIPTION
Default to UEFI everywhere, but allow the user to override that value
by setting Spec.BootMode.

Implements https://github.com/metal3-io/metal3-docs/blob/master/design/baremetal-operator/explicit-boot-mode.md

Fixes #422 