### PR TITLE
Pass go tests flags via env.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 RUN_NAMESPACE = metal3
-GO_TEST_FLAGS = $(VERBOSE)
+GO_TEST_FLAGS = $(TEST_FLAGS)
 DEBUG = --debug
 COVER_PROFILE = cover.out
 
@@ -63,7 +63,7 @@ test: generate lint manifests unit ## Run common developer tests
 
 .PHONY: unit
 unit: ## Run unit tests
-	go test ./... $(VERBOSE) -coverprofile $(COVER_PROFILE)
+	go test ./... $(GO_TEST_FLAGS) -coverprofile $(COVER_PROFILE)
 
 .PHONY: unit-cover
 unit-cover: ## Run unit tests with code coverage
@@ -72,7 +72,7 @@ unit-cover: ## Run unit tests with code coverage
 
 .PHONY: unit-verbose
 unit-verbose: ## Run unit tests with verbose output
-	VERBOSE=-v make unit
+	TEST_FLAGS=-v make unit
 
 ## --------------------------------------
 ## Linter Targets

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -5,20 +5,21 @@ set -eux
 IS_CONTAINER=${IS_CONTAINER:-false}
 ARTIFACTS=${ARTIFACTS:-/tmp}
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+TEST_FLAGS="${TEST_FLAGS:--v}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
   eval "$(go env)"
   cd "${GOPATH}"/src/github.com/metal3-io/baremetal-operator
   export XDG_CACHE_HOME="/tmp/.cache"
 
-  export VERBOSE=-v
   export COVER_PROFILE="${ARTIFACTS}"/cover.out
 
-  make -e unit-cover
+  TEST_FLAGS=${TEST_FLAGS} make -e unit-cover
 
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
+    --env TEST_FLAGS="${TEST_FLAGS}" \
     --env DEPLOY_KERNEL_URL=http://172.22.0.1/images/ironic-python-agent.kernel \
     --env DEPLOY_RAMDISK_URL=http://172.22.0.1/images/ironic-python-agent.initramfs \
     --env IRONIC_ENDPOINT=http://localhost:6385/v1/ \


### PR DESCRIPTION
To make local development more convenient this PR add ability to pass go test flags via envars directly to unit-tests that are started in docker/podman instance.

So effectively one could use something like this:
```
CONTAINER_RUNTIME=docker TEST_FLAGS="-failfast" ./hack/unit.sh
```

Setting `failfast` flag and removing verbose output is super-helpful on local dev environment when screen is small (less to scroll) and CPU/MEM resources are limited, so running all tests takes some time.

(mainly this is scroll issue actually, but could also be helpful in other cases) 

Signed-off-by: s3rj1k <evasive.gyron@gmail.com>