### PR TITLE
Fix path in install kustomize

### DIFF
--- a/tools/install_kustomize.sh
+++ b/tools/install_kustomize.sh
@@ -35,9 +35,9 @@ EOF
         mkdir -p "./bin"
       fi
       curl -L -O "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${MINIMUM_KUSTOMIZE_VERSION}/kustomize_v${MINIMUM_KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz"
-      tar -xzvf kustomize_v${MINIMUM_KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
-      mv kustomize ./bin
-      rm kustomize_v${MINIMUM_KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
+      tar --one-top-level=tmp -xzvf kustomize_v${MINIMUM_KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
+      mv tmp/kustomize ./bin
+      rm -rf tmp kustomize_v${MINIMUM_KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
     else
       echo "Missing required binary: $(PWD)bin/kustomize"
       return 2


### PR DESCRIPTION
When running `make build`, I encountered the following error:

```
$ make build
./bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
cd tools; ./install_kustomize.sh
Verifying kustomize version
kustomize not found, installing
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   661  100   661    0     0   3755      0 --:--:-- --:--:-- --:--:--  3755
100 12.5M  100 12.5M    0     0  6312k      0  0:00:02  0:00:02 --:--:-- 8614k
kustomize
mv: cannot stat 'kustomize': No such file or directory
./bin/controller-gen "crd:trivialVersions=false,allowDangerousTypes=true,crdVersions=v1" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
tools/bin/kustomize build config/default > config/render/capm3.yaml
/bin/sh: tools/bin/kustomize: No such file or directory
make: *** [Makefile:147: manifests] Error 127
```

This PR fixes the path.