### PR TITLE
Allocate Ironic port when node exists and has no port allocated.

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -287,10 +287,6 @@ func (p *ironicProvisioner) listAllPorts(address string) ([]ports.Port, error) {
 
 	pager := ports.List(p.client, opts)
 
-	if pager.Err != nil {
-		return allPorts, pager.Err
-	}
-
 	allPages, err := pager.AllPages()
 
 	if err != nil {
@@ -329,9 +325,6 @@ func (p *ironicProvisioner) nodeHasAssignedPort(ironicNode *nodes.Node) (bool, e
 	}
 
 	pager := ports.List(p.client, opts)
-	if pager.Err != nil {
-		return false, errors.Wrap(pager.Err, "failed to list ports")
-	}
 
 	allPages, err := pager.AllPages()
 	if err != nil {
@@ -1696,9 +1689,6 @@ func (p *ironicProvisioner) loadBusyHosts() (hosts map[string]struct{}, err erro
 	pager := nodes.List(p.client, nodes.ListOpts{
 		Fields: []string{"uuid,name,provision_state,driver_internal_info,target_provision_state"},
 	})
-	if pager.Err != nil {
-		return nil, pager.Err
-	}
 
 	page, err := pager.AllPages()
 	if err != nil {


### PR DESCRIPTION
This PR fixes issues below:

 - While node is created in Ironic DB and some misfortune happens to Ironic pod or DB pod, Ironic does not allocate port created node, this in turn breaks inspection with Ironic erroring on absence of allocated port, operator does not handle this case and stuck in erroring reconcile loop until back-off timer is triggered.
 
When node has no allocated port to it, Ironic returns this error
```
No lookup attributes were found, inspector won't be able to find it after introspection, consider creating ironic ports or providing an IPMI address
```

_IPMI address part is just wrong, BMC creds are checked in Registering state and are validated, also they where validated manually just in case._

After checking sources that return this error in: https://github.com/openstack/ironic-inspector/blob/stable/victoria/ironic_inspector/introspect.py#L102-L119
We can clearly see that this error is indeed because of not allocated port to node (no MAC), this also is verified by this unix pipe magic for specified host.

```
kubectl get bmh worker-1 -o jsonpath='{.spec.bootMACAddress}' | xargs -rI{} --verbose openstack baremetal port show --address '{}' -f value --fields node_uuid | xargs -rI{} --verbose openstack baremetal node show {} -f value --fields name
```

 