### PR TITLE
Avoid getting stuck in ValidateManagementAccess due to node state

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -505,6 +505,14 @@ func (p *ironicProvisioner) ValidateManagementAccess(credentialsChanged bool) (r
 			nodes.ProvisionStateOpts{Target: nodes.TargetManage},
 		)
 
+	case nodes.Verifying:
+		// If we're still waiting for the state to change in Ironic,
+		// return true to indicate that we're dirty and need to be
+		// reconciled again.
+		result.RequeueAfter = provisionRequeueDelay
+		result.Dirty = true
+		return result, nil
+
 	case nodes.Manageable:
 		p.log.Info("have manageable host")
 		return result, nil
@@ -521,11 +529,6 @@ func (p *ironicProvisioner) ValidateManagementAccess(credentialsChanged bool) (r
 		return result, nil
 
 	default:
-		// If we're still waiting for the state to change in Ironic,
-		// return true to indicate that we're dirty and need to be
-		// reconciled again.
-		result.RequeueAfter = provisionRequeueDelay
-		result.Dirty = true
 		return result, nil
 	}
 }

--- a/pkg/provisioner/ironic/validatemanagementaccess_test.go
+++ b/pkg/provisioner/ironic/validatemanagementaccess_test.go
@@ -136,6 +136,71 @@ func TestValidateManagementAccessExistingNode(t *testing.T) {
 	assert.Equal(t, "uuid", host.Status.Provisioning.ID)
 }
 
+func TestValidateManagementAccessExistingNodeStatus(t *testing.T) {
+	statuses := []nodes.ProvisionState{
+		nodes.Manageable,
+		nodes.Available,
+		nodes.Active,
+		nodes.DeployWait,
+		nodes.Deploying,
+		nodes.DeployFail,
+		nodes.DeployDone,
+		nodes.Deleting,
+		nodes.Deleted,
+		nodes.Cleaning,
+		nodes.CleanWait,
+		nodes.CleanFail,
+		nodes.Error,
+		nodes.Rebuild,
+		nodes.Inspecting,
+		nodes.InspectFail,
+		nodes.InspectWait,
+		nodes.Adopting,
+		nodes.AdoptFail,
+		nodes.Rescue,
+		nodes.RescueFail,
+		nodes.Rescuing,
+		nodes.UnrescueFail,
+	}
+
+	for _, status := range statuses {
+		t.Run(string(status), func(t *testing.T) {
+			// Create a host without a bootMACAddress and with a BMC that
+			// does not require one.
+			host := makeHost()
+			host.Spec.BootMACAddress = ""
+			host.Status.Provisioning.ID = "" // so we don't lookup by uuid
+
+			createCallback := func(node nodes.Node) {
+				t.Fatal("create callback should not be invoked for existing node")
+			}
+
+			ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).Node(nodes.Node{
+				Name:           host.Name,
+				UUID:           "", // to match status in host
+				ProvisionState: string(status),
+			})
+			ironic.Start()
+			defer ironic.Stop()
+
+			auth := clients.AuthConfig{Type: clients.NoAuth}
+			prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher,
+				ironic.Endpoint(), auth, testserver.NewInspector(t).Endpoint(), auth,
+			)
+			if err != nil {
+				t.Fatalf("could not create provisioner: %s", err)
+			}
+
+			result, err := prov.ValidateManagementAccess(false)
+			if err != nil {
+				t.Fatalf("error from ValidateManagementAccess: %s", err)
+			}
+			assert.Equal(t, "", result.ErrorMessage)
+			assert.Equal(t, false, result.Dirty)
+		})
+	}
+}
+
 func TestValidateManagementAccessNewCredentials(t *testing.T) {
 	// Create a host without a bootMACAddress and with a BMC that
 	// does not require one.


### PR DESCRIPTION
It is not safe to assume in ValidateManagementAccess() that the ironic
state will eventually converge to manageable, available, or active. The
state may in fact be something (like e.g. adopt failed) that requires
action on the part of the actual provisioning function for the current
state to resolve. We previously weren't allowing that, because
ValidateManagementAccess() was always forcing a requeue whenever it
encountered a node in another state.

Since b7b10d79a86bb8e5f04fc86986c7b84fb1a34871 we call
ValidateManagementAccess() in substantially every provisioning state, so
there are even more node states (e.g. inspect failed) that we could get
stuck in.

Move the code for handling the verifying state so that it runs only in
that state, and allow all other states from manageable on to be handled
by the host state machine.