### PR TITLE
Fail registration when boot MAC conflicts

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -60,6 +60,19 @@ var bootModeCapabilities = map[metal3v1alpha1.BootMode]string{
 	metal3v1alpha1.Legacy: "boot_mode:bios",
 }
 
+type macAddressConflictError struct {
+	Address      string
+	ExistingNode string
+}
+
+func (e macAddressConflictError) Error() string {
+	return fmt.Sprintf("MAC address %s conflicts with existing node %s", e.Address, e.ExistingNode)
+}
+
+func NewMacAddressConflictError(address, node string) error {
+	return macAddressConflictError{Address: address, ExistingNode: node}
+}
+
 func init() {
 	// NOTE(dhellmann): Use Fprintf() to report errors instead of
 	// logging, because logging is not configured yet in init().
@@ -310,7 +323,7 @@ func (p *ironicProvisioner) findExistingHost() (ironicNode *nodes.Node, err erro
 
 			// If the node has a name, this means we didn't find it above.
 			if ironicNode.Name != "" {
-				return nil, errors.New(fmt.Sprint("node found by MAC but has a name: ", ironicNode.Name))
+				return nil, NewMacAddressConflictError(p.host.Spec.BootMACAddress, ironicNode.Name)
 			}
 
 			return ironicNode, nil
@@ -342,7 +355,12 @@ func (p *ironicProvisioner) ValidateManagementAccess(credentialsChanged, force b
 
 	ironicNode, err = p.findExistingHost()
 	if err != nil {
-		result, err = transientError(errors.Wrap(err, "failed to find existing host"))
+		switch err.(type) {
+		case macAddressConflictError:
+			result, err = operationFailed(err.Error())
+		default:
+			result, err = transientError(errors.Wrap(err, "failed to find existing host"))
+		}
 		return
 	}
 

--- a/pkg/provisioner/ironic/validatemanagementaccess_test.go
+++ b/pkg/provisioner/ironic/validatemanagementaccess_test.go
@@ -574,8 +574,9 @@ func TestValidateManagementAccessExistingPortButHasName(t *testing.T) {
 		t.Fatalf("could not create provisioner: %s", err)
 	}
 
-	_, _, err = prov.ValidateManagementAccess(false, false)
-	assert.EqualError(t, err, "failed to find existing host: node found by MAC but has a name: wrong-name")
+	res, _, err := prov.ValidateManagementAccess(false, false)
+	assert.Nil(t, err)
+	assert.Equal(t, res.ErrorMessage, "MAC address 11:11:11:11:11:11 conflicts with existing node wrong-name")
 }
 
 func TestValidateManagementAccessAddTwoHostsWithSameMAC(t *testing.T) {


### PR DESCRIPTION
If we can't find a node by name, and have to resort to using MAC address
lookup, we can't accept a node that has a name.  In that scenario, we
have detected a MAC address collision, and human intervention is
required.  We signal this by returning an `operationFailed` provisioning
result with the offending MAC address in the error message.