### PR TITLE
Make operationHistory none-required field

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -558,7 +558,7 @@ type BareMetalHostStatus struct {
 
 	// OperationHistory holds information about operations performed
 	// on this host.
-	OperationHistory OperationHistory `json:"operationHistory"`
+	OperationHistory OperationHistory `json:"operationHistory,omitempty"`
 
 	// ErrorCount records how many times the host has encoutered an error since the last successful operation
 	// +kubebuilder:default:=0

--- a/config/crd/bases/metal3.io_baremetalhosts.yaml
+++ b/config/crd/bases/metal3.io_baremetalhosts.yaml
@@ -631,7 +631,6 @@ spec:
             - errorCount
             - errorMessage
             - hardwareProfile
-            - operationHistory
             - operationalStatus
             - poweredOn
             - provisioning

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -629,7 +629,6 @@ spec:
             - errorCount
             - errorMessage
             - hardwareProfile
-            - operationHistory
             - operationalStatus
             - poweredOn
             - provisioning


### PR DESCRIPTION
When migrating from older CRDs this filed is not available in bmh CRs.
Making this optional fixes ability to edit bmh CRs that where created before operationHistory filed was introduced.

Signed-off-by: s3rj1k <evasive.gyron@gmail.com>