### PR TITLE
Don't immediately retry on Inspect fail

### DIFF
--- a/pkg/provisioner/ironic/inspecthardware_test.go
+++ b/pkg/provisioner/ironic/inspecthardware_test.go
@@ -23,6 +23,8 @@ func TestInspectHardware(t *testing.T) {
 		ironic    *testserver.IronicMock
 		inspector *testserver.InspectorMock
 
+		force bool
+
 		expectedDirty        bool
 		expectedRequestAfter int
 		expectedResultError  string
@@ -130,6 +132,32 @@ func TestInspectHardware(t *testing.T) {
 			expectedRequestAfter: 15,
 		},
 		{
+			name: "inspection-failed",
+			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+				UUID:           nodeUUID,
+				ProvisionState: string(nodes.InspectFail),
+			}),
+			inspector: testserver.NewInspector(t).Ready().WithIntrospectionFailed(nodeUUID, http.StatusNotFound),
+
+			expectedResultError: "Inspection failed",
+		},
+		{
+			name: "inspection-failed force",
+			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+				UUID:           nodeUUID,
+				ProvisionState: string(nodes.InspectFail),
+			}).NodeUpdate(nodes.Node{
+				UUID:           nodeUUID,
+				ProvisionState: string(nodes.InspectFail),
+			}).WithNodeStatesProvisionUpdate(nodeUUID),
+			inspector: testserver.NewInspector(t).Ready().WithIntrospectionFailed(nodeUUID, http.StatusNotFound),
+			force:     true,
+
+			expectedDirty:        true,
+			expectedRequestAfter: 10,
+			expectedPublish:      "InspectionStarted Hardware inspection started",
+		},
+		{
 			name: "inspection-complete",
 			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
 				UUID:           nodeUUID,
@@ -177,7 +205,7 @@ func TestInspectHardware(t *testing.T) {
 			}
 
 			prov.status.ID = nodeUUID
-			result, details, err := prov.InspectHardware(false)
+			result, details, err := prov.InspectHardware(tc.force)
 
 			assert.Equal(t, tc.expectedDirty, result.Dirty)
 			assert.Equal(t, time.Second*time.Duration(tc.expectedRequestAfter), result.RequeueAfter)

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -673,8 +673,8 @@ func (p *ironicProvisioner) InspectHardware(force bool) (result provisioner.Resu
 				p.log.Info("inspection already started")
 				result, err = operationContinuing(introspectionRequeueDelay)
 				return
-			default:
-				if nodes.ProvisionState(ironicNode.ProvisionState) == nodes.InspectFail && !force {
+			case nodes.InspectFail:
+				if !force {
 					p.log.Info("starting inspection failed", "error", status.Error)
 					failure := ironicNode.LastError
 					if failure == "" {
@@ -683,6 +683,8 @@ func (p *ironicProvisioner) InspectHardware(force bool) (result provisioner.Resu
 					result, err = operationFailed(failure)
 					return
 				}
+				fallthrough
+			default:
 				p.log.Info("updating boot mode before hardware inspection")
 				op, value := buildCapabilitiesValue(ironicNode, p.host.Status.Provisioning.BootMode)
 				updates := nodes.UpdateOpts{

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -676,12 +676,12 @@ func (p *ironicProvisioner) InspectHardware(force bool) (result provisioner.Resu
 			default:
 				if nodes.ProvisionState(ironicNode.ProvisionState) == nodes.InspectFail && !force {
 					p.log.Info("starting inspection failed", "error", status.Error)
-					if ironicNode.LastError == "" {
-						result.ErrorMessage = "Inspection failed"
-					} else {
-						result.ErrorMessage = ironicNode.LastError
+					failure := ironicNode.LastError
+					if failure == "" {
+						failure = "Inspection failed"
 					}
-					err = nil
+					result, err = operationFailed(failure)
+					return
 				}
 				p.log.Info("updating boot mode before hardware inspection")
 				op, value := buildCapabilitiesValue(ironicNode, p.host.Status.Provisioning.BootMode)


### PR DESCRIPTION
Ensure that if the ironic node enters the InspectFail state, we not only report the error but also wait until after the exponential backoff before retrying, instead of retrying immediately.

The previous attempt to fix this in 2d02462fb45dbb5dd9dd0189ce91e0c417bbab2e didn't take due to a missing return.