### PR TITLE
Fix tls certificate fetch path 

### DIFF
--- a/config/basic-auth/default/credentials.yaml
+++ b/config/basic-auth/default/credentials.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: controller-manager
+  namespace: system
 spec:
   template:
     spec:

--- a/config/basic-auth/default/kustomization.yaml
+++ b/config/basic-auth/default/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: metal3
+namespace: baremetal-operator-system
 resources:
 - ../../default
 

--- a/config/basic-auth/tls/credentials.yaml
+++ b/config/basic-auth/tls/credentials.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: controller-manager
+  namespace: system
 spec:
   template:
     spec:

--- a/config/basic-auth/tls/kustomization.yaml
+++ b/config/basic-auth/tls/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: metal3
+namespace: baremetal-operator-system
 resources:
 - ../../tls
 

--- a/config/tls/kustomization.yaml
+++ b/config/tls/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: metal3
+namespace: baremetal-operator-system
 resources:
 - ../default
 

--- a/config/tls/tls_ca.yaml
+++ b/config/tls/tls_ca.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: controller-manager
+  namespace: system
 spec:
   template:
     spec:

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -51,7 +51,7 @@ IRONIC_AUTH_DIR="${IRONIC_AUTH_DIR:-"${IRONIC_DATA_DIR}auth/"}"
 IRONIC_CERTS_DIR="${IRONIC_CERTS_DIR:-"${IRONIC_DATA_DIR}certs/"}"
 
 sudo mkdir -p "${IRONIC_DATA_DIR}"
-sudo chown -R "${USER}:${USER}" "${IRONIC_DATA_DIR}"
+sudo chown -R "${USER}:$(id -gn)" "${IRONIC_DATA_DIR}"
 mkdir -p "${IRONIC_AUTH_DIR}"
 mkdir -p "${IRONIC_CERTS_DIR}"
 
@@ -154,7 +154,7 @@ if [ "${DEPLOY_TLS}" == "true" ]; then
     fi
 
     if [ "${DEPLOY_BMO}" == "true" ]; then
-        cp "${IRONIC_CACERT_FILE}" "${SCRIPTDIR}/deploy/tls/ca.crt"
+        cp "${IRONIC_CACERT_FILE}" "${SCRIPTDIR}/config/tls/ca.crt"
         [ "${IRONIC_CACERT_FILE}" == "${IRONIC_INSPECTOR_CACERT_FILE}" ] || \
         cat "${IRONIC_INSPECTOR_CACERT_FILE}" >> "${SCRIPTDIR}/config/tls/ca.crt"
     fi


### PR DESCRIPTION
This is a fix to the tls certificate path. It should be `config` instead of `deploy`