### PR TITLE
Get correct image checksum in getImageUpdateOptsForNode()

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -721,7 +721,7 @@ func (p *ironicProvisioner) UpdateHardwareState() (hwState provisioner.HardwareS
 }
 
 func (p *ironicProvisioner) getImageUpdateOptsForNode(ironicNode *nodes.Node, imageData *metal3v1alpha1.Image) (updates nodes.UpdateOpts, err error) {
-	checksum, checksumType, ok := p.host.GetImageChecksum()
+	checksum, checksumType, ok := imageData.GetChecksum()
 	if !ok {
 		p.log.Info("image/checksum not found for host")
 		return


### PR DESCRIPTION
We always want to get the checksum from the Image passed as imageData.
Due to an inadvertant change during the refactoring that created this
method (177d9efb4d627f6c3d9fae92e0b68c94c06aa713), we were always
getting the checksum from the Image in the Spec, even though imageData
may reference the one in the Status during registration.

This meant that during deprovisioning (with no image in the Spec),
adoption would fail as the node would not have image data added during
registration.