### PR TITLE
Attempt to hard power off node before it is deleted

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -52,6 +52,10 @@ const (
 	rebootAnnotationPrefix        = "reboot.metal3.io"
 	inspectAnnotationPrefix       = "inspect.metal3.io"
 	hardwareDetailsAnnotation     = inspectAnnotationPrefix + "/hardwaredetails"
+
+	// Maximum number of times node Power off would be retried before
+	// it would be deleted.
+	maxPowerOffRetryCount = 3
 )
 
 // BareMetalHostReconciler reconciles a BareMetalHost object
@@ -483,7 +487,7 @@ func (r *BareMetalHostReconciler) actionDeleting(prov provisioner.Provisioner, i
 		return deleteComplete{}
 	}
 
-	provResult, err := prov.Delete()
+	provResult, err := prov.Delete(info.host.Status.ErrorCount <= maxPowerOffRetryCount)
 	if err != nil {
 		return actionError{errors.Wrap(err, "failed to delete")}
 	}

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -490,6 +490,9 @@ func (r *BareMetalHostReconciler) actionDeleting(prov provisioner.Provisioner, i
 	if provResult.Dirty {
 		return actionContinue{provResult.RequeueAfter}
 	}
+	if provResult.ErrorMessage != "" {
+		return recordActionFailure(info, metal3v1alpha1.PowerManagementError, provResult.ErrorMessage)
+	}
 
 	// Remove finalizer to allow deletion
 	info.host.Finalizers = utils.FilterStringFromList(

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -643,7 +643,7 @@ func (m *mockProvisioner) Deprovision(force bool) (result provisioner.Result, er
 	return m.getNextResultByMethod("Deprovision"), err
 }
 
-func (m *mockProvisioner) Delete() (result provisioner.Result, err error) {
+func (m *mockProvisioner) Delete(retryPowerOff bool) (result provisioner.Result, err error) {
 	return m.getNextResultByMethod("Delete"), err
 }
 

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -288,7 +288,7 @@ func (p *demoProvisioner) Deprovision(force bool) (result provisioner.Result, er
 // Delete removes the host from the provisioning system. It may be
 // called multiple times, and should return true for its dirty flag
 // until the deprovisioning operation is completed.
-func (p *demoProvisioner) Delete() (result provisioner.Result, err error) {
+func (p *demoProvisioner) Delete(retryPowerOff bool) (result provisioner.Result, err error) {
 	p.log.Info("deleting host")
 	return result, nil
 }

--- a/pkg/provisioner/empty/empty.go
+++ b/pkg/provisioner/empty/empty.go
@@ -68,7 +68,7 @@ func (p *emptyProvisioner) Deprovision(force bool) (provisioner.Result, error) {
 // Delete removes the host from the provisioning system. It may be
 // called multiple times, and should return true for its dirty flag
 // until the deprovisioning operation is completed.
-func (p *emptyProvisioner) Delete() (provisioner.Result, error) {
+func (p *emptyProvisioner) Delete(retryPowerOff bool) (provisioner.Result, error) {
 	return provisioner.Result{}, nil
 }
 

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -241,7 +241,7 @@ func (p *fixtureProvisioner) Deprovision(force bool) (result provisioner.Result,
 // Delete removes the host from the provisioning system. It may be
 // called multiple times, and should return true for its dirty flag
 // until the deprovisioning operation is completed.
-func (p *fixtureProvisioner) Delete() (result provisioner.Result, err error) {
+func (p *fixtureProvisioner) Delete(retryPowerOff bool) (result provisioner.Result, err error) {
 	p.log.Info("deleting host")
 
 	if !p.state.Deleted {

--- a/pkg/provisioner/ironic/delete_test.go
+++ b/pkg/provisioner/ironic/delete_test.go
@@ -143,6 +143,19 @@ func TestDelete(t *testing.T) {
 				Value: true,
 			},
 		},
+		{
+			name: "power-change-with-locked-host",
+			ironic: testserver.NewIronic(t).Node(
+				nodes.Node{
+					UUID:           nodeUUID,
+					ProvisionState: "active",
+					Maintenance:    true,
+					PowerState:     powerOn,
+				},
+			).WithNodeStatesPower(nodeUUID, http.StatusConflict).WithNodeStatesPowerUpdate(nodeUUID, http.StatusConflict),
+			expectedDirty:        false,
+			expectedRequestAfter: 0,
+		},
 	}
 
 	for _, tc := range cases {
@@ -205,7 +218,7 @@ func TestDeleteWithPowerOff(t *testing.T) {
 		expectedError               string
 	}{
 		{
-			name: "test-power-change-without-force",
+			name: "power-change-without-retry",
 			ironic: testserver.NewIronic(t).Node(
 				nodes.Node{
 					UUID:           nodeUUID,
@@ -219,7 +232,7 @@ func TestDeleteWithPowerOff(t *testing.T) {
 			expectedError:               "",
 		},
 		{
-			name: "test-power-change-with-force",
+			name: "power-change-with-retry",
 			ironic: testserver.NewIronic(t).Node(
 				nodes.Node{
 					UUID:           nodeUUID,

--- a/pkg/provisioner/ironic/power_test.go
+++ b/pkg/provisioner/ironic/power_test.go
@@ -72,8 +72,9 @@ func TestPowerOn(t *testing.T) {
 				TargetProvisionState: "",
 				UUID:                 nodeUUID,
 			}).WithNodeStatesPower(nodeUUID, http.StatusConflict).WithNodeStatesPowerUpdate(nodeUUID, http.StatusConflict),
-			expectedRequestAfter: 10,
-			expectedDirty:        true,
+			expectedRequestAfter: 0,
+			expectedDirty:        false,
+			expectedError:        true,
 		},
 	}
 
@@ -184,8 +185,9 @@ func TestPowerOff(t *testing.T) {
 				TargetProvisionState: "",
 				UUID:                 nodeUUID,
 			}).WithNodeStatesPower(nodeUUID, http.StatusConflict).WithNodeStatesPowerUpdate(nodeUUID, http.StatusConflict),
-			expectedRequestAfter: 10,
-			expectedDirty:        true,
+			expectedRequestAfter: 0,
+			expectedDirty:        false,
+			expectedError:        true,
 		},
 	}
 

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -77,7 +77,7 @@ type Provisioner interface {
 	// Delete removes the host from the provisioning system. It may be
 	// called multiple times, and should return true for its dirty
 	// flag until the deletion operation is completed.
-	Delete() (result Result, err error)
+	Delete(retryPowerOff bool) (result Result, err error)
 
 	// PowerOn ensures the server is powered on independently of any image
 	// provisioning operation.


### PR DESCRIPTION
When a BareMetalHost is deleted, power it off before performing
the delete operation.
Fixes #410