### PR TITLE
Bug: fix missing Inspecting state

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -709,7 +709,7 @@ func (p *ironicProvisioner) InspectHardware(force bool) (result provisioner.Resu
 		result, err = operationFailed(status.Error)
 		return
 	}
-	if !status.Finished || nodes.ProvisionState(ironicNode.ProvisionState) == nodes.InspectWait {
+	if !status.Finished || (nodes.ProvisionState(ironicNode.ProvisionState) == nodes.Inspecting || nodes.ProvisionState(ironicNode.ProvisionState) == nodes.InspectWait) {
 		p.log.Info("inspection in progress", "started_at", status.StartedAt)
 		result, err = operationContinuing(introspectionRequeueDelay)
 		return


### PR DESCRIPTION
We are missing ironic node Inspecting state in this particular place. This was initially done in https://github.com/metal3-io/baremetal-operator/pull/607 but it was suggested by @dtantsur to have this fix separately so that it can be also bakcported in OpenShift BMO older versions. 