### PR TITLE
Look up existing nodes by MAC address

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -230,6 +230,31 @@ func (p *ironicProvisioner) validateNode(ironicNode *nodes.Node) (errorMessage s
 	return "", nil
 }
 
+func (p *ironicProvisioner) listAllPorts(address string) ([]ports.Port, error) {
+	var allPorts []ports.Port
+
+	opts := ports.ListOpts{}
+
+	if address != "" {
+		opts.Address = address
+	}
+
+	pager := ports.List(p.client, opts)
+
+	if pager.Err != nil {
+		return allPorts, pager.Err
+	}
+
+	allPages, err := pager.AllPages()
+
+	if err != nil {
+		return allPorts, err
+	}
+
+	return ports.ExtractPorts(allPages)
+
+}
+
 // Look for an existing registration for the host in Ironic.
 func (p *ironicProvisioner) findExistingHost() (ironicNode *nodes.Node, err error) {
 	// Try to load the node by UUID
@@ -258,11 +283,48 @@ func (p *ironicProvisioner) findExistingHost() (ironicNode *nodes.Node, err erro
 		p.log.Info("found existing node by name")
 		return ironicNode, nil
 	case gophercloud.ErrDefault404:
-		return nil, nil
+		p.log.Info(
+			fmt.Sprintf("node with name %s doesn't exist", p.host.Name))
 	default:
 		return nil, errors.Wrap(err,
 			fmt.Sprintf("failed to find node by name %s", p.host.Name))
 	}
+
+	// Try to load the node by port address
+	p.log.Info("looking for existing node by MAC", "MAC", p.host.Spec.BootMACAddress)
+	allPorts, err := p.listAllPorts(p.host.Spec.BootMACAddress)
+
+	if err != nil {
+		p.log.Info("failed to find an existing port with address", "MAC", p.host.Spec.BootMACAddress)
+		return nil, nil
+	}
+
+	if len(allPorts) > 0 {
+		nodeUUID := allPorts[0].NodeUUID
+		ironicNode, err = nodes.Get(p.client, nodeUUID).Extract()
+		switch err.(type) {
+		case nil:
+			p.log.Info("found existing node by ID")
+
+			// If the node has a name, this means we didn't find it above.
+			if ironicNode.Name != "" {
+				return nil, errors.New(fmt.Sprint("node found by MAC but has a name: ", ironicNode.Name))
+			}
+
+			return ironicNode, nil
+		case gophercloud.ErrDefault404:
+			return nil, errors.Wrap(err,
+				fmt.Sprintf("port exists but linked node doesn't %s", nodeUUID))
+		default:
+			return nil, errors.Wrap(err,
+				fmt.Sprintf("port exists but failed to find linked node by ID %s", nodeUUID))
+		}
+	} else {
+		p.log.Info("port with address doesn't exist", "MAC", p.host.Spec.BootMACAddress)
+	}
+
+	return nil, nil
+
 }
 
 // ValidateManagementAccess registers the host with the provisioning

--- a/pkg/provisioner/ironic/validatemanagementaccess_test.go
+++ b/pkg/provisioner/ironic/validatemanagementaccess_test.go
@@ -201,6 +201,7 @@ func TestValidateManagementAccessLinkExistingIronicNodeByMAC(t *testing.T) {
 
 	ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).Node(existingNode).Port(existingNodePort)
 	ironic.AddDefaultResponse("/v1/nodes/myhost", "GET", http.StatusNotFound, "")
+	ironic.AddDefaultResponse("/v1/nodes/"+existingNode.UUID, "PATCH", http.StatusOK, "{}")
 	ironic.Start()
 	defer ironic.Stop()
 


### PR DESCRIPTION
If an existing Ironic node, and a BMH share a MAC address, link them together.

Also includes some new functions in the test server for testing port logic