### PR TITLE
Added base64 credentials encoding

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -346,7 +346,8 @@ status:
     credentialsVersion: "5562"
 ```
 
-And here is the secret `bmo-master-0-bmc-secret` holding the host's BMC credentials, base64 encoded:
+And here is the secret `bmo-master-0-bmc-secret` holding the host's 
+BMC credentials, base64 encoded:
 
 `$echo -n 'admin' | base64`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -349,13 +349,14 @@ status:
 And here is the secret `bmo-master-0-bmc-secret` holding the host's 
 BMC credentials, base64 encoded:
 
-`$echo -n 'admin' | base64`
+```console
+$echo -n 'admin' | base64
 
-`YWRtaW4=`
+YWRtaW4=
 
-`$echo -n 'password' | base64`
+$echo -n 'password' | base64
 
-`cGFzc3dvcmQ=`
+cGFzc3dvcmQ=
 
 Copy the above base64 encoded username and password pair and 
 paste it into the yaml as mentioned below.

--- a/docs/api.md
+++ b/docs/api.md
@@ -348,6 +348,16 @@ status:
 
 And here it is the secret `bmo-master-0-bmc-secret` holding the host's BMC credentials:
 
+`$echo -n 'admin' | base64`
+
+`YWRtaW4=`
+
+`$echo -n 'password' | base64`
+
+`cGFzc3dvcmQ=`
+
+Copy the above base64 encoded username and password pair and paste it in the yaml as mentioned below.
+
 ```yaml
 ---
 apiVersion: v1

--- a/docs/api.md
+++ b/docs/api.md
@@ -346,7 +346,7 @@ status:
     credentialsVersion: "5562"
 ```
 
-And here is the secret `bmo-master-0-bmc-secret` holding the host's 
+And here is the secret `bmo-master-0-bmc-secret` holding the host's
 BMC credentials, base64 encoded:
 
 ```console
@@ -357,8 +357,9 @@ YWRtaW4=
 $echo -n 'password' | base64
 
 cGFzc3dvcmQ=
+```
 
-Copy the above base64 encoded username and password pair and 
+Copy the above base64 encoded username and password pair and
 paste it into the yaml as mentioned below.
 
 ```yaml

--- a/docs/api.md
+++ b/docs/api.md
@@ -346,7 +346,7 @@ status:
     credentialsVersion: "5562"
 ```
 
-And here it is the secret `bmo-master-0-bmc-secret` holding the host's BMC credentials:
+And here is the secret `bmo-master-0-bmc-secret` holding the host's BMC credentials, base64 encoded:
 
 `$echo -n 'admin' | base64`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -357,7 +357,8 @@ BMC credentials, base64 encoded:
 
 `cGFzc3dvcmQ=`
 
-Copy the above base64 encoded username and password pair and paste it in the yaml as mentioned below.
+Copy the above base64 encoded username and password pair and 
+paste it into the yaml as mentioned below.
 
 ```yaml
 ---


### PR DESCRIPTION
The credentials have to be encoded by base64 before pasting them in YAML.