### PR TITLE
Fix error reporting when creating an host with invalid BMC url

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -1183,15 +1183,6 @@ func (r *BareMetalHostReconciler) buildAndValidateBMCCredentials(request ctrl.Re
 		return nil, nil, &EmptyBMCAddressError{message: "Missing BMC connection detail 'Address'"}
 	}
 
-	// pass the bmc address to bmc.NewAccessDetails which will do
-	// more in-depth checking on the url to ensure it is
-	// a valid bmc address, returning a bmc.UnknownBMCTypeError
-	// if it is not conformant
-	_, err = bmc.NewAccessDetails(host.Spec.BMC.Address, host.Spec.BMC.DisableCertificateVerification)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	bmcCreds = &bmc.Credentials{
 		Username: string(bmcCredsSecret.Data["username"]),
 		Password: string(bmcCredsSecret.Data["password"]),

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -69,6 +69,8 @@ type Fixture struct {
 	image metal3v1alpha1.Image
 	// state to manage power
 	poweredOn bool
+
+	validateError string
 }
 
 // New returns a new Fixture Provisioner
@@ -83,6 +85,10 @@ func (f *Fixture) New(hostData provisioner.HostData, publisher provisioner.Event
 	return p, nil
 }
 
+func (f *Fixture) SetValidateError(message string) {
+	f.validateError = message
+}
+
 func (p *fixtureProvisioner) HasProvisioningCapacity() (result bool, err error) {
 	return true, nil
 }
@@ -91,6 +97,11 @@ func (p *fixtureProvisioner) HasProvisioningCapacity() (result bool, err error) 
 // host to verify that the location and credentials work.
 func (p *fixtureProvisioner) ValidateManagementAccess(data provisioner.ManagementAccessData, credentialsChanged, force bool) (result provisioner.Result, provID string, err error) {
 	p.log.Info("testing management access")
+
+	if p.state.validateError != "" {
+		result.ErrorMessage = p.state.validateError
+		return
+	}
 
 	// Fill in the ID of the host in the provisioning system
 	if p.provID == "" {


### PR DESCRIPTION
This PR addresses the problem reported in https://github.com/metal3-io/baremetal-operator/issues/843.

Note that it completes the changes introduced by @zaneb in [beea4d0](https://github.com/metal3-io/baremetal-operator/commit/beea4d0ead807a8f19b38d538db3502ee3504b97) which already fixed the problem of deleting a BMH resource being created with a malformed BMC address (such issue originally also addressed by @kirankt in #713)