### PR TITLE
Add Tilt setup

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,166 @@
+# -*- mode: Python -*-
+
+update_settings(k8s_upsert_timeout_secs=60)  # on first tilt up, often can take longer than 30 seconds
+
+# set defaults
+settings = {
+    "allowed_contexts": [
+        "kind-bmo"
+    ],
+    "preload_images_for_kind": True,
+    "kind_cluster_name": "bmo",
+    "enable_providers": [],
+}
+
+keys = []
+
+always_enable_providers = ["metal3-bmo"]
+providers = {}
+extra_args = settings.get("extra_args", {})
+
+# global settings
+settings.update(read_json(
+    "tilt-settings.json",
+    default = {},
+))
+
+if settings.get("trigger_mode") == "manual":
+    trigger_mode(TRIGGER_MODE_MANUAL)
+
+if "allowed_contexts" in settings:
+    allow_k8s_contexts(settings.get("allowed_contexts"))
+
+if "default_registry" in settings:
+    default_registry(settings.get("default_registry"))
+
+def load_provider_tiltfiles(provider_repos):
+    for repo in provider_repos:
+        file = repo + "/tilt-provider.json"
+        provider_details = read_json(file, default = {})
+        if type(provider_details) != type([]):
+            provider_details = [provider_details]
+        for item in provider_details:
+            provider_name = item["name"]
+            provider_config = item["config"]
+            if "context" in provider_config:
+                provider_config["context"] = repo + "/" + provider_config["context"]
+            else:
+                provider_config["context"] = repo
+            if "kustomize_config" not in provider_config:
+                provider_config["kustomize_config"] = True
+            if "go_main" not in provider_config:
+                provider_config["go_main"] = "main.go"
+            providers[provider_name] = provider_config
+
+def validate_auth():
+    substitutions = settings.get("kustomize_substitutions", {})
+    missing = [k for k in keys if k not in substitutions]
+    if missing:
+        fail("missing kustomize_substitutions keys {} in tilt-setting.json".format(missing))
+
+tilt_helper_dockerfile_header = """
+# Tilt image
+FROM golang:1.13.15 as tilt-helper
+# Support live reloading with Tilt
+RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
+    wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \
+    chmod +x /start.sh && chmod +x /restart.sh
+"""
+
+tilt_dockerfile_header = """
+FROM gcr.io/distroless/base:debug as tilt
+WORKDIR /
+COPY --from=tilt-helper /start.sh .
+COPY --from=tilt-helper /restart.sh .
+COPY manager .
+"""
+
+# Configures a provider by doing the following:
+#
+# 1. Enables a local_resource go build of the provider's manager binary
+# 2. Configures a docker build for the provider, with live updating of the manager binary
+# 3. Runs kustomize for the provider's config/ and applies it
+def enable_provider(name):
+    p = providers.get(name)
+
+    name = p.get("name", name)
+    context = p.get("context")
+    go_main = p.get("go_main")
+
+    # Prefix each live reload dependency with context. For example, for if the context is
+    # test/infra/docker and main.go is listed as a dep, the result is test/infra/docker/main.go. This adjustment is
+    # needed so Tilt can watch the correct paths for changes.
+    live_reload_deps = []
+    for d in p.get("live_reload_deps", []):
+        live_reload_deps.append(context + "/" + d)
+
+    # Set up a local_resource build of the provider's manager binary. The provider is expected to have a main.go in
+    # manager_build_path or the main.go must be provided via go_main option. The binary is written to .tiltbuild/manager.
+    local_resource(
+        name + "_manager",
+        cmd = "cd " + context + ';mkdir -p .tiltbuild;CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags \'-extldflags "-static"\' -o .tiltbuild/manager ' + go_main,
+        deps = live_reload_deps,
+    )
+
+    additional_docker_helper_commands = p.get("additional_docker_helper_commands", "")
+    additional_docker_build_commands = p.get("additional_docker_build_commands", "")
+
+    dockerfile_contents = "\n".join([
+        tilt_helper_dockerfile_header,
+        additional_docker_helper_commands,
+        tilt_dockerfile_header,
+        additional_docker_build_commands,
+    ])
+
+    # Set up an image build for the provider. The live update configuration syncs the output from the local_resource
+    # build into the container.
+    entrypoint = ["sh", "/start.sh", "/manager"]
+    provider_args = extra_args.get(name)
+    if provider_args:
+        entrypoint.extend(provider_args)
+
+    docker_build(
+        ref = p.get("image"),
+        context = context + "/.tiltbuild/",
+        dockerfile_contents = dockerfile_contents,
+        target = "tilt",
+        entrypoint = entrypoint,
+        only = "manager",
+        live_update = [
+            sync(context + "/.tiltbuild/manager", "/manager"),
+            run("sh /restart.sh"),
+        ],
+    )
+
+    # Copy all the substitutions from the user's tilt-settings.json into the environment. Otherwise, the substitutions
+    # are not available and their placeholders will be replaced with the empty string when we call kustomize +
+    # envsubst below.
+    substitutions = settings.get("kustomize_substitutions", {})
+    os.environ.update(substitutions)
+
+    # Apply the kustomized yaml for this provider
+    yaml = str(kustomizesub(context + "/deploy/default"))
+    k8s_yaml(blob(yaml))
+
+def kustomizesub(folder):
+    yaml = local('kustomize build {}'.format(folder), quiet=True)
+    return yaml
+
+# Users may define their own Tilt customizations in tilt.d. This directory is excluded from git and these files will
+# not be checked in to version control.
+def include_user_tilt_files():
+    user_tiltfiles = listdir("tilt.d")
+    for f in user_tiltfiles:
+        include(f)
+
+##############################
+# Actual work happens here
+##############################
+
+validate_auth()
+
+include_user_tilt_files()
+
+load_provider_tiltfiles(["."])
+local("make tools/bin/kustomize")
+enable_provider("metal3-bmo")

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -80,7 +80,20 @@ your environment.
 
 ## Using Tilt for development
 
-It is possible to develop Baremetal Operator using Tilt with CAPM3. Please
+It is easy to use Tilt for BMO deployment. Once you have a local instance
+of Ironic running, just run
+
+```sh
+  make tilt-up
+```
+
+and clean it with
+
+```sh
+  make kind-reset
+```
+
+It is also possible to develop Baremetal Operator using Tilt with CAPM3. Please
 refer to
 [the development setup guide of CAPM3](https://github.com/metal3-io/cluster-api-provider-metal3/blob/master/docs/dev-setup.md#tilt-for-dev-in-capm3)
 and specially the [Baremetal Operator Integration](https://github.com/metal3-io/cluster-api-provider-metal3/blob/master/docs/dev-setup.md#including-baremetal-operator-and-ip-address-manager)

--- a/hack/kind_with_registry.sh
+++ b/hack/kind_with_registry.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# desired cluster name; default is "kind"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-bmo}"
+
+if [[ "$(kind get clusters)" =~ .*"${KIND_CLUSTER_NAME}".* ]]; then
+  echo "cluster already exists, moving on"
+  exit 0
+fi
+
+# create registry container unless it already exists
+kind_version=$(kind version)
+kind_network='kind'
+reg_name='registry'
+reg_port='5000'
+case "${kind_version}" in
+  "kind v0.7."* | "kind v0.6."* | "kind v0.5."*)
+    kind_network='bridge'
+    ;;
+esac
+
+# create registry container unless it already exists
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
+    registry:2
+fi
+
+reg_host="${reg_name}"
+if [ "${kind_network}" = "bridge" ]; then
+    reg_host="$(docker inspect -f '{{.NetworkSettings.IPAddress}}' "${reg_name}")"
+fi
+echo "Registry Host: ${reg_host}"
+
+# create a cluster with the local registry enabled in containerd
+cat <<EOF | kind create cluster --name "${KIND_CLUSTER_NAME}" --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://${reg_host}:${reg_port}"]
+EOF
+
+for node in $(kind get nodes --name "${KIND_CLUSTER_NAME}"); do
+  kubectl annotate node "${node}" tilt.dev/registry=localhost:${reg_port};
+done
+
+if [ "${kind_network}" != "bridge" ]; then
+  containers=$(docker network inspect ${kind_network} -f "{{range .Containers}}{{.Name}} {{end}}")
+  needs_connect="true"
+  for c in $containers; do
+    if [ "$c" = "${reg_name}" ]; then
+      needs_connect="false"
+    fi
+  done
+  if [ "${needs_connect}" = "true" ]; then
+    docker network connect "${kind_network}" "${reg_name}" || true
+  fi
+fi

--- a/tools/install_kustomize.sh
+++ b/tools/install_kustomize.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+ARCH=amd64
+MINIMUM_KUSTOMIZE_VERSION=3.5.5
+
+# Ensure the kustomize tool exists and is a viable version, or installs it
+verify_kustomize_version() {
+
+  echo "Verifying kustomize version"
+  # If kustomize is available on the path, verify the version
+  if [ -x "$(command -v ./bin/kustomize)" ]; then
+    local kustomize_version
+    kustomize_version=$(./bin/kustomize version | grep -P '(?<=kustomize/v)[0-9]+\.[0-9]+\.[0-9]+' -o)
+    if [[ "${MINIMUM_KUSTOMIZE_VERSION}" != $(echo -e "${MINIMUM_KUSTOMIZE_VERSION}\n${kustomize_version}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]; then
+      if [[ "${OSTYPE}" == "linux-gnu" ]]; then
+        echo "Kustomize version ${kustomize_version}, expected ${MINIMUM_KUSTOMIZE_VERSION}"
+        echo "Updating, removing the old version"
+        rm ./bin/kustomize
+      else
+        cat <<EOF
+Detected kustomize version: ${kustomize_version}.
+Requires ${MINIMUM_KUSTOMIZE_VERSION} or greater.
+Please install ${MINIMUM_KUSTOMIZE_VERSION} or later as $(PWD)bin/kustomize.
+EOF
+        return 2
+      fi
+    fi
+  fi
+
+  # If kustomize is not available on the path, get it
+  if ! [ -x "$(command -v ./bin/kustomize)" ]; then
+    if [[ "${OSTYPE}" == "linux-gnu" ]]; then
+      echo 'kustomize not found, installing'
+      if ! [ -d "./bin" ]; then
+        mkdir -p "./bin"
+      fi
+      curl -L -O "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${MINIMUM_KUSTOMIZE_VERSION}/kustomize_v${MINIMUM_KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz"
+      tar -xzvf kustomize_v${MINIMUM_KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
+      mv kustomize ./bin
+      rm kustomize_v${MINIMUM_KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
+    else
+      echo "Missing required binary: $(PWD)bin/kustomize"
+      return 2
+    fi
+  fi
+}
+
+verify_kustomize_version


### PR DESCRIPTION
This commit adds a setup to deploy BMO in a Tilt environment for
easier development. The image is built and reloaded live from
changes in the code. This commit:

- adds Tiltfile
- adds script to install kustomize locally
- adds script to start kind with a registry