### PR TITLE
make logger names more consistent

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -516,7 +516,7 @@ func (r *BareMetalHostReconciler) actionMatchProfile(prov provisioner.Provisione
 func (r *BareMetalHostReconciler) actionProvisioning(prov provisioner.Provisioner, info *reconcileInfo) actionResult {
 	hostConf := &hostConfigData{
 		host:   info.host,
-		log:    info.log,
+		log:    info.log.WithName("host_config_data"),
 		client: r,
 	}
 	info.log.Info("provisioning")

--- a/controllers/metal3.io/demo_test.go
+++ b/controllers/metal3.io/demo_test.go
@@ -28,7 +28,7 @@ func newDemoReconciler(initObjs ...runtime.Object) *BareMetalHostReconciler {
 		Client:             c,
 		Scheme:             scheme.Scheme,
 		ProvisionerFactory: demo.New,
-		Log:                ctrl.Log.WithName("controller").WithName("baremetalhost").WithName("demo").WithName("test"),
+		Log:                ctrl.Log.WithName("controller").WithName("BareMetalHost"),
 	}
 }
 

--- a/controllers/metal3.io/host_config_data_test.go
+++ b/controllers/metal3.io/host_config_data_test.go
@@ -227,7 +227,7 @@ func TestProvisionWithHostConfig(t *testing.T) {
 			c.Create(goctx.TODO(), tc.NetworkDataSecret)
 			hcd := &hostConfigData{
 				host:   tc.Host,
-				log:    ctrl.Log.WithName("Test").WithName(tc.Scenario),
+				log:    ctrl.Log.WithName("controllers").WithName("BareMetalHost").WithName("host_config_data"),
 				client: c,
 			}
 

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -315,7 +315,7 @@ func (hb *hostBuilder) SetImageURL(url string) *hostBuilder {
 
 func makeDefaultReconcileInfo(host *metal3v1alpha1.BareMetalHost) *reconcileInfo {
 	return &reconcileInfo{
-		log:     logf.Log.WithName("test"),
+		log:     logf.Log.WithName("controllers").WithName("BareMetalHost").WithName("host_state_machine"),
 		host:    host,
 		request: ctrl.Request{},
 		bmcCredsSecret: &corev1.Secret{

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -11,7 +11,7 @@ import (
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 )
 
-var log = logf.Log.WithName("demo")
+var log = logf.Log.WithName("provisioner").WithName("demo")
 var deprovisionRequeueDelay = time.Second * 10
 var provisionRequeueDelay = time.Second * 10
 

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -11,7 +11,7 @@ import (
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 )
 
-var log = logf.Log.WithName("fixture")
+var log = logf.Log.WithName("provisioner").WithName("fixture")
 var deprovisionRequeueDelay = time.Second * 10
 var provisionRequeueDelay = time.Second * 10
 

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -27,7 +27,7 @@ import (
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/hardwaredetails"
 )
 
-var log = logf.Log.WithName("baremetalhost_ironic")
+var log = logf.Log.WithName("provisioner").WithName("ironic")
 var deprovisionRequeueDelay = time.Second * 10
 var provisionRequeueDelay = time.Second * 10
 var powerRequeueDelay = time.Second * 10


### PR DESCRIPTION
Use consistent capitalization and naming conventions for the loggers.