### PR TITLE
Add a unit test for unsupported secure boot

### DIFF
--- a/pkg/provisioner/ironic/validatemanagementaccess_test.go
+++ b/pkg/provisioner/ironic/validatemanagementaccess_test.go
@@ -620,3 +620,29 @@ func TestValidateManagementAccessAddTwoHostsWithSameMAC(t *testing.T) {
 	assert.Equal(t, "", result.ErrorMessage)
 	assert.NotEqual(t, "", provID)
 }
+
+func TestValidateManagementAccessUnsupportedSecureBoot(t *testing.T) {
+	// Create a host without a bootMACAddress and with a BMC that
+	// requires one.
+	host := makeHost()
+	host.Spec.BootMode = metal3v1alpha1.UEFISecureBoot
+	host.Status.Provisioning.ID = "" // so we don't lookup by uuid
+
+	ironic := testserver.NewIronic(t).Ready().NoNode(host.Name)
+	ironic.Start()
+	defer ironic.Stop()
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nil,
+		ironic.Endpoint(), auth, testserver.NewInspector(t).Endpoint(), auth,
+	)
+	if err != nil {
+		t.Fatalf("could not create provisioner: %s", err)
+	}
+
+	result, _, err := prov.ValidateManagementAccess(false, false)
+	if err != nil {
+		t.Fatalf("error from ValidateManagementAccess: %s", err)
+	}
+	assert.Contains(t, result.ErrorMessage, "does not support secure boot")
+}


### PR DESCRIPTION
Follow-up to https://github.com/metal3-io/baremetal-operator/pull/786