### PR TITLE
Ironic: Don't adopt after clean failure during deprovisioning

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1053,6 +1053,19 @@ func (p *ironicProvisioner) Adopt(force bool) (result provisioner.Result, err er
 		return transientError(fmt.Errorf("Invalid state for adopt: %s",
 			ironicNode.ProvisionState))
 	case nodes.Manageable:
+		_, hasImageSource := ironicNode.InstanceInfo["image_source"]
+		_, hasBootISO := ironicNode.InstanceInfo["boot_iso"]
+		if p.status.State == metal3v1alpha1.StateDeprovisioning &&
+			!(hasImageSource || hasBootISO) {
+			// If we got here after a fresh registration and image data is
+			// available, it should have been added to the node during
+			// registration. If it isn't present then we got here due to a
+			// failed cleaning on deprovision. The node will be cleaned again
+			// before the next provisioning, so just allow the controller to
+			// continue without adopting.
+			p.log.Info("no image info; not adopting", "state", ironicNode.ProvisionState)
+			return operationComplete()
+		}
 		return p.changeNodeProvisionState(
 			ironicNode,
 			nodes.ProvisionStateOpts{
@@ -1298,6 +1311,7 @@ func (p *ironicProvisioner) Deprovision(force bool) (result provisioner.Result, 
 		)
 
 	case nodes.CleanFail:
+		p.log.Info("cleaning failed")
 		if ironicNode.Maintenance {
 			p.log.Info("clearing maintenance flag")
 			return p.setMaintenanceFlag(ironicNode, false)
@@ -1310,6 +1324,14 @@ func (p *ironicProvisioner) Deprovision(force bool) (result provisioner.Result, 
 			ironicNode,
 			nodes.ProvisionStateOpts{Target: nodes.TargetManage},
 		)
+
+	case nodes.Manageable:
+		// We end up here after CleanFail. Because cleaning happens in the
+		// process of moving from manageable to available, the node will still
+		// get cleaned before we provision it again. Therefore, just declare
+		// deprovisioning complete.
+		p.log.Info("deprovisioning node is in manageable state")
+		return operationComplete()
 
 	case nodes.Available:
 		p.publisher("DeprovisioningComplete", "Image deprovisioning completed")

--- a/pkg/provisioner/ironic/provision_test.go
+++ b/pkg/provisioner/ironic/provision_test.go
@@ -198,6 +198,23 @@ func TestDeprovision(t *testing.T) {
 			expectedRequestAfter: 10,
 			expectedDirty:        true,
 		},
+		{
+			name: "clean fail state",
+			ironic: testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
+				ProvisionState: string(nodes.CleanFail),
+				UUID:           nodeUUID,
+			}),
+			expectedRequestAfter: 10,
+			expectedDirty:        true,
+		},
+		{
+			name: "manageable state",
+			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+				ProvisionState: string(nodes.Manageable),
+				UUID:           nodeUUID,
+			}),
+			expectedDirty: false,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
During deprovisioning of a Host, if 'deleting' (i.e. deprovisioning) the
node succeeds (i.e. it doesn't go to the Error state) but the automated
cleaning that follows fails, the only way to recover is to return the
node to the manageable state.

Previously, once in the manageable state we would attempt adoption on
the node so that we could deprovision again. However, in the course of
'deleting' the node, the image information is cleared from it so it
cannot be adopted again. (Adoption continues to be the right thing to do
if the node has just been re-registered due to the Ironic database being
recreated, and in that case the image information is present since it
gets added during the initial registration.)

To work around this, don't attempt to adopt during the Deprovisioning
state if the node is manageable and the image data is not present.
Handle the manageable state in Deprovision() by declaring the
deprovisioning complete.

A node in the manageable state cannot be re-provisioned without first
being cleaned - it must go through cleaning to reach the available state
before it can be provisioned. Provisioning already handles nodes in the
manageable state, as this is how they begin after the initial inspection
of the host before the first provisioning (which does the initial
cleaning).

In the long term it might be better to declare Deprovisioning complete as soon as cleaning _begins_, and move the Host to a new Preparing state which will retry the cleaning until the node can be moved to `available`. In the meantime though, this should resolve the bug.