### PR TITLE
allow mock ironic/inspector service to run without specifying a port

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -122,13 +122,13 @@ func LogStartup() {
 
 // A private function to construct an ironicProvisioner (rather than a
 // Provisioner interface) in a consistent way for tests.
-func newProvisionerWithURLs(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher, ironicURL, inspectorURL string) (*ironicProvisioner, error) {
-	clientIronic, err := clients.IronicClient(ironicURL, ironicAuth)
+func newProvisionerWithSettings(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher, ironicURL string, ironicAuthSettings clients.AuthConfig, inspectorURL string, inspectorAuthSettings clients.AuthConfig) (*ironicProvisioner, error) {
+	clientIronic, err := clients.IronicClient(ironicURL, ironicAuthSettings)
 	if err != nil {
 		return nil, err
 	}
 
-	clientInspector, err := clients.InspectorClient(inspectorURL, inspectorAuth)
+	clientInspector, err := clients.InspectorClient(inspectorURL, inspectorAuthSettings)
 	if err != nil {
 		return nil, err
 	}
@@ -158,8 +158,8 @@ func newProvisionerWithURLs(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Cre
 // A private function to construct an ironicProvisioner (rather than a
 // Provisioner interface) in a consistent way for tests.
 func newProvisioner(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher) (*ironicProvisioner, error) {
-	return newProvisionerWithURLs(host, bmcCreds, publisher,
-		ironicEndpoint, inspectorEndpoint,
+	return newProvisionerWithSettings(host, bmcCreds, publisher,
+		ironicEndpoint, ironicAuth, inspectorEndpoint, inspectorAuth,
 	)
 }
 

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -122,13 +122,13 @@ func LogStartup() {
 
 // A private function to construct an ironicProvisioner (rather than a
 // Provisioner interface) in a consistent way for tests.
-func newProvisioner(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher) (*ironicProvisioner, error) {
-	clientIronic, err := clients.IronicClient(ironicEndpoint, ironicAuth)
+func newProvisionerWithURLs(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher, ironicURL, inspectorURL string) (*ironicProvisioner, error) {
+	clientIronic, err := clients.IronicClient(ironicURL, ironicAuth)
 	if err != nil {
 		return nil, err
 	}
 
-	clientInspector, err := clients.InspectorClient(inspectorEndpoint, inspectorAuth)
+	clientInspector, err := clients.InspectorClient(inspectorURL, inspectorAuth)
 	if err != nil {
 		return nil, err
 	}
@@ -153,6 +153,14 @@ func newProvisioner(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials
 	}
 
 	return p, nil
+}
+
+// A private function to construct an ironicProvisioner (rather than a
+// Provisioner interface) in a consistent way for tests.
+func newProvisioner(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher) (*ironicProvisioner, error) {
+	return newProvisionerWithURLs(host, bmcCreds, publisher,
+		ironicEndpoint, inspectorEndpoint,
+	)
 }
 
 // New returns a new Ironic Provisioner

--- a/pkg/provisioner/ironic/ironic_test.go
+++ b/pkg/provisioner/ironic/ironic_test.go
@@ -137,7 +137,7 @@ func TestGetUpdateOptsForNodeWithRootHints(t *testing.T) {
 	auth := clients.AuthConfig{Type: clients.NoAuth}
 
 	prov, err := newProvisionerWithSettings(makeHost(), bmc.Credentials{}, eventPublisher,
-		"https://localhost", auth, "http://localhost", auth,
+		"https://ironic.test", auth, "https://ironic.test", auth,
 	)
 	ironicNode := &nodes.Node{}
 
@@ -223,7 +223,7 @@ func TestGetUpdateOptsForNodeVirtual(t *testing.T) {
 	auth := clients.AuthConfig{Type: clients.NoAuth}
 
 	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, eventPublisher,
-		"https://localhost", auth, "http://localhost", auth,
+		"https://ironic.test", auth, "https://ironic.test", auth,
 	)
 	ironicNode := &nodes.Node{}
 
@@ -321,7 +321,7 @@ func TestGetUpdateOptsForNodeDell(t *testing.T) {
 	auth := clients.AuthConfig{Type: clients.NoAuth}
 
 	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, eventPublisher,
-		"https://localhost", auth, "http://localhost", auth,
+		"https://ironic.test", auth, "https://ironic.test", auth,
 	)
 	ironicNode := &nodes.Node{}
 
@@ -488,7 +488,7 @@ func (m *mockServer) Endpoint() string {
 	if m == nil || m.server == nil {
 		// The consumer of this method expects something valid, but
 		// won't use it if m is nil.
-		return "http://localhost/v1/"
+		return "https://ironic.test/v1/"
 	}
 	response := m.server.URL + "/v1/"
 	m.t.Logf("%s: endpoint: %s/", m.name, response)

--- a/pkg/provisioner/ironic/ironic_test.go
+++ b/pkg/provisioner/ironic/ironic_test.go
@@ -134,8 +134,11 @@ func TestProvisionerIsReady(t *testing.T) {
 func TestGetUpdateOptsForNodeWithRootHints(t *testing.T) {
 
 	eventPublisher := func(reason, message string) {}
+	auth := clients.AuthConfig{Type: clients.NoAuth}
 
-	prov, err := newProvisioner(makeHost(), bmc.Credentials{}, eventPublisher)
+	prov, err := newProvisionerWithSettings(makeHost(), bmc.Credentials{}, eventPublisher,
+		"https://localhost", auth, "http://localhost", auth,
+	)
 	ironicNode := &nodes.Node{}
 
 	patches, err := prov.getUpdateOptsForNode(ironicNode)
@@ -217,8 +220,11 @@ func TestGetUpdateOptsForNodeVirtual(t *testing.T) {
 	}
 
 	eventPublisher := func(reason, message string) {}
+	auth := clients.AuthConfig{Type: clients.NoAuth}
 
-	prov, err := newProvisioner(host, bmc.Credentials{}, eventPublisher)
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, eventPublisher,
+		"https://localhost", auth, "http://localhost", auth,
+	)
 	ironicNode := &nodes.Node{}
 
 	patches, err := prov.getUpdateOptsForNode(ironicNode)
@@ -312,8 +318,11 @@ func TestGetUpdateOptsForNodeDell(t *testing.T) {
 	}
 
 	eventPublisher := func(reason, message string) {}
+	auth := clients.AuthConfig{Type: clients.NoAuth}
 
-	prov, err := newProvisioner(host, bmc.Credentials{}, eventPublisher)
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, eventPublisher,
+		"https://localhost", auth, "http://localhost", auth,
+	)
 	ironicNode := &nodes.Node{}
 
 	patches, err := prov.getUpdateOptsForNode(ironicNode)

--- a/pkg/provisioner/ironic/ironic_test.go
+++ b/pkg/provisioner/ironic/ironic_test.go
@@ -15,6 +15,7 @@ import (
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
 	"k8s.io/utils/pointer"
 )
 
@@ -106,8 +107,10 @@ func TestProvisionerIsReady(t *testing.T) {
 				defer tc.inspector.stop()
 			}
 
-			prov, err := newProvisionerWithURLs(makeHost(), bmc.Credentials{}, nil,
-				tc.ironic.Endpoint(), tc.inspector.Endpoint(),
+			auth := clients.AuthConfig{Type: clients.NoAuth}
+
+			prov, err := newProvisionerWithSettings(makeHost(), bmc.Credentials{}, nil,
+				tc.ironic.Endpoint(), auth, tc.inspector.Endpoint(), auth,
 			)
 			ready, err := prov.IsReady()
 


### PR DESCRIPTION
Rewrite the mock server for the ironic provisioner ready checks so it
does not need a specific port. This will
eventually make it easier to expand the server to support other tests.