### PR TITLE
Add BuildTime to manager binary.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,12 @@ GOLANGCI_LINT := $(BIN_DIR)/golangci-lint
 KUSTOMIZE := $(BIN_DIR)/kustomize
 
 # See pkg/version.go for details
-SOURCE_GIT_COMMIT ?= $(shell git rev-parse --verify 'HEAD^{commit}')
+SOURCE_GIT_COMMIT ?= $(shell git rev-parse --short HEAD)
 BUILD_VERSION ?= $(shell git describe --always --abbrev=40 --dirty)
-export LDFLAGS="-X github.com/metal3-io/baremetal-operator/pkg/version.Raw=${BUILD_VERSION} -X github.com/metal3-io/baremetal-operator/pkg/version.Commit=${SOURCE_GIT_COMMIT}"
+VERSION_URI = "github.com/metal3-io/baremetal-operator/pkg/version"
+export LDFLAGS="-X $(VERSION_URI).Raw=${BUILD_VERSION} \
+                -X $(VERSION_URI).Commit=${SOURCE_GIT_COMMIT} \
+                -X $(VERSION_URI).BuildTime=$(shell date +%Y-%m-%dT%H:%M:%S%z)"
 
 # Set some variables the operator expects to have in order to work
 # Those need to be the same as in config/default/ironic.env
@@ -117,7 +120,7 @@ build: generate manifests manager tools ## Build everything
 
 .PHONY: manager
 manager: generate lint ## Build manager binary
-	go build -ldflags $(LDFLAGS) -o bin/manager main.go
+	go build -ldflags $(LDFLAGS) -o bin/$(OPERATOR_NAME) main.go
 
 .PHONY: run
 run: generate lint manifests ## Run against the configured Kubernetes cluster in ~/.kube/config

--- a/main.go
+++ b/main.go
@@ -57,7 +57,9 @@ func init() {
 func printVersion() {
 	setupLog.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	setupLog.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-	setupLog.Info(fmt.Sprintf("baremetal-operator version: %s", version.String))
+	setupLog.Info(fmt.Sprintf("Git commit: %s", version.Commit))
+	setupLog.Info(fmt.Sprintf("Build time: %s", version.BuildTime))
+	setupLog.Info(fmt.Sprintf("Component: %s", version.String))
 }
 
 func setupChecks(mgr ctrl.Manager) {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,5 +14,9 @@ var (
 
 	// Commit is the commit hash from which the software was built.
 	// Set via LDFLAGS in Makefile.
-	Commit = ""
+	Commit = "unknown"
+
+	// BuildTime is the string representation of build time.
+	// Set via LDFLAGS in Makefile.
+	BuildTime = "unknown"
 )


### PR DESCRIPTION
This PR adds BuildTime variable to manager binary and populates this variable during build via Makefile.

Additional small fixes:
 - use short git commit hash in manager binary
 - use $(OPERATOR_NAME) variable for manager output name (to sync with Dockerfile)
 - do not print empty variables in manager binary version package (Dockerfile does not set them)

Signed-off-by: s3rj1k <evasive.gyron@gmail.com>