### PR TITLE
Extend RAID configuration for iDRAC BMC type

### DIFF
--- a/pkg/bmc/idrac.go
+++ b/pkg/bmc/idrac.go
@@ -87,7 +87,7 @@ func (a *iDracAccessDetails) PowerInterface() string {
 }
 
 func (a *iDracAccessDetails) RAIDInterface() string {
-	return "no-raid"
+	return "idrac-wsman"
 }
 
 func (a *iDracAccessDetails) VendorInterface() string {


### PR DESCRIPTION
This PR also fix mis-configured function calls
buildManualCleaningSteps() and setTargetRAIDCfg().
They were using Status.Provisioning.RAID instead of
Spec.RAID. This now correctly performs RAID configuration.