### PR TITLE
Remove finalizer when deleting a host with a malformed BMC address

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -210,6 +210,18 @@ func (r *BareMetalHostReconciler) Reconcile(request ctrl.Request) (result ctrl.R
 	}
 	prov, err := r.ProvisionerFactory(host, *bmcCreds, info.publishEvent)
 	if err != nil {
+		if !info.host.DeletionTimestamp.IsZero() {
+			// Remove the finalizer, if present
+			if hostHasFinalizer(host) {
+				info.log.Info(
+					"removing finalizer",
+					"timestamp", info.host.DeletionTimestamp,
+				)
+
+				host.Finalizers = utils.FilterStringFromList(
+					host.Finalizers, metal3v1alpha1.BareMetalHostFinalizer)
+			}
+		}
 		return ctrl.Result{}, errors.Wrap(err, "failed to create provisioner")
 	}
 


### PR DESCRIPTION
Sometimes when a host is created with a malformed BMC address, trying to immediately delete it will cause in an error and the deletion hangs. This is because a valid driver for this URL cannot be found and the code to remove the finalizer is not run. This PR ensures that the finalizer is removed when the URL is malformed and the deletion timestamp is non zero.