### PR TITLE
Add kubebuilder validation for ClockSpeed

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -313,6 +313,7 @@ type Image struct {
 // data structures.
 
 // ClockSpeed is a clock speed in MHz
+// +kubebuilder:validation:Format=double
 type ClockSpeed float64
 
 // ClockSpeed multipliers

--- a/config/crd/bases/metal3.io_baremetalhosts.yaml
+++ b/config/crd/bases/metal3.io_baremetalhosts.yaml
@@ -293,6 +293,7 @@ spec:
                         type: string
                       clockMegahertz:
                         description: ClockSpeed is a clock speed in MHz
+                        format: double
                         type: number
                       count:
                         type: integer

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -291,6 +291,7 @@ spec:
                         type: string
                       clockMegahertz:
                         description: ClockSpeed is a clock speed in MHz
+                        format: double
                         type: number
                       count:
                         type: integer


### PR DESCRIPTION
This small patch adds kubebuilder validation format for ClockSpeed as double.

Signed-off-by: seivanov <seivanov@mirantis.com>