### PR TITLE
Fix issues with deprovisioning after an error/failover

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1329,7 +1329,7 @@ func (p *ironicProvisioner) Deprovision(force bool) (result provisioner.Result, 
 		p.log.Info("cleaning")
 		return operationContinuing(deprovisionRequeueDelay)
 
-	case nodes.Active:
+	case nodes.Active, nodes.DeployFail:
 		p.log.Info("starting deprovisioning")
 		p.publisher("DeprovisioningStarted", "Image deprovisioning started")
 		return p.changeNodeProvisionState(

--- a/pkg/provisioner/ironic/provision_test.go
+++ b/pkg/provisioner/ironic/provision_test.go
@@ -146,6 +146,15 @@ func TestDeprovision(t *testing.T) {
 			expectedDirty:        true,
 		},
 		{
+			name: "deploy failed state",
+			ironic: testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
+				ProvisionState: string(nodes.DeployFail),
+				UUID:           nodeUUID,
+			}),
+			expectedRequestAfter: 10,
+			expectedDirty:        true,
+		},
+		{
 			name: "error state",
 			ironic: testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
 				ProvisionState: string(nodes.Error),


### PR DESCRIPTION
If provisioning fails and the node ends up in the `deploy failed` state,
we try to recover by deprovisioning. That would work better if we
actually handled `deploy failed` in `Deprovision()`.

Only call `Adopt()` if the previous provisioning completed and recorded
the requisite image data.