### PR TITLE
add -boot-mode argument to make-bm-worker

### DIFF
--- a/cmd/make-bm-worker/main.go
+++ b/cmd/make-bm-worker/main.go
@@ -16,6 +16,7 @@ func main() {
 	var disableCertificateVerification = flag.Bool("disableCertificateVerification", false, "will skip certificate validation when true")
 	var hardwareProfile = flag.String("hardwareprofile", "", "hardwareProfile to be used")
 	var macAddress = flag.String("boot-mac", "", "boot-mac for bootMACAddress")
+	var bootMode = flag.String("boot-mode", "", "boot-mode for host (UEFI or legacy)")
 	var verbose = flag.Bool("v", false, "turn on verbose output")
 	var consumer = flag.String(
 		"consumer", "", "specify name of a related, existing, consumer to link")
@@ -42,6 +43,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if *bootMode != "" && *bootMode != "UEFI" && *bootMode != "legacy" {
+		fmt.Fprintf(os.Stderr, "Invalid boot mode %q, use \"UEFI\" or \"legacy\"\n", *bootMode)
+		os.Exit(1)
+	}
+
 	template := templates.Template{
 		Name:                           strings.Replace(hostName, "_", "-", -1),
 		BMCAddress:                     *bmcAddress,
@@ -52,6 +58,9 @@ func main() {
 		BootMacAddress:                 *macAddress,
 		Consumer:                       strings.TrimSpace(*consumer),
 		ConsumerNamespace:              strings.TrimSpace(*consumerNamespace),
+	}
+	if bootMode != nil {
+		template.BootMode = *bootMode
 	}
 	if *verbose {
 		fmt.Fprintf(os.Stderr, "%v", template)

--- a/cmd/make-bm-worker/templates/templates.go
+++ b/cmd/make-bm-worker/templates/templates.go
@@ -29,6 +29,9 @@ spec:
 {{- if .BootMacAddress }}
   bootMACAddress: {{ .BootMacAddress }}
 {{- end }}
+{{- if .BootMode }}
+  bootMode: {{ .BootMode }}
+{{- end }}
   bmc:
     address: {{ .BMCAddress }}
     credentialsName: {{ .Name }}-bmc-secret
@@ -51,6 +54,7 @@ type Template struct {
 	Password                       string
 	HardwareProfile                string
 	BootMacAddress                 string
+	BootMode                       string
 	Consumer                       string
 	ConsumerNamespace              string
 }


### PR DESCRIPTION
metal3-dev-env uses this program to create host resources. In order to
let metal3-dev-env change the boot mode for hosts, we need to add an
option to pass the value through to the template.