### PR TITLE
Fix image name in manager + other small nits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ BUILD_VERSION ?= $(shell git describe --always --abbrev=40 --dirty)
 export LDFLAGS="-X github.com/metal3-io/baremetal-operator/pkg/version.Raw=${BUILD_VERSION} -X github.com/metal3-io/baremetal-operator/pkg/version.Commit=${SOURCE_GIT_COMMIT}"
 
 # Set some variables the operator expects to have in order to work
-# Those need to be the same as in deploy/ironic_ci.env
+# Those need to be the same as in config/default/ironic.env
 export OPERATOR_NAME=baremetal-operator
 export DEPLOY_KERNEL_URL=http://172.22.0.1:6180/images/ironic-python-agent.kernel
 export DEPLOY_RAMDISK_URL=http://172.22.0.1:6180/images/ironic-python-agent.initramfs

--- a/Tiltfile
+++ b/Tiltfile
@@ -139,7 +139,7 @@ def enable_provider(name):
     os.environ.update(substitutions)
 
     # Apply the kustomized yaml for this provider
-    yaml = str(kustomizesub(context + "/deploy/default"))
+    yaml = str(kustomizesub(context + "/config"))
     k8s_yaml(blob(yaml))
 
 def kustomizesub(folder):

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -20,7 +20,7 @@ spec:
         - /baremetal-operator
         args:
         - --enable-leader-election
-        image: controller:latest
+        image: quay.io/metal3-io/baremetal-operator
         imagePullPolicy: Always
         env:
           - name: POD_NAME

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -830,7 +830,7 @@ spec:
         envFrom:
         - configMapRef:
             name: baremetal-operator-ironic
-        image: controller:latest
+        image: quay.io/metal3-io/baremetal-operator
         imagePullPolicy: Always
         name: manager
         resources:

--- a/ironic-deployment/keepalived/kustomization.yaml
+++ b/ironic-deployment/keepalived/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: metal3
 resources:
-- ../../deploy/namespace
+- ../../config/namespace
 - ../ironic
 configMapGenerator:
 - envs:


### PR DESCRIPTION
This PR changes the name in `config/manager/manager.yaml` to point to `quay.io/metal3-io/baremetal-operator`

It also does some other changes to take the new config/ dir into account. 