### PR TITLE
Fix bug: never set target_raid_config

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1246,8 +1246,8 @@ func (p *ironicProvisioner) ironicHasSameImage(ironicNode *nodes.Node) (sameImag
 func (p *ironicProvisioner) buildManualCleaningSteps(bmcAccess bmc.AccessDetails) (cleanSteps []nodes.CleanStep, err error) {
 	// Build raid clean steps
 	if bmcAccess.RAIDInterface() != "no-raid" {
-		cleanSteps = append(cleanSteps, BuildRAIDCleanSteps(p.host.Status.Provisioning.RAID)...)
-	} else if p.host.Status.Provisioning.RAID != nil {
+		cleanSteps = append(cleanSteps, BuildRAIDCleanSteps(p.host.Spec.RAID)...)
+	} else if p.host.Spec.RAID != nil {
 		return nil, fmt.Errorf("RAID settings are defined, but the node's driver %s does not support RAID", bmcAccess.Driver())
 	}
 

--- a/pkg/provisioner/ironic/raid.go
+++ b/pkg/provisioner/ironic/raid.go
@@ -16,13 +16,13 @@ func setTargetRAIDCfg(p *ironicProvisioner, ironicNode *nodes.Node) (err error) 
 	var logicalDisks []nodes.LogicalDisk
 
 	// Build target for RAID configuration steps
-	logicalDisks, err = BuildTargetRAIDCfg(p.host.Status.Provisioning.RAID)
+	logicalDisks, err = BuildTargetRAIDCfg(p.host.Spec.RAID)
 	if len(logicalDisks) == 0 || err != nil {
 		return
 	}
 
 	// set root volume
-	if p.host.Status.Provisioning.RootDeviceHints == nil {
+	if p.host.Spec.RootDeviceHints == nil {
 		logicalDisks[0].IsRootVolume = new(bool)
 		*logicalDisks[0].IsRootVolume = true
 	} else {


### PR DESCRIPTION
Signed-off-by: zouyu <zouy.fnst@cn.fujitsu.com>

Due to the change of the code in [baremetalhost_controller.go](https://github.com/metal3-io/baremetal-operator/blob/master/controllers/metal3.io/baremetalhost_controller.go#L217), the `saveHostProvisioningSettings()` called [here](https://github.com/metal3-io/baremetal-operator/blob/master/controllers/metal3.io/baremetalhost_controller.go#L687) didn't change `p.host`, so the value of `p.host.Status.Provisioning.RAID` is always nil. 

