### PR TITLE
Make 'get bmh' output concise and column one-word

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -582,11 +582,11 @@ type ProvisionStatus struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:shortName=bmh;bmhost
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.operationalStatus",description="Operational status"
-// +kubebuilder:printcolumn:name="Provisioning Status",type="string",JSONPath=".status.provisioning.state",description="Provisioning status"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.operationalStatus",description="Operational status",priority=1
+// +kubebuilder:printcolumn:name="Provisioning_Status",type="string",JSONPath=".status.provisioning.state",description="Provisioning status"
 // +kubebuilder:printcolumn:name="Consumer",type="string",JSONPath=".spec.consumerRef.name",description="Consumer using this host"
-// +kubebuilder:printcolumn:name="BMC",type="string",JSONPath=".spec.bmc.address",description="Address of management controller"
-// +kubebuilder:printcolumn:name="Hardware Profile",type="string",JSONPath=".status.hardwareProfile",description="The type of hardware detected"
+// +kubebuilder:printcolumn:name="BMC",type="string",JSONPath=".spec.bmc.address",description="Address of management controller",priority=1
+// +kubebuilder:printcolumn:name="Hardware_Profile",type="string",JSONPath=".status.hardwareProfile",description="The type of hardware detected",priority=1
 // +kubebuilder:printcolumn:name="Online",type="string",JSONPath=".spec.online",description="Whether the host is online or not"
 // +kubebuilder:printcolumn:name="Error",type="string",JSONPath=".status.errorMessage",description="Most recent error"
 // +kubebuilder:object:root=true

--- a/config/crd/bases/metal3.io_baremetalhosts.yaml
+++ b/config/crd/bases/metal3.io_baremetalhosts.yaml
@@ -23,10 +23,11 @@ spec:
     - description: Operational status
       jsonPath: .status.operationalStatus
       name: Status
+      priority: 1
       type: string
     - description: Provisioning status
       jsonPath: .status.provisioning.state
-      name: Provisioning Status
+      name: Provisioning_Status
       type: string
     - description: Consumer using this host
       jsonPath: .spec.consumerRef.name
@@ -35,10 +36,12 @@ spec:
     - description: Address of management controller
       jsonPath: .spec.bmc.address
       name: BMC
+      priority: 1
       type: string
     - description: The type of hardware detected
       jsonPath: .status.hardwareProfile
-      name: Hardware Profile
+      name: Hardware_Profile
+      priority: 1
       type: string
     - description: Whether the host is online or not
       jsonPath: .spec.online

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -21,10 +21,11 @@ spec:
     - description: Operational status
       jsonPath: .status.operationalStatus
       name: Status
+      priority: 1
       type: string
     - description: Provisioning status
       jsonPath: .status.provisioning.state
-      name: Provisioning Status
+      name: Provisioning_Status
       type: string
     - description: Consumer using this host
       jsonPath: .spec.consumerRef.name
@@ -33,10 +34,12 @@ spec:
     - description: Address of management controller
       jsonPath: .spec.bmc.address
       name: BMC
+      priority: 1
       type: string
     - description: The type of hardware detected
       jsonPath: .status.hardwareProfile
-      name: Hardware Profile
+      name: Hardware_Profile
+      priority: 1
       type: string
     - description: Whether the host is online or not
       jsonPath: .spec.online


### PR DESCRIPTION
Change column 'Provisioning Status' to 'Provisioning_Status'
Change column 'Hardware Profile' to 'Hardware_Profile'
Columns 'Status', 'BMC', 'Hardware_Profile' only visible with '-o wide'