### PR TITLE
Set bmh 'name' in metadata as hostname

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1456,6 +1456,7 @@ func (p *ironicProvisioner) Provision(hostConf provisioner.HostConfigData) (resu
 			"metal3-name":      p.host.ObjectMeta.Name,
 			"local-hostname":   p.host.ObjectMeta.Name,
 			"local_hostname":   p.host.ObjectMeta.Name,
+			"name":             p.host.ObjectMeta.Name,
 		}
 		metaDataRaw, err := hostConf.MetaData()
 		if err != nil {


### PR DESCRIPTION
This will set 'name' field of metaData as bmh name, otherwise by default ironic name gets set as hostname by default and ~ in hostname seems to be problematic for kubeadm during cloudinit nodeRegistration.