### PR TITLE
Always update image details

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -492,18 +492,6 @@ func (p *ironicProvisioner) ValidateManagementAccess(data provisioner.Management
 				return
 			}
 		}
-
-		if data.CurrentImage != nil {
-			updatesImage, optsErr := p.getImageUpdateOptsForNode(ironicNode, data.CurrentImage, data.BootMode)
-			if optsErr != nil {
-				result, err = transientError(errors.Wrap(optsErr, "Could not get Image options for node"))
-				return
-			}
-			if len(updatesImage) != 0 {
-				updates = append(updates, updatesImage...)
-
-			}
-		}
 	} else {
 		// FIXME(dhellmann): At this point we have found an existing
 		// node in ironic by looking it up. We need to check its
@@ -536,6 +524,16 @@ func (p *ironicProvisioner) ValidateManagementAccess(data provisioner.Management
 			// We don't return here because we also have to set the
 			// target provision state to manageable, which happens
 			// below.
+		}
+	}
+	if data.CurrentImage != nil {
+		updatesImage, optsErr := p.getImageUpdateOptsForNode(ironicNode, data.CurrentImage, data.BootMode)
+		if optsErr != nil {
+			result, err = transientError(errors.Wrap(optsErr, "Could not get Image options for node"))
+			return
+		}
+		if len(updatesImage) != 0 {
+			updates = append(updates, updatesImage...)
 		}
 	}
 	if ironicNode.AutomatedClean == nil ||


### PR DESCRIPTION
Always update the image data within `ValidateManagementAccess()` regardless of Ironic node existence or not. Currently, image data update is happening only if Ironic node doesn't exist. That means, if we failed to write image data, we won't be able to update it again in the next retries since node already exists.
Fixes https://github.com/metal3-io/baremetal-operator/issues/839.

