### PR TITLE
Better handling of power management errors

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -1005,7 +1005,7 @@ func (r *BareMetalHostReconciler) manageHostPower(prov provisioner.Provisioner, 
 		"reboot process", desiredPowerOnState != info.host.Spec.Online)
 
 	if desiredPowerOnState {
-		provResult, err = prov.PowerOn()
+		provResult, err = prov.PowerOn(info.host.Status.ErrorType == metal3v1alpha1.PowerManagementError)
 	} else {
 		if info.host.Status.ErrorCount > 0 {
 			desiredRebootMode = metal3v1alpha1.RebootModeHard

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -1007,7 +1007,10 @@ func (r *BareMetalHostReconciler) manageHostPower(prov provisioner.Provisioner, 
 	if desiredPowerOnState {
 		provResult, err = prov.PowerOn()
 	} else {
-		provResult, err = prov.PowerOff(desiredRebootMode)
+		if info.host.Status.ErrorCount > 0 {
+			desiredRebootMode = metal3v1alpha1.RebootModeHard
+		}
+		provResult, err = prov.PowerOff(desiredRebootMode, info.host.Status.ErrorType == metal3v1alpha1.PowerManagementError)
 	}
 	if err != nil {
 		return actionError{errors.Wrap(err, "failed to manage power state of host")}

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -1176,7 +1176,7 @@ func (m *mockProvisioner) PowerOn() (result provisioner.Result, err error) {
 	return m.getNextResultByMethod("PowerOn"), err
 }
 
-func (m *mockProvisioner) PowerOff(rebootMode metal3v1alpha1.RebootMode) (result provisioner.Result, err error) {
+func (m *mockProvisioner) PowerOff(rebootMode metal3v1alpha1.RebootMode, force bool) (result provisioner.Result, err error) {
 	return m.getNextResultByMethod("PowerOff"), err
 }
 

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -1172,7 +1172,7 @@ func (m *mockProvisioner) Detach() (result provisioner.Result, err error) {
 	return res, err
 }
 
-func (m *mockProvisioner) PowerOn() (result provisioner.Result, err error) {
+func (m *mockProvisioner) PowerOn(force bool) (result provisioner.Result, err error) {
 	return m.getNextResultByMethod("PowerOn"), err
 }
 

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -305,7 +305,7 @@ func (p *demoProvisioner) Detach() (result provisioner.Result, err error) {
 
 // PowerOn ensures the server is powered on independently of any image
 // provisioning operation.
-func (p *demoProvisioner) PowerOn() (result provisioner.Result, err error) {
+func (p *demoProvisioner) PowerOn(force bool) (result provisioner.Result, err error) {
 
 	hostName := p.objectMeta.Name
 	switch hostName {

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -326,7 +326,7 @@ func (p *demoProvisioner) PowerOn() (result provisioner.Result, err error) {
 
 // PowerOff ensures the server is powered off independently of any image
 // provisioning operation.
-func (p *demoProvisioner) PowerOff(rebootMode metal3v1alpha1.RebootMode) (result provisioner.Result, err error) {
+func (p *demoProvisioner) PowerOff(rebootMode metal3v1alpha1.RebootMode, force bool) (result provisioner.Result, err error) {
 
 	hostName := p.objectMeta.Name
 	switch hostName {

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -291,7 +291,7 @@ func (p *fixtureProvisioner) Detach() (result provisioner.Result, err error) {
 
 // PowerOn ensures the server is powered on independently of any image
 // provisioning operation.
-func (p *fixtureProvisioner) PowerOn() (result provisioner.Result, err error) {
+func (p *fixtureProvisioner) PowerOn(force bool) (result provisioner.Result, err error) {
 	p.log.Info("ensuring host is powered on")
 
 	if !p.state.poweredOn {

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -307,7 +307,7 @@ func (p *fixtureProvisioner) PowerOn() (result provisioner.Result, err error) {
 
 // PowerOff ensures the server is powered off independently of any image
 // provisioning operation.
-func (p *fixtureProvisioner) PowerOff(rebootMode metal3v1alpha1.RebootMode) (result provisioner.Result, err error) {
+func (p *fixtureProvisioner) PowerOff(rebootMode metal3v1alpha1.RebootMode, force bool) (result provisioner.Result, err error) {
 	p.log.Info("ensuring host is powered off")
 
 	if p.state.poweredOn {

--- a/pkg/provisioner/ironic/errors.go
+++ b/pkg/provisioner/ironic/errors.go
@@ -18,6 +18,16 @@ func (e SoftPowerOffFailed) Error() string {
 	return "Soft power off has failed on BMC"
 }
 
+// HardPowerOffFailed is returned when the hard power off command
+// finishes with failure.
+type HardPowerOffFailed struct {
+	Address string
+}
+
+func (e HardPowerOffFailed) Error() string {
+	return "Hard power off has failed on BMC"
+}
+
 // HostLockedError is returned when the BMC host is
 // locked.
 type HostLockedError struct {

--- a/pkg/provisioner/ironic/errors.go
+++ b/pkg/provisioner/ironic/errors.go
@@ -18,16 +18,6 @@ func (e SoftPowerOffFailed) Error() string {
 	return "Soft power off has failed on BMC"
 }
 
-// HardPowerOffFailed is returned when the hard power off command
-// finishes with failure.
-type HardPowerOffFailed struct {
-	Address string
-}
-
-func (e HardPowerOffFailed) Error() string {
-	return "Hard power off has failed on BMC"
-}
-
 // HostLockedError is returned when the BMC host is
 // locked.
 type HostLockedError struct {

--- a/pkg/provisioner/ironic/errors.go
+++ b/pkg/provisioner/ironic/errors.go
@@ -9,15 +9,6 @@ func (e SoftPowerOffUnsupportedError) Error() string {
 	return "soft power off is unsupported on BMC"
 }
 
-// SoftPowerOffFailed is returned when the soft power off command
-// finishes with failure.
-type SoftPowerOffFailed struct {
-}
-
-func (e SoftPowerOffFailed) Error() string {
-	return "Soft power off has failed on BMC"
-}
-
 // HostLockedError is returned when the BMC host is
 // locked.
 type HostLockedError struct {

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1519,7 +1519,7 @@ func (p *ironicProvisioner) changePower(ironicNode *nodes.Node, target nodes.Tar
 
 // PowerOn ensures the server is powered on independently of any image
 // provisioning operation.
-func (p *ironicProvisioner) PowerOn() (result provisioner.Result, err error) {
+func (p *ironicProvisioner) PowerOn(force bool) (result provisioner.Result, err error) {
 	p.log.Info("ensuring host is powered on")
 
 	ironicNode, err := p.getNode()
@@ -1535,7 +1535,7 @@ func (p *ironicProvisioner) PowerOn() (result provisioner.Result, err error) {
 			p.log.Info("waiting for power status to change")
 			return operationContinuing(powerRequeueDelay)
 		}
-		if ironicNode.LastError != "" {
+		if ironicNode.LastError != "" && !force {
 			p.log.Info("PowerOn operation failed", "msg", ironicNode.LastError)
 			return operationFailed(fmt.Sprintf("PowerOn operation failed: %s",
 				ironicNode.LastError))

--- a/pkg/provisioner/ironic/power_test.go
+++ b/pkg/provisioner/ironic/power_test.go
@@ -214,7 +214,7 @@ func TestPowerOff(t *testing.T) {
 			}
 
 			// We pass the RebootMode type here to define the reboot action
-			result, err := prov.PowerOff(tc.rebootMode)
+			result, err := prov.PowerOff(tc.rebootMode, false)
 
 			assert.Equal(t, tc.expectedDirty, result.Dirty)
 			assert.Equal(t, time.Second*time.Duration(tc.expectedRequestAfter), result.RequeueAfter)

--- a/pkg/provisioner/ironic/power_test.go
+++ b/pkg/provisioner/ironic/power_test.go
@@ -101,7 +101,7 @@ func TestPowerOn(t *testing.T) {
 				t.Fatalf("could not create provisioner: %s", err)
 			}
 
-			result, err := prov.PowerOn()
+			result, err := prov.PowerOn(false)
 
 			assert.Equal(t, tc.expectedDirty, result.Dirty)
 			assert.Equal(t, time.Second*time.Duration(tc.expectedRequestAfter), result.RequeueAfter)

--- a/pkg/provisioner/ironic/power_test.go
+++ b/pkg/provisioner/ironic/power_test.go
@@ -293,7 +293,7 @@ func TestPowerOff(t *testing.T) {
 				assert.Error(t, err)
 			}
 			if tc.expectedErrorResult {
-				assert.Contains(t, result.ErrorMessage, "hardPowerOff operation failed")
+				assert.Contains(t, result.ErrorMessage, "hard power off failed")
 			}
 
 		})

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -149,7 +149,7 @@ type Provisioner interface {
 	// PowerOff ensures the server is powered off independently of any image
 	// provisioning operation. The boolean argument may be used to specify
 	// if a hard reboot (force power off) is required - true if so.
-	PowerOff(rebootMode metal3v1alpha1.RebootMode) (result Result, err error)
+	PowerOff(rebootMode metal3v1alpha1.RebootMode, force bool) (result Result, err error)
 
 	// IsReady checks if the provisioning backend is available to accept
 	// all the incoming requests.

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -144,7 +144,7 @@ type Provisioner interface {
 
 	// PowerOn ensures the server is powered on independently of any image
 	// provisioning operation.
-	PowerOn() (result Result, err error)
+	PowerOn(force bool) (result Result, err error)
 
 	// PowerOff ensures the server is powered off independently of any image
 	// provisioning operation. The boolean argument may be used to specify


### PR DESCRIPTION
Attempts to fix https://github.com/metal3-io/baremetal-operator/issues/828

This fix should have the following components based on the above bug:
1. If Ironic accepts the power state change but is unable to carry it out (expressed via LastError from ironic), that should result in PowerOn() and PowerOff() returning an ErrorMessage. 
2. Refactor PowerOff() in such a way that if soft power off fails, it proceeds to hard power off without reporting an error. It is possible that this logic is moved out of here and into Ironic itself.
3. Add a force flag to the PowerOff() so that it skips soft power off and directly proceeds to hard power off after the previous call results in an error.