### PR TITLE
Handle hardwaredetails annotation value error

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -274,7 +274,7 @@ func (r *BareMetalHostReconciler) updateHardwareDetails(request ctrl.Request, ho
 	if host.Status.HardwareDetails == nil || inspectionDisabled(host) {
 		objHardwareDetails, err := r.getHardwareDetailsFromAnnotation(host)
 		if err != nil {
-			return updated, errors.Wrap(err, "Error getting HardwareDetails from annotation")
+			return updated, errors.Wrap(err, "Error parsing HardwareDetails from annotation")
 		}
 		if objHardwareDetails != nil {
 			host.Status.HardwareDetails = objHardwareDetails
@@ -1038,9 +1038,10 @@ func (r *BareMetalHostReconciler) getHardwareDetailsFromAnnotation(host *metal3v
 	if annotations[hardwareDetailsAnnotation] == "" {
 		return nil, nil
 	}
-	content := []byte(annotations[hardwareDetailsAnnotation])
 	objHardwareDetails := &metal3v1alpha1.HardwareDetails{}
-	if err := json.Unmarshal(content, objHardwareDetails); err != nil {
+	decoder := json.NewDecoder(strings.NewReader(annotations[hardwareDetailsAnnotation]))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(objHardwareDetails); err != nil {
 		return nil, err
 	}
 	return objHardwareDetails, nil

--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -267,6 +267,28 @@ func TestHardwareDetails_StatusPresentInspectDisabled(t *testing.T) {
 	)
 }
 
+// TestHardwareDetails_Invalid
+// Tests scenario where the hardwaredetails value is invalid
+func TestHardwareDetails_Invalid(t *testing.T) {
+	host := newDefaultHost(t)
+	badAnnotation := fmt.Sprintf("{\"hardware\": %s}", hwdAnnotation)
+	host.Annotations = map[string]string{
+		inspectAnnotationPrefix:   "disabled",
+		hardwareDetailsAnnotation: badAnnotation,
+	}
+	time := metav1.Now()
+	host.Status.LastUpdated = &time
+	hwd := metal3v1alpha1.HardwareDetails{}
+	hwd.Hostname = "existinghost"
+	host.Status.HardwareDetails = &hwd
+
+	r := newTestReconciler(host)
+	request := newRequest(host)
+	_, err := r.Reconcile(context.Background(), request)
+	expectedErr := "json: unknown field"
+	assert.Contains(t, err.Error(), expectedErr)
+}
+
 // TestStatusAnnotation_EmptyStatus ensures that status is manually populated
 // when status annotation is present and status field is empty.
 func TestStatusAnnotation_EmptyStatus(t *testing.T) {


### PR DESCRIPTION
Currently we only handle the case where the json fails to parse
e.g is invalid json, but we silently ignore any value which is
valid data but fails to unpack into the HardwareDetails object.

In this case we should avoid removing the annotation since it's
not been copied into the status.hardware, and return an error
so the user can detect that the json data wasn't in the expected
format.