### PR TITLE
Add a Makefile target for running manifest validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,10 @@ lint: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT):
 	./hack/install-golangci-lint.sh
 
+.PHONY: manifest-lint
+manifest-lint: ## Run manifest validation
+	./hack/manifestlint.sh
+
 ## --------------------------------------
 ## Build/Run Targets
 ## --------------------------------------

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,7 +18,7 @@ The tests can be run via `make`
 make test
 ```
 
-Run linters test before pushing your commit
+Run linters test before pushing your commit.
 
 ```bash
 make lint

--- a/hack/manifestlint.sh
+++ b/hack/manifestlint.sh
@@ -20,8 +20,11 @@ CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 # matches our regexp pattern (i.e. kustom, patch). 
 
 if [ "${IS_CONTAINER}" != "false" ]; then
+    { set +x; } 2>/dev/null
+    echo "<-------------------------STARTING MANIFESTS VALIDATION CHECKS------------------------->"
     kubeval --strict --ignore-missing-schemas \
     -d config,examples -i kustom,patch -o tap
+    echo "<-------------------------COMPLETED MANIFESTS VALIDATION CHECKS------------------------>"
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \


### PR DESCRIPTION
This adds a new `manifest-lint` target in the Makefile to run
manifest validation checks via ./hack/manifestlint.sh script.