### PR TITLE
Change kustomize path from tools/bin/ to bin/

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -162,5 +162,5 @@ validate_auth()
 include_user_tilt_files()
 
 load_provider_tiltfiles(["."])
-local("make tools/bin/kustomize")
+local("make bin/kustomize")
 enable_provider("metal3-bmo")

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -175,17 +175,17 @@ if [ "${DEPLOY_TLS}" == "true" ]; then
 fi
 
 pushd "${SCRIPTDIR}"
-make tools/bin/kustomize
+make bin/kustomize
 popd
 
 if [ "${DEPLOY_BMO}" == "true" ]; then
     # shellcheck disable=SC2086
-    "${SCRIPTDIR}/tools/bin/kustomize" build "${BMO_SCENARIO}" | kubectl apply ${KUBECTL_ARGS} -f -
+    "${SCRIPTDIR}/bin/kustomize" build "${BMO_SCENARIO}" | kubectl apply ${KUBECTL_ARGS} -f -
 fi
 
 if [ "${DEPLOY_IRONIC}" == "true" ]; then
     # shellcheck disable=SC2086
-    "${SCRIPTDIR}/tools/bin/kustomize" build "${IRONIC_SCENARIO}" | kubectl apply ${KUBECTL_ARGS} -f -
+    "${SCRIPTDIR}/bin/kustomize" build "${IRONIC_SCENARIO}" | kubectl apply ${KUBECTL_ARGS} -f -
 fi
 
 if [ "${DEPLOY_BASIC_AUTH}" == "true" ]; then


### PR DESCRIPTION
cc #692 

In #691, we moved the kustomize binary from `tools/bin/kustomize` to `bin/kustomize` but forgot to update a few paths. This PR fixes those issues.