### PR TITLE
Disable unnecessary Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ go:
   - "1.15.3"
 
 env:
-  - TARGET=unit-verbose
   - TARGET=docker
-  - TARGET=lint
 
 script: make $TARGET


### PR DESCRIPTION
All of the Travis tests except building the Docker image have duplicates
in Prow, so stop running them.