### PR TITLE
Add TLS support between Ironic and BMO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ tags
 /tilt.d
 tilt-settings.json
 tilt_config.json
+
+*.crt
+*.key

--- a/cmd/get-hardware-details/main.go
+++ b/cmd/get-hardware-details/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/v1/introspection"
 
@@ -21,8 +22,19 @@ type options struct {
 
 func main() {
 	opts := getOptions()
+	ironicTrustedCAFile := os.Getenv("IRONIC_CACERT_FILE")
+	ironicInsecureStr := os.Getenv("IRONIC_INSECURE")
+	ironicInsecure := false
+	if strings.ToLower(ironicInsecureStr) == "true" {
+		ironicInsecure = true
+	}
 
-	inspector, err := clients.InspectorClient(opts.Endpoint, opts.AuthConfig)
+	tlsConf := clients.TLSConfig{
+		TrustedCAFile:      ironicTrustedCAFile,
+		InsecureSkipVerify: ironicInsecure,
+	}
+
+	inspector, err := clients.InspectorClient(opts.Endpoint, opts.AuthConfig, tlsConf)
 	if err != nil {
 		fmt.Printf("could not get inspector client: %s", err)
 		os.Exit(1)

--- a/deploy/tls/kustomization.yaml
+++ b/deploy/tls/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metal3
+resources:
+- ../default
+
+secretGenerator:
+  - name: ironic-cacert
+    files:
+    - crt=ca.crt
+
+patchesStrategicMerge:
+- tls_ca.yaml

--- a/deploy/tls/tls_ca.yaml
+++ b/deploy/tls/tls_ca.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metal3-baremetal-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: baremetal-operator
+        volumeMounts:
+          - name: cacert
+            mountPath: "/opt/metal3/certs/ca"
+            readOnly: true
+      volumes:
+      - name: cacert
+        secret:
+          secretName: ironic-cacert

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,11 @@ Ironic.
 `IRONIC_INSPECTOR_ENDPOINT` -- The URL for the operator to use when talking to
 Ironic Inspector.
 
+`IRONIC_CACERT_FILE` -- The path of the CA certificate file of Ironic, if needed
+
+`IRONIC_INSECURE` -- ("True", "False") Whether to skip the ironic certificate
+validation. It is highly recommend to not set it to True.
+
 `BMO_CONCURRENCY` -- The number of concurrent reconciles performed by the
 Operator. Default is 3.
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -35,6 +35,9 @@ deploy/
 │   ├── role_binding.yaml
 │   ├── role.yaml
 │   └── service_account.yaml
+├── tls
+│   ├── kustomization.yaml
+│   └── tls_ca.yaml
 └── role.yaml -> rbac/role.yaml
 ```
 
@@ -66,6 +69,9 @@ namely `default`,  `ironic` and `keepalived`. `default` and `ironic` deploy
 only ironic, `keepalived` deploys the ironic with keepalived. As the name
 implies, `keepalived/keepalived_patch.yaml` patches the default image URL
 through kustomization.
+
+## Deployment commands
+
 The user should run following commands to be able to meet requirements of each
 use case as provided below:
 
@@ -89,6 +95,64 @@ kustomize build $BMOPATH/ironic-deployment/default | kubectl apply -f-
 ```
 
 where $BMOPATH points to the baremetal-operator path.
+
+### Deploying with TLS
+
+For this, you need to first copy your Ironic CA Certificate or the ironic
+certificate itself, then build the kustomization for baremetal operator:
+
+```sh
+   cp <path-to-certificate> $BMOPATH/deploy/tls/ca.crt
+   ./tools/bin/kustomize build $BMOPATH/deploy/tls | kubectl apply -f -
+```
+
+Then you need to copy all your certificates and build the kustomization for
+ironic. The Ironic CA certificate is not required
+
+```sh
+   cp <path-to-ca-certificate> $BMOPATH/ironic-deployment/tls/ironic-ca.crt
+   cp <path-to-ca-certificate> $BMOPATH/ironic-deployment/tls/ironic-inspector-ca.crt
+
+   cp <path-to-tls-certificate> $BMOPATH/ironic-deployment/tls/ironic.crt
+   cp <path-to-tls-cert-key> $BMOPATH/ironic-deployment/tls/ironic.key
+
+   cp <path-to-inspector-tls-certificate> \
+   $BMOPATH/ironic-deployment/tls/ironic-inspector.crt
+   cp <path-to-inspector-tls-cert-key> \
+   $BMOPATH/ironic-deployment/tls/ironic-inspector.key
+
+   ./tools/bin/kustomize build $BMOPATH/ironic-deployment/tls | \
+   kubectl apply -f -
+```
+
+### Deploying with Keepalived and TLS
+
+For this, you need to first copy your Ironic CA Certificate, then build the
+kustomization for baremetal operator:
+
+```sh
+   cp <path-to-ca-certificate> $BMOPATH/deploy/tls/ca.crt
+   ./tools/bin/kustomize build $BMOPATH/deploy/tls | kubectl apply -f -
+```
+
+Then you need to copy all your certificates and build the kustomization for
+ironic:
+
+```sh
+   cp <path-to-ca-certificate> $BMOPATH/ironic-deployment/keepalived-tls/ironic-ca.crt
+   cp <path-to-ca-certificate> $BMOPATH/ironic-deployment/keepalived-tls/ironic-inspector-ca.crt
+
+   cp <path-to-tls-certificate> $BMOPATH/ironic-deployment/keepalived-tls/ironic.crt
+   cp <path-to-tls-cert-key> $BMOPATH/ironic-deployment/keepalived-tls/ironic.key
+
+   cp <path-to-inspector-tls-certificate> \
+   $BMOPATH/ironic-deployment/keepalived-tls/ironic-inspector.crt
+   cp <path-to-inspector-tls-cert-key> \
+   $BMOPATH/ironic-deployment/keepalived-tls/ironic-inspector.key
+
+   ./tools/bin/kustomize build $BMOPATH/ironic-deployment/keepalived-tls | \
+   kubectl apply -f -
+```
 
 #### Useful tips
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/stretchr/testify v1.6.1
+	go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738
 	k8s.io/api v0.19.0
 	k8s.io/apimachinery v0.19.0
 	k8s.io/client-go v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,7 @@ github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHo
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
@@ -373,6 +374,7 @@ github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738 h1:VcrIfasaLFkyjk6KNlXQSzO+B0fZcnECiDrKJsfxka0=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.1.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=

--- a/ironic-deployment/ironic/ironic.yaml
+++ b/ironic-deployment/ironic/ironic.yaml
@@ -56,11 +56,28 @@ spec:
           envFrom:
             - configMapRef:
                 name: ironic-bmo-configmap
-        - name: ironic
+        - name: ironic-api
           image: quay.io/metal3-io/ironic
           imagePullPolicy: Always
           command:
-            - /bin/runironic
+            - /bin/runironic-api
+          volumeMounts:
+            - mountPath: /shared
+              name: ironic-data-volume
+          envFrom:
+            - configMapRef:
+                name: ironic-bmo-configmap
+          env:
+            - name: MARIADB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mariadb-password
+                  key: password
+        - name: ironic-conductor
+          image: quay.io/metal3-io/ironic
+          imagePullPolicy: Always
+          command:
+            - /bin/runironic-conductor
           volumeMounts:
             - mountPath: /shared
               name: ironic-data-volume

--- a/ironic-deployment/keepalived-tls/kustomization.yaml
+++ b/ironic-deployment/keepalived-tls/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metal3
+resources:
+- ../default
+
+  secretGenerator:
+  - name: ironic-ca-cert
+    files:
+    - tls.crt=ironic-ca.crt
+  - name: ironic-cert
+    files:
+    - tls.crt=ironic.crt
+    - tls.key=ironic.key
+    type: "kubernetes.io/tls"
+  - name: ironic-inspector-cert
+    files:
+    - tls.crt=ironic-inspector.crt
+    - tls.key=ironic-inspector.key
+    type: "kubernetes.io/tls"
+
+  patchesStrategicMerge:
+  - tls.yaml
+

--- a/ironic-deployment/keepalived-tls/tls.yaml
+++ b/ironic-deployment/keepalived-tls/tls.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metal3-ironic
+spec:
+  template:
+    spec:
+      containers:
+      - name: ironic
+        volumeMounts:
+        - name: cert-ironic
+          mountPath: "/certs/ironic"
+          readOnly: true
+        - name: cert-ironic-ca
+          mountPath: "/certs/ca/ironic"
+          readOnly: true
+      - name: ironic-inspector
+        volumeMounts:
+        - name: cert-ironic-ca
+          mountPath: "/certs/ca/ironic"
+          readOnly: true
+        - name: cert-ironic-inspector
+          mountPath: "/certs/ironic-inspector"
+          readOnly: true
+      volumes:
+      - name: cert-ironic-ca
+        secret:
+          secretName: ironic-ca-cert
+      - name: cert-ironic
+        secret:
+          secretName: ironic-cert
+      - name: cert-ironic-inspector
+        secret:
+          secretName: ironic-inspector-cert

--- a/ironic-deployment/tls/kustomization.yaml
+++ b/ironic-deployment/tls/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metal3
+resources:
+- ../keepalived
+
+secretGenerator:
+- name: ironic-ca-cert
+  files:
+  - tls.crt=ironic-ca.crt
+- name: ironic-inspector-ca-cert
+  files:
+  - tls.crt=ironic-inspector-ca.crt
+- name: ironic-cert
+  files:
+  - tls.crt=ironic.crt
+  - tls.key=ironic.key
+  type: "kubernetes.io/tls"
+- name: ironic-inspector-cert
+  files:
+  - tls.crt=ironic-inspector.crt
+  - tls.key=ironic-inspector.key
+  type: "kubernetes.io/tls"
+
+patchesStrategicMerge:
+- tls.yaml

--- a/ironic-deployment/tls/tls.yaml
+++ b/ironic-deployment/tls/tls.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metal3-ironic
+spec:
+  template:
+    spec:
+      containers:
+      - name: ironic
+        volumeMounts:
+        - name: cert-ironic
+          mountPath: "/certs/ironic"
+          readOnly: true
+        - name: cert-ironic-ca
+          mountPath: "/certs/ca/ironic"
+          readOnly: true
+        - name: cert-ironic-inspector-ca
+          mountPath: "/certs/ca/ironic-inspector"
+          readOnly: true
+      - name: ironic-inspector
+        volumeMounts:
+        - name: cert-ironic-ca
+          mountPath: "/certs/ca/ironic"
+          readOnly: true
+        - name: cert-ironic-inspector
+          mountPath: "/certs/ironic-inspector"
+          readOnly: true
+      volumes:
+      - name: cert-ironic-ca
+        secret:
+          secretName: ironic-ca-cert
+      - name: cert-ironic-inspector-ca
+        secret:
+          secretName: ironic-inspector-ca-cert
+      - name: cert-ironic
+        secret:
+          secretName: ironic-cert
+      - name: cert-ironic-inspector
+        secret:
+          secretName: ironic-inspector-cert


### PR DESCRIPTION
This PR introduces support for TLS using a custom CA certificate in BMO and modifies the deployment file to be able to deploy Ironic, inspector and BMO with TLS enabled.

This requires https://github.com/metal3-io/ironic-image/pull/198 and https://github.com/metal3-io/ironic-inspector-image/pull/62