### PR TITLE
Review registration log traces for Provisioner

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -94,6 +94,7 @@ func (r *BareMetalHostReconciler) Reconcile(ctx context.Context, request ctrl.Re
 	}()
 
 	reqLogger := r.Log.WithValues("baremetalhost", request.NamespacedName)
+	reqLogger.Info("start")
 
 	// Fetch the BareMetalHost
 	host := &metal3v1alpha1.BareMetalHost{}


### PR DESCRIPTION
This PR introduce a debug logger for the provisioner, to avoid printing too many traces in the log during the steady cases.