### PR TITLE
Improved Provisioner readiness check

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1819,7 +1819,7 @@ func (p *ironicProvisioner) softPowerOff() (result provisioner.Result, err error
 func (p *ironicProvisioner) IsReady() (result bool, err error) {
 	p.log.Info("verifying ironic provisioner dependencies")
 
-	checker := newIronicDependenciesChecker(p.client, p.inspector, p.log)
+	checker := newIronicDependenciesChecker(p.client, p.inspector, &p.host, p.log)
 	return checker.IsReady()
 }
 

--- a/pkg/provisioner/ironic/ready_test.go
+++ b/pkg/provisioner/ironic/ready_test.go
@@ -25,7 +25,7 @@ func TestProvisionerIsReady(t *testing.T) {
 	}{
 		{
 			name:                   "IsReady",
-			ironic:                 testserver.NewIronic(t).Ready().WithDrivers(),
+			ironic:                 testserver.NewIronic(t).Ready().WithTestDriver(),
 			inspector:              testserver.NewInspector(t).Ready(),
 			expectedIronicCalls:    "/v1;/v1/drivers;",
 			expectedInspectorCalls: "/v1;",
@@ -33,7 +33,13 @@ func TestProvisionerIsReady(t *testing.T) {
 		},
 		{
 			name:                "NoDriversLoaded",
-			ironic:              testserver.NewIronic(t).Ready(),
+			ironic:              testserver.NewIronic(t).Ready().WithNoDrivers(),
+			inspector:           testserver.NewInspector(t).Ready(),
+			expectedIronicCalls: "/v1;/v1/drivers;",
+		},
+		{
+			name:                "WrongDriversLoaded",
+			ironic:              testserver.NewIronic(t).Ready().WithFakeHardwareDriver(),
 			inspector:           testserver.NewInspector(t).Ready(),
 			expectedIronicCalls: "/v1;/v1/drivers;",
 		},
@@ -44,7 +50,7 @@ func TestProvisionerIsReady(t *testing.T) {
 		},
 		{
 			name:                "InspectorDown",
-			ironic:              testserver.NewIronic(t).Ready().WithDrivers(),
+			ironic:              testserver.NewIronic(t).Ready().WithTestDriver(),
 			expectedIronicCalls: "/v1;/v1/drivers;",
 			expectedIsReady:     false,
 		},
@@ -64,7 +70,7 @@ func TestProvisionerIsReady(t *testing.T) {
 		},
 		{
 			name:                   "InspectorNotOk",
-			ironic:                 testserver.NewIronic(t).Ready().WithDrivers(),
+			ironic:                 testserver.NewIronic(t).Ready().WithTestDriver(),
 			inspector:              testserver.NewInspector(t).NotReady(http.StatusInternalServerError),
 			expectedIsReady:        false,
 			expectedIronicCalls:    "/v1;/v1/drivers;",

--- a/pkg/provisioner/ironic/testserver/ironic.go
+++ b/pkg/provisioner/ironic/testserver/ironic.go
@@ -61,9 +61,38 @@ func (m *IronicMock) NotReady(errorCode int) *IronicMock {
 	return m
 }
 
-// WithDrivers configures the server so /v1/drivers returns a valid value
-func (m *IronicMock) WithDrivers() *IronicMock {
-	m.ResponseWithCode("/v1/drivers", `
+func (m *IronicMock) withDrivers(payload string) *IronicMock {
+	m.ResponseWithCode("/v1/drivers", payload, http.StatusOK)
+	return m
+}
+
+// WithTestDriver configures the server so /v1/drivers returns the test driver
+func (m *IronicMock) WithTestDriver() *IronicMock {
+	m.withDrivers(`
+	{
+		"drivers": [{
+			"hosts": [
+			  "master-2.ostest.test.metalkube.org"
+			],
+			"links": [
+			  {
+				"href": "http://[fd00:1101::3]:6385/v1/drivers/test",
+				"rel": "self"
+			  },
+			  {
+				"href": "http://[fd00:1101::3]:6385/drivers/test",
+				"rel": "bookmark"
+			  }
+			],
+			"name": "test"
+		}]
+	}`)
+	return m
+}
+
+// WithFakeHardwareDriver configures the server so /v1/drivers returns the fake-hardware driver
+func (m *IronicMock) WithFakeHardwareDriver() *IronicMock {
+	m.withDrivers(`
 	{
 		"drivers": [{
 			"hosts": [
@@ -81,8 +110,16 @@ func (m *IronicMock) WithDrivers() *IronicMock {
 			],
 			"name": "fake-hardware"
 		}]
-	}
-	`, http.StatusOK)
+	}`)
+	return m
+}
+
+// WithNoDrivers configures the server so /v1/drivers returns an empty list
+func (m *IronicMock) WithNoDrivers() *IronicMock {
+	m.withDrivers(`
+	{
+		"drivers": []
+	}`)
 	return m
 }
 


### PR DESCRIPTION
This PR introduce a better readiness check for the Ironic provisioner, by checking if the required host driver has been loaded by Ironic or not - instead of just counting the number of drivers loaded. More detail can be found in [1]

[1] https://github.com/metal3-io/ironic-image/pull/233
