### PR TITLE
Added namespace 'metal3'

### DIFF
--- a/ironic-deployment/ironic/ironic.yaml
+++ b/ironic-deployment/ironic/ironic.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metal3-ironic
+  namespace: metal3
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Running both ironic and baremetal-operator in single namespace would be much easier to debug and fetch the statuses of each component by a single 'kubectl get all -n metal3' command instead of running both in different namespaces.