### PR TITLE
Remove main.go path in tilt-provider.json file

### DIFF
--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -2,10 +2,9 @@
     "name": "metal3-bmo",
     "config": {
         "kustomize_config": false,
-        "go_main": "cmd/manager/main.go",
         "image": "quay.io/metal3-io/baremetal-operator",
         "live_reload_deps": [
-            "cmd", "pkg", "go.mod", "go.sum"
+            "apis", "cmd", "pkg", "config", "controllers", "go.mod", "go.sum", "main.go"
         ]
     }
 }


### PR DESCRIPTION
This PR removes the main-go path in tilt-provider.json file. This enable bmo to run properly when [using Tilt](https://github.com/metal3-io/cluster-api-provider-metal3/blob/master/docs/dev-setup.md#tilt-development-environment)