### PR TITLE
Add "NET_RAW" to ironic-endpoint-keepalived

### DIFF
--- a/ironic-deployment/keepalived/keepalived_patch.yaml
+++ b/ironic-deployment/keepalived/keepalived_patch.yaml
@@ -11,7 +11,7 @@ spec:
         name: ironic-endpoint-keepalived
         securityContext:
               capabilities:
-                add: ["NET_ADMIN"]
+                add: ["NET_ADMIN", "NET_RAW"]
         envFrom:
           - configMapRef:
               name: ironic-bmo-configmap


### PR DESCRIPTION
The capability 'NET_RAW' is needed to open a raw socket in ironic-endpoint-keepalived otherwise the container will fail.