### PR TITLE
Fix manager namespace in docs

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -9,7 +9,7 @@
 1. Create a namespace to host the operator
 
     ```bash
-    kubectl create namespace metal3
+    kubectl create namespace baremetal-operator-system
     ```
 
 1. Install operator in the cluster


### PR DESCRIPTION
Update the document to instruct creating [`baremetal-operator-system`](https://github.com/metal3-io/baremetal-operator/blob/40246049da00e2f98beaf5d2a451472e0a1c0f35/config/default/kustomization.yaml#L2) namespace instead of `metal3`




