### PR TITLE
Remove root_gb workaround

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -840,34 +840,13 @@ func (p *ironicProvisioner) getUpdateOptsForNode(ironicNode *nodes.Node) (update
 	}
 	updates = append(updates, imageOpts...)
 
-	// root_gb
-	//
-	// FIXME(dhellmann): We have to provide something for the disk
-	// size until https://storyboard.openstack.org/#!/story/2005165 is
-	// fixed in ironic.
-	var op nodes.UpdateOp
-	if _, ok := ironicNode.InstanceInfo["root_gb"]; !ok {
-		op = nodes.AddOp
-		p.log.Info("adding root_gb")
-	} else {
-		op = nodes.ReplaceOp
-		p.log.Info("updating root_gb")
-	}
-	updates = append(
-		updates,
-		nodes.UpdateOperation{
-			Op:    op,
-			Path:  "/instance_info/root_gb",
-			Value: hwProf.RootGB,
-		},
-	)
-
 	// root_device
 	//
 	// FIXME(dhellmann): We need to specify the root device to receive
 	// the image. That should come from some combination of inspecting
 	// the host to see what is available and the hardware profile to
 	// give us instructions.
+	var op nodes.UpdateOp
 	if _, ok := ironicNode.Properties["root_device"]; !ok {
 		op = nodes.AddOp
 		p.log.Info("adding root_device")

--- a/pkg/provisioner/ironic/updateopts_test.go
+++ b/pkg/provisioner/ironic/updateopts_test.go
@@ -154,10 +154,6 @@ func TestGetUpdateOptsForNodeVirtual(t *testing.T) {
 			Value: "27720611-e5d1-45d3-ba3a-222dcfaa4ca2",
 		},
 		{
-			Path:  "/instance_info/root_gb",
-			Value: 10,
-		},
-		{
 			Path:  "/properties/cpu_arch",
 			Value: "x86_64",
 		},
@@ -252,10 +248,6 @@ func TestGetUpdateOptsForNodeDell(t *testing.T) {
 		{
 			Path:  "/instance_uuid",
 			Value: "27720611-e5d1-45d3-ba3a-222dcfaa4ca2",
-		},
-		{
-			Path:  "/instance_info/root_gb",
-			Value: 10,
 		},
 		{
 			Path:  "/properties/cpu_arch",


### PR DESCRIPTION
This isn't required for whole-disk images but was added prior to
https://storyboard.openstack.org/#!/story/2005165 which landed some
time ago.