### PR TITLE
Change base image to distroless

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,17 +1,15 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
+FROM registry.hub.docker.com/library/golang:1.14 AS builder
 WORKDIR /go/src/github.com/metal3-io/baremetal-operator
 COPY . .
 RUN make build
 
-FROM quay.io/metal3-io/base-image
-
+# Copy the controller-manager into a thin image
+# BMO has a dependency preventing us to use the static one,
+# using the base one instead
+FROM gcr.io/distroless/base:latest
+WORKDIR /
 COPY --from=builder /go/src/github.com/metal3-io/baremetal-operator/build/_output/bin/baremetal-operator /
-
-RUN if ! rpm -q genisoimage; \
-    then yum install -y genisoimage && \
-    yum clean all && \
-    rm -rf /var/cache/yum/*; \
-    fi
+USER nobody
 
 LABEL io.k8s.display-name="Metal3 BareMetal Operator" \
       io.k8s.description="This is the image for the Metal3 BareMetal Operator."


### PR DESCRIPTION
The metal3 base image was based on Centos 7 and very outdated.
Using distroless image as base, the size of BMO image went
down from 1.76GB to 45MB.