### PR TITLE
Parameterize docker registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
-FROM registry.hub.docker.com/library/golang:1.15.3 AS builder
+ARG OVERRIDE_DOCKER_HUB_REGISTRY=${OVERRIDE_DOCKER_HUB_REGISTRY:-"registry.hub.docker.com"}
+
+FROM "${OVERRIDE_DOCKER_HUB_REGISTRY}/"library/golang:1.15.3 AS builder
 
 WORKDIR /workspace
 

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ help:  ## Display this help
 	@echo "  GO_TEST_FLAGS    -- flags to pass to --go-test-flags ($(GO_TEST_FLAGS))"
 	@echo "  DEBUG            -- debug flag, if any ($(DEBUG))"
 
+# Default Image pull registry
+OVERRIDE_DOCKER_HUB_REGISTRY ?= "registry.hub.docker.com"
+
 # Image URL to use all building/pushing image targets
 IMG ?= baremetal-operator:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
@@ -167,7 +170,7 @@ $(CONTROLLER_GEN):
 
 .PHONY: docker
 docker: generate manifests ## Build the docker image
-	docker build . -t ${IMG}
+	docker build . -t ${IMG} --build-arg OVERRIDE_DOCKER_HUB_REGISTRY=${OVERRIDE_DOCKER_HUB_REGISTRY}
 
 # Push the docker image
 .PHONY: docker-push

--- a/hack/Dockerfile.golint
+++ b/hack/Dockerfile.golint
@@ -1,4 +1,6 @@
-FROM registry.hub.docker.com/library/golang:1.15.3
+ARG OVERRIDE_DOCKER_HUB_REGISTRY=${OVERRIDE_DOCKER_HUB_REGISTRY:-"registry.hub.docker.com"}
+
+FROM "${OVERRIDE_DOCKER_HUB_REGISTRY}"/library/golang:1.15.3
 
 RUN go get -u golang.org/x/lint/golint
 


### PR DESCRIPTION
This PR parameterizes the docker registry for building images.
Which registry is used determined by the following variable, with the give default value.
Exporting the variables per Dockerfile allows this repo to be independent of `metal3-dev-env`
This has an effect when using `Makefile` and  the value is overridden. 

`export OVERRIDE_DOCKER_HUB_REGISTRY=${OVERRIDE_DOCKER_HUB_REGISTRY:-"registry.hub.docker.com"}
`

If you wish to use a different registry, please assign value in a `HOST:PORT/path` format.