### PR TITLE
Add info about 'config/render/capm3.yaml in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Bare Metal Operator
 
-[![Ubuntu V1alpha3 build status](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a3_integration_test_ubuntu/badge/icon?subject=Ubuntu%20E2E%20V1alpha3)](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a3_integration_test_ubuntu/)
-[![CentOS V1alpha3 build status](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a3_integration_test_centos/badge/icon?subject=CentOS%20E2E%20V1alpha3)](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a3_integration_test_centos/)
+[![Ubuntu V1alpha4 build status](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a4_integration_test_ubuntu/badge/icon?subject=Ubuntu%20E2E%20V1alpha4)](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a4_integration_test_ubuntu/)
+[![CentOS V1alpha4 build status](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a4_integration_test_centos/badge/icon?subject=CentOS%20E2E%20V1alpha4)](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a4_integration_test_centos/)
 
 The Bare Metal Operator implements a Kubernetes API for managing bare metal
 hosts.  It maintains an inventory of available hosts as instances of the
@@ -27,3 +27,13 @@ components, see the [Metal³ docs](https://github.com/metal3-io/metal3-docs).
 * [Configuration](docs/configuration.md)
 * [Testing](docs/testing.md)
 * [Publishing Images](docs/publishing-images.md)
+
+### Important Notes
+
+Whenever there is a change in `config/` directory, please remember to run the
+following command:
+
+`make manifests`
+
+This will render the `config/render/capm3.yaml`. Please do not change the
+content of `config/render/capm3.yaml` manually.


### PR DESCRIPTION
This PR adds important information about 'config/render/capm3.yaml in README. This was not clear before. Please check the README for more detail