### PR TITLE
Fix Keepalived container to stop cleanly

### DIFF
--- a/resources/keepalived-docker/Dockerfile
+++ b/resources/keepalived-docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu
-copy sample.keepalived.conf /etc/keepalived/keepalived.conf
+ENV DEBIAN_FRONTEND=noninteractive
+COPY sample.keepalived.conf /etc/keepalived/keepalived.conf
 COPY  manage-keepalived.sh manage-keepalived.sh
 RUN apt update -y && apt install keepalived -y
-ENTRYPOINT /bin/bash manage-keepalived.sh && tail -f /dev/null
+ENTRYPOINT ["/bin/bash", "manage-keepalived.sh"]

--- a/resources/keepalived-docker/manage-keepalived.sh
+++ b/resources/keepalived-docker/manage-keepalived.sh
@@ -5,12 +5,4 @@ export interface=$PROVISIONING_INTERFACE
 sed  -i "s~INTERFACE~$interface~g" /etc/keepalived/keepalived.conf
 sed  -i "s~CHANGEIP~$assignedIP~g" /etc/keepalived/keepalived.conf
 
-while true;do
-        /etc/init.d/keepalived start
-	if (ip a show "$interface" |grep "inet $assignedIP"); then
-           echo "waiting for VIP to be assigned on interface $interface"
-        else
-           exit 0
-        fi
-        sleep 1
-done
+exec /usr/sbin/keepalived -n -l

--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -6,13 +6,14 @@ SCRIPTPATH="$(dirname "$(readlink -f "${0}")")"
 
 IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic:master"}
 IRONIC_INSPECTOR_IMAGE=${IRONIC_INSPECTOR_IMAGE:-"quay.io/metal3-io/ironic-inspector"}
-IRONIC_ENDPOINT_KEEPALIVED_IMAGE=${IRONIC_ENDPOINT_KEEPALIVED_IMAGE:-"quay.io/metal3-io/keepalived"}
+IRONIC_KEEPALIVED_IMAGE=${IRONIC_KEEPALIVED_IMAGE:-"quay.io/metal3-io/keepalived"}
 IPA_DOWNLOADER_IMAGE=${IPA_DOWNLOADER_IMAGE:-"quay.io/metal3-io/ironic-ipa-downloader:master"}
 IRONIC_DATA_DIR=${IRONIC_DATA_DIR:-"/opt/metal3-dev-env/ironic"}
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
 sudo "${CONTAINER_RUNTIME}" pull "$IRONIC_IMAGE"
 sudo "${CONTAINER_RUNTIME}" pull "$IRONIC_INSPECTOR_IMAGE"
+sudo "${CONTAINER_RUNTIME}" pull "$IRONIC_KEEPALIVED_IMAGE"
 
 mkdir -p "$IRONIC_DATA_DIR/html/images"
 pushd "$IRONIC_DATA_DIR/html/images"
@@ -86,7 +87,7 @@ sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name ironic \
 # shellcheck disable=SC2086
 sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name ironic-endpoint-keepalived \
     ${POD} --env-file "${SCRIPTPATH}/../deploy/ironic_ci.env" \
-    -v "$IRONIC_DATA_DIR:/shared" "${IRONIC_ENDPOINT_KEEPALIVED_IMAGE}"
+    -v "$IRONIC_DATA_DIR:/shared" "${IRONIC_KEEPALIVED_IMAGE}"
 
 # Start Ironic Inspector
 # shellcheck disable=SC2086


### PR DESCRIPTION
Currently the keepalived container, when stopped does not remove the ip
address it sets as VIP. This commit fixes it so that the VIP is removed when the
container is stopped