### PR TITLE
Make BMH HardwareDetails fields optional

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -355,24 +355,24 @@ const (
 
 // CPU describes one processor on the host.
 type CPU struct {
-	Arch           string     `json:"arch"`
-	Model          string     `json:"model"`
-	ClockMegahertz ClockSpeed `json:"clockMegahertz"`
-	Flags          []string   `json:"flags"`
-	Count          int        `json:"count"`
+	Arch           string     `json:"arch,omitempty"`
+	Model          string     `json:"model,omitempty"`
+	ClockMegahertz ClockSpeed `json:"clockMegahertz,omitempty"`
+	Flags          []string   `json:"flags,omitempty"`
+	Count          int        `json:"count,omitempty"`
 }
 
 // Storage describes one storage device (disk, SSD, etc.) on the host.
 type Storage struct {
 	// The Linux device name of the disk, e.g. "/dev/sda". Note that this
 	// may not be stable across reboots.
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// Whether this disk represents rotational storage
-	Rotational bool `json:"rotational"`
+	Rotational bool `json:"rotational,omitempty"`
 
 	// The size of the disk in Bytes
-	SizeBytes Capacity `json:"sizeBytes"`
+	SizeBytes Capacity `json:"sizeBytes,omitempty"`
 
 	// The name of the vendor of the device
 	Vendor string `json:"vendor,omitempty"`
@@ -381,7 +381,7 @@ type Storage struct {
 	Model string `json:"model,omitempty"`
 
 	// The serial number of the device
-	SerialNumber string `json:"serialNumber"`
+	SerialNumber string `json:"serialNumber,omitempty"`
 
 	// The WWN of the device
 	WWN string `json:"wwn,omitempty"`
@@ -404,7 +404,7 @@ type VLANID int32
 
 // VLAN represents the name and ID of a VLAN
 type VLAN struct {
-	ID VLANID `json:"id"`
+	ID VLANID `json:"id,omitempty"`
 
 	Name string `json:"name,omitempty"`
 }
@@ -412,68 +412,68 @@ type VLAN struct {
 // NIC describes one network interface on the host.
 type NIC struct {
 	// The name of the network interface, e.g. "en0"
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// The vendor and product IDs of the NIC, e.g. "0x8086 0x1572"
-	Model string `json:"model"`
+	Model string `json:"model,omitempty"`
 
 	// The device MAC address
 	// +kubebuilder:validation:Pattern=`[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}`
-	MAC string `json:"mac"`
+	MAC string `json:"mac,omitempty"`
 
 	// The IP address of the interface. This will be an IPv4 or IPv6 address
 	// if one is present.  If both IPv4 and IPv6 addresses are present in a
 	// dual-stack environment, two nics will be output, one with each IP.
-	IP string `json:"ip"`
+	IP string `json:"ip,omitempty"`
 
 	// The speed of the device in Gigabits per second
-	SpeedGbps int `json:"speedGbps"`
+	SpeedGbps int `json:"speedGbps,omitempty"`
 
 	// The VLANs available
 	VLANs []VLAN `json:"vlans,omitempty"`
 
 	// The untagged VLAN ID
-	VLANID VLANID `json:"vlanId"`
+	VLANID VLANID `json:"vlanId,omitempty"`
 
 	// Whether the NIC is PXE Bootable
-	PXE bool `json:"pxe"`
+	PXE bool `json:"pxe,omitempty"`
 }
 
 // Firmware describes the firmware on the host.
 type Firmware struct {
 	// The BIOS for this firmware
-	BIOS BIOS `json:"bios"`
+	BIOS BIOS `json:"bios,omitempty"`
 }
 
 // BIOS describes the BIOS version on the host.
 type BIOS struct {
 	// The release/build date for this BIOS
-	Date string `json:"date"`
+	Date string `json:"date,omitempty"`
 
 	// The vendor name for this BIOS
-	Vendor string `json:"vendor"`
+	Vendor string `json:"vendor,omitempty"`
 
 	// The version of the BIOS
-	Version string `json:"version"`
+	Version string `json:"version,omitempty"`
 }
 
 // HardwareDetails collects all of the information about hardware
 // discovered on the host.
 type HardwareDetails struct {
-	SystemVendor HardwareSystemVendor `json:"systemVendor"`
-	Firmware     Firmware             `json:"firmware"`
-	RAMMebibytes int                  `json:"ramMebibytes"`
-	NIC          []NIC                `json:"nics"`
-	Storage      []Storage            `json:"storage"`
-	CPU          CPU                  `json:"cpu"`
-	Hostname     string               `json:"hostname"`
+	SystemVendor HardwareSystemVendor `json:"systemVendor,omitempty"`
+	Firmware     Firmware             `json:"firmware,omitempty"`
+	RAMMebibytes int                  `json:"ramMebibytes,omitempty"`
+	NIC          []NIC                `json:"nics,omitempty"`
+	Storage      []Storage            `json:"storage,omitempty"`
+	CPU          CPU                  `json:"cpu,omitempty"`
+	Hostname     string               `json:"hostname,omitempty"`
 }
 
 // HardwareSystemVendor stores details about the whole hardware system.
 type HardwareSystemVendor struct {
-	Manufacturer string `json:"manufacturer"`
-	ProductName  string `json:"productName"`
-	SerialNumber string `json:"serialNumber"`
+	Manufacturer string `json:"manufacturer,omitempty"`
+	ProductName  string `json:"productName,omitempty"`
+	SerialNumber string `json:"serialNumber,omitempty"`
 }
 
 // CredentialsStatus contains the reference and version of the last

--- a/config/crd/bases/metal3.io_baremetalhosts.yaml
+++ b/config/crd/bases/metal3.io_baremetalhosts.yaml
@@ -306,12 +306,6 @@ spec:
                         type: array
                       model:
                         type: string
-                    required:
-                    - arch
-                    - clockMegahertz
-                    - count
-                    - flags
-                    - model
                     type: object
                   firmware:
                     description: Firmware describes the firmware on the host.
@@ -328,13 +322,7 @@ spec:
                           version:
                             description: The version of the BIOS
                             type: string
-                        required:
-                        - date
-                        - vendor
-                        - version
                         type: object
-                    required:
-                    - bios
                     type: object
                   hostname:
                     type: string
@@ -380,18 +368,8 @@ spec:
                                 type: integer
                               name:
                                 type: string
-                            required:
-                            - id
                             type: object
                           type: array
-                      required:
-                      - ip
-                      - mac
-                      - model
-                      - name
-                      - pxe
-                      - speedGbps
-                      - vlanId
                       type: object
                     type: array
                   ramMebibytes:
@@ -431,11 +409,6 @@ spec:
                         wwnWithExtension:
                           description: The WWN with the extension
                           type: string
-                      required:
-                      - name
-                      - rotational
-                      - serialNumber
-                      - sizeBytes
                       type: object
                     type: array
                   systemVendor:
@@ -447,19 +420,7 @@ spec:
                         type: string
                       serialNumber:
                         type: string
-                    required:
-                    - manufacturer
-                    - productName
-                    - serialNumber
                     type: object
-                required:
-                - cpu
-                - firmware
-                - hostname
-                - nics
-                - ramMebibytes
-                - storage
-                - systemVendor
                 type: object
               hardwareProfile:
                 description: The name of the profile matching the hardware details.

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -304,12 +304,6 @@ spec:
                         type: array
                       model:
                         type: string
-                    required:
-                    - arch
-                    - clockMegahertz
-                    - count
-                    - flags
-                    - model
                     type: object
                   firmware:
                     description: Firmware describes the firmware on the host.
@@ -326,13 +320,7 @@ spec:
                           version:
                             description: The version of the BIOS
                             type: string
-                        required:
-                        - date
-                        - vendor
-                        - version
                         type: object
-                    required:
-                    - bios
                     type: object
                   hostname:
                     type: string
@@ -378,18 +366,8 @@ spec:
                                 type: integer
                               name:
                                 type: string
-                            required:
-                            - id
                             type: object
                           type: array
-                      required:
-                      - ip
-                      - mac
-                      - model
-                      - name
-                      - pxe
-                      - speedGbps
-                      - vlanId
                       type: object
                     type: array
                   ramMebibytes:
@@ -429,11 +407,6 @@ spec:
                         wwnWithExtension:
                           description: The WWN with the extension
                           type: string
-                      required:
-                      - name
-                      - rotational
-                      - serialNumber
-                      - sizeBytes
                       type: object
                     type: array
                   systemVendor:
@@ -445,19 +418,7 @@ spec:
                         type: string
                       serialNumber:
                         type: string
-                    required:
-                    - manufacturer
-                    - productName
-                    - serialNumber
                     type: object
-                required:
-                - cpu
-                - firmware
-                - hostname
-                - nics
-                - ramMebibytes
-                - storage
-                - systemVendor
                 type: object
               hardwareProfile:
                 description: The name of the profile matching the hardware details.


### PR DESCRIPTION
Currently we force the status annotation to provide every
field, but when #796 lands it may be preferable to allow
a subset, so it's possible to set only a subset of the
hardware status fields when inspection is disabled.