### PR TITLE
Add import order and grouping validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ $(GOPATH)/bin/gosec:
 .PHONY: fmt
 fmt: ## Run go fmt against code
 	go fmt ./...
+	go run ./hack/validate-imports ./
 
 .PHONY: vet
 vet: ## Run go vet against code

--- a/apis/metal3.io/v1alpha1/baremetalhost_types_test.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/cmd/get-hardware-details/main.go
+++ b/cmd/get-hardware-details/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/v1/introspection"
+
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/hardwaredetails"
 )

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -8,15 +8,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	corev1 "k8s.io/api/core/v1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-
 	"k8s.io/client-go/kubernetes/scheme"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/controllers/metal3.io/demo_test.go
+++ b/controllers/metal3.io/demo_test.go
@@ -5,9 +5,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
-
 	"k8s.io/client-go/kubernetes/scheme"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/controllers/metal3.io/host_config_data.go
+++ b/controllers/metal3.io/host_config_data.go
@@ -4,17 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-
-	"github.com/go-logr/logr"
-
-	corev1 "k8s.io/api/core/v1"
-
-	"k8s.io/apimachinery/pkg/types"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // hostConfigData is an implementation of host configuration data interface.

--- a/controllers/metal3.io/host_config_data_test.go
+++ b/controllers/metal3.io/host_config_data_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 

--- a/controllers/metal3.io/host_state_machine.go
+++ b/controllers/metal3.io/host_state_machine.go
@@ -3,10 +3,10 @@ package controllers
 import (
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // hostStateMachine is a finite state machine that manages transitions between

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -3,17 +3,15 @@ package controllers
 import (
 	"testing"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	"github.com/metal3-io/baremetal-operator/pkg/bmc"
-
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 )
 
 func testStateMachine(host *metal3v1alpha1.BareMetalHost) *hostStateMachine {
@@ -278,7 +276,7 @@ func host(state metal3v1alpha1.ProvisioningState) *hostBuilder {
 			Status: metal3v1alpha1.BareMetalHostStatus{
 				Provisioning: metal3v1alpha1.ProvisionStatus{
 					State:    state,
-					BootMode: v1alpha1.DefaultBootMode,
+					BootMode: metal3v1alpha1.DefaultBootMode,
 				},
 				GoodCredentials: metal3v1alpha1.CredentialsStatus{
 					Reference: &corev1.SecretReference{

--- a/controllers/metal3.io/metrics.go
+++ b/controllers/metal3.io/metrics.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 

--- a/hack/validate-imports/validate-imports.go
+++ b/hack/validate-imports/validate-imports.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const local = "github.com/metal3-io/baremetal-operator"
+
+type importSpecs []*ast.ImportSpec
+
+func (is importSpecs) Len() int           { return len(is) }
+func (is importSpecs) Less(i, j int) bool { return is[i].Path.Value < is[j].Path.Value }
+func (is importSpecs) Swap(i, j int)      { is[i], is[j] = is[j], is[i] }
+
+var _ sort.Interface = importSpecs{}
+
+type importType int
+
+// at most one import group of each type may exist in a validated source file,
+// specifically in the order declared below
+const (
+	importStd   importType = 1 << iota // go standard library
+	importDot                          // "." imports (ginkgo and gomega)
+	importOther                        // non-local imports
+	importLocal                        // local imports
+)
+
+func typeForImport(imp *ast.ImportSpec) importType {
+	path := strings.Trim(imp.Path.Value, `"`)
+
+	//fmt.Printf("typeForImport %s\n", path)
+	switch {
+	case imp.Name != nil && imp.Name.Name == ".":
+		return importDot
+	case strings.HasPrefix(path, local+"/"):
+		return importLocal
+	case strings.ContainsRune(path, '.'):
+		return importOther
+	default:
+		return importStd
+	}
+}
+
+func validateImport(imp *ast.ImportSpec) (errs []error) {
+	path := strings.Trim(imp.Path.Value, `"`)
+
+	switch typeForImport(imp) {
+	case importDot:
+		switch path {
+		case "github.com/onsi/ginkgo",
+			"github.com/onsi/gomega",
+			"github.com/onsi/gomega/gstruct":
+		default:
+			errs = append(errs, fmt.Errorf("invalid . import %s", imp.Path.Value))
+		}
+	}
+
+	return
+}
+
+func check(path string) (errs []error) {
+	var fset token.FileSet
+
+	f, err := parser.ParseFile(&fset, path, nil, parser.ImportsOnly)
+	if err != nil {
+		return []error{err}
+	}
+
+	var groups [][]*ast.ImportSpec
+
+	for i, imp := range f.Imports {
+		// if there's more than one line between this and the previous import,
+		// break open a new import group
+		if i == 0 || fset.Position(f.Imports[i].Pos()).Line-fset.Position(f.Imports[i-1].Pos()).Line > 1 {
+			groups = append(groups, []*ast.ImportSpec{})
+		}
+
+		groups[len(groups)-1] = append(groups[len(groups)-1], imp)
+	}
+
+	// seenTypes holds a bitmask of the importTypes seen up to this point, so
+	// that we can detect duplicate groups.  We can also detect misordered
+	// groups, because when we set a bit (say 0b0100), we actually set all the
+	// trailing bits (0b0111) as sentinels
+	var seenTypes importType
+
+	for groupnum, group := range groups {
+		if !sort.IsSorted(importSpecs(group)) {
+			errs = append(errs, fmt.Errorf("group %d: imports are not sorted", groupnum+1))
+		}
+
+		groupImportType := typeForImport(group[0])
+		//fmt.Printf("groupImportType %d: %s\n", groupImportType, group[0].Path.Value)
+
+		if (seenTypes & groupImportType) != 0 { // check if single bit is already set...
+			errs = append(errs, fmt.Errorf("group %d(%d): duplicate group or invalid group ordering", groupnum+1, groupImportType))
+		}
+		seenTypes |= groupImportType<<1 - 1 // ...but set all trailing bits
+
+		for _, imp := range group {
+			errs = append(errs, validateImport(imp)...)
+		}
+
+		for _, imp := range group {
+			if typeForImport(imp) != groupImportType {
+				errs = append(errs, fmt.Errorf("group %d: mixed import type", groupnum+1))
+				break
+			}
+		}
+	}
+
+	return
+}
+
+func main() {
+	var rv int
+	for _, path := range os.Args[1:] {
+		if err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if !info.IsDir() && strings.HasSuffix(path, ".go") {
+				for _, err := range check(path) {
+					fmt.Printf("%s: %v\n", path, err)
+					rv = 1
+				}
+			}
+
+			return nil
+		}); err != nil {
+			panic(err)
+		}
+	}
+	os.Exit(rv)
+}

--- a/pkg/provisioner/ironic/capabilities_test.go
+++ b/pkg/provisioner/ironic/capabilities_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/stretchr/testify/assert"
+
+	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 )
 
 func TestBuildCapabilitiesValue(t *testing.T) {

--- a/pkg/provisioner/ironic/hardwaredetails/hardwaredetails.go
+++ b/pkg/provisioner/ironic/hardwaredetails/hardwaredetails.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/v1/introspection"
+
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 )
 

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -6,17 +6,14 @@ import (
 	"strings"
 	"time"
 
-	"sigs.k8s.io/yaml"
-
+	"github.com/go-logr/logr"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/ports"
 	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/v1/introspection"
-
 	"github.com/pkg/errors"
-
-	"github.com/go-logr/logr"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/yaml"
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/bmc"

--- a/pkg/provisioner/ironic/ready_test.go
+++ b/pkg/provisioner/ironic/ready_test.go
@@ -4,10 +4,11 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/metal3-io/baremetal-operator/pkg/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/testserver"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestProvisionerIsReady(t *testing.T) {

--- a/pkg/provisioner/ironic/updateopts_test.go
+++ b/pkg/provisioner/ironic/updateopts_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	"github.com/metal3-io/baremetal-operator/pkg/bmc"
-	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+
+	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
 )
 
 func TestGetUpdateOptsForNodeWithRootHints(t *testing.T) {


### PR DESCRIPTION
This enforces the following format

```
import (
   <std library>

   <ginko "." imports>

   <imports from other projects>

   <imports from this project>
)
```

Full disclosure, this is originally from a project I worked on before:  https://github.com/Azure/ARO-RP/blob/master/hack/validate-imports/validate-imports.go
The point is to prevent having to make boring/nit-picky comments on PRs.