### PR TITLE
Add support for build variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,9 @@ PACKAGES = $(foreach dir,$(CODE_DIRS),$(dir)/...)
 COVER_PROFILE = cover.out
 
 # See pkg/version.go for details
-GIT_COMMIT="$(shell git rev-parse --verify 'HEAD^{commit}')"
-export LDFLAGS="-X github.com/metal3-io/baremetal-operator/pkg/version.Raw=$(shell git describe --always --abbrev=40 --dirty) -X github.com/metal3-io/baremetal-operator/pkg/version.Commit=${GIT_COMMIT}"
+SOURCE_GIT_COMMIT ?= $(shell git rev-parse --verify 'HEAD^{commit}')
+BUILD_VERSION ?= $(shell git describe --always --abbrev=40 --dirty)
+export LDFLAGS="-X github.com/metal3-io/baremetal-operator/pkg/version.Raw=${BUILD_VERSION} -X github.com/metal3-io/baremetal-operator/pkg/version.Commit=${SOURCE_GIT_COMMIT}"
 
 # Set some variables the operator expects to have in order to work
 # Those need to be the same as in deploy/ironic_ci.env


### PR DESCRIPTION
This PR adds support for OpenShift build variables in order to set the build version and the correct source git commit reference