### PR TITLE
Add idrac-redfish url type (continue)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -36,6 +36,10 @@ communicate with them.
   * `idrac://` (or `idrac+http://` to disable TLS).
   * `idrac-virtualmedia://` to use virtual media instead of PXE
     for attaching the provisioning image to the host.
+  * `idrac-redfish://` may be used to manage iDRAC controller with the
+    Redfish protocol over HTTPS. The URL must also contain a path to
+    the Redfish API system endpoint.
+    `idrac-redfish://myhost.example/redfish/v1/Systems/System.Embedded.1`
 * Fujitsu iRMC
   * `irmc://<host>:<port>`, where `<port>` is optional if using the default.
 * HUAWEI ibmc

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -539,6 +539,18 @@ func TestStaticDriverInfo(t *testing.T) {
 		},
 
 		{
+			Scenario:   "idrac redfish",
+			input:      "idrac-redfish://192.168.122.1",
+			needsMac:   true,
+			driver:     "idrac",
+			boot:       "ipxe",
+			management: "idrac-redfish",
+			power:      "idrac-redfish",
+			raid:       "no-raid",
+			vendor:     "no-vendor",
+		},
+
+		{
 			Scenario: "ilo5 virtual media",
 			input:    "ilo5-virtualmedia://192.168.122.1",
 			needsMac: true,
@@ -877,6 +889,18 @@ func TestDriverInfo(t *testing.T) {
 		{
 			Scenario: "ilo5 virtual media",
 			input:    "ilo5-virtualmedia://192.168.122.1/foo/bar",
+			expects: map[string]interface{}{
+				"redfish_address":   "https://192.168.122.1",
+				"redfish_system_id": "/foo/bar",
+				"redfish_password":  "",
+				"redfish_username":  "",
+				"redfish_verify_ca": false,
+			},
+		},
+
+		{
+			Scenario: "idrac redfish",
+			input:    "idrac-redfish://192.168.122.1/foo/bar",
 			expects: map[string]interface{}{
 				"redfish_address":   "https://192.168.122.1",
 				"redfish_system_id": "/foo/bar",

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -9,6 +9,7 @@ func init() {
 	schemes := []string{"http", "https"}
 	RegisterFactory("redfish", newRedfishAccessDetails, schemes)
 	RegisterFactory("ilo5-redfish", newRedfishAccessDetails, schemes)
+	RegisterFactory("idrac-redfish", newRedfishiDracAccessDetails, schemes)
 }
 
 func redfishDetails(parsedURL *url.URL, disableCertificateVerification bool) *redfishAccessDetails {
@@ -24,11 +25,21 @@ func newRedfishAccessDetails(parsedURL *url.URL, disableCertificateVerification 
 	return redfishDetails(parsedURL, disableCertificateVerification), nil
 }
 
+func newRedfishiDracAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+	return &redfishiDracAccessDetails{
+		*redfishDetails(parsedURL, disableCertificateVerification),
+	}, nil
+}
+
 type redfishAccessDetails struct {
 	bmcType                        string
 	host                           string
 	path                           string
 	disableCertificateVerification bool
+}
+
+type redfishiDracAccessDetails struct {
+	redfishAccessDetails
 }
 
 const redfishDefaultScheme = "https"
@@ -109,4 +120,30 @@ func (a *redfishAccessDetails) VendorInterface() string {
 
 func (a *redfishAccessDetails) SupportsSecureBoot() bool {
 	return true
+}
+
+// iDrac Redfish Overrides
+
+func (a *redfishiDracAccessDetails) Driver() string {
+	return "idrac"
+}
+
+func (a *redfishiDracAccessDetails) BootInterface() string {
+	return "ipxe"
+}
+
+func (a *redfishiDracAccessDetails) ManagementInterface() string {
+	return "idrac-redfish"
+}
+
+func (a *redfishiDracAccessDetails) PowerInterface() string {
+	return "idrac-redfish"
+}
+
+func (a *redfishiDracAccessDetails) RAIDInterface() string {
+	return "no-raid"
+}
+
+func (a *redfishiDracAccessDetails) VendorInterface() string {
+	return "no-vendor"
 }


### PR DESCRIPTION
This is a rebased and gofmted #419 

Original PR description below

-------------------------------------------

The idrac BMCs have partiular handling of boot mode as configuration
change requests which need to be honored only at power state changes
as opposed to immediately, because this can conflict and over-write
existing configuration jobs.

While we shouldn't be in this state without more advanced bmc
features being leveraged, it is best to use the vendor supported
hardware type and interfaces for using redfish with their hardware.

This boot interface defaults to using iPXE, as opposed to virtual
media. A separate idrac specific redfish virtual media interface
already existed in the baremetal-operator.