### PR TITLE
Improve communications between controller and provisioner

### DIFF
--- a/controllers/metal3.io/action_result.go
+++ b/controllers/metal3.io/action_result.go
@@ -25,17 +25,6 @@ type actionResult interface {
 	Dirty() bool
 }
 
-// actionContinueNoWrite is a result indicating that the current action is still
-// in progress, and that the resource should remain in the same provisioning
-// state without writing the status
-type actionContinueNoWrite struct {
-	actionContinue
-}
-
-func (r actionContinueNoWrite) Dirty() bool {
-	return false
-}
-
 // actionContinue is a result indicating that the current action is still
 // in progress, and that the resource should remain in the same provisioning
 // state.
@@ -51,6 +40,17 @@ func (r actionContinue) Result() (result reconcile.Result, err error) {
 }
 
 func (r actionContinue) Dirty() bool {
+	return false
+}
+
+// actionUpdate is a result indicating that the current action is still
+// in progress, and that the resource should remain in the same provisioning
+// state but write new Status data.
+type actionUpdate struct {
+	actionContinue
+}
+
+func (r actionUpdate) Dirty() bool {
 	return true
 }
 

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -208,7 +208,7 @@ func (r *BareMetalHostReconciler) Reconcile(request ctrl.Request) (result ctrl.R
 		request:        request,
 		bmcCredsSecret: bmcCredsSecret,
 	}
-	prov, err := r.ProvisionerFactory(host, *bmcCreds, info.publishEvent)
+	prov, err := r.ProvisionerFactory(*host, *bmcCreds, info.publishEvent)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to create provisioner")
 	}

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -423,7 +423,7 @@ func (r *BareMetalHostReconciler) actionUnmanaged(prov provisioner.Provisioner, 
 }
 
 // Test the credentials by connecting to the management controller.
-func (r *BareMetalHostReconciler) actionRegistering(prov provisioner.Provisioner, info *reconcileInfo) actionResult {
+func (r *BareMetalHostReconciler) registerHost(prov provisioner.Provisioner, info *reconcileInfo) actionResult {
 	info.log.Info("registering and validating access to management controller",
 		"credentials", info.host.Status.TriedCredentials)
 	dirty := false
@@ -481,13 +481,9 @@ func (r *BareMetalHostReconciler) actionRegistering(prov provisioner.Provisioner
 	}
 
 	if dirty {
-		// Normally returning actionComplete would be sufficient to ensure
-		// changes are written, but when this is called in a state other than
-		// Registering, the state machine will ignore actionComplete and
-		// proceed with the action function for the current state.
-		return actionUpdate{}
+		return actionComplete{}
 	}
-	return actionComplete{}
+	return nil
 }
 
 // Ensure we have the information about the hardware on the host.

--- a/controllers/metal3.io/host_state_machine.go
+++ b/controllers/metal3.io/host_state_machine.go
@@ -172,8 +172,6 @@ func (hsm *hostStateMachine) ensureRegistered(info *reconcileInfo) (result actio
 		return
 	}
 
-	needsReregister := false
-
 	switch hsm.NextState {
 	case metal3v1alpha1.StateNone, metal3v1alpha1.StateUnmanaged:
 		// We haven't yet reached the Registration state, so don't attempt
@@ -184,31 +182,23 @@ func (hsm *hostStateMachine) ensureRegistered(info *reconcileInfo) (result actio
 		return
 	case metal3v1alpha1.StateRegistering:
 	default:
-		needsReregister = (hsm.Host.Status.ErrorType == metal3v1alpha1.RegistrationError ||
-			!hsm.Host.Status.GoodCredentials.Match(*info.bmcCredsSecret))
-		if needsReregister {
+		if hsm.Host.Status.ErrorType == metal3v1alpha1.RegistrationError ||
+			!hsm.Host.Status.GoodCredentials.Match(*info.bmcCredsSecret) {
 			info.log.Info("Retrying registration")
 			recordStateBegin(hsm.Host, metal3v1alpha1.StateRegistering, metav1.Now())
 		}
 	}
 
-	result = hsm.Reconciler.actionRegistering(hsm.Provisioner, info)
-	if _, complete := result.(actionComplete); complete {
-		if hsm.NextState != metal3v1alpha1.StateRegistering {
-			if recordStateEnd(info, hsm.Host, metal3v1alpha1.StateRegistering, metav1.Now()) {
-				return actionUpdate{}
-			}
+	result = hsm.Reconciler.registerHost(hsm.Provisioner, info)
+	_, complete := result.(actionComplete)
+	if (result == nil || complete) &&
+		hsm.NextState != metal3v1alpha1.StateRegistering {
+		if recordStateEnd(info, hsm.Host, metal3v1alpha1.StateRegistering, metav1.Now()) {
+			result = actionUpdate{}
 		}
-		if needsReregister {
-			// Host was re-registered, so requeue and run the state machine on
-			// the next reconcile
-			result = actionContinue{}
-		} else {
-			// Allow the state machine to run, either because we were just
-			// reconfirming an existing registration, or because we are in the
-			// Registering state
-			result = nil
-		}
+	}
+	if complete {
+		result = actionUpdate{}
 	}
 	return
 }

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -18,7 +18,7 @@ import (
 
 func testStateMachine(host *metal3v1alpha1.BareMetalHost) *hostStateMachine {
 	r := newTestReconciler()
-	p, _ := r.ProvisionerFactory(host, bmc.Credentials{},
+	p, _ := r.ProvisionerFactory(*host.DeepCopy(), bmc.Credentials{},
 		func(reason, message string) {})
 	return newHostStateMachine(host, r, p, true)
 }

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -375,8 +375,8 @@ func (m *mockProvisioner) InspectHardware(force bool) (result provisioner.Result
 	return m.nextResult, details, err
 }
 
-func (m *mockProvisioner) UpdateHardwareState() (result provisioner.Result, err error) {
-	return m.nextResult, err
+func (m *mockProvisioner) UpdateHardwareState() (hwState provisioner.HardwareState, err error) {
+	return
 }
 
 func (m *mockProvisioner) Adopt(force bool) (result provisioner.Result, err error) {

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -366,8 +366,8 @@ func (m *mockProvisioner) setNextResult(dirty bool) {
 	}
 }
 
-func (m *mockProvisioner) ValidateManagementAccess(credentialsChanged, force bool) (result provisioner.Result, err error) {
-	return m.nextResult, err
+func (m *mockProvisioner) ValidateManagementAccess(credentialsChanged, force bool) (result provisioner.Result, provID string, err error) {
+	return m.nextResult, "", err
 }
 
 func (m *mockProvisioner) InspectHardware(force bool) (result provisioner.Result, details *metal3v1alpha1.HardwareDetails, err error) {

--- a/main.go
+++ b/main.go
@@ -118,22 +118,24 @@ func main() {
 		os.Exit(1)
 	}
 
-	provisionerFactory := func(host *metal3iov1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publish provisioner.EventPublisher) (provisioner.Provisioner, error) {
+	provisionerFactory := func(host metal3iov1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publish provisioner.EventPublisher) (provisioner.Provisioner, error) {
 		isUnmanaged := host.Spec.ExternallyProvisioned && !host.HasBMCDetails()
+
+		hostCopy := host.DeepCopy()
 
 		if runInTestMode {
 			ctrl.Log.Info("using test provisioner")
 			fix := fixture.Fixture{}
-			return fix.New(host, bmcCreds, publish)
+			return fix.New(*hostCopy, bmcCreds, publish)
 		} else if runInDemoMode {
 			ctrl.Log.Info("using demo provisioner")
-			return demo.New(host, bmcCreds, publish)
+			return demo.New(*hostCopy, bmcCreds, publish)
 		} else if isUnmanaged {
 			ctrl.Log.Info("using empty provisioner")
-			return empty.New(host, bmcCreds, publish)
+			return empty.New(*hostCopy, bmcCreds, publish)
 		}
 		ironic.LogStartup()
-		return ironic.New(host, bmcCreds, publish)
+		return ironic.New(*hostCopy, bmcCreds, publish)
 	}
 
 	if err = (&metal3iocontroller.BareMetalHostReconciler{

--- a/main.go
+++ b/main.go
@@ -123,7 +123,8 @@ func main() {
 
 		if runInTestMode {
 			ctrl.Log.Info("using test provisioner")
-			return fixture.New(host, bmcCreds, publish)
+			fix := fixture.Fixture{}
+			return fix.New(host, bmcCreds, publish)
 		} else if runInDemoMode {
 			ctrl.Log.Info("using demo provisioner")
 			return demo.New(host, bmcCreds, publish)

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -68,7 +68,7 @@ func New(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher
 
 // ValidateManagementAccess tests the connection information for the
 // host to verify that the location and credentials work.
-func (p *demoProvisioner) ValidateManagementAccess(credentialsChanged, force bool) (result provisioner.Result, err error) {
+func (p *demoProvisioner) ValidateManagementAccess(credentialsChanged, force bool) (result provisioner.Result, provID string, err error) {
 	p.log.Info("testing management access")
 
 	hostName := p.host.ObjectMeta.Name
@@ -88,14 +88,14 @@ func (p *demoProvisioner) ValidateManagementAccess(credentialsChanged, force boo
 
 	default:
 		if p.host.Status.Provisioning.ID == "" {
-			p.host.Status.Provisioning.ID = p.host.ObjectMeta.Name
+			provID = p.host.ObjectMeta.Name
 			p.log.Info("setting provisioning id",
 				"provisioningID", p.host.Status.Provisioning.ID)
 			result.Dirty = true
 		}
 	}
 
-	return result, nil
+	return
 }
 
 // InspectHardware updates the HardwareDetails field of the host with

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -174,12 +174,10 @@ func (p *demoProvisioner) InspectHardware(force bool) (result provisioner.Result
 // UpdateHardwareState fetches the latest hardware state of the server
 // and updates the HardwareDetails field of the host with details. It
 // is expected to do this in the least expensive way possible, such as
-// reading from a cache, and return dirty only if any state
-// information has changed.
-func (p *demoProvisioner) UpdateHardwareState() (result provisioner.Result, err error) {
+// reading from a cache.
+func (p *demoProvisioner) UpdateHardwareState() (hwState provisioner.HardwareState, err error) {
 	p.log.Info("updating hardware state")
-	result.Dirty = false
-	return result, nil
+	return
 }
 
 // Adopt allows an externally-provisioned server to be adopted.

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -46,7 +46,7 @@ const (
 // and uses Ironic to manage the host.
 type demoProvisioner struct {
 	// the host to be managed by this provisioner
-	host *metal3v1alpha1.BareMetalHost
+	host metal3v1alpha1.BareMetalHost
 	// the bmc credentials
 	bmcCreds bmc.Credentials
 	// a logger configured for this host
@@ -56,7 +56,7 @@ type demoProvisioner struct {
 }
 
 // New returns a new Ironic Provisioner
-func New(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher) (provisioner.Provisioner, error) {
+func New(host metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher) (provisioner.Provisioner, error) {
 	p := &demoProvisioner{
 		host:      host,
 		bmcCreds:  bmcCreds,

--- a/pkg/provisioner/empty/empty.go
+++ b/pkg/provisioner/empty/empty.go
@@ -21,8 +21,8 @@ func New(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher
 
 // ValidateManagementAccess tests the connection information for the
 // host to verify that the location and credentials work.
-func (p *emptyProvisioner) ValidateManagementAccess(credentialsChanged, force bool) (provisioner.Result, error) {
-	return provisioner.Result{}, nil
+func (p *emptyProvisioner) ValidateManagementAccess(credentialsChanged, force bool) (provisioner.Result, string, error) {
+	return provisioner.Result{}, "", nil
 }
 
 // InspectHardware updates the HardwareDetails field of the host with

--- a/pkg/provisioner/empty/empty.go
+++ b/pkg/provisioner/empty/empty.go
@@ -15,7 +15,7 @@ type emptyProvisioner struct {
 }
 
 // New returns a new Empty Provisioner
-func New(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher) (provisioner.Provisioner, error) {
+func New(host metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher) (provisioner.Provisioner, error) {
 	return &emptyProvisioner{}, nil
 }
 

--- a/pkg/provisioner/empty/empty.go
+++ b/pkg/provisioner/empty/empty.go
@@ -36,10 +36,9 @@ func (p *emptyProvisioner) InspectHardware(force bool) (provisioner.Result, *met
 // UpdateHardwareState fetches the latest hardware state of the server
 // and updates the HardwareDetails field of the host with details. It
 // is expected to do this in the least expensive way possible, such as
-// reading from a cache, and return dirty only if any state
-// information has changed.
-func (p *emptyProvisioner) UpdateHardwareState() (provisioner.Result, error) {
-	return provisioner.Result{}, nil
+// reading from a cache.
+func (p *emptyProvisioner) UpdateHardwareState() (provisioner.HardwareState, error) {
+	return provisioner.HardwareState{}, nil
 }
 
 // Adopt allows an externally-provisioned server to be adopted.

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -77,21 +77,19 @@ func NewMock(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publi
 
 // ValidateManagementAccess tests the connection information for the
 // host to verify that the location and credentials work.
-func (p *fixtureProvisioner) ValidateManagementAccess(credentialsChanged, force bool) (result provisioner.Result, err error) {
+func (p *fixtureProvisioner) ValidateManagementAccess(credentialsChanged, force bool) (result provisioner.Result, provID string, err error) {
 	p.log.Info("testing management access")
 
 	// Fill in the ID of the host in the provisioning system
 	if p.host.Status.Provisioning.ID == "" {
-		p.host.Status.Provisioning.ID = "temporary-fake-id"
-		p.log.Info("setting provisioning id",
-			"provisioningID", p.host.Status.Provisioning.ID)
+		provID = "temporary-fake-id"
 		result.Dirty = true
 		result.RequeueAfter = time.Second * 5
 		p.publisher("Registered", "Registered new host")
-		return result, nil
+		return
 	}
 
-	return result, nil
+	return
 }
 
 // InspectHardware updates the HardwareDetails field of the host with

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -45,7 +45,7 @@ func (cd *fixtureHostConfigData) MetaData() (string, error) {
 // and uses Ironic to manage the host.
 type fixtureProvisioner struct {
 	// the host to be managed by this provisioner
-	host *metal3v1alpha1.BareMetalHost
+	host metal3v1alpha1.BareMetalHost
 	// the bmc credentials
 	bmcCreds bmc.Credentials
 	// a logger configured for this host
@@ -70,9 +70,9 @@ type Fixture struct {
 }
 
 // New returns a new Ironic FixtureProvisioner
-func (f *Fixture) New(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher) (provisioner.Provisioner, error) {
+func (f *Fixture) New(host metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher) (provisioner.Provisioner, error) {
 	p := &fixtureProvisioner{
-		host:      host,
+		host:      *host.DeepCopy(),
 		bmcCreds:  bmcCreds,
 		log:       log.WithValues("host", host.Name),
 		publisher: publisher,

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -157,14 +157,12 @@ func (p *fixtureProvisioner) InspectHardware(force bool) (result provisioner.Res
 // UpdateHardwareState fetches the latest hardware state of the server
 // and updates the HardwareDetails field of the host with details. It
 // is expected to do this in the least expensive way possible, such as
-// reading from a cache, and return dirty only if any state
-// information has changed.
-func (p *fixtureProvisioner) UpdateHardwareState() (result provisioner.Result, err error) {
+// reading from a cache.
+func (p *fixtureProvisioner) UpdateHardwareState() (hwState provisioner.HardwareState, err error) {
 	if !p.host.NeedsProvisioning() {
 		p.log.Info("updating hardware state")
-		result.Dirty = false
 	}
-	return result, nil
+	return
 }
 
 // Adopt allows an externally-provisioned server to be adopted.

--- a/pkg/provisioner/ironic/delete_test.go
+++ b/pkg/provisioner/ironic/delete_test.go
@@ -50,7 +50,7 @@ func TestDelete(t *testing.T) {
 				},
 			).DeleteError(nodeUUID, http.StatusConflict),
 			expectedDirty:        true,
-			expectedRequestAfter: 0,
+			expectedRequestAfter: provisionRequeueDelay,
 		},
 		{
 			name: "delete-host-not-found",
@@ -122,7 +122,7 @@ func TestDelete(t *testing.T) {
 			).NodeUpdateError(nodeUUID, http.StatusConflict),
 
 			expectedDirty:        true,
-			expectedRequestAfter: 0,
+			expectedRequestAfter: provisionRequeueDelay,
 		},
 		{
 			name: "not-in-maintenance-update",

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -388,7 +388,7 @@ func (p *ironicProvisioner) ValidateManagementAccess(credentialsChanged, force b
 		// Store the ID so other methods can assume it is set and so
 		// we can find the node again later.
 		p.status.ID = ironicNode.UUID
-		result.Dirty = true
+		result, err = hostUpdated()
 		p.log.Info("setting provisioning id", "ID", p.status.ID)
 
 		// If we know the MAC, create a port. Otherwise we will have
@@ -447,7 +447,7 @@ func (p *ironicProvisioner) ValidateManagementAccess(credentialsChanged, force b
 			// Store the ID so other methods can assume it is set and
 			// so we can find the node using that value next time.
 			p.status.ID = ironicNode.UUID
-			result.Dirty = true
+			result, err = hostUpdated()
 			p.log.Info("setting provisioning id", "ID", p.status.ID)
 		}
 
@@ -717,7 +717,7 @@ func (p *ironicProvisioner) UpdateHardwareState() (result provisioner.Result, er
 	if discoveredVal != p.host.Status.PoweredOn {
 		p.log.Info("updating power status", "discovered", discoveredVal)
 		p.host.Status.PoweredOn = discoveredVal
-		result.Dirty = true
+		return hostUpdated()
 	}
 	return result, nil
 }

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -105,7 +105,7 @@ func init() {
 // and uses Ironic to manage the host.
 type ironicProvisioner struct {
 	// the host to be managed by this provisioner
-	host *metal3v1alpha1.BareMetalHost
+	host metal3v1alpha1.BareMetalHost
 	// a shorter path to the provisioning status data structure
 	status *metal3v1alpha1.ProvisionStatus
 	// access parameters for the BMC
@@ -137,7 +137,7 @@ func LogStartup() {
 
 // A private function to construct an ironicProvisioner (rather than a
 // Provisioner interface) in a consistent way for tests.
-func newProvisionerWithSettings(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher, ironicURL string, ironicAuthSettings clients.AuthConfig, inspectorURL string, inspectorAuthSettings clients.AuthConfig) (*ironicProvisioner, error) {
+func newProvisionerWithSettings(host metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher, ironicURL string, ironicAuthSettings clients.AuthConfig, inspectorURL string, inspectorAuthSettings clients.AuthConfig) (*ironicProvisioner, error) {
 	tlsConf := clients.TLSConfig{
 		TrustedCAFile:      ironicTrustedCAFile,
 		InsecureSkipVerify: ironicInsecure,
@@ -156,7 +156,7 @@ func newProvisionerWithSettings(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc
 		clientIronic, clientInspector)
 }
 
-func newProvisionerWithIronicClients(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher, clientIronic *gophercloud.ServiceClient, clientInspector *gophercloud.ServiceClient) (*ironicProvisioner, error) {
+func newProvisionerWithIronicClients(host metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher, clientIronic *gophercloud.ServiceClient, clientInspector *gophercloud.ServiceClient) (*ironicProvisioner, error) {
 
 	bmcAccess, err := bmc.NewAccessDetails(host.Spec.BMC.Address, host.Spec.BMC.DisableCertificateVerification)
 	if err != nil {
@@ -182,7 +182,7 @@ func newProvisionerWithIronicClients(host *metal3v1alpha1.BareMetalHost, bmcCred
 
 // New returns a new Ironic Provisioner using the global configuration
 // for finding the Ironic services.
-func New(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher) (provisioner.Provisioner, error) {
+func New(host metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher) (provisioner.Provisioner, error) {
 	var err error
 	if clientIronicSingleton == nil || clientInspectorSingleton == nil {
 		tlsConf := clients.TLSConfig{

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1138,8 +1138,7 @@ func (p *ironicProvisioner) Provision(hostConf provisioner.HostConfigData) (resu
 			// top of relational databases...
 			if ironicNode.LastError == "" {
 				p.log.Info("failed but error message not available")
-				result.Dirty = true
-				return result, nil
+				return retryAfterDelay(provisionRequeueDelay)
 			}
 			p.log.Info("found error", "msg", ironicNode.LastError)
 			result.ErrorMessage = fmt.Sprintf("Image provisioning failed: %s",
@@ -1520,9 +1519,7 @@ func (p *ironicProvisioner) PowerOff() (result provisioner.Result, err error) {
 		case SoftPowerOffUnsupportedError, SoftPowerOffFailed:
 			return p.hardPowerOff()
 		case HostLockedError:
-			result.RequeueAfter = powerRequeueDelay
-			result.Dirty = true
-			return result, nil
+			return retryAfterDelay(powerRequeueDelay)
 		default:
 			result.RequeueAfter = powerRequeueDelay
 			return result, err

--- a/pkg/provisioner/ironic/ironic_test.go
+++ b/pkg/provisioner/ironic/ironic_test.go
@@ -16,10 +16,10 @@ func init() {
 	logf.SetLogger(logf.ZapLogger(true))
 }
 
-func makeHost() *metal3v1alpha1.BareMetalHost {
+func makeHost() metal3v1alpha1.BareMetalHost {
 	rotational := true
 
-	return &metal3v1alpha1.BareMetalHost{
+	return metal3v1alpha1.BareMetalHost{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myhost",
 			Namespace: "myns",

--- a/pkg/provisioner/ironic/power_test.go
+++ b/pkg/provisioner/ironic/power_test.go
@@ -73,7 +73,6 @@ func TestPowerOn(t *testing.T) {
 			}).WithNodeStatesPower(nodeUUID, http.StatusConflict).WithNodeStatesPowerUpdate(nodeUUID, http.StatusConflict),
 			expectedRequestAfter: 10,
 			expectedDirty:        true,
-			expectedError:        true,
 		},
 	}
 

--- a/pkg/provisioner/ironic/provision_test.go
+++ b/pkg/provisioner/ironic/provision_test.go
@@ -66,7 +66,7 @@ func TestProvision(t *testing.T) {
 				ProvisionState: string(nodes.Active),
 				UUID:           nodeUUID,
 			}),
-			expectedRequestAfter: 10,
+			expectedRequestAfter: 0,
 			expectedDirty:        false,
 		},
 		{

--- a/pkg/provisioner/ironic/provision_test.go
+++ b/pkg/provisioner/ironic/provision_test.go
@@ -22,6 +22,7 @@ func TestProvision(t *testing.T) {
 		ironic               *testserver.IronicMock
 		expectedDirty        bool
 		expectedError        bool
+		expectedErrorMessage bool
 		expectedRequestAfter int
 	}{
 		{
@@ -31,7 +32,8 @@ func TestProvision(t *testing.T) {
 				UUID:           nodeUUID,
 			}),
 			expectedRequestAfter: 0,
-			expectedDirty:        true,
+			expectedDirty:        false,
+			expectedErrorMessage: true,
 		},
 		{
 			name: "cleanFail state",
@@ -58,7 +60,8 @@ func TestProvision(t *testing.T) {
 				UUID:           nodeUUID,
 			}),
 			expectedRequestAfter: 0,
-			expectedDirty:        true,
+			expectedDirty:        false,
+			expectedErrorMessage: true,
 		},
 		{
 			name: "active state",
@@ -108,6 +111,11 @@ func TestProvision(t *testing.T) {
 
 			assert.Equal(t, tc.expectedDirty, result.Dirty)
 			assert.Equal(t, time.Second*time.Duration(tc.expectedRequestAfter), result.RequeueAfter)
+			if !tc.expectedErrorMessage {
+				assert.Equal(t, "", result.ErrorMessage)
+			} else {
+				assert.NotEqual(t, "", result.ErrorMessage)
+			}
 			if !tc.expectedError {
 				assert.NoError(t, err)
 			} else {

--- a/pkg/provisioner/ironic/result.go
+++ b/pkg/provisioner/ironic/result.go
@@ -16,10 +16,6 @@ func retryAfterDelay(delay time.Duration) (provisioner.Result, error) {
 	}, nil
 }
 
-func hostUpdated() (provisioner.Result, error) {
-	return provisioner.Result{Dirty: true}, nil
-}
-
 func operationContinuing(delay time.Duration) (provisioner.Result, error) {
 	return provisioner.Result{
 		Dirty:        true,

--- a/pkg/provisioner/ironic/result.go
+++ b/pkg/provisioner/ironic/result.go
@@ -1,0 +1,40 @@
+package ironic
+
+import (
+	"time"
+
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
+)
+
+func retryAfterDelay(delay time.Duration) (provisioner.Result, error) {
+	// TODO(zaneb): this is currently indistinguishable from the result of
+	// operationContinuing() from the caller's perspective. Changes are
+	// required to the Result structure to enable this to be distinguished.
+	return provisioner.Result{
+		Dirty:        true,
+		RequeueAfter: delay,
+	}, nil
+}
+
+func hostUpdated() (provisioner.Result, error) {
+	return provisioner.Result{Dirty: true}, nil
+}
+
+func operationContinuing(delay time.Duration) (provisioner.Result, error) {
+	return provisioner.Result{
+		Dirty:        true,
+		RequeueAfter: delay,
+	}, nil
+}
+
+func operationComplete() (provisioner.Result, error) {
+	return provisioner.Result{}, nil
+}
+
+func operationFailed(message string) (provisioner.Result, error) {
+	return provisioner.Result{ErrorMessage: message}, nil
+}
+
+func transientError(err error) (provisioner.Result, error) {
+	return provisioner.Result{}, err
+}

--- a/pkg/provisioner/ironic/updateopts_test.go
+++ b/pkg/provisioner/ironic/updateopts_test.go
@@ -83,7 +83,7 @@ func TestGetUpdateOptsForNodeWithRootHints(t *testing.T) {
 }
 
 func TestGetUpdateOptsForNodeVirtual(t *testing.T) {
-	host := &metal3v1alpha1.BareMetalHost{
+	host := metal3v1alpha1.BareMetalHost{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myhost",
 			Namespace: "myns",
@@ -188,7 +188,7 @@ func TestGetUpdateOptsForNodeVirtual(t *testing.T) {
 }
 
 func TestGetUpdateOptsForNodeDell(t *testing.T) {
-	host := &metal3v1alpha1.BareMetalHost{
+	host := metal3v1alpha1.BareMetalHost{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myhost",
 			Namespace: "myns",

--- a/pkg/provisioner/ironic/validatemanagementaccess_test.go
+++ b/pkg/provisioner/ironic/validatemanagementaccess_test.go
@@ -33,7 +33,7 @@ func TestValidateManagementAccessNoMAC(t *testing.T) {
 		t.Fatalf("could not create provisioner: %s", err)
 	}
 
-	result, err := prov.ValidateManagementAccess(false, false)
+	result, _, err := prov.ValidateManagementAccess(false, false)
 	if err != nil {
 		t.Fatalf("error from ValidateManagementAccess: %s", err)
 	}
@@ -63,7 +63,7 @@ func TestValidateManagementAccessMACOptional(t *testing.T) {
 		t.Fatalf("could not create provisioner: %s", err)
 	}
 
-	result, err := prov.ValidateManagementAccess(false, false)
+	result, _, err := prov.ValidateManagementAccess(false, false)
 	if err != nil {
 		t.Fatalf("error from ValidateManagementAccess: %s", err)
 	}
@@ -95,13 +95,13 @@ func TestValidateManagementAccessCreateNode(t *testing.T) {
 		t.Fatalf("could not create provisioner: %s", err)
 	}
 
-	result, err := prov.ValidateManagementAccess(false, false)
+	result, provID, err := prov.ValidateManagementAccess(false, false)
 	if err != nil {
 		t.Fatalf("error from ValidateManagementAccess: %s", err)
 	}
 	assert.Equal(t, "", result.ErrorMessage)
 	assert.NotEqual(t, "", createdNode.UUID)
-	assert.Equal(t, createdNode.UUID, host.Status.Provisioning.ID)
+	assert.Equal(t, createdNode.UUID, provID)
 }
 
 func TestValidateManagementAccessExistingNode(t *testing.T) {
@@ -130,12 +130,12 @@ func TestValidateManagementAccessExistingNode(t *testing.T) {
 		t.Fatalf("could not create provisioner: %s", err)
 	}
 
-	result, err := prov.ValidateManagementAccess(false, false)
+	result, provID, err := prov.ValidateManagementAccess(false, false)
 	if err != nil {
 		t.Fatalf("error from ValidateManagementAccess: %s", err)
 	}
 	assert.Equal(t, "", result.ErrorMessage)
-	assert.Equal(t, "uuid", host.Status.Provisioning.ID)
+	assert.Equal(t, "uuid", provID)
 }
 
 func TestValidateManagementAccessExistingNodeContinue(t *testing.T) {
@@ -193,7 +193,7 @@ func TestValidateManagementAccessExistingNodeContinue(t *testing.T) {
 				t.Fatalf("could not create provisioner: %s", err)
 			}
 
-			result, err := prov.ValidateManagementAccess(false, false)
+			result, _, err := prov.ValidateManagementAccess(false, false)
 			if err != nil {
 				t.Fatalf("error from ValidateManagementAccess: %s", err)
 			}
@@ -238,7 +238,7 @@ func TestValidateManagementAccessExistingNodeWaiting(t *testing.T) {
 				t.Fatalf("could not create provisioner: %s", err)
 			}
 
-			result, err := prov.ValidateManagementAccess(false, false)
+			result, _, err := prov.ValidateManagementAccess(false, false)
 			if err != nil {
 				t.Fatalf("error from ValidateManagementAccess: %s", err)
 			}
@@ -280,12 +280,12 @@ func TestValidateManagementAccessNewCredentials(t *testing.T) {
 		t.Fatalf("could not create provisioner: %s", err)
 	}
 
-	result, err := prov.ValidateManagementAccess(true, false)
+	result, provID, err := prov.ValidateManagementAccess(true, false)
 	if err != nil {
 		t.Fatalf("error from ValidateManagementAccess: %s", err)
 	}
 	assert.Equal(t, "", result.ErrorMessage)
-	assert.Equal(t, "uuid", host.Status.Provisioning.ID)
+	assert.Equal(t, "uuid", provID)
 
 	updates := ironic.GetLastNodeUpdateRequestFor("uuid")
 	newValues := updates[0].Value.(map[string]interface{})
@@ -327,12 +327,12 @@ func TestValidateManagementAccessLinkExistingIronicNodeByMAC(t *testing.T) {
 		t.Fatalf("could not create provisioner: %s", err)
 	}
 
-	result, err := prov.ValidateManagementAccess(false, false)
+	result, provID, err := prov.ValidateManagementAccess(false, false)
 	if err != nil {
 		t.Fatalf("error from ValidateManagementAccess: %s", err)
 	}
 	assert.Equal(t, "", result.ErrorMessage)
-	assert.NotEqual(t, "", host.Status.Provisioning.ID)
+	assert.NotEqual(t, "", provID)
 }
 
 func TestValidateManagementAccessExistingPortWithWrongUUID(t *testing.T) {
@@ -370,7 +370,7 @@ func TestValidateManagementAccessExistingPortWithWrongUUID(t *testing.T) {
 		t.Fatalf("could not create provisioner: %s", err)
 	}
 
-	_, err = prov.ValidateManagementAccess(false, false)
+	_, _, err = prov.ValidateManagementAccess(false, false)
 	assert.EqualError(t, err, "failed to find existing host: port exists but linked node doesn't random-wrong-id: Resource not found")
 }
 
@@ -412,7 +412,7 @@ func TestValidateManagementAccessExistingPortButHasName(t *testing.T) {
 		t.Fatalf("could not create provisioner: %s", err)
 	}
 
-	_, err = prov.ValidateManagementAccess(false, false)
+	_, _, err = prov.ValidateManagementAccess(false, false)
 	assert.EqualError(t, err, "failed to find existing host: node found by MAC but has a name: wrong-name")
 }
 
@@ -450,10 +450,10 @@ func TestValidateManagementAccessAddTwoHostsWithSameMAC(t *testing.T) {
 		t.Fatalf("could not create provisioner: %s", err)
 	}
 
-	result, err := prov.ValidateManagementAccess(false, false)
+	result, provID, err := prov.ValidateManagementAccess(false, false)
 	if err != nil {
 		t.Fatalf("error from ValidateManagementAccess: %s", err)
 	}
 	assert.Equal(t, "", result.ErrorMessage)
-	assert.NotEqual(t, "", host.Status.Provisioning.ID)
+	assert.NotEqual(t, "", provID)
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -43,7 +43,7 @@ type Provisioner interface {
 	// of credentials it has are different from the credentials it has
 	// previously been using, without implying that either set of
 	// credentials is correct.
-	ValidateManagementAccess(credentialsChanged, force bool) (result Result, err error)
+	ValidateManagementAccess(credentialsChanged, force bool) (result Result, provID string, err error)
 
 	// InspectHardware updates the HardwareDetails field of the host with
 	// details of devices discovered on the hardware. It may be called

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -54,9 +54,8 @@ type Provisioner interface {
 	// UpdateHardwareState fetches the latest hardware state of the
 	// server and updates the HardwareDetails field of the host with
 	// details. It is expected to do this in the least expensive way
-	// possible, such as reading from a cache, and return dirty only
-	// if any state information has changed.
-	UpdateHardwareState() (result Result, err error)
+	// possible, such as reading from a cache.
+	UpdateHardwareState() (hwState HardwareState, err error)
 
 	// Adopt brings an externally-provisioned host under management by
 	// the provisioner.
@@ -100,6 +99,13 @@ type Result struct {
 	RequeueAfter time.Duration
 	// Any error message produced by the provisioner.
 	ErrorMessage string
+}
+
+// HardwareState holds the response from an UpdateHardwareState call
+type HardwareState struct {
+	// PoweredOn is a pointer to a bool indicating whether the Host is currently
+	// powered on. The value is nil if the power state cannot be determined.
+	PoweredOn *bool
 }
 
 var NeedsRegistration = errors.New("Host not registered")

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -17,7 +17,7 @@ Package provisioning defines the API for talking to the provisioning backend.
 type EventPublisher func(reason, message string)
 
 // Factory is the interface for creating new Provisioner objects.
-type Factory func(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publish EventPublisher) (Provisioner, error)
+type Factory func(host metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publish EventPublisher) (Provisioner, error)
 
 // HostConfigData retrieves host configuration data
 type HostConfigData interface {


### PR DESCRIPTION
Use semantic functions (`retryAfterDelay()`, `operationContinuing()`, `operationComplete()`, `operationFailed()`, `transientError()`) to generate return values from ironic provisioner. This is a first step toward changing the `provisioner.Result` type to include richer information (e.g. to be able to distinguish between a request to retry after a delay and the operation simply continuing).

Stop writing to the BareMetalHost Status subresource in the provisioner, and require all changes to be communicated back to the controller via return values from the Provisioner interface.

Only update the BareMetalHost Status subresource when something has changed, instead of on ~every reconcile.