### PR TITLE
Add capm3 specific configurations in config/ dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ deploy: $(KUSTOMIZE) manifests ## Deploy controller in the configured Kubernetes
 .PHONY: manifests
 manifests: $(CONTROLLER_GEN) $(KUSTOMIZE) ## Generate manifests e.g. CRD, RBAC etc.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases 
-	$(KUSTOMIZE) build config/default > config/render/deployment.yaml
+	$(KUSTOMIZE) build config/default > config/render/capm3.yaml
 
 .PHONY: generate
 generate: $(CONTROLLER_GEN) ## Generate code

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- namespace
+- default

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,10 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-  name: baremetal-operator-system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -24,7 +17,7 @@ spec:
     spec:
       containers:
       - command:
-        - /manager
+        - /baremetal-operator
         args:
         - --enable-leader-election
         image: controller:latest

--- a/config/namespace/kustomization.yaml
+++ b/config/namespace/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml

--- a/config/namespace/namespace.yaml
+++ b/config/namespace/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: baremetal-operator-system

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -1,10 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-  name: baremetal-operator-system
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -812,7 +805,7 @@ spec:
         - --metrics-addr=127.0.0.1:8085
         - --enable-leader-election
         command:
-        - /manager
+        - /baremetal-operator
         image: controller:latest
         name: manager
         resources:


### PR DESCRIPTION
We realized that for capm3 having the namespace in `config/manager/manager.yaml` is problematic, fetching it out of there and adding it in its own directory (namespace). 

To allow using namespace and default, a root level kustomization is added. 

Fixing, the command for `config/manager/manager.yaml` from `manager` to `baremetal-operator`