### PR TITLE
Handle re-registration in all states

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -849,27 +849,31 @@ func (host *BareMetalHost) OperationMetricForState(operation ProvisioningState) 
 
 // GetImageChecksum returns the hash value and its algo.
 func (host *BareMetalHost) GetImageChecksum() (string, string, bool) {
-	if host.Spec.Image == nil {
-		return "", "", false
+	return host.Spec.Image.GetChecksum()
+}
+
+func (image *Image) GetChecksum() (checksum, checksumType string, ok bool) {
+	if image == nil {
+		return
 	}
 
-	checksum := host.Spec.Image.Checksum
-	checksumType := host.Spec.Image.ChecksumType
-
-	if checksum == "" {
+	if image.Checksum == "" {
 		// Return empty if checksum is not provided
-		return "", "", false
+		return
 	}
-	if checksumType == "" {
-		// If only checksum is specified. Assume type is md5
-		return checksum, string(MD5), true
-	}
-	switch checksumType {
+
+	switch image.ChecksumType {
+	case "":
+		checksumType = string(MD5)
 	case MD5, SHA256, SHA512:
-		return checksum, string(checksumType), true
+		checksumType = string(image.ChecksumType)
 	default:
-		return "", "", false
+		return
 	}
+
+	checksum = image.Checksum
+	ok = true
+	return
 }
 
 // +kubebuilder:object:root=true

--- a/controllers/metal3.io/action_result.go
+++ b/controllers/metal3.io/action_result.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"errors"
 	"math"
 	"math/rand"
 	"time"
@@ -8,6 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	metal3 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 )
 
 const maxBackOffCount = 10
@@ -94,6 +96,10 @@ func (r actionError) Result() (result reconcile.Result, err error) {
 
 func (r actionError) Dirty() bool {
 	return false
+}
+
+func (r actionError) NeedsRegistration() bool {
+	return errors.Is(r.err, provisioner.NeedsRegistration)
 }
 
 // actionFailed is a result indicating that the current action has failed,

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -181,6 +181,7 @@ func (r *BareMetalHostReconciler) Reconcile(request ctrl.Request) (result ctrl.R
 	// management controller.
 	var bmcCreds *bmc.Credentials
 	var bmcCredsSecret *corev1.Secret
+	haveCreds := false
 	switch host.Status.Provisioning.State {
 	case metal3v1alpha1.StateNone, metal3v1alpha1.StateUnmanaged:
 		bmcCreds = &bmc.Credentials{}
@@ -194,6 +195,8 @@ func (r *BareMetalHostReconciler) Reconcile(request ctrl.Request) (result ctrl.R
 			} else {
 				return r.credentialsErrorResult(err, request, host)
 			}
+		} else {
+			haveCreds = true
 		}
 	}
 
@@ -219,7 +222,7 @@ func (r *BareMetalHostReconciler) Reconcile(request ctrl.Request) (result ctrl.R
 		return ctrl.Result{Requeue: true, RequeueAfter: provisionerNotReadyRetryDelay}, nil
 	}
 
-	stateMachine := newHostStateMachine(host, r, prov)
+	stateMachine := newHostStateMachine(host, r, prov, haveCreds)
 	actResult := stateMachine.ReconcileState(info)
 	result, err = actResult.Result()
 

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -565,7 +565,7 @@ func clearHostProvisioningSettings(host *metal3v1alpha1.BareMetalHost) {
 func (r *BareMetalHostReconciler) actionDeprovisioning(prov provisioner.Provisioner, info *reconcileInfo) actionResult {
 	// Adopt the host in case it has been re-registered during the
 	// deprovisioning process before it completed
-	provResult, err := prov.Adopt()
+	provResult, err := prov.Adopt(info.host.Status.ErrorType == metal3v1alpha1.RegistrationError)
 	if err != nil {
 		return actionError{err}
 	}
@@ -699,7 +699,7 @@ func (r *BareMetalHostReconciler) manageHostPower(prov provisioner.Provisioner, 
 // action. We use the Adopt() API to make sure that the provisioner is aware of
 // the provisioning details. Then we monitor its power status.
 func (r *BareMetalHostReconciler) actionManageSteadyState(prov provisioner.Provisioner, info *reconcileInfo) actionResult {
-	provResult, err := prov.Adopt()
+	provResult, err := prov.Adopt(info.host.Status.ErrorType == metal3v1alpha1.RegistrationError)
 	if err != nil {
 		return actionError{err}
 	}

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -20,7 +20,7 @@ func testStateMachine(host *metal3v1alpha1.BareMetalHost) *hostStateMachine {
 	r := newTestReconciler()
 	p, _ := r.ProvisionerFactory(host, bmc.Credentials{},
 		func(reason, message string) {})
-	return newHostStateMachine(host, r, p)
+	return newHostStateMachine(host, r, p, true)
 }
 
 func TestProvisioningCancelled(t *testing.T) {
@@ -205,7 +205,7 @@ func TestErrorCountIncreasedWhenProvisionerFails(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.Scenario, func(t *testing.T) {
 			prov := &mockProvisioner{}
-			hsm := newHostStateMachine(tt.Host, &BareMetalHostReconciler{}, prov)
+			hsm := newHostStateMachine(tt.Host, &BareMetalHostReconciler{}, prov, true)
 			info := makeDefaultReconcileInfo(tt.Host)
 
 			prov.setNextError("some error")
@@ -220,7 +220,7 @@ func TestErrorCountIncreasedWhenProvisionerFails(t *testing.T) {
 func TestErrorCountIncreasedWhenRegistrationFails(t *testing.T) {
 	bmh := host(metal3v1alpha1.StateRegistering).build()
 	prov := &mockProvisioner{}
-	hsm := newHostStateMachine(bmh, &BareMetalHostReconciler{}, prov)
+	hsm := newHostStateMachine(bmh, &BareMetalHostReconciler{}, prov, true)
 	info := makeDefaultReconcileInfo(bmh)
 	bmh.Status.GoodCredentials = metal3v1alpha1.CredentialsStatus{}
 
@@ -265,7 +265,7 @@ func TestErrorCountCleared(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.Scenario, func(t *testing.T) {
 			prov := &mockProvisioner{}
-			hsm := newHostStateMachine(tt.Host, &BareMetalHostReconciler{}, prov)
+			hsm := newHostStateMachine(tt.Host, &BareMetalHostReconciler{}, prov, true)
 			info := makeDefaultReconcileInfo(tt.Host)
 
 			info.host.Status.ErrorCount = 1

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -367,7 +367,7 @@ func (m *mockProvisioner) UpdateHardwareState() (result provisioner.Result, err 
 	return m.nextResult, err
 }
 
-func (m *mockProvisioner) Adopt() (result provisioner.Result, err error) {
+func (m *mockProvisioner) Adopt(force bool) (result provisioner.Result, err error) {
 	return m.nextResult, err
 }
 

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -183,7 +183,7 @@ func (p *demoProvisioner) UpdateHardwareState() (result provisioner.Result, err 
 }
 
 // Adopt allows an externally-provisioned server to be adopted.
-func (p *demoProvisioner) Adopt() (result provisioner.Result, err error) {
+func (p *demoProvisioner) Adopt(force bool) (result provisioner.Result, err error) {
 	p.log.Info("adopting host")
 	result.Dirty = false
 	return

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -170,7 +170,7 @@ func (p *fixtureProvisioner) UpdateHardwareState() (result provisioner.Result, e
 }
 
 // Adopt allows an externally-provisioned server to be adopted.
-func (p *fixtureProvisioner) Adopt() (result provisioner.Result, err error) {
+func (p *fixtureProvisioner) Adopt(force bool) (result provisioner.Result, err error) {
 	p.log.Info("adopting host")
 	if p.host.Spec.ExternallyProvisioned && !p.adopted {
 		p.adopted = true

--- a/pkg/provisioner/ironic/adopt_test.go
+++ b/pkg/provisioner/ironic/adopt_test.go
@@ -61,8 +61,8 @@ func TestAdopt(t *testing.T) {
 				UUID:           nodeUUID,
 			}),
 
-			expectedDirty:        true,
-			expectedRequestAfter: 10,
+			expectedDirty: false,
+			expectedError: true,
 		},
 		{
 			name: "node-in-AdoptFail",

--- a/pkg/provisioner/ironic/adopt_test.go
+++ b/pkg/provisioner/ironic/adopt_test.go
@@ -23,6 +23,7 @@ func TestAdopt(t *testing.T) {
 		expectedDirty        bool
 		expectedError        bool
 		expectedRequestAfter int
+		force                bool
 	}{
 		{
 			name: "node-in-enroll",
@@ -74,6 +75,17 @@ func TestAdopt(t *testing.T) {
 			expectedDirty:        false,
 			expectedRequestAfter: 0,
 		},
+		{
+			name: "node-in-AdoptFail force retry",
+			ironic: testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
+				ProvisionState: string(nodes.AdoptFail),
+				UUID:           nodeUUID,
+			}),
+
+			expectedDirty:        true,
+			expectedRequestAfter: 10,
+			force:                true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -100,7 +112,7 @@ func TestAdopt(t *testing.T) {
 			}
 
 			prov.status.ID = nodeUUID
-			result, err := prov.Adopt()
+			result, err := prov.Adopt(tc.force)
 
 			assert.Equal(t, tc.expectedDirty, result.Dirty)
 			assert.Equal(t, time.Second*time.Duration(tc.expectedRequestAfter), result.RequeueAfter)

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1237,8 +1237,17 @@ func (p *ironicProvisioner) Deprovision() (result provisioner.Result, err error)
 	)
 
 	switch nodes.ProvisionState(ironicNode.ProvisionState) {
+	case nodes.Error:
+		return p.changeNodeProvisionState(
+			ironicNode,
+			nodes.ProvisionStateOpts{Target: nodes.TargetManage},
+		)
 
-	case nodes.Error, nodes.CleanFail:
+	case nodes.CleanFail:
+		if ironicNode.Maintenance {
+			p.log.Info("clearing maintenance flag")
+			return p.setMaintenanceFlag(ironicNode, false)
+		}
 		return p.changeNodeProvisionState(
 			ironicNode,
 			nodes.ProvisionStateOpts{Target: nodes.TargetManage},

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -560,7 +560,7 @@ func (p *ironicProvisioner) InspectHardware() (result provisioner.Result, detail
 		return
 	}
 	if ironicNode == nil {
-		return result, nil, fmt.Errorf("no ironic node for host")
+		return result, nil, provisioner.NeedsRegistration
 	}
 
 	status, err := introspection.GetIntrospectionStatus(p.inspector, ironicNode.UUID).Extract()
@@ -650,7 +650,7 @@ func (p *ironicProvisioner) UpdateHardwareState() (result provisioner.Result, er
 		return result, errors.Wrap(err, "failed to find existing host")
 	}
 	if ironicNode == nil {
-		return result, fmt.Errorf("no ironic node for host")
+		return result, provisioner.NeedsRegistration
 	}
 
 	var discoveredVal bool
@@ -1043,7 +1043,7 @@ func (p *ironicProvisioner) Provision(hostConf provisioner.HostConfigData) (resu
 		return result, errors.Wrap(err, "could not find host to receive image")
 	}
 	if ironicNode == nil {
-		return result, fmt.Errorf("no ironic node for host")
+		return result, provisioner.NeedsRegistration
 	}
 
 	p.log.Info("provisioning image to host", "state", ironicNode.ProvisionState)

--- a/pkg/provisioner/ironic/provision_test.go
+++ b/pkg/provisioner/ironic/provision_test.go
@@ -119,12 +119,21 @@ func TestDeprovision(t *testing.T) {
 		expectedRequestAfter int
 	}{
 		{
+			name: "active state",
+			ironic: testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
+				ProvisionState: string(nodes.Active),
+				UUID:           nodeUUID,
+			}),
+			expectedRequestAfter: 10,
+			expectedDirty:        true,
+		},
+		{
 			name: "error state",
 			ironic: testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
 				ProvisionState: string(nodes.Error),
 				UUID:           nodeUUID,
 			}),
-			expectedRequestAfter: 0,
+			expectedRequestAfter: 10,
 			expectedDirty:        true,
 		},
 		{
@@ -135,24 +144,6 @@ func TestDeprovision(t *testing.T) {
 			}),
 			expectedRequestAfter: 0,
 			expectedDirty:        false,
-		},
-		{
-			name: "inspecting state",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
-				ProvisionState: string(nodes.Inspecting),
-				UUID:           nodeUUID,
-			}),
-			expectedRequestAfter: 15,
-			expectedDirty:        true,
-		},
-		{
-			name: "inspectWait state",
-			ironic: testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
-				ProvisionState: string(nodes.InspectWait),
-				UUID:           nodeUUID,
-			}),
-			expectedRequestAfter: 10,
-			expectedDirty:        true,
 		},
 		{
 			name: "deleting state",
@@ -180,34 +171,6 @@ func TestDeprovision(t *testing.T) {
 			}),
 			expectedRequestAfter: 10,
 			expectedDirty:        true,
-		},
-
-		{
-			name: "Manageable state",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
-				ProvisionState: string(nodes.Manageable),
-				UUID:           nodeUUID,
-			}),
-			expectedRequestAfter: 0,
-			expectedDirty:        false,
-		},
-		{
-			name: "Enroll state",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
-				ProvisionState: string(nodes.Enroll),
-				UUID:           nodeUUID,
-			}),
-			expectedRequestAfter: 0,
-			expectedDirty:        false,
-		},
-		{
-			name: "Verifying state",
-			ironic: testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
-				ProvisionState: string(nodes.Verifying),
-				UUID:           nodeUUID,
-			}),
-			expectedRequestAfter: 0,
-			expectedDirty:        false,
 		},
 	}
 

--- a/pkg/provisioner/ironic/provision_test.go
+++ b/pkg/provisioner/ironic/provision_test.go
@@ -39,7 +39,7 @@ func TestProvision(t *testing.T) {
 				ProvisionState: string(nodes.Manageable),
 				UUID:           nodeUUID,
 			}),
-			expectedRequestAfter: 0,
+			expectedRequestAfter: 10,
 			expectedDirty:        true,
 		},
 		{
@@ -48,7 +48,7 @@ func TestProvision(t *testing.T) {
 				ProvisionState: string(nodes.Available),
 				UUID:           nodeUUID,
 			}),
-			expectedRequestAfter: 10,
+			expectedRequestAfter: 0,
 			expectedDirty:        true,
 		},
 		{
@@ -133,8 +133,8 @@ func TestDeprovision(t *testing.T) {
 				ProvisionState: string(nodes.Available),
 				UUID:           nodeUUID,
 			}),
-			expectedRequestAfter: 10,
-			expectedDirty:        true,
+			expectedRequestAfter: 0,
+			expectedDirty:        false,
 		},
 		{
 			name: "inspecting state",

--- a/pkg/provisioner/ironic/updatehardwarestate_test.go
+++ b/pkg/provisioner/ironic/updatehardwarestate_test.go
@@ -101,7 +101,7 @@ func TestUpdateHardwareState(t *testing.T) {
 			name:   "not-ironic-node",
 			ironic: testserver.NewIronic(t).Ready().NoNode(nodeUUID).NoNode("myhost"),
 
-			expectedError: "no ironic node for host",
+			expectedError: "Host not registered",
 		},
 	}
 

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -60,7 +60,7 @@ type Provisioner interface {
 
 	// Adopt brings an externally-provisioned host under management by
 	// the provisioner.
-	Adopt() (result Result, err error)
+	Adopt(force bool) (result Result, err error)
 
 	// Provision writes the image from the host spec to the host. It
 	// may be called multiple times, and should return true for its

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -1,6 +1,7 @@
 package provisioner
 
 import (
+	"errors"
 	"time"
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
@@ -100,3 +101,5 @@ type Result struct {
 	// Any error message produced by the provisioner.
 	ErrorMessage string
 }
+
+var NeedsRegistration = errors.New("Host not registered")


### PR DESCRIPTION
Ensure that regardless of the current provisioning state, we always re-register the Node in ironic if the ironic database has been lost.
Ensure that if this occurs during deprovisioning, the Node is re-adopted so that we commence deprovisioning again, so that the Host is always left in a clean state.

This also changes the steady state that we use for Ready hosts in Ironic. Previously we would try to maintain the ironic state as `manageable`. Now we maintain it in `available` if possible. This means that we don't end up doing a second automated cleaning on provisioning if we have just done an automated cleaning on deprovisioning.