### PR TITLE
Use errorType intead of errorMessage

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -596,7 +596,7 @@ type ProvisionStatus struct {
 // +kubebuilder:printcolumn:name="BMC",type="string",JSONPath=".spec.bmc.address",description="Address of management controller",priority=1
 // +kubebuilder:printcolumn:name="Hardware_Profile",type="string",JSONPath=".status.hardwareProfile",description="The type of hardware detected",priority=1
 // +kubebuilder:printcolumn:name="Online",type="string",JSONPath=".spec.online",description="Whether the host is online or not"
-// +kubebuilder:printcolumn:name="Error",type="string",JSONPath=".status.errorMessage",description="Most recent error"
+// +kubebuilder:printcolumn:name="Error",type="string",JSONPath=".status.errorType",description="Type of the most recent error"
 // +kubebuilder:object:root=true
 type BareMetalHost struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/bases/metal3.io_baremetalhosts.yaml
+++ b/config/crd/bases/metal3.io_baremetalhosts.yaml
@@ -47,8 +47,8 @@ spec:
       jsonPath: .spec.online
       name: Online
       type: string
-    - description: Most recent error
-      jsonPath: .status.errorMessage
+    - description: Type of the most recent error
+      jsonPath: .status.errorType
       name: Error
       type: string
     name: v1alpha1

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -45,8 +45,8 @@ spec:
       jsonPath: .spec.online
       name: Online
       type: string
-    - description: Most recent error
-      jsonPath: .status.errorMessage
+    - description: Type of the most recent error
+      jsonPath: .status.errorType
       name: Error
       type: string
     name: v1alpha1


### PR DESCRIPTION
Show `status.errorType` intead of `status.errorMessage` under ERROR field when listing baremetalhosts

Fixes https://github.com/metal3-io/baremetal-operator/issues/721