### PR TITLE
Limit the number of hosts simultaneously provisioned

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -116,6 +116,8 @@ const (
 	// OperationalStatusError is the status value for when the host
 	// has any sort of error.
 	OperationalStatusError OperationalStatus = "error"
+
+	OperationalStatusDelayed = "delayed"
 )
 
 // ErrorType indicates the class of problem that has caused the Host resource
@@ -523,7 +525,7 @@ type BareMetalHostStatus struct {
 	// after modifying this file
 
 	// OperationalStatus holds the status of the host
-	// +kubebuilder:validation:Enum="";OK;discovered;error
+	// +kubebuilder:validation:Enum="";OK;discovered;error;delayed
 	OperationalStatus OperationalStatus `json:"operationalStatus"`
 
 	// ErrorType indicates the type of failure encountered when the

--- a/config/crd/bases/metal3.io_baremetalhosts.yaml
+++ b/config/crd/bases/metal3.io_baremetalhosts.yaml
@@ -525,6 +525,7 @@ spec:
                 - OK
                 - discovered
                 - error
+                - delayed
                 type: string
               poweredOn:
                 description: indicator for whether or not the host is powered on

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -523,6 +523,7 @@ spec:
                 - OK
                 - discovered
                 - error
+                - delayed
                 type: string
               poweredOn:
                 description: indicator for whether or not the host is powered on

--- a/controllers/metal3.io/action_result_test.go
+++ b/controllers/metal3.io/action_result_test.go
@@ -11,7 +11,7 @@ import (
 func TestBackoffIncrements(t *testing.T) {
 
 	var backOff time.Duration
-	for i := 0; i < maxBackOffCount; i++ {
+	for i := 1; i <= maxBackOffCount; i++ {
 		prev := backOff
 		backOff = calculateBackoff(i)
 

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -53,9 +53,6 @@ const (
 	rebootAnnotationPrefix        = "reboot.metal3.io"
 )
 
-func init() {
-}
-
 // BareMetalHostReconciler reconciles a BareMetalHost object
 type BareMetalHostReconciler struct {
 	client.Client
@@ -214,7 +211,6 @@ func (r *BareMetalHostReconciler) Reconcile(request ctrl.Request) (result ctrl.R
 	}
 
 	ready, err := prov.IsReady()
-
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to check services availability")
 	}
@@ -293,6 +289,15 @@ func recordActionFailure(info *reconcileInfo, errorType metal3v1alpha1.ErrorType
 	info.publishEvent(eventType, errorMessage)
 
 	return actionFailed{dirty: true, ErrorType: errorType, errorCount: info.host.Status.ErrorCount}
+}
+
+func recordActionDelayed(info *reconcileInfo) actionResult {
+
+	counter := delayedProvisioningHostCounters.With(hostMetricLabels(info.request))
+	info.postSaveCallbacks = append(info.postSaveCallbacks, counter.Inc)
+
+	info.host.SetOperationalStatus(metal3v1alpha1.OperationalStatusDelayed)
+	return actionDelayed{}
 }
 
 func (r *BareMetalHostReconciler) credentialsErrorResult(err error, request ctrl.Request, host *metal3v1alpha1.BareMetalHost) (ctrl.Result, error) {

--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -1290,12 +1290,14 @@ func TestUpdateEventHandler(t *testing.T) {
 
 func TestErrorCountIncrementsAlways(t *testing.T) {
 
+	errorTypes := []metal3v1alpha1.ErrorType{metal3v1alpha1.RegistrationError, metal3v1alpha1.InspectionError, metal3v1alpha1.ProvisioningError, metal3v1alpha1.PowerManagementError}
+
 	b := &metal3v1alpha1.BareMetalHost{}
 	assert.Equal(t, b.Status.ErrorCount, 0)
 
-	setErrorMessage(b, metal3v1alpha1.RegistrationError, "An error message")
-	assert.Equal(t, b.Status.ErrorCount, 1)
-
-	setErrorMessage(b, metal3v1alpha1.InspectionError, "Another error message")
-	assert.Equal(t, b.Status.ErrorCount, 2)
+	for _, c := range errorTypes {
+		before := b.Status.ErrorCount
+		setErrorMessage(b, c, "An error message")
+		assert.Equal(t, before+1, b.Status.ErrorCount)
+	}
 }

--- a/controllers/metal3.io/metrics.go
+++ b/controllers/metal3.io/metrics.go
@@ -61,6 +61,10 @@ var hostConfigDataError = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Name: "metal3_host_config_data_error_total",
 	Help: "Number of times the operator has failed to retrieve host configuration data",
 }, []string{labelHostDataType})
+var delayedProvisioningHostCounters = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Name: "metal3_delayed__provisioning_total",
+	Help: "The number of times hosts have been delayed while provisioning due a busy provisioner",
+}, []string{labelHostNamespace, labelHostName})
 
 var slowOperationBuckets = []float64{30, 90, 180, 360, 720, 1440}
 
@@ -111,7 +115,8 @@ func init() {
 		reconcileCounters,
 		reconcileErrorCounter,
 		actionFailureCounters,
-		powerChangeAttempts)
+		powerChangeAttempts,
+		delayedProvisioningHostCounters)
 
 	for _, collector := range stateTime {
 		metrics.Registry.MustRegister(collector)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,12 @@ validation. It is highly recommend to not set it to True.
 `BMO_CONCURRENCY` -- The number of concurrent reconciles performed by the
 Operator. Default is 3.
 
+`PROVISIONING_LIMIT` -- The desired maximum number of hosts that could be provisioned
+simultaneously by the Operator. The Operator will try to enforce this limit,
+but overflows could happen in case of slow provisioners and / or higher number of
+concurrent reconciles. For such reasons, it is highly recommended to keep
+BMO_CONCURRENCY value lower than the requested PROVISIONING_LIMIT. Default is 20.
+
 Kustomization Configuration
 ---------------------------
 

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -66,6 +66,10 @@ func New(host metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher 
 	return p, nil
 }
 
+func (m *demoProvisioner) HasProvisioningCapacity() (result bool, err error) {
+	return true, nil
+}
+
 // ValidateManagementAccess tests the connection information for the
 // host to verify that the location and credentials work.
 func (p *demoProvisioner) ValidateManagementAccess(credentialsChanged, force bool) (result provisioner.Result, provID string, err error) {

--- a/pkg/provisioner/empty/empty.go
+++ b/pkg/provisioner/empty/empty.go
@@ -83,3 +83,7 @@ func (p *emptyProvisioner) PowerOff() (provisioner.Result, error) {
 func (p *emptyProvisioner) IsReady() (bool, error) {
 	return true, nil
 }
+
+func (p *emptyProvisioner) HasProvisioningCapacity() (result bool, err error) {
+	return true, nil
+}

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -21,6 +21,7 @@ type fixtureHostConfigData struct {
 	metaData    string
 }
 
+// NewHostConfigData creates new host configuration data
 func NewHostConfigData(userData string, networkData string, metaData string) provisioner.HostConfigData {
 	return &fixtureHostConfigData{
 		userData:    userData,
@@ -79,6 +80,10 @@ func (f *Fixture) New(host metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credential
 		state:     f,
 	}
 	return p, nil
+}
+
+func (p *fixtureProvisioner) HasProvisioningCapacity() (result bool, err error) {
+	return true, nil
 }
 
 // ValidateManagementAccess tests the connection information for the

--- a/pkg/provisioner/ironic/provisioncapacity_test.go
+++ b/pkg/provisioner/ironic/provisioncapacity_test.go
@@ -1,0 +1,102 @@
+package ironic
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/metal3-io/baremetal-operator/pkg/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/testserver"
+)
+
+func TestHasProvisioningCapacity(t *testing.T) {
+
+	provisioningStates := []nodes.ProvisionState{nodes.Cleaning, nodes.CleanWait, nodes.Inspecting, nodes.InspectWait, nodes.Deploying, nodes.DeployWait}
+
+	cases := []struct {
+		name              string
+		provisioningLimit int
+		nodeStates        []nodes.ProvisionState
+		hostName          string
+
+		expectedHasCapacity bool
+		expectedError       string
+	}{
+		{
+			name:              "no-capacity",
+			provisioningLimit: 6,
+			nodeStates:        provisioningStates,
+
+			expectedHasCapacity: false,
+		},
+		{
+			name:              "enough-capacity",
+			provisioningLimit: 7,
+			nodeStates:        provisioningStates,
+
+			expectedHasCapacity: true,
+		},
+		{
+			name:              "ignore-check-if-already-provisioning",
+			provisioningLimit: 6,
+			nodeStates:        provisioningStates,
+			hostName:          "node-1",
+
+			expectedHasCapacity: true,
+		},
+		{
+			name:              "enough-capacity-due-not-provisioning-states",
+			provisioningLimit: 1,
+			nodeStates:        []nodes.ProvisionState{nodes.Active, nodes.AdoptFail, nodes.Adopting, nodes.Available, nodes.CleanFail},
+
+			expectedHasCapacity: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			allNodes := []nodes.Node{}
+			for n, state := range tc.nodeStates {
+				allNodes = append(allNodes, nodes.Node{
+					Name:           fmt.Sprintf("node-%d", n),
+					ProvisionState: string(state),
+				})
+			}
+
+			ironic := testserver.NewIronic(t).Nodes(allNodes).Start()
+			defer ironic.Stop()
+
+			inspector := testserver.NewInspector(t).Start()
+			defer inspector.Stop()
+
+			host := makeHost()
+			host.Name = tc.hostName
+
+			auth := clients.AuthConfig{Type: clients.NoAuth}
+
+			maxProvisioningHosts = tc.provisioningLimit
+
+			prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher,
+				ironic.Endpoint(), auth, inspector.Endpoint(), auth,
+			)
+			if err != nil {
+				t.Fatalf("could not create provisioner: %s", err)
+			}
+
+			result, err := prov.HasProvisioningCapacity()
+
+			assert.Equal(t, tc.expectedHasCapacity, result)
+
+			if tc.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Regexp(t, tc.expectedError, err.Error())
+			}
+		})
+	}
+}

--- a/pkg/provisioner/ironic/testserver/ironic.go
+++ b/pkg/provisioner/ironic/testserver/ironic.go
@@ -254,3 +254,15 @@ func (m *IronicMock) Port(port ports.Port) *IronicMock {
 
 	return m
 }
+
+// Nodes configure the server with a valid response for /v1/nodes
+func (m *IronicMock) Nodes(allNodes []nodes.Node) *IronicMock {
+	resp := struct {
+		Nodes []nodes.Node `json:"nodes"`
+	}{
+		Nodes: allNodes,
+	}
+
+	m.ResponseJSON(m.buildURL("/v1/nodes", http.MethodGet), resp)
+	return m
+}

--- a/pkg/provisioner/ironic/testserver/server.go
+++ b/pkg/provisioner/ironic/testserver/server.go
@@ -70,12 +70,12 @@ func (m *MockServer) Endpoint() string {
 
 func (m *MockServer) logRequest(r *http.Request, response string) {
 	m.t.Logf("%s: %s %s -> %s", m.name, r.Method, r.URL, response)
-	m.Requests += r.RequestURI + ";"
+	m.Requests += r.URL.Path + ";"
 
 	bodyRaw, _ := ioutil.ReadAll(r.Body)
 
 	m.FullRequests = append(m.FullRequests, simpleRequest{
-		pattern: r.URL.String(),
+		pattern: r.URL.Path,
 		method:  r.Method,
 		body:    string(bodyRaw),
 	})
@@ -93,8 +93,7 @@ func (m *MockServer) Handler(pattern string, handlerFunc http.HandlerFunc) *Mock
 func (m *MockServer) buildHandler(pattern string) func(http.ResponseWriter, *http.Request) {
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
-
-		if response, ok := m.responsesByMethod[r.URL.String()][r.Method]; ok {
+		if response, ok := m.responsesByMethod[r.URL.Path][r.Method]; ok {
 			m.sendData(w, r, response.code, response.payload)
 			return
 		}
@@ -224,7 +223,7 @@ func (m *MockServer) AddDefaultResponse(patternWithVars string, httpMethod strin
 
 func (m *MockServer) defaultHandler(w http.ResponseWriter, r *http.Request) {
 
-	url := r.URL.String()
+	url := r.URL.Path
 	method := r.Method
 
 	for _, response := range m.defaultResponses {

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -87,6 +87,9 @@ type Provisioner interface {
 	// IsReady checks if the provisioning backend is available to accept
 	// all the incoming requests.
 	IsReady() (result bool, err error)
+
+	// HasProvisioningCapacity checks if the backend has a free provisioning slot for the current host
+	HasProvisioningCapacity() (result bool, err error)
 }
 
 // Result holds the response from a call in the Provsioner API.


### PR DESCRIPTION
This PR introduces a soft limit for the number of hosts being simultaneously being provisioned.

Design doc: https://github.com/metal3-io/metal3-docs/blob/master/design/baremetal-operator/limit-hosts-provisioning.md. 

A new configuration variable is provided, called `PROVISIONING_LIMIT` (defaulted to 20), to specify the desired batch size that the operator will try to honor while provisioning new hosts. If there are no available slots, the current action for an host will be rescheduled using a fixed backoff with jittering to spread evenly the delayed requests.
Due the asynchronous behaviour of the Ironic subsystem, and the configurable level of concurrency of the operator, it's not possible to guarantee that such limit will be always respected, and occasional overflows could happen especially during the initial burst; nevertheless the operator will try to enforce such limit as much as possible, and for such reason it's recommended to keep a configuration where PROVISIONING_LIMIT is greater than BMO_CONCURRENCY.

----
__Demo__

Here's a quick demo of the current implementation, using a limit set to 8 and a BMO concurrency level of 3 (demo speeded up). A batch of additional 15 nodes is added to the cluster. It is possible to note the overflow on the initial burst, then the limit is maintained until the provisioning was completed.

[![asciicast](https://asciinema.org/a/9baJxFlOqEh5XlRXCYHrPKQfC.svg)](https://asciinema.org/a/9baJxFlOqEh5XlRXCYHrPKQfC)