### PR TITLE
Added encoding of credentials using base64

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -346,7 +346,21 @@ status:
     credentialsVersion: "5562"
 ```
 
-And here it is the secret `bmo-master-0-bmc-secret` holding the host's BMC credentials:
+And here is the secret `bmo-master-0-bmc-secret` holding the host's
+BMC credentials, base64 encoded:
+
+```console
+$echo -n 'admin' | base64
+
+YWRtaW4=
+
+$echo -n 'password' | base64
+
+cGFzc3dvcmQ=
+```
+
+Copy the above base64 encoded username and password pair and
+paste it into the yaml as mentioned below.
 
 ```yaml
 ---


### PR DESCRIPTION
The credentials have to be encoded by base64 before pasting them in YAML.