### PR TITLE
Update local ironic documentation with TLS information

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -81,6 +81,31 @@ The following environment variables can be passed to configure the ironic:
 - IRONIC_FAST_TRACK - whether to enable fast_track provisioning or not
   (default true)
 
+In case you want to run the local ironic containers with TLS and basic
+authentication enabled, you also need to export the following variables:
+
+### TLS variables
+
+- IRONIC_CACERT_FILE
+- IRONIC_CERT_FILE
+- IRONIC_KEY_FILE
+- IRONIC_INSPECTOR_CACERT_FILE
+- IRONIC_INSPECTOR_CERT_FILE
+- IRONIC_INSPECTOR_KEY_FILE
+
+### Basic authentication variables
+
+- IRONIC_USERNAME
+- IRONIC_PASSWORD
+- IRONIC_INSPECTOR_USERNAME
+- IRONIC_INSPECTOR_PASSWORD
+
+The names of these variables are self explanatory. TLS variables expect the
+path of the corresponding certificate/key file as their value. Basic
+authentication variables expect the corresponding value as string.  Note that,
+these variables **do not** have any default value. So if they are not set, the
+ironic container will run with TLS and basic authentication disabled.
+
 ## Using Tilt for development
 
 It is easy to use Tilt for BMO deployment. Once you have a local instance


### PR DESCRIPTION
This PR updates the documentation to add TLS variables that need to be exported in case the local ironic containers are expected to run with TLS enabled. 