### PR TITLE
Add a new field to bmh.Status "ProvisionCount"

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -643,6 +643,10 @@ type BareMetalHostStatus struct {
 	// ErrorCount records how many times the host has encoutered an error since the last successful operation
 	// +kubebuilder:default:=0
 	ErrorCount int `json:"errorCount"`
+
+	// ProvisionCount records how many times the host has been provisioned.
+	// +kubebuilder:default:=0
+	ProvisionCount int `json:"provisionCount"`
 }
 
 // ProvisionStatus holds the state information for a single target.

--- a/config/crd/bases/metal3.io_baremetalhosts.yaml
+++ b/config/crd/bases/metal3.io_baremetalhosts.yaml
@@ -593,6 +593,10 @@ spec:
               poweredOn:
                 description: indicator for whether or not the host is powered on
                 type: boolean
+              provisionCount:
+                default: 0
+                description: ProvisionCount records how many times the host has been provisioned.
+                type: integer
               provisioning:
                 description: Information tracked by the provisioner.
                 properties:
@@ -798,6 +802,7 @@ spec:
             - hardwareProfile
             - operationalStatus
             - poweredOn
+            - provisionCount
             - provisioning
             type: object
         type: object

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -591,6 +591,10 @@ spec:
               poweredOn:
                 description: indicator for whether or not the host is powered on
                 type: boolean
+              provisionCount:
+                default: 0
+                description: ProvisionCount records how many times the host has been provisioned.
+                type: integer
               provisioning:
                 description: Information tracked by the provisioner.
                 properties:
@@ -796,6 +800,7 @@ spec:
             - hardwareProfile
             - operationalStatus
             - poweredOn
+            - provisionCount
             - provisioning
             type: object
         type: object

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -709,6 +709,7 @@ func (r *BareMetalHostReconciler) actionProvisioning(prov provisioner.Provisione
 		return actionContinue{}
 	}
 
+	info.host.Status.ProvisionCount++
 	provResult, err := prov.Provision(hostConf)
 	if err != nil {
 		return actionError{errors.Wrap(err, "failed to provision")}

--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -1035,6 +1035,8 @@ func TestProvision(t *testing.T) {
 	host.Spec.Online = true
 	r := newTestReconciler(host)
 
+	assert.Equal(t, 0, host.Status.ProvisionCount)
+
 	tryReconcile(t, r, host,
 		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
 			t.Logf("image details: %v", host.Spec.Image)
@@ -1046,6 +1048,7 @@ func TestProvision(t *testing.T) {
 			return false
 		},
 	)
+	assert.Equal(t, 1, host.Status.ProvisionCount)
 }
 
 // TestExternallyProvisionedTransitions ensures that host enters the


### PR DESCRIPTION
This is to show how many times we’ve tried to provision a host.