### PR TITLE
Fix livenessProve for BMO

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,10 +31,10 @@ spec:
           - configMapRef:
               name: ironic
         name: manager
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9440
+          initialDelaySeconds: 3
+          periodSeconds: 3
       terminationGracePeriodSeconds: 10
-      livenessProbe:
-        httpGet:
-          path: /healthz
-          port: 9440
-        initialDelaySeconds: 3
-        periodSeconds: 3

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -862,11 +862,11 @@ spec:
             name: baremetal-operator-ironic
         image: quay.io/metal3-io/baremetal-operator
         imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9440
+          initialDelaySeconds: 3
+          periodSeconds: 3
         name: manager
-      livenessProbe:
-        httpGet:
-          path: /healthz
-          port: 9440
-        initialDelaySeconds: 3
-        periodSeconds: 3
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
v1alpha3 based CI jobs are failing by not being able to render livenessProbe field. It seems due to the indentation in the deployment manifest.

```
+ /home/****/go/src/github.com/metal3-io/baremetal-operator/tools/deploy.sh true false true true true
~/go/src/github.com/metal3-io/baremetal-operator ~/go/src/github.com/metal3-io/baremetal-operator
make[1]: Entering directory '/home/****/go/src/github.com/metal3-io/baremetal-operator'
./tools/install_kustomize.sh
+ OUTPUT=bin/kustomize
+ '[' -d vendor ']'
+ CMDPATH=/home/****/go/pkg/mod/sigs.k8s.io/kustomize/kustomize/v3@v3.8.5
+ '[' '!' -f /home/****/go/pkg/mod/sigs.k8s.io/kustomize/kustomize/v3@v3.8.5 ']'
+ go mod download
+ go build -o bin/kustomize /home/****/go/pkg/mod/sigs.k8s.io/kustomize/kustomize/v3@v3.8.5
make[1]: Leaving directory '/home/****/go/src/github.com/metal3-io/baremetal-operator'
~/go/src/github.com/metal3-io/baremetal-operator
namespace/baremetal-operator-system created
customresourcedefinition.apiextensions.k8s.io/baremetalhosts.metal3.io created
role.rbac.authorization.k8s.io/baremetal-operator-leader-election-role created
clusterrole.rbac.authorization.k8s.io/baremetal-operator-manager-role created
clusterrole.rbac.authorization.k8s.io/baremetal-operator-proxy-role created
clusterrole.rbac.authorization.k8s.io/baremetal-operator-metrics-reader created
rolebinding.rbac.authorization.k8s.io/baremetal-operator-leader-election-rolebinding created
clusterrolebinding.rbac.authorization.k8s.io/baremetal-operator-manager-rolebinding created
clusterrolebinding.rbac.authorization.k8s.io/baremetal-operator-proxy-rolebinding created
configmap/baremetal-operator-ironic created
secret/ironic-cacert-5f6442557f created
secret/ironic-credentials-h2c498hb8k created
secret/ironic-inspector-credentials-h2c498hb8k created
service/baremetal-operator-controller-manager-metrics-service created
error: error validating "STDIN": error validating data: ValidationError(Deployment.spec.template.spec): unknown field "livenessProbe" in io.k8s.api.core.v1.PodSpec; if you choose to ignore these errors, turn validation off with --validate=false
make: *** [Makefile:10: launch_mgmt_cluster] Error 1
```

This fixes indentation in the deployment and main.go for the responses.