### PR TITLE
Ask Ironic to include NodeUUID when querying ports

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -233,7 +233,9 @@ func (p *ironicProvisioner) validateNode(ironicNode *nodes.Node) (errorMessage s
 func (p *ironicProvisioner) listAllPorts(address string) ([]ports.Port, error) {
 	var allPorts []ports.Port
 
-	opts := ports.ListOpts{}
+	opts := ports.ListOpts{
+		Fields: []string{"node_uuid"},
+	}
 
 	if address != "" {
 		opts.Address = address

--- a/pkg/provisioner/ironic/testserver/ironic.go
+++ b/pkg/provisioner/ironic/testserver/ironic.go
@@ -236,7 +236,8 @@ func (m *IronicMock) WithNodeValidate(nodeUUID string) *IronicMock {
 // Port configures the server with a valid response for
 //    [GET] /v1/nodes/<node uuid>/ports
 //    [GET] /v1/ports
-//    [GET] /v1/ports?=address=<node uuid>
+//    [GET] /v1/ports?address=<mac>
+//    [GET] /v1/ports?address=<mac>&fields=node_uuid
 func (m *IronicMock) Port(port ports.Port) *IronicMock {
 	if port.NodeUUID == "" {
 		m.MockServer.t.Error("When using withPort(), the port must include a NodeUUID.")
@@ -251,6 +252,7 @@ func (m *IronicMock) Port(port ports.Port) *IronicMock {
 	m.ResponseJSON(m.buildURL("/v1/nodes/"+port.NodeUUID+"/ports", http.MethodGet), resp)
 	m.ResponseJSON(m.buildURL("/v1/ports", http.MethodGet), resp)
 	m.ResponseJSON(m.buildURL("/v1/ports?address="+address, http.MethodGet), resp)
+	m.ResponseJSON(m.buildURL("/v1/ports?address="+address+"&fields=node_uuid", http.MethodGet), resp)
 
 	return m
 }


### PR DESCRIPTION
When registering a new host, we check if its bootMACAddress conflicts
with any existing Ironic nodes.  This procedure queries Ironic ports,
and if a port is found, we use the port's NodeUUID to find the
conflicting node.  However, we are using `ports.List()` which only
returns minimal resources by default; e.g. any returned ports will have
their NodeUUID property set to an empty string.

We are now explicitly asking for Ironic to include the `node_uuid`
field.

We also adjust the mock test mechanism to account for this.

