### PR TITLE
Extend RAID configuration for iDRAC BMC type

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -94,6 +94,7 @@ func (r *BareMetalHostReconciler) Reconcile(ctx context.Context, request ctrl.Re
 	}()
 
 	reqLogger := r.Log.WithValues("baremetalhost", request.NamespacedName)
+	reqLogger.Info("start")
 
 	// Fetch the BareMetalHost
 	host := &metal3v1alpha1.BareMetalHost{}

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -450,7 +450,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "ipxe",
 			management: "",
 			power:      "",
-			raid:       "",
+			raid:       "no-raid",
 			vendor:     "",
 		},
 
@@ -462,7 +462,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "ipxe",
 			management: "",
 			power:      "",
-			raid:       "",
+			raid:       "no-raid",
 			vendor:     "",
 		},
 
@@ -474,7 +474,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "ipxe",
 			management: "",
 			power:      "",
-			raid:       "",
+			raid:       "no-raid",
 			vendor:     "",
 		},
 
@@ -498,7 +498,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "ipxe",
 			management: "",
 			power:      "",
-			raid:       "",
+			raid:       "no-raid",
 			vendor:     "",
 		},
 
@@ -510,7 +510,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "redfish-virtual-media",
 			management: "",
 			power:      "",
-			raid:       "",
+			raid:       "no-raid",
 			vendor:     "",
 		},
 
@@ -522,7 +522,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "redfish-virtual-media",
 			management: "",
 			power:      "",
-			raid:       "",
+			raid:       "no-raid",
 			vendor:     "",
 		},
 
@@ -534,7 +534,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "redfish-virtual-media",
 			management: "",
 			power:      "",
-			raid:       "",
+			raid:       "no-raid",
 			vendor:     "",
 		},
 
@@ -630,7 +630,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "ilo-ipxe",
 			management: "",
 			power:      "",
-			raid:       "",
+			raid:       "no-raid",
 			vendor:     "",
 		},
 

--- a/pkg/bmc/ibmc.go
+++ b/pkg/bmc/ibmc.go
@@ -91,7 +91,7 @@ func (a *ibmcAccessDetails) PowerInterface() string {
 }
 
 func (a *ibmcAccessDetails) RAIDInterface() string {
-	return ""
+	return "no-raid"
 }
 
 func (a *ibmcAccessDetails) VendorInterface() string {

--- a/pkg/bmc/idrac.go
+++ b/pkg/bmc/idrac.go
@@ -87,7 +87,7 @@ func (a *iDracAccessDetails) PowerInterface() string {
 }
 
 func (a *iDracAccessDetails) RAIDInterface() string {
-	return ""
+	return "no-raid"
 }
 
 func (a *iDracAccessDetails) VendorInterface() string {

--- a/pkg/bmc/idrac.go
+++ b/pkg/bmc/idrac.go
@@ -87,7 +87,7 @@ func (a *iDracAccessDetails) PowerInterface() string {
 }
 
 func (a *iDracAccessDetails) RAIDInterface() string {
-	return "no-raid"
+	return "idrac-wsman"
 }
 
 func (a *iDracAccessDetails) VendorInterface() string {

--- a/pkg/bmc/ilo4.go
+++ b/pkg/bmc/ilo4.go
@@ -83,7 +83,7 @@ func (a *iLOAccessDetails) PowerInterface() string {
 }
 
 func (a *iLOAccessDetails) RAIDInterface() string {
-	return ""
+	return "no-raid"
 }
 
 func (a *iLOAccessDetails) VendorInterface() string {

--- a/pkg/bmc/ipmi.go
+++ b/pkg/bmc/ipmi.go
@@ -86,7 +86,7 @@ func (a *ipmiAccessDetails) PowerInterface() string {
 }
 
 func (a *ipmiAccessDetails) RAIDInterface() string {
-	return ""
+	return "no-raid"
 }
 
 func (a *ipmiAccessDetails) VendorInterface() string {

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -111,7 +111,7 @@ func (a *redfishAccessDetails) PowerInterface() string {
 }
 
 func (a *redfishAccessDetails) RAIDInterface() string {
-	return ""
+	return "no-raid"
 }
 
 func (a *redfishAccessDetails) VendorInterface() string {

--- a/pkg/bmc/redfish_virtualmedia.go
+++ b/pkg/bmc/redfish_virtualmedia.go
@@ -79,7 +79,7 @@ func (a *redfishVirtualMediaAccessDetails) PowerInterface() string {
 }
 
 func (a *redfishVirtualMediaAccessDetails) RAIDInterface() string {
-	return ""
+	return "no-raid"
 }
 
 func (a *redfishVirtualMediaAccessDetails) VendorInterface() string {

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1237,7 +1237,7 @@ func (p *ironicProvisioner) ironicHasSameImage(ironicNode *nodes.Node) (sameImag
 
 func (p *ironicProvisioner) buildManualCleaningSteps() (cleanSteps []nodes.CleanStep, err error) {
 	// Build raid clean steps
-	if p.bmcAccess.RAIDInterface() != "" {
+	if p.bmcAccess.RAIDInterface() != "no-raid" {
 		cleanSteps = append(cleanSteps, BuildRAIDCleanSteps(p.host.Status.Provisioning.RAID)...)
 	} else if p.host.Status.Provisioning.RAID != nil {
 		return nil, fmt.Errorf("RAID settings are defined, but the node's driver %s does not support RAID", p.bmcAccess.Driver())
@@ -1249,7 +1249,7 @@ func (p *ironicProvisioner) buildManualCleaningSteps() (cleanSteps []nodes.Clean
 }
 
 func (p *ironicProvisioner) startManualCleaning(ironicNode *nodes.Node) (success bool, result provisioner.Result, err error) {
-	if p.bmcAccess.RAIDInterface() != "" {
+	if p.bmcAccess.RAIDInterface() != "no-raid" {
 		// Set raid configuration
 		err = setTargetRAIDCfg(p, ironicNode)
 		if err != nil {

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -144,6 +144,8 @@ type ironicProvisioner struct {
 	inspector *gophercloud.ServiceClient
 	// a logger configured for this host
 	log logr.Logger
+	// a debug logger configured for this host
+	debugLog logr.Logger
 	// an event publisher for recording significant events
 	publisher provisioner.EventPublisher
 }
@@ -189,6 +191,8 @@ func newProvisionerWithIronicClients(host metal3v1alpha1.BareMetalHost, bmcCreds
 		return nil, errors.Wrap(err, "failed to parse BMC address information")
 	}
 
+	provisionerLogger := log.WithValues("host", host.Name)
+
 	// Ensure we have a microversion high enough to get the features
 	// we need.
 	clientIronic.Microversion = "1.56"
@@ -199,7 +203,8 @@ func newProvisionerWithIronicClients(host metal3v1alpha1.BareMetalHost, bmcCreds
 		bmcCreds:  bmcCreds,
 		client:    clientIronic,
 		inspector: clientInspector,
-		log:       log.WithValues("host", host.Name),
+		log:       provisionerLogger,
+		debugLog:  provisionerLogger.V(1),
 		publisher: publisher,
 	}
 
@@ -292,7 +297,7 @@ func (p *ironicProvisioner) findExistingHost() (ironicNode *nodes.Node, err erro
 		ironicNode, err = nodes.Get(p.client, p.status.ID).Extract()
 		switch err.(type) {
 		case nil:
-			p.log.Info("found existing node by ID")
+			p.debugLog.Info("found existing node by ID")
 			return ironicNode, nil
 		case gophercloud.ErrDefault404:
 			// Look by ID failed, trying to lookup by hostname in case it was
@@ -308,7 +313,7 @@ func (p *ironicProvisioner) findExistingHost() (ironicNode *nodes.Node, err erro
 	ironicNode, err = nodes.Get(p.client, p.host.Name).Extract()
 	switch err.(type) {
 	case nil:
-		p.log.Info("found existing node by name")
+		p.debugLog.Info("found existing node by name")
 		return ironicNode, nil
 	case gophercloud.ErrDefault404:
 		p.log.Info(
@@ -332,7 +337,7 @@ func (p *ironicProvisioner) findExistingHost() (ironicNode *nodes.Node, err erro
 		ironicNode, err = nodes.Get(p.client, nodeUUID).Extract()
 		switch err.(type) {
 		case nil:
-			p.log.Info("found existing node by ID")
+			p.debugLog.Info("found existing node by ID")
 
 			// If the node has a name, this means we didn't find it above.
 			if ironicNode.Name != "" {
@@ -364,7 +369,7 @@ func (p *ironicProvisioner) findExistingHost() (ironicNode *nodes.Node, err erro
 func (p *ironicProvisioner) ValidateManagementAccess(credentialsChanged, force bool) (result provisioner.Result, provID string, err error) {
 	var ironicNode *nodes.Node
 
-	p.log.Info("validating management access")
+	p.debugLog.Info("validating management access")
 
 	ironicNode, err = p.findExistingHost()
 	if err != nil {
@@ -585,18 +590,16 @@ func (p *ironicProvisioner) ValidateManagementAccess(credentialsChanged, force b
 		return
 
 	case nodes.Manageable:
-		p.log.Info("have manageable host")
 		return
 
 	case nodes.Available:
 		// The host is fully registered (and probably wasn't cleanly
 		// deleted previously)
-		p.log.Info("have available host")
 		return
 
 	case nodes.Active:
 		// The host is already running, maybe it's a master?
-		p.log.Info("have active host", "image_source", ironicNode.InstanceInfo["image_source"])
+		p.debugLog.Info("have active host", "image_source", ironicNode.InstanceInfo["image_source"])
 		return
 
 	default:
@@ -737,7 +740,7 @@ func (p *ironicProvisioner) InspectHardware(force bool) (result provisioner.Resu
 // is expected to do this in the least expensive way possible, such as
 // reading from a cache.
 func (p *ironicProvisioner) UpdateHardwareState() (hwState provisioner.HardwareState, err error) {
-	p.log.Info("updating hardware state")
+	p.debugLog.Info("updating hardware state")
 
 	ironicNode, err := p.findExistingHost()
 	if err != nil {
@@ -1829,7 +1832,7 @@ func (p *ironicProvisioner) softPowerOff() (result provisioner.Result, err error
 
 // IsReady checks if the provisioning backend is available
 func (p *ironicProvisioner) IsReady() (result bool, err error) {
-	p.log.Info("verifying ironic provisioner dependencies")
+	p.debugLog.Info("verifying ironic provisioner dependencies")
 
 	checker := newIronicDependenciesChecker(p.client, p.inspector, p.log)
 	return checker.IsReady()

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1238,7 +1238,7 @@ func (p *ironicProvisioner) ironicHasSameImage(ironicNode *nodes.Node) (sameImag
 func (p *ironicProvisioner) buildManualCleaningSteps() (cleanSteps []nodes.CleanStep, err error) {
 	// Build raid clean steps
 	if p.bmcAccess.RAIDInterface() != "no-raid" {
-		cleanSteps = append(cleanSteps, BuildRAIDCleanSteps(p.host.Status.Provisioning.RAID)...)
+		cleanSteps = append(cleanSteps, BuildRAIDCleanSteps(p.host.Spec.RAID)...)
 	} else if p.host.Status.Provisioning.RAID != nil {
 		return nil, fmt.Errorf("RAID settings are defined, but the node's driver %s does not support RAID", p.bmcAccess.Driver())
 	}

--- a/pkg/provisioner/ironic/raid.go
+++ b/pkg/provisioner/ironic/raid.go
@@ -16,7 +16,7 @@ func setTargetRAIDCfg(p *ironicProvisioner, ironicNode *nodes.Node) (err error) 
 	var logicalDisks []nodes.LogicalDisk
 
 	// Build target for RAID configuration steps
-	logicalDisks, err = BuildTargetRAIDCfg(p.host.Status.Provisioning.RAID)
+	logicalDisks, err = BuildTargetRAIDCfg(p.host.Spec.RAID)
 	if len(logicalDisks) == 0 || err != nil {
 		return
 	}

--- a/pkg/provisioner/ironic/testbmc/testbmc.go
+++ b/pkg/provisioner/ironic/testbmc/testbmc.go
@@ -75,7 +75,7 @@ func (a *testAccessDetails) PowerInterface() string {
 }
 
 func (a *testAccessDetails) RAIDInterface() string {
-	return ""
+	return "no-raid"
 }
 
 func (a *testAccessDetails) VendorInterface() string {

--- a/pkg/provisioner/ironic/validatemanagementaccess_test.go
+++ b/pkg/provisioner/ironic/validatemanagementaccess_test.go
@@ -620,3 +620,29 @@ func TestValidateManagementAccessAddTwoHostsWithSameMAC(t *testing.T) {
 	assert.Equal(t, "", result.ErrorMessage)
 	assert.NotEqual(t, "", provID)
 }
+
+func TestValidateManagementAccessUnsupportedSecureBoot(t *testing.T) {
+	// Create a host without a bootMACAddress and with a BMC that
+	// requires one.
+	host := makeHost()
+	host.Spec.BootMode = metal3v1alpha1.UEFISecureBoot
+	host.Status.Provisioning.ID = "" // so we don't lookup by uuid
+
+	ironic := testserver.NewIronic(t).Ready().NoNode(host.Name)
+	ironic.Start()
+	defer ironic.Stop()
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nil,
+		ironic.Endpoint(), auth, testserver.NewInspector(t).Endpoint(), auth,
+	)
+	if err != nil {
+		t.Fatalf("could not create provisioner: %s", err)
+	}
+
+	result, _, err := prov.ValidateManagementAccess(false, false)
+	if err != nil {
+		t.Fatalf("error from ValidateManagementAccess: %s", err)
+	}
+	assert.Contains(t, result.ErrorMessage, "does not support secure boot")
+}


### PR DESCRIPTION
Extend RAID configuration for iDRAC BMC type

This PR also fix mis-configured function calls
buildManualCleaningSteps() and setTargetRAIDCfg().
They were using Status.Provisioning.RAID instead of
Spec.RAID. This now correctly performs RAID configuration.