### PR TITLE
Correct the description of HardwareDetails fields

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -360,7 +360,8 @@ type CPU struct {
 
 // Storage describes one storage device (disk, SSD, etc.) on the host.
 type Storage struct {
-	// A name for the disk, e.g. "disk 1 (boot)"
+	// The Linux device name of the disk, e.g. "/dev/sda". Note that this
+	// may not be stable across reboots.
 	Name string `json:"name"`
 
 	// Whether this disk represents rotational storage
@@ -406,20 +407,21 @@ type VLAN struct {
 
 // NIC describes one network interface on the host.
 type NIC struct {
-	// The name of the NIC, e.g. "nic-1"
+	// The name of the network interface, e.g. "en0"
 	Name string `json:"name"`
 
-	// The name of the model, e.g. "virt-io"
+	// The vendor and product IDs of the NIC, e.g. "0x8086 0x1572"
 	Model string `json:"model"`
 
-	// The device MAC addr
+	// The device MAC address
 	// +kubebuilder:validation:Pattern=`[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}`
 	MAC string `json:"mac"`
 
-	// The IP address of the device
+	// The IP address of the interface. This will be an IPv4 address if one is
+	// present, and only an IPv6 address if there is no IPv4 address.
 	IP string `json:"ip"`
 
-	// The speed of the device
+	// The speed of the device in Gigabits per second
 	SpeedGbps int `json:"speedGbps"`
 
 	// The VLANs available

--- a/config/crd/bases/metal3.io_baremetalhosts.yaml
+++ b/config/crd/bases/metal3.io_baremetalhosts.yaml
@@ -399,23 +399,26 @@ spec:
                       description: NIC describes one network interface on the host.
                       properties:
                         ip:
-                          description: The IP address of the device
+                          description: The IP address of the interface. This will
+                            be an IPv4 address if one is present, and only an IPv6
+                            address if there is no IPv4 address.
                           type: string
                         mac:
-                          description: The device MAC addr
+                          description: The device MAC address
                           pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
                           type: string
                         model:
-                          description: The name of the model, e.g. "virt-io"
+                          description: The vendor and product IDs of the NIC, e.g.
+                            "0x8086 0x1572"
                           type: string
                         name:
-                          description: The name of the NIC, e.g. "nic-1"
+                          description: The name of the network interface, e.g. "en0"
                           type: string
                         pxe:
                           description: Whether the NIC is PXE Bootable
                           type: boolean
                         speedGbps:
-                          description: The speed of the device
+                          description: The speed of the device in Gigabits per second
                           type: integer
                         vlanId:
                           description: The untagged VLAN ID
@@ -464,7 +467,8 @@ spec:
                           description: Hardware model
                           type: string
                         name:
-                          description: A name for the disk, e.g. "disk 1 (boot)"
+                          description: The Linux device name of the disk, e.g. "/dev/sda".
+                            Note that this may not be stable across reboots.
                           type: string
                         rotational:
                           description: Whether this disk represents rotational storage

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -333,23 +333,23 @@ spec:
                       description: NIC describes one network interface on the host.
                       properties:
                         ip:
-                          description: The IP address of the device
+                          description: The IP address of the interface. This will be an IPv4 address if one is present, and only an IPv6 address if there is no IPv4 address.
                           type: string
                         mac:
-                          description: The device MAC addr
+                          description: The device MAC address
                           pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
                           type: string
                         model:
-                          description: The name of the model, e.g. "virt-io"
+                          description: The vendor and product IDs of the NIC, e.g. "0x8086 0x1572"
                           type: string
                         name:
-                          description: The name of the NIC, e.g. "nic-1"
+                          description: The name of the network interface, e.g. "en0"
                           type: string
                         pxe:
                           description: Whether the NIC is PXE Bootable
                           type: boolean
                         speedGbps:
-                          description: The speed of the device
+                          description: The speed of the device in Gigabits per second
                           type: integer
                         vlanId:
                           description: The untagged VLAN ID
@@ -397,7 +397,7 @@ spec:
                           description: Hardware model
                           type: string
                         name:
-                          description: A name for the disk, e.g. "disk 1 (boot)"
+                          description: The Linux device name of the disk, e.g. "/dev/sda". Note that this may not be stable across reboots.
                           type: string
                         rotational:
                           description: Whether this disk represents rotational storage


### PR DESCRIPTION
In the HardwareDetails output, our description of a disk's Name field
and some of the NIC fields were pretty misleading about what they
actually contains.