### PR TITLE
ensure the boot mode is set in ironic before starting inspection

### DIFF
--- a/pkg/controller/baremetalhost/host_state_machine.go
+++ b/pkg/controller/baremetalhost/host_state_machine.go
@@ -103,7 +103,8 @@ func (hsm *hostStateMachine) updateHostStateFrom(initialState metal3v1alpha1.Pro
 			// it needs error handling logic that we can't support in
 			// this function.
 			if updateBootModeStatus(hsm.Host) {
-				info.log.Info("saving boot mode")
+				info.log.Info("saving boot mode",
+					"new mode", hsm.Host.Status.Provisioning.BootMode)
 			}
 		}
 	}

--- a/pkg/controller/baremetalhost/host_state_machine.go
+++ b/pkg/controller/baremetalhost/host_state_machine.go
@@ -88,6 +88,24 @@ func (hsm *hostStateMachine) updateHostStateFrom(initialState metal3v1alpha1.Pro
 			stateChanges.With(stateChangeMetricLabels(initialState, hsm.NextState)).Inc()
 		})
 		hsm.Host.Status.Provisioning.State = hsm.NextState
+		// Here we assume that if we're being asked to change the
+		// state, the return value of ReconcileState (our caller) is
+		// set up to ensure the change in the host is written back to
+		// the API. That means we can safely update any status fields
+		// along with the state.
+		switch hsm.NextState {
+		case metal3v1alpha1.StateRegistering,
+			metal3v1alpha1.StateInspecting,
+			metal3v1alpha1.StateProvisioning:
+			// TODO: When the user-selectable profile field is
+			// removed, move saveHostProvisioningSettings() from the
+			// controller to this point. We can't move it yet because
+			// it needs error handling logic that we can't support in
+			// this function.
+			if updateBootModeStatus(hsm.Host) {
+				info.log.Info("saving boot mode")
+			}
+		}
 	}
 }
 
@@ -200,9 +218,6 @@ func (hsm *hostStateMachine) handleRegistering(info *reconcileInfo) actionResult
 			hsm.NextState = metal3v1alpha1.StateProvisioned
 		case hsm.Host.NeedsHardwareInspection():
 			hsm.NextState = metal3v1alpha1.StateInspecting
-			if updateBootModeStatus(hsm.Host) {
-				info.log.Info("saving boot mode")
-			}
 		case hsm.Host.NeedsHardwareProfile():
 			hsm.NextState = metal3v1alpha1.StateMatchProfile
 		default:
@@ -256,9 +271,6 @@ func (hsm *hostStateMachine) handleExternallyProvisioned(info *reconcileInfo) ac
 	switch {
 	case hsm.Host.NeedsHardwareInspection():
 		hsm.NextState = metal3v1alpha1.StateInspecting
-		if updateBootModeStatus(hsm.Host) {
-			info.log.Info("saving boot mode")
-		}
 	case hsm.Host.NeedsHardwareProfile():
 		hsm.NextState = metal3v1alpha1.StateMatchProfile
 	default:
@@ -278,9 +290,6 @@ func (hsm *hostStateMachine) handleReady(info *reconcileInfo) actionResult {
 	switch r := actResult.(type) {
 	case actionComplete:
 		hsm.NextState = metal3v1alpha1.StateProvisioning
-		if updateBootModeStatus(hsm.Host) {
-			info.log.Info("saving boot mode")
-		}
 	case actionFailed:
 		switch r.ErrorType {
 		case metal3v1alpha1.PowerManagementError:

--- a/pkg/controller/baremetalhost/host_state_machine_test.go
+++ b/pkg/controller/baremetalhost/host_state_machine_test.go
@@ -384,3 +384,81 @@ func (m *mockProvisioner) PowerOff() (result provisioner.Result, err error) {
 func (m *mockProvisioner) IsReady() (result bool, err error) {
 	return
 }
+
+func TestUpdateBootModeStatus(t *testing.T) {
+	testCases := []struct {
+		Scenario       string
+		SpecValue      metal3v1alpha1.BootMode
+		StatusValue    metal3v1alpha1.BootMode
+		ExpectedValue  metal3v1alpha1.BootMode
+		ExpectedChange bool
+	}{
+		{
+			Scenario:       "default",
+			SpecValue:      "",
+			StatusValue:    "",
+			ExpectedValue:  metal3v1alpha1.DefaultBootMode,
+			ExpectedChange: true,
+		},
+
+		{
+			Scenario:       "set UEFI",
+			SpecValue:      metal3v1alpha1.UEFI,
+			StatusValue:    "",
+			ExpectedValue:  metal3v1alpha1.UEFI,
+			ExpectedChange: true,
+		},
+
+		{
+			Scenario:       "already UEFI",
+			SpecValue:      metal3v1alpha1.UEFI,
+			StatusValue:    metal3v1alpha1.UEFI,
+			ExpectedValue:  metal3v1alpha1.UEFI,
+			ExpectedChange: false,
+		},
+
+		{
+			Scenario:       "set Legacy",
+			SpecValue:      metal3v1alpha1.Legacy,
+			StatusValue:    "",
+			ExpectedValue:  metal3v1alpha1.Legacy,
+			ExpectedChange: true,
+		},
+
+		{
+			Scenario:       "already Legacy",
+			SpecValue:      metal3v1alpha1.Legacy,
+			StatusValue:    metal3v1alpha1.Legacy,
+			ExpectedValue:  metal3v1alpha1.Legacy,
+			ExpectedChange: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			host := metal3v1alpha1.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myhost",
+					Namespace: "myns",
+				},
+				Spec: metal3v1alpha1.BareMetalHostSpec{
+					Image: &metal3v1alpha1.Image{
+						URL: "not-empty",
+					},
+					Online:   true,
+					BootMode: tc.SpecValue,
+				},
+				Status: metal3v1alpha1.BareMetalHostStatus{
+					Provisioning: metal3v1alpha1.ProvisionStatus{
+						Image: metal3v1alpha1.Image{
+							URL: "also-not-empty",
+						},
+						BootMode: tc.StatusValue,
+					},
+				},
+			}
+			changed := updateBootModeStatus(&host)
+			assert.Equal(t, tc.ExpectedChange, changed, "unexpected change response")
+			assert.Equal(t, tc.ExpectedValue, host.Status.Provisioning.BootMode)
+		})
+	}
+}


### PR DESCRIPTION
We were previously only updating the host status copy of the boot mode
when we entered the inspecting state or provisioning states. This change
extends that to set it correctly during the registration process, too,
so that when the node is created in ironic it is given the right mode.

We were only updating the boot mode in ironic during registration and
during provisioning. This change updates the mode in ironic before
starting provisioning.