### PR TITLE
unittests: Add a mechanism for simulating a lost ironic db

### DIFF
--- a/pkg/provisioner/ironic/testserver/ironic_test.go
+++ b/pkg/provisioner/ironic/testserver/ironic_test.go
@@ -1,0 +1,98 @@
+package testserver
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
+)
+
+func TestIronicDatabaseClearing(t *testing.T) {
+	ironic := NewIronic(t).WithDefaultResponses()
+	ironic.AddDefaultResponse("/v1/nodes", "POST", http.StatusCreated, "{}")
+	ironic.Start()
+	defer ironic.Stop()
+
+	endpoint := ironic.Endpoint()
+
+	url := endpoint + "nodes/uuid"
+
+	resp, err := http.Get(url) // #nosec
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fail()
+	}
+
+	ironic.ClearDatabase()
+
+	resp, err = http.Get(url) // #nosec
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fail()
+	}
+
+	// After clearing the db, POSTs should still work
+	resp, err = http.PostForm(endpoint+"nodes", nil)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fail()
+	}
+}
+
+func TestIronicDatabaseClearingNode(t *testing.T) {
+	ironic := NewIronic(t).WithDefaultResponses().Node(nodes.Node{
+		UUID: "abc",
+	})
+	ironic.AddDefaultResponse("/v1/nodes", "POST", http.StatusCreated, "{}")
+	ironic.Start()
+	defer ironic.Stop()
+
+	endpoint := ironic.Endpoint()
+
+	url := endpoint + "nodes/uuid"
+
+	resp, err := http.Get(url) // #nosec
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fail()
+	}
+
+	ironic.ClearDatabase()
+
+	resp, err = http.Get(url) // #nosec
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fail()
+	}
+
+	// After clearing the db, POSTs should still work
+	resp, err = http.PostForm(endpoint+"nodes", nil)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Calling the new `ClearDatabase()` method will change all registered non-POST handlers to reply with a 404.  Attempts to to create new resources via POST requests will still succeed.

