### PR TITLE
Fix kustomization path

### DIFF
--- a/config/basic-auth/default/kustomization.yaml
+++ b/config/basic-auth/default/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: baremetal-operator-system
 resources:
-- ../../default
+- ../../
 
 secretGenerator:
   - name: ironic-credentials

--- a/config/tls/kustomization.yaml
+++ b/config/tls/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: baremetal-operator-system
 resources:
-- ../default
+- ../
 
 secretGenerator:
   - name: ironic-cacert

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -36,7 +36,7 @@ fi
 if [ "${DEPLOY_TLS}" == "true" ]; then
     BMO_SCENARIO="${BMO_SCENARIO}/tls"
     IRONIC_SCENARIO="${IRONIC_SCENARIO}/tls"
-else
+elif [ "${DEPLOY_BASIC_AUTH}" == "true" ]; then
     BMO_SCENARIO="${BMO_SCENARIO}/default"
 fi
 


### PR DESCRIPTION
This PR fixes the kustomization path for CAPM3 v1alpha3. It should point to `config/` to include the namespace