### PR TITLE
[WIP] Limit the number of hosts simultaneously provisioned (BMO only version)

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -136,6 +136,9 @@ const (
 	// PowerManagementError is an error condition occurring when the
 	// controller is unable to modify the power state of the Host.
 	PowerManagementError ErrorType = "power management error"
+	// TooManyHostsError is an error condition occurring when
+	// there are too many hosts simultaneously being provisioned
+	TooManyHostsError ErrorType = "too many hosts error"
 )
 
 // ProvisioningState defines the states the provisioner will report
@@ -520,7 +523,7 @@ type BareMetalHostStatus struct {
 
 	// ErrorType indicates the type of failure encountered when the
 	// OperationalStatus is OperationalStatusError
-	// +kubebuilder:validation:Enum=registration error;inspection error;provisioning error;power management error
+	// +kubebuilder:validation:Enum=registration error;inspection error;provisioning error;power management error;too many hosts error
 	ErrorType ErrorType `json:"errorType,omitempty"`
 
 	// LastUpdated identifies when this status was last observed.

--- a/config/crd/bases/metal3.io_baremetalhosts.yaml
+++ b/config/crd/bases/metal3.io_baremetalhosts.yaml
@@ -262,6 +262,7 @@ spec:
                 - inspection error
                 - provisioning error
                 - power management error
+                - too many hosts error
                 type: string
               goodCredentials:
                 description: the last credentials we were able to validate as working

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -260,6 +260,7 @@ spec:
                 - inspection error
                 - provisioning error
                 - power management error
+                - too many hosts error
                 type: string
               goodCredentials:
                 description: the last credentials we were able to validate as working

--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -95,12 +95,7 @@ func newTestReconcilerWithProvisionerFactory(factory provisioner.Factory, initOb
 	bmcSecret := newBMCCredsSecret(defaultSecretName, "User", "Pass")
 	c.Create(goctx.TODO(), bmcSecret)
 
-	return &BareMetalHostReconciler{
-		Client:             c,
-		Scheme:             scheme.Scheme,
-		ProvisionerFactory: factory,
-		Log:                ctrl.Log.WithName("controllers").WithName("BareMetalHost"),
-	}
+	return NewBareMetalHostReconciler(c, scheme.Scheme, factory)
 }
 
 func newTestReconciler(initObjs ...runtime.Object) *BareMetalHostReconciler {

--- a/controllers/metal3.io/demo_test.go
+++ b/controllers/metal3.io/demo_test.go
@@ -8,7 +8,6 @@ import (
 
 	"k8s.io/client-go/kubernetes/scheme"
 
-	ctrl "sigs.k8s.io/controller-runtime"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -24,12 +23,7 @@ func newDemoReconciler(initObjs ...runtime.Object) *BareMetalHostReconciler {
 	bmcSecret := newSecret(defaultSecretName, map[string]string{"username": "User", "password": "Pass"})
 	c.Create(goctx.TODO(), bmcSecret)
 
-	return &BareMetalHostReconciler{
-		Client:             c,
-		Scheme:             scheme.Scheme,
-		ProvisionerFactory: demo.New,
-		Log:                ctrl.Log.WithName("controller").WithName("BareMetalHost"),
-	}
+	return NewBareMetalHostReconciler(c, scheme.Scheme, demo.New)
 }
 
 // TestDemoRegistrationError tests that a host with the right name reports

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -205,7 +205,7 @@ func TestErrorCountIncreasedWhenProvisionerFails(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.Scenario, func(t *testing.T) {
 			prov := &mockProvisioner{}
-			hsm := newHostStateMachine(tt.Host, &BareMetalHostReconciler{}, prov)
+			hsm := newHostStateMachine(tt.Host, newTestReconciler(), prov)
 			info := makeDefaultReconcileInfo(tt.Host)
 
 			prov.setNextError("some error")
@@ -220,7 +220,7 @@ func TestErrorCountIncreasedWhenProvisionerFails(t *testing.T) {
 func TestErrorCountIncreasedWhenRegistrationFails(t *testing.T) {
 	bmh := host(metal3v1alpha1.StateRegistering).build()
 	prov := &mockProvisioner{}
-	hsm := newHostStateMachine(bmh, &BareMetalHostReconciler{}, prov)
+	hsm := newHostStateMachine(bmh, newTestReconciler(), prov)
 	info := makeDefaultReconcileInfo(bmh)
 	bmh.Status.GoodCredentials = metal3v1alpha1.CredentialsStatus{}
 
@@ -265,7 +265,7 @@ func TestErrorCountCleared(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.Scenario, func(t *testing.T) {
 			prov := &mockProvisioner{}
-			hsm := newHostStateMachine(tt.Host, &BareMetalHostReconciler{}, prov)
+			hsm := newHostStateMachine(tt.Host, newTestReconciler(), prov)
 			info := makeDefaultReconcileInfo(tt.Host)
 
 			info.host.Status.ErrorCount = 1

--- a/main.go
+++ b/main.go
@@ -128,12 +128,8 @@ func main() {
 		ironic.LogStartup()
 	}
 
-	if err = (&metal3iocontroller.BareMetalHostReconciler{
-		Client:             mgr.GetClient(),
-		Log:                ctrl.Log.WithName("controllers").WithName("BareMetalHost"),
-		Scheme:             mgr.GetScheme(),
-		ProvisionerFactory: provisionerFactory,
-	}).SetupWithManager(mgr); err != nil {
+	reconciler := metal3iocontroller.NewBareMetalHostReconciler(mgr.GetClient(), mgr.GetScheme(), provisionerFactory)
+	if err = reconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BareMetalHost")
 		os.Exit(1)
 	}


### PR DESCRIPTION
While testing #725 with an high number of nodes I found it wasn't not working as expected, so I deployed an alternative implementation which adopted a different approach in respect to the one originally discussed.

Adding some notes here to provide as much as possible additional details.

---

The problem encountered was an immediate surge when provisioning simultaneously an higher number of nodes, resulting in a breach to the configured threshold: the BMO reconcile loop processed the provisioning requests very rapidly, way before the Ironic subsystem was able to update its status and communicate it back. And things get worse when the BMO concurrency level is increased.

So, this PR bypasses such limitation by observing directly the BMO states instead of the Ironic ones, and by preventing an host to transition in a provisionable state (_Inspecting_ or _Provisioning_) if there isn't a free slot available. This resulted in a simpler and more reliable check.

A very small critical section has been introduced to cope with the BMO concurrency level to handle properly a synchronized counter (a set) tracking the hosts currently being provisioned.

When an host cannot transition to a provisionable state due the lack of free slots, the action is rescheduled with an exponential backoff (by reusing the existing ErrorCount mechanism). A new ErrorType has been introduced to keep track of such situation. The current host state is left unchanged.

A preliminary check is applied when processing an host _already delayed_: if there are no free slots then the request is immediately rescheduled, to avoid putting unnecessary additional stress to the Ironic subsystem.

