### PR TITLE
Update golang to latest to match version across all repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 go:
-  - "1.13.7"
+  - "1.15.3"
 
 env:
   - TARGET=unit-verbose

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.hub.docker.com/library/golang:1.14 AS builder
+FROM registry.hub.docker.com/library/golang:1.15.3 AS builder
 
 WORKDIR /workspace
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -60,7 +60,7 @@ def validate_auth():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.14 as tilt-helper
+FROM golang:1.15.3 as tilt-helper
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/baremetal-operator
 
-go 1.14
+go 1.15
 
 require (
 	github.com/go-logr/logr v0.2.1

--- a/hack/Dockerfile.golint
+++ b/hack/Dockerfile.golint
@@ -1,4 +1,4 @@
-FROM registry.hub.docker.com/library/golang:1.14
+FROM registry.hub.docker.com/library/golang:1.15.3
 
 RUN go get -u golang.org/x/lint/golint
 

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -32,6 +32,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/baremetal-operator:rw,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/baremetal-operator \
-    registry.hub.docker.com/library/golang:1.14 \
+    registry.hub.docker.com/library/golang:1.15.3 \
     /go/src/github.com/metal3-io/baremetal-operator/hack/generate.sh "${@}"
 fi;

--- a/hack/gofmt.sh
+++ b/hack/gofmt.sh
@@ -22,6 +22,6 @@ else
     --volume "${PWD}:/workdir:rw,z" \
     --entrypoint sh \
     --workdir /workdir \
-    registry.hub.docker.com/library/golang:1.14 \
+    registry.hub.docker.com/library/golang:1.15.3 \
     /workdir/hack/gofmt.sh "${@}"
 fi;

--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -43,6 +43,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/baremetal-operator:rw,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/baremetal-operator \
-    registry.hub.docker.com/library/golang:1.15.2 \
+    registry.hub.docker.com/library/golang:1.15.3 \
     /go/src/github.com/metal3-io/baremetal-operator/hack/gomod.sh "${@}"
 fi;

--- a/hack/govet.sh
+++ b/hack/govet.sh
@@ -15,6 +15,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/baremetal-operator:ro,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/baremetal-operator \
-    registry.hub.docker.com/library/golang:1.14 \
+    registry.hub.docker.com/library/golang:1.15.3 \
     /go/src/github.com/metal3-io/baremetal-operator/hack/govet.sh "${@}"
 fi;

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -26,6 +26,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/baremetal-operator:rw,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/baremetal-operator \
-    registry.hub.docker.com/library/golang:1.14 \
+    registry.hub.docker.com/library/golang:1.15.3 \
     /go/src/github.com/metal3-io/baremetal-operator/hack/unit.sh "${@}"
 fi;


### PR DESCRIPTION
**What this PR does / why we need it:**
In order to avoid differences in go version across all repositories, this PR updates go to the latest in hack scripts. The motivation behind this is from [project-infra/pull/124](https://github.com/metal3-io/project-infra/pull/124).