### PR TITLE
Filter out status updates from the reconcile loop

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -19,6 +19,7 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
@@ -1173,4 +1174,127 @@ func TestProvisionerIsReady(t *testing.T) {
 			return ready
 		},
 	)
+}
+
+func TestUpdateEventHandler(t *testing.T) {
+	cases := []struct {
+		name            string
+		event           event.UpdateEvent
+		expectedProcess bool
+	}{
+		{
+			name: "process-non-bmh-events",
+			event: event.UpdateEvent{
+				ObjectOld: &corev1.Secret{},
+				ObjectNew: &corev1.Secret{},
+			},
+			expectedProcess: true,
+		},
+		{
+			name: "process-generation-change",
+			event: event.UpdateEvent{
+				ObjectOld: &metal3v1alpha1.BareMetalHost{},
+				ObjectNew: &metal3v1alpha1.BareMetalHost{},
+				MetaOld:   &metav1.ObjectMeta{Generation: 0},
+				MetaNew:   &metav1.ObjectMeta{Generation: 1},
+			},
+
+			expectedProcess: true,
+		},
+		{
+			name: "skip-if-same-generation-finalizers-and-annotations",
+			event: event.UpdateEvent{
+				ObjectOld: &metal3v1alpha1.BareMetalHost{},
+				ObjectNew: &metal3v1alpha1.BareMetalHost{},
+				MetaOld: &metav1.ObjectMeta{
+					Generation: 0,
+					Finalizers: []string{metal3v1alpha1.BareMetalHostFinalizer},
+					Annotations: map[string]string{
+						metal3v1alpha1.PausedAnnotation: "true",
+					},
+				},
+				MetaNew: &metav1.ObjectMeta{
+					Generation: 0,
+					Finalizers: []string{metal3v1alpha1.BareMetalHostFinalizer},
+					Annotations: map[string]string{
+						metal3v1alpha1.PausedAnnotation: "true",
+					},
+				},
+			},
+
+			expectedProcess: false,
+		},
+		{
+			name: "process-same-generation-annotations-change",
+			event: event.UpdateEvent{
+				ObjectOld: &metal3v1alpha1.BareMetalHost{},
+				ObjectNew: &metal3v1alpha1.BareMetalHost{},
+				MetaOld: &metav1.ObjectMeta{
+					Generation:  0,
+					Finalizers:  []string{metal3v1alpha1.BareMetalHostFinalizer},
+					Annotations: map[string]string{},
+				},
+				MetaNew: &metav1.ObjectMeta{
+					Generation: 0,
+					Finalizers: []string{metal3v1alpha1.BareMetalHostFinalizer},
+					Annotations: map[string]string{
+						metal3v1alpha1.PausedAnnotation: "true",
+					},
+				},
+			},
+
+			expectedProcess: true,
+		},
+		{
+			name: "process-same-generation-finalizers-change",
+			event: event.UpdateEvent{
+				ObjectOld: &metal3v1alpha1.BareMetalHost{},
+				ObjectNew: &metal3v1alpha1.BareMetalHost{},
+				MetaOld: &metav1.ObjectMeta{
+					Generation: 0,
+					Finalizers: []string{},
+					Annotations: map[string]string{
+						metal3v1alpha1.PausedAnnotation: "true",
+					},
+				},
+				MetaNew: &metav1.ObjectMeta{
+					Generation: 0,
+					Finalizers: []string{metal3v1alpha1.BareMetalHostFinalizer},
+					Annotations: map[string]string{
+						metal3v1alpha1.PausedAnnotation: "true",
+					},
+				},
+			},
+
+			expectedProcess: true,
+		},
+		{
+			name: "process-same-generation-finalizers-and-annotation-change",
+			event: event.UpdateEvent{
+				ObjectOld: &metal3v1alpha1.BareMetalHost{},
+				ObjectNew: &metal3v1alpha1.BareMetalHost{},
+				MetaOld: &metav1.ObjectMeta{
+					Generation:  0,
+					Finalizers:  []string{},
+					Annotations: map[string]string{},
+				},
+				MetaNew: &metav1.ObjectMeta{
+					Generation: 0,
+					Finalizers: []string{metal3v1alpha1.BareMetalHostFinalizer},
+					Annotations: map[string]string{
+						metal3v1alpha1.PausedAnnotation: "true",
+					},
+				},
+			},
+
+			expectedProcess: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newTestReconciler()
+			assert.Equal(t, tc.expectedProcess, r.updateEventHandler(tc.event))
+		})
+	}
 }


### PR DESCRIPTION
Everytime the BMH status is saved the `LastUpdated` field is updated with the current time, and a new update is generated if the marshalled string results different from the previous version (up to the seconds), producing more reconcile loops than needed.
This PR filters out all the updates on the Status by ignoring all those ones that do not increase the Generation field (except for the finalizers and annotations) [1]

[1] https://www.openshift.com/blog/kubernetes-operators-best-practices
