### PR TITLE
Enable golint with golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ run:
 linters:
   disable-all: true
   enable: [
+    "golint",
     "govet",
     "goimports",
     "gofmt",

--- a/Makefile
+++ b/Makefile
@@ -81,12 +81,6 @@ unit-verbose: ## Run unit tests with verbose output
 .PHONY: linters
 linters: lint generate-check fmt-check
 
-.PHONY: sec
-sec: lint
-
-.PHONY: fmt
-fmt: lint
-
 .PHONY: vet
 vet: lint
 
@@ -118,7 +112,7 @@ demo: generate lint manifests ## Run in demo mode
 	go run -ldflags $(LDFLAGS) ./main.go -namespace=$(RUN_NAMESPACE) -dev -demo-mode
 
 .PHONY: run-test-mode
-run-test-mode: generate fmt vet manifests ## Run against the configured Kubernetes cluster in ~/.kube/config
+run-test-mode: generate fmt-check lint manifests ## Run against the configured Kubernetes cluster in ~/.kube/config
 	go run -ldflags $(LDFLAGS) ./main.go -namespace=$(RUN_NAMESPACE) -dev -test-mode
 
 .PHONY: install

--- a/controllers/metal3.io/action_result.go
+++ b/controllers/metal3.io/action_result.go
@@ -113,7 +113,7 @@ func (r actionError) Dirty() bool {
 }
 
 func (r actionError) NeedsRegistration() bool {
-	return errors.Is(r.err, provisioner.NeedsRegistration)
+	return errors.Is(r.err, provisioner.ErrNeedsRegistration)
 }
 
 // actionFailed is a result indicating that the current action has failed,

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -77,7 +77,7 @@ func New(hostData provisioner.HostData, publisher provisioner.EventPublisher) (p
 	return p, nil
 }
 
-func (m *demoProvisioner) HasCapacity() (result bool, err error) {
+func (p *demoProvisioner) HasCapacity() (result bool, err error) {
 	return true, nil
 }
 

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -303,7 +303,7 @@ func (p *ironicProvisioner) listAllPorts(address string) ([]ports.Port, error) {
 
 func (p *ironicProvisioner) getNode() (*nodes.Node, error) {
 	if p.nodeID == "" {
-		return nil, provisioner.NeedsRegistration
+		return nil, provisioner.ErrNeedsRegistration
 	}
 
 	ironicNode, err := nodes.Get(p.client, p.nodeID).Extract()
@@ -314,7 +314,7 @@ func (p *ironicProvisioner) getNode() (*nodes.Node, error) {
 	case gophercloud.ErrDefault404:
 		// Look by ID failed, trying to lookup by hostname in case it was
 		// previously created
-		return nil, provisioner.NeedsRegistration
+		return nil, provisioner.ErrNeedsRegistration
 	default:
 		return nil, errors.Wrap(err,
 			fmt.Sprintf("failed to find node by ID %s", p.nodeID))
@@ -325,7 +325,7 @@ func (p *ironicProvisioner) getNode() (*nodes.Node, error) {
 func (p *ironicProvisioner) findExistingHost(bootMACAddress string) (ironicNode *nodes.Node, err error) {
 	// Try to load the node by UUID
 	ironicNode, err = p.getNode()
-	if !errors.Is(err, provisioner.NeedsRegistration) {
+	if !errors.Is(err, provisioner.ErrNeedsRegistration) {
 		return
 	}
 
@@ -1609,7 +1609,7 @@ func (p *ironicProvisioner) Deprovision(force bool) (result provisioner.Result, 
 func (p *ironicProvisioner) Delete() (result provisioner.Result, err error) {
 	ironicNode, err := p.getNode()
 	if err != nil {
-		if errors.Is(err, provisioner.NeedsRegistration) {
+		if errors.Is(err, provisioner.ErrNeedsRegistration) {
 			p.log.Info("no node found, already deleted")
 			return operationComplete()
 		}

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -173,4 +173,5 @@ type HardwareState struct {
 	PoweredOn *bool
 }
 
-var NeedsRegistration = errors.New("Host not registered")
+// ErrNeedsRegistration raised if the host is not registered
+var ErrNeedsRegistration = errors.New("Host not registered")


### PR DESCRIPTION
Most linters are disabled by default when using golangci-lint, we need
to explicitely enable them if we want them to run.
This change enables the basic golint support.
For more info please check https://golangci-lint.run/usage/quick-start