### PR TITLE
Prepend the namespace to ironic nodenames to avoid conflicts

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,6 +27,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         envFrom:
           - configMapRef:
               name: ironic

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -1039,6 +1039,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         envFrom:
         - configMapRef:
             name: baremetal-operator-ironic

--- a/main.go
+++ b/main.go
@@ -103,13 +103,18 @@ func main() {
 
 	printVersion()
 
+	leaderElectionNamespace := os.Getenv("POD_NAMESPACE")
+	if leaderElectionNamespace == "" {
+		leaderElectionNamespace = watchNamespace
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                  scheme,
 		MetricsBindAddress:      metricsAddr,
 		Port:                    0, // Add flag with default of 9443 when adding webhooks
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "baremetal-operator",
-		LeaderElectionNamespace: watchNamespace,
+		LeaderElectionNamespace: leaderElectionNamespace,
 		Namespace:               watchNamespace,
 		HealthProbeBindAddress:  healthAddr,
 	})

--- a/pkg/provisioner/ironic/delete_test.go
+++ b/pkg/provisioner/ironic/delete_test.go
@@ -86,7 +86,7 @@ func TestDelete(t *testing.T) {
 		},
 		{
 			name:   "not-ironic-node",
-			ironic: testserver.NewIronic(t).Ready().NoNode(nodeUUID).NoNode("myhost"),
+			ironic: testserver.NewIronic(t).Ready().NoNode(nodeUUID).NoNode("myns" + nameSeparator + "myhost").NoNode("myhost"),
 		},
 		{
 			name: "available-node",

--- a/pkg/provisioner/ironic/findhost_test.go
+++ b/pkg/provisioner/ironic/findhost_test.go
@@ -23,7 +23,7 @@ func TestFindExistingHost(t *testing.T) {
 			name:           "no-node",
 			hostName:       "name",
 			provisioningID: "uuid",
-			ironic:         testserver.NewIronic(t).NoNode("name").NoNode("uuid"),
+			ironic:         testserver.NewIronic(t).NoNode("myns" + nameSeparator + "name").NoNode("name").NoNode("uuid"),
 		},
 		{
 			name:           "by-name",
@@ -31,21 +31,21 @@ func TestFindExistingHost(t *testing.T) {
 			provisioningID: "uuid",
 			ironic: testserver.NewIronic(t).NoNode("uuid").
 				Node(nodes.Node{
-					Name: "name",
+					Name: "myns" + nameSeparator + "name",
 					UUID: "different-uuid",
 				}),
-			nodeName: "name",
+			nodeName: "myns" + nameSeparator + "name",
 		},
 		{
 			name:           "by-uuid",
 			hostName:       "name",
 			provisioningID: "uuid",
-			ironic: testserver.NewIronic(t).NoNode("name").
+			ironic: testserver.NewIronic(t).NoNode("myns" + nameSeparator + "name").NoNode("name").
 				Node(nodes.Node{
-					Name: "different-name",
+					Name: "myns" + nameSeparator + "different-name",
 					UUID: "uuid",
 				}),
-			nodeName: "different-name",
+			nodeName: "myns" + nameSeparator + "different-name",
 		},
 	}
 

--- a/pkg/provisioner/ironic/provisioncapacity_test.go
+++ b/pkg/provisioner/ironic/provisioncapacity_test.go
@@ -62,7 +62,7 @@ func TestHasProvisioningCapacity(t *testing.T) {
 			allNodes := []nodes.Node{}
 			for n, state := range tc.nodeStates {
 				allNodes = append(allNodes, nodes.Node{
-					Name:           fmt.Sprintf("node-%d", n),
+					Name:           fmt.Sprintf("myns%snode-%d", nameSeparator, n),
 					ProvisionState: string(state),
 				})
 			}

--- a/pkg/provisioner/ironic/updatehardwarestate_test.go
+++ b/pkg/provisioner/ironic/updatehardwarestate_test.go
@@ -90,15 +90,15 @@ func TestUpdateHardwareState(t *testing.T) {
 			name: "node-not-found-by-name",
 
 			hostName: "worker-0",
-			ironic:   testserver.NewIronic(t).Ready().NoNode(nodeUUID).NodeError("myhost", http.StatusGatewayTimeout),
+			ironic:   testserver.NewIronic(t).Ready().NoNode(nodeUUID).NodeError("myns.myhost", http.StatusGatewayTimeout),
 
-			expectedError: "failed to find existing host: failed to find node by name worker-0: EOF",
+			expectedError: "failed to find existing host: failed to find node by name myns.worker-0: EOF",
 
 			expectUnreadablePower: true,
 		},
 		{
 			name:   "not-ironic-node",
-			ironic: testserver.NewIronic(t).Ready().NoNode(nodeUUID).NoNode("myhost"),
+			ironic: testserver.NewIronic(t).Ready().NoNode(nodeUUID).NoNode("myns" + nameSeparator + "myhost").NoNode("myhost"),
 
 			expectedError: "Host not registered",
 

--- a/pkg/provisioner/ironic/validatemanagementaccess_test.go
+++ b/pkg/provisioner/ironic/validatemanagementaccess_test.go
@@ -22,7 +22,7 @@ func TestValidateManagementAccessNoMAC(t *testing.T) {
 	host.Spec.BootMACAddress = ""
 	host.Status.Provisioning.ID = "" // so we don't lookup by uuid
 
-	ironic := testserver.NewIronic(t).Ready().NoNode(host.Name)
+	ironic := testserver.NewIronic(t).Ready().NoNode(host.Namespace + nameSeparator + host.Name).NoNode(host.Name)
 	ironic.Start()
 	defer ironic.Stop()
 
@@ -50,7 +50,7 @@ func TestValidateManagementAccessMACOptional(t *testing.T) {
 	// Set up ironic server to return the node
 	ironic := testserver.NewIronic(t).Ready().
 		Node(nodes.Node{
-			Name: host.Name,
+			Name: host.Namespace + nameSeparator + host.Name,
 			UUID: host.Status.Provisioning.ID,
 		})
 	ironic.Start()
@@ -85,7 +85,7 @@ func TestValidateManagementAccessCreateNodeNoImage(t *testing.T) {
 		createdNode = &node
 	}
 
-	ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).NoNode(host.Name)
+	ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).NoNode(host.Namespace + nameSeparator + host.Name).NoNode(host.Name)
 	ironic.Start()
 	defer ironic.Stop()
 
@@ -120,7 +120,7 @@ func TestValidateManagementAccessCreateWithImage(t *testing.T) {
 		createdNode = &node
 	}
 
-	ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).NoNode(host.Name)
+	ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).NoNode(host.Namespace + nameSeparator + host.Name).NoNode(host.Name)
 	ironic.AddDefaultResponse("/v1/nodes/node-0", "PATCH", http.StatusOK, "{}")
 	ironic.Start()
 	defer ironic.Stop()
@@ -158,7 +158,7 @@ func TestValidateManagementAccessCreateWithLiveIso(t *testing.T) {
 		createdNode = &node
 	}
 
-	ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).NoNode(host.Name)
+	ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).NoNode(host.Namespace + nameSeparator + host.Name).NoNode(host.Name)
 	ironic.AddDefaultResponse("/v1/nodes/node-0", "PATCH", http.StatusOK, "{}")
 	ironic.Start()
 	defer ironic.Stop()
@@ -236,7 +236,7 @@ func TestValidateManagementAccessCreateNodeImageSpecOrStatus(t *testing.T) {
 				createdNode = &node
 			}
 
-			ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).NoNode(host.Name)
+			ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).NoNode(host.Namespace + nameSeparator + host.Name).NoNode(host.Name)
 			ironic.NodeUpdate(nodes.Node{UUID: "node-0"})
 			ironic.Start()
 			defer ironic.Stop()
@@ -278,7 +278,7 @@ func TestValidateManagementAccessExistingNode(t *testing.T) {
 	}
 
 	ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).Node(nodes.Node{
-		Name: host.Name,
+		Name: host.Namespace + nameSeparator + host.Name,
 		UUID: "uuid",
 	})
 	ironic.Start()
@@ -298,6 +298,43 @@ func TestValidateManagementAccessExistingNode(t *testing.T) {
 	}
 	assert.Equal(t, "", result.ErrorMessage)
 	assert.Equal(t, "uuid", provID)
+}
+
+func TestValidateManagementAccessExistingNodeNameUpdate(t *testing.T) {
+	// Create a host without a bootMACAddress and with a BMC that
+	// does not require one.
+	host := makeHost()
+	host.Spec.BootMACAddress = ""
+	host.Status.Provisioning.ID = "uuid"
+
+	ironic := testserver.NewIronic(t).
+		Node(
+			nodes.Node{
+				Name: host.Name,
+				UUID: "uuid",
+			}).
+		NodeUpdate(
+			nodes.Node{
+				Name: host.Namespace + nameSeparator + host.Name,
+				UUID: "uuid",
+			})
+	ironic.Start()
+	defer ironic.Stop()
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher,
+		ironic.Endpoint(), auth, testserver.NewInspector(t).Endpoint(), auth,
+	)
+	if err != nil {
+		t.Fatalf("could not create provisioner: %s", err)
+	}
+
+	result, _, err := prov.ValidateManagementAccess(false, false)
+	if err != nil {
+		t.Fatalf("error from ValidateManagementAccess: %s", err)
+	}
+	assert.Equal(t, "", result.ErrorMessage)
+	assert.Equal(t, false, result.Dirty)
 }
 
 func TestValidateManagementAccessExistingNodeContinue(t *testing.T) {
@@ -340,7 +377,7 @@ func TestValidateManagementAccessExistingNodeContinue(t *testing.T) {
 			}
 
 			ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).Node(nodes.Node{
-				Name:           host.Name,
+				Name:           host.Namespace + nameSeparator + host.Name,
 				UUID:           "", // to match status in host
 				ProvisionState: string(status),
 			})
@@ -384,7 +421,7 @@ func TestValidateManagementAccessExistingNodeWaiting(t *testing.T) {
 			}
 
 			node := nodes.Node{
-				Name:           host.Name,
+				Name:           host.Namespace + nameSeparator + host.Name,
 				UUID:           "uuid", // to match status in host
 				ProvisionState: string(status),
 			}
@@ -420,12 +457,12 @@ func TestValidateManagementAccessNewCredentials(t *testing.T) {
 	ironic := testserver.NewIronic(t).
 		Node(
 			nodes.Node{
-				Name: host.Name,
+				Name: host.Namespace + nameSeparator + host.Name,
 				UUID: "uuid",
 			}).
 		NodeUpdate(
 			nodes.Node{
-				Name: host.Name,
+				Name: host.Namespace + nameSeparator + host.Name,
 				UUID: "uuid",
 				DriverInfo: map[string]interface{}{
 					"test_address": "test.bmc",
@@ -472,6 +509,7 @@ func TestValidateManagementAccessLinkExistingIronicNodeByMAC(t *testing.T) {
 	}
 
 	ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).Node(existingNode).Port(existingNodePort)
+	ironic.AddDefaultResponse("/v1/nodes/myns"+nameSeparator+"myhost", "GET", http.StatusNotFound, "")
 	ironic.AddDefaultResponse("/v1/nodes/myhost", "GET", http.StatusNotFound, "")
 	ironic.AddDefaultResponse("/v1/nodes/"+existingNode.UUID, "PATCH", http.StatusOK, "{}")
 	ironic.Start()
@@ -515,6 +553,7 @@ func TestValidateManagementAccessExistingPortWithWrongUUID(t *testing.T) {
 	}
 
 	ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).Node(existingNode).Port(existingNodePort)
+	ironic.AddDefaultResponse("/v1/nodes/myns"+nameSeparator+"myhost", "GET", http.StatusNotFound, "")
 	ironic.AddDefaultResponse("/v1/nodes/myhost", "GET", http.StatusNotFound, "")
 	ironic.AddDefaultResponse("/v1/nodes/random-wrong-id", "GET", http.StatusNotFound, "")
 	ironic.Start()
@@ -558,6 +597,7 @@ func TestValidateManagementAccessExistingPortButHasName(t *testing.T) {
 	}
 
 	ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).Node(existingNode).Port(existingNodePort)
+	ironic.AddDefaultResponse("/v1/nodes/myns"+nameSeparator+"myhost", "GET", http.StatusNotFound, "")
 	ironic.AddDefaultResponse("/v1/nodes/myhost", "GET", http.StatusNotFound, "")
 	ironic.Start()
 	defer ironic.Stop()
@@ -583,7 +623,7 @@ func TestValidateManagementAccessAddTwoHostsWithSameMAC(t *testing.T) {
 
 	existingNode := nodes.Node{
 		UUID: "33ce8659-7400-4c68-9535-d10766f07a58",
-		Name: "myhost",
+		Name: "myns" + nameSeparator + "myhost",
 	}
 
 	existingNodePort := ports.Port{
@@ -628,7 +668,7 @@ func TestValidateManagementAccessUnsupportedSecureBoot(t *testing.T) {
 	host.Spec.BootMode = metal3v1alpha1.UEFISecureBoot
 	host.Status.Provisioning.ID = "" // so we don't lookup by uuid
 
-	ironic := testserver.NewIronic(t).Ready().NoNode(host.Name)
+	ironic := testserver.NewIronic(t).Ready().NoNode("myns" + nameSeparator + host.Name).NoNode(host.Name)
 	ironic.Start()
 	defer ironic.Stop()
 


### PR DESCRIPTION
Modify the hostname for ironic to prepend the namespace to the name to avoid naming conflicts. 
