### PR TITLE
Add support for using pre-configured boot settings

### DIFF
--- a/pkg/bmc/ipmi_noop.go
+++ b/pkg/bmc/ipmi_noop.go
@@ -1,0 +1,98 @@
+package bmc
+
+import (
+	"net/url"
+)
+
+func init() {
+	RegisterFactory("ipmi-noop", newIPMINoopAccessDetails, []string{})
+	RegisterFactory("libvirt-noop", newIPMINoopAccessDetails, []string{})
+}
+
+func newIPMINoopAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+	return &ipmiNoopAccessDetails{
+		bmcType:                        parsedURL.Scheme,
+		portNum:                        parsedURL.Port(),
+		hostname:                       parsedURL.Hostname(),
+		disableCertificateVerification: disableCertificateVerification,
+	}, nil
+}
+
+type ipmiNoopAccessDetails struct {
+	bmcType                        string
+	portNum                        string
+	hostname                       string
+	disableCertificateVerification bool
+}
+
+const ipmiDefaultPort = "623"
+
+func (a *ipmiNoopAccessDetails) Type() string {
+	return a.bmcType
+}
+
+// NeedsMAC returns true when the host is going to need a separate
+// port created rather than having it discovered.
+func (a *ipmiNoopAccessDetails) NeedsMAC() bool {
+	// libvirt-based hosts used for dev and testing require a MAC
+	// address, specified as part of the host, but we don't want the
+	// provisioner to have to know the rules about which drivers
+	// require what so we hide that detail inside this class and just
+	// let the provisioner know that "some" drivers require a MAC and
+	// it should ask.
+	return a.bmcType == "libvirt"
+}
+
+func (a *ipmiNoopAccessDetails) Driver() string {
+	return "ipmi"
+}
+
+func (a *ipmiNoopAccessDetails) DisableCertificateVerification() bool {
+	return a.disableCertificateVerification
+}
+
+// DriverInfo returns a data structure to pass as the DriverInfo
+// parameter when creating a node in Ironic. The structure is
+// pre-populated with the access information, and the caller is
+// expected to add any other information that might be needed (such as
+// the kernel and ramdisk locations).
+func (a *ipmiNoopAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interface{} {
+	result := map[string]interface{}{
+		"ipmi_port":     a.portNum,
+		"ipmi_username": bmcCreds.Username,
+		"ipmi_password": bmcCreds.Password,
+		"ipmi_address":  a.hostname,
+	}
+
+	if a.disableCertificateVerification {
+		result["ipmi_verify_ca"] = false
+	}
+	if a.portNum == "" {
+		result["ipmi_port"] = ipmiDefaultPort
+	}
+	return result
+}
+
+func (a *ipmiNoopAccessDetails) BootInterface() string {
+	return "ipxe"
+}
+
+func (a *ipmiNoopAccessDetails) ManagementInterface() string {
+	return "noop"
+}
+
+func (a *ipmiNoopAccessDetails) PowerInterface() string {
+	return ""
+}
+
+func (a *ipmiNoopAccessDetails) RAIDInterface() string {
+	return ""
+}
+
+func (a *ipmiNoopAccessDetails) VendorInterface() string {
+	return ""
+}
+
+func (a *ipmiNoopAccessDetails) SupportsSecureBoot() bool {
+	return false
+}

--- a/pkg/bmc/redfish_noop.go
+++ b/pkg/bmc/redfish_noop.go
@@ -1,0 +1,112 @@
+package bmc
+
+import (
+	"net/url"
+	"strings"
+)
+
+func init() {
+	schemes := []string{"http", "https"}
+	RegisterFactory("redfish-noop", newRedfishNoopAccessDetails, schemes)
+	RegisterFactory("ilo5-redfish-noop", newRedfishNoopAccessDetails, schemes)
+}
+
+func redfishNoopDetails(parsedURL *url.URL, disableCertificateVerification bool) *redfishAccessDetails {
+	return &redfishAccessDetails{
+		bmcType:                        parsedURL.Scheme,
+		host:                           parsedURL.Host,
+		path:                           parsedURL.Path,
+		disableCertificateVerification: disableCertificateVerification,
+	}
+}
+
+func newRedfishNoopAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+	return redfishDetails(parsedURL, disableCertificateVerification), nil
+}
+
+type redfishNoopAccessDetails struct {
+	bmcType                        string
+	host                           string
+	path                           string
+	disableCertificateVerification bool
+}
+
+const redfishNoopDefaultScheme = "https"
+
+func (a *redfishNoopAccessDetails) Type() string {
+	return a.bmcType
+}
+
+// NeedsMAC returns true when the host is going to need a separate
+// port created rather than having it discovered.
+func (a *redfishNoopAccessDetails) NeedsMAC() bool {
+	// For the inspection to work, we need a MAC address
+	// https://github.com/metal3-io/baremetal-operator/pull/284#discussion_r317579040
+	return true
+}
+
+func (a *redfishNoopAccessDetails) Driver() string {
+	return "redfish"
+}
+
+func (a *redfishNoopAccessDetails) DisableCertificateVerification() bool {
+	return a.disableCertificateVerification
+}
+
+func getRedfishNoopAddress(bmcType, host string) string {
+	redfishAddress := []string{}
+	schemes := strings.Split(bmcType, "+")
+	if len(schemes) > 1 {
+		redfishAddress = append(redfishAddress, schemes[1])
+	} else {
+		redfishAddress = append(redfishAddress, redfishDefaultScheme)
+	}
+	redfishAddress = append(redfishAddress, "://")
+	redfishAddress = append(redfishAddress, host)
+	return strings.Join(redfishAddress, "")
+}
+
+// DriverInfo returns a data structure to pass as the DriverInfo
+// parameter when creating a node in Ironic. The structure is
+// pre-populated with the access information, and the caller is
+// expected to add any other information that might be needed (such as
+// the kernel and ramdisk locations).
+func (a *redfishNoopAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interface{} {
+	result := map[string]interface{}{
+		"redfish_system_id": a.path,
+		"redfish_username":  bmcCreds.Username,
+		"redfish_password":  bmcCreds.Password,
+		"redfish_address":   getRedfishAddress(a.bmcType, a.host),
+	}
+
+	if a.disableCertificateVerification {
+		result["redfish_verify_ca"] = false
+	}
+
+	return result
+}
+
+// That can be either pxe or redfish-virtual-media
+func (a *redfishNoopAccessDetails) BootInterface() string {
+	return "ipxe"
+}
+
+func (a *redfishNoopAccessDetails) ManagementInterface() string {
+	return "noop"
+}
+
+func (a *redfishNoopAccessDetails) PowerInterface() string {
+	return ""
+}
+
+func (a *redfishNoopAccessDetails) RAIDInterface() string {
+	return ""
+}
+
+func (a *redfishNoopAccessDetails) VendorInterface() string {
+	return ""
+}
+
+func (a *redfishNoopAccessDetails) SupportsSecureBoot() bool {
+	return true
+}


### PR DESCRIPTION
This change adds support for using Ironic noop management_interface in Metal3
by adding new BMC types: redfish-noop:// and ipmi-noop://.
This is a useful feature while running Metal3 on hardware with issues around
boot settings management, or in cases where the operator requires a very
specific boot configuration.