### PR TITLE
add health check endpoint

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -39,3 +39,9 @@ spec:
             cpu: 100m
             memory: 20Mi
       terminationGracePeriodSeconds: 10
+      livenessProbe:
+        httpGet:
+          path: /healthz
+          port: 9440
+        initialDelaySeconds: 3
+        periodSeconds: 3

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -870,4 +870,10 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+      livenessProbe:
+        httpGet:
+          path: /healthz
+          port: 9440
+        initialDelaySeconds: 3
+        periodSeconds: 3
       terminationGracePeriodSeconds: 10

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ func main() {
 	var devLogging bool
 	var runInTestMode bool
 	var runInDemoMode bool
+	var healthAddr string
 
 	// From CAPI point of view, BMO should be able to watch all namespaces
 	// in case of a deployment that is not multi-tenant. If the deployment
@@ -79,6 +80,8 @@ func main() {
 	flag.BoolVar(&runInTestMode, "test-mode", false, "disable ironic communication")
 	flag.BoolVar(&runInDemoMode, "demo-mode", false,
 		"use the demo provisioner to set host states")
+	flag.StringVar(&healthAddr, "health-addr", ":9440",
+		"The address the health endpoint binds to.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(devLogging)))
@@ -93,6 +96,7 @@ func main() {
 		LeaderElectionID:        "baremetal-operator",
 		LeaderElectionNamespace: watchNamespace,
 		Namespace:               watchNamespace,
+		HealthProbeBindAddress:  healthAddr,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
Add a command line option to specify the address for a health-check
endpoint and use the address to configure that endpoint in the
controller.

Fixes #656