### PR TITLE
Force retry when adoption fails

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -123,6 +123,9 @@ const (
 type ErrorType string
 
 const (
+	// ProvisionedRegistrationError is an error condition occurring when the controller
+	// is unable to re-register an already provisioned host.
+	ProvisionedRegistrationError ErrorType = "provisioned registration error"
 	// RegistrationError is an error condition occurring when the
 	// controller is unable to connect to the Host's baseboard management
 	// controller.
@@ -522,7 +525,7 @@ type BareMetalHostStatus struct {
 
 	// ErrorType indicates the type of failure encountered when the
 	// OperationalStatus is OperationalStatusError
-	// +kubebuilder:validation:Enum=registration error;inspection error;provisioning error;power management error
+	// +kubebuilder:validation:Enum=provisioned registration error;registration error;inspection error;provisioning error;power management error
 	ErrorType ErrorType `json:"errorType,omitempty"`
 
 	// LastUpdated identifies when this status was last observed.

--- a/config/crd/bases/metal3.io_baremetalhosts.yaml
+++ b/config/crd/bases/metal3.io_baremetalhosts.yaml
@@ -262,6 +262,7 @@ spec:
               errorType:
                 description: ErrorType indicates the type of failure encountered when the OperationalStatus is OperationalStatusError
                 enum:
+                - provisioned registration error
                 - registration error
                 - inspection error
                 - provisioning error

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -260,6 +260,7 @@ spec:
               errorType:
                 description: ErrorType indicates the type of failure encountered when the OperationalStatus is OperationalStatusError
                 enum:
+                - provisioned registration error
                 - registration error
                 - inspection error
                 - provisioning error


### PR DESCRIPTION
Currently when adoption fails, we use RegistrationError but this gets
cleared any time registration succeeds. We need a separate signal for
adoption failure, which allows us to force retry the adoption again.

Fixes #697