### PR TITLE
remove test dependency from docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ $(CONTROLLER_GEN):
 ## --------------------------------------
 
 .PHONY: docker
-docker: test ## Build the docker image
+docker: generate manifests ## Build the docker image
 	docker build . -t ${IMG}
 
 # Push the docker image


### PR DESCRIPTION
There doesn't seem to be much point in running all of the lint and
unit tests before building the docker image, and it means we have to
keep the CI system set up to run extra tools in that job. This patch
removes the dependency so `make docker` only builds the image.