### PR TITLE
Decouple Unmanaged state from externallyProvisioned

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,7 +121,7 @@ func main() {
 	}
 
 	provisionerFactory := func(host metal3iov1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publish provisioner.EventPublisher) (provisioner.Provisioner, error) {
-		isUnmanaged := host.Spec.ExternallyProvisioned && !host.HasBMCDetails()
+		isUnmanaged := !host.HasBMCDetails()
 
 		hostCopy := host.DeepCopy()
 


### PR DESCRIPTION
Any host which lacks BMC details should reach the Unmanaged
state regardless of whether it is externally provisioned or not.

Currently in this case we encounter an error creating the ironic
provisioner, because it expects BMC details to exist:

```
2021-03-22T18:15:46.443Z	ERROR	controller-runtime.manager.controller.baremetalhost	Reconciler error	{"reconciler group": "metal3.io", "reconciler kind": "BareMetalHost", "name": "ostest-worker-2", "namespace": "openshift-machine-api", "error": "failed to create provisioner: failed to parse BMC address information: missing BMC address", "errorVerbose": "missing BMC address\ngithub.com/metal3-io/baremetal-operator/pkg/bmc.NewAccessDetails\n\t/home/shardy/baremetal-operator/pkg/bmc/access.go:116\ngithub.com/metal3-io/baremetal-operator/pkg/provisioner/ironic.newProvisionerWithIronicClients\n\t/home/shardy/baremetal-operator/pkg/provisioner/ironic/ironic.go:186\ngithub.com/metal3-io/baremetal-operator/pkg/provisioner/ironic.New\n\t/home/shardy/baremetal-operator/pkg/provisioner/ironic/ironic.go:229\nmain.main.func1\n\t/home/shardy/baremetal-operator/main.go:140\ngithub.com/metal3-io/baremetal-operator/controllers/metal3%2eio.(*BareMetalHostReconciler).Reconcile
...
```

With this change we see the expected state:

```
2021-03-22T18:20:42.036Z	INFO	controllers.BareMetalHost	changing provisioning state	{"baremetalhost": "openshift-machine-api/ostest-worker-2", "provisioningState": "", "old": "", "new": "unmanaged"}
2021-03-22T18:20:42.036Z	INFO	controllers.BareMetalHost	saving host status	{"baremetalhost": "openshift-machine-api/ostest-worker-2", "provisioningState": "", "operational status": "discovered", "provisioning state": "unmanaged"}
2021-03-22T18:20:42.046Z	INFO	controllers.BareMetalHost	publishing event	{"baremetalhost": "openshift-machine-api/ostest-worker-2", "reason": "Discovered", "message": "Discovered host with no BMC details"}
```