### PR TITLE
modify power_interface for irmc

### DIFF
--- a/pkg/bmc/irmc.go
+++ b/pkg/bmc/irmc.go
@@ -74,7 +74,7 @@ func (a *iRMCAccessDetails) ManagementInterface() string {
 }
 
 func (a *iRMCAccessDetails) PowerInterface() string {
-	return ""
+	return "ipmitool"
 }
 
 func (a *iRMCAccessDetails) RAIDInterface() string {


### PR DESCRIPTION
When `irmc` `power_interface` is used, Soft Reboot (Graceful Reset) and Soft Power Off (Graceful Power Off)
are only available if `ServerView` agents are installed.
Modify the value of `power_interface` to `ipmitool`, so that soft power off can be used directly.

Signed-off-by: Zhou Hao <zhouhao@fujitsu.com>