### PR TITLE
handle externally provisioned hosts without image settings

### DIFF
--- a/pkg/controller/baremetalhost/host_state_machine.go
+++ b/pkg/controller/baremetalhost/host_state_machine.go
@@ -206,6 +206,11 @@ func (hsm *hostStateMachine) handleRegistrationError(info *reconcileInfo) action
 		hsm.NextState = metal3v1alpha1.StateRegistering
 		return actionComplete{}
 	}
+	if hsm.Host.Spec.Image != nil {
+		info.log.Info("Image is set; will retry registration")
+		hsm.NextState = metal3v1alpha1.StateRegistering
+		return actionComplete{}
+	}
 	return actionFailed{}
 }
 

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -398,11 +398,6 @@ func (p *ironicProvisioner) ValidateManagementAccess(credentialsChanged bool) (r
 		}
 	}
 
-	// ironicNode, err = nodes.Get(p.client, p.status.ID).Extract()
-	// if err != nil {
-	// 	return result, errors.Wrap(err, "failed to get provisioning state in ironic")
-	// }
-
 	p.log.Info("current provision state",
 		"lastError", ironicNode.LastError,
 		"current", ironicNode.ProvisionState,

--- a/pkg/provisioner/ironic/ironic_test.go
+++ b/pkg/provisioner/ironic/ironic_test.go
@@ -136,7 +136,7 @@ func TestGetUpdateOptsForNodeWithRootHints(t *testing.T) {
 	prov, err := newProvisioner(makeHost(), bmc.Credentials{}, eventPublisher)
 	ironicNode := &nodes.Node{}
 
-	patches, err := prov.getUpdateOptsForNode(ironicNode)
+	patches, err := prov.getUpdateOptsForNode(ironicNode, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +219,7 @@ func TestGetUpdateOptsForNodeVirtual(t *testing.T) {
 	prov, err := newProvisioner(host, bmc.Credentials{}, eventPublisher)
 	ironicNode := &nodes.Node{}
 
-	patches, err := prov.getUpdateOptsForNode(ironicNode)
+	patches, err := prov.getUpdateOptsForNode(ironicNode, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -314,7 +314,7 @@ func TestGetUpdateOptsForNodeDell(t *testing.T) {
 	prov, err := newProvisioner(host, bmc.Credentials{}, eventPublisher)
 	ironicNode := &nodes.Node{}
 
-	patches, err := prov.getUpdateOptsForNode(ironicNode)
+	patches, err := prov.getUpdateOptsForNode(ironicNode, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -468,7 +468,7 @@ func TestGetUpdateOptsForNodeBootMode(t *testing.T) {
 			}
 
 			prov, err := newProvisioner(&host, bmc.Credentials{}, eventPublisher)
-			patches, err := prov.getUpdateOptsForNode(&tc.Node)
+			patches, err := prov.getUpdateOptsForNode(&tc.Node, true)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -506,7 +506,8 @@ func makeHost() *metal3v1alpha1.BareMetalHost {
 		},
 		Spec: metal3v1alpha1.BareMetalHostSpec{
 			Image: &metal3v1alpha1.Image{
-				URL: "not-empty",
+				URL:      "not-empty",
+				Checksum: "not-empty",
 			},
 			Online:          true,
 			HardwareProfile: "libvirt",


### PR DESCRIPTION
Update the IronicProvisioner to deal with externally provisioned hosts that
have no image settings by recording an error message of our own.

When the host does have image settings, ensure they are sent to Ironic 
before telling it to adopt the host, in case they were not present when the
host was registered (this is similar to what we do for provisioning).

Addresses #608