### PR TITLE
Fix TLS transport connection establishment

### DIFF
--- a/pkg/provisioner/ironic/clients/client.go
+++ b/pkg/provisioner/ironic/clients/client.go
@@ -37,6 +37,7 @@ func updateHTTPClient(client *gophercloud.ServiceClient, tlsConf TLSConfig) (*go
 		}
 	}
 	tlsTransport, err := transport.NewTransport(tlsInfo, tlsConnectionTimeout)
+	tlsTransport.DisableKeepAlives = true
 	if err != nil {
 		return client, err
 	}


### PR DESCRIPTION
This PR fixes #709 
To be specific, this PR disables keepalive while opening http connections, so that the socket connections don't remain open.