### PR TITLE
Always retry provisioning operations on failure (continue)

### DIFF
--- a/deploy/crds/metal3.io_baremetalhosts_crd.yaml
+++ b/deploy/crds/metal3.io_baremetalhosts_crd.yaml
@@ -303,6 +303,10 @@ spec:
           status:
             description: BareMetalHostStatus defines the observed state of BareMetalHost
             properties:
+              errorCount:
+                description: ErrorCount records how many times the host has encoutered
+                  an error since the last successful operation
+                type: integer
               errorMessage:
                 description: the last error message reported by the provisioning subsystem
                 type: string
@@ -702,6 +706,7 @@ spec:
                     type: string
                 type: object
             required:
+            - errorCount
             - errorMessage
             - hardwareProfile
             - operationHistory

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -545,6 +545,9 @@ type BareMetalHostStatus struct {
 	// OperationHistory holds information about operations performed
 	// on this host.
 	OperationHistory OperationHistory `json:"operationHistory"`
+
+	// ErrorCount records how many times the host has encoutered an error since the last successful operation
+	ErrorCount int `json:"errorCount"`
 }
 
 // ProvisionStatus holds the state information for a single target.
@@ -611,22 +614,12 @@ func (host *BareMetalHost) Available() bool {
 }
 
 // SetErrorMessage updates the ErrorMessage in the host Status struct
-// when necessary and returns true when a change is made or false when
-// no change is made.
-func (host *BareMetalHost) SetErrorMessage(errType ErrorType, message string) (dirty bool) {
-	if host.Status.OperationalStatus != OperationalStatusError {
-		host.Status.OperationalStatus = OperationalStatusError
-		dirty = true
-	}
-	if host.Status.ErrorType != errType {
-		host.Status.ErrorType = errType
-		dirty = true
-	}
-	if host.Status.ErrorMessage != message {
-		host.Status.ErrorMessage = message
-		dirty = true
-	}
-	return dirty
+// and increases the ErrorCount
+func (host *BareMetalHost) SetErrorMessage(errType ErrorType, message string) {
+	host.Status.OperationalStatus = OperationalStatusError
+	host.Status.ErrorType = errType
+	host.Status.ErrorMessage = message
+	host.Status.ErrorCount++
 }
 
 // ClearError removes any existing error message.
@@ -639,6 +632,10 @@ func (host *BareMetalHost) ClearError() (dirty bool) {
 	}
 	if host.Status.ErrorMessage != "" {
 		host.Status.ErrorMessage = ""
+		dirty = true
+	}
+	if host.Status.ErrorCount != 0 {
+		host.Status.ErrorCount = 0
 		dirty = true
 	}
 	return dirty

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types_test.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types_test.go
@@ -554,3 +554,39 @@ func TestBootMode(t *testing.T) {
 		})
 	}
 }
+
+func TestErrorCountIncrementsAlways(t *testing.T) {
+
+	b := &BareMetalHost{}
+	assert.Equal(t, b.Status.ErrorCount, 0)
+
+	b.SetErrorMessage(RegistrationError, "An error message")
+	assert.Equal(t, b.Status.ErrorCount, 1)
+
+	b.SetErrorMessage(InspectionError, "Another error message")
+	assert.Equal(t, b.Status.ErrorCount, 2)
+}
+
+func TestClearErrorCount(t *testing.T) {
+
+	b := &BareMetalHost{
+		Status: BareMetalHostStatus{
+			ErrorCount: 5,
+		},
+	}
+
+	assert.True(t, b.ClearError())
+	assert.Equal(t, 0, b.Status.ErrorCount)
+}
+
+func TestClearErrorCountOnlyIfNotZero(t *testing.T) {
+
+	b := &BareMetalHost{
+		Status: BareMetalHostStatus{
+			ErrorCount: 5,
+		},
+	}
+
+	assert.True(t, b.ClearError())
+	assert.False(t, b.ClearError())
+}

--- a/pkg/controller/baremetalhost/action_result_test.go
+++ b/pkg/controller/baremetalhost/action_result_test.go
@@ -1,0 +1,30 @@
+package baremetalhost
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackoffIncrements(t *testing.T) {
+
+	var backOff time.Duration
+	for i := 0; i < maxBackOffCount; i++ {
+		prev := backOff
+		backOff = calculateBackoff(i)
+
+		assert.GreaterOrEqual(t, backOff.Milliseconds(), prev.Milliseconds())
+	}
+
+}
+
+func TestMaxBackoffDuration(t *testing.T) {
+
+	maxBackOffDuration := (time.Minute * time.Duration(math.Exp2(float64(maxBackOffCount)))).Milliseconds()
+
+	assert.LessOrEqual(t, calculateBackoff(maxBackOffCount-1).Milliseconds(), maxBackOffDuration)
+	assert.LessOrEqual(t, calculateBackoff(maxBackOffCount+1).Milliseconds(), maxBackOffDuration)
+	assert.LessOrEqual(t, calculateBackoff(maxBackOffCount+100).Milliseconds(), maxBackOffDuration)
+}


### PR DESCRIPTION
This PR replaces the one started from @honza on PR #584.

Reconciliation loop now retries the operation whenever an action failure is detected, with a backoff. The backoff calculation has been reviewed and some jitter added, and the error count is zeroed when the action succeeds.