### PR TITLE
Fix adoption in ExternallyProvisioned state

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -541,9 +541,11 @@ func getCurrentImage(host *metal3v1alpha1.BareMetalHost) *metal3v1alpha1.Image {
 	}
 
 	// If we are in the process of provisioning an image, return that image
-	if host.Status.Provisioning.State == metal3v1alpha1.StateProvisioning &&
-		host.Spec.Image != nil && host.Spec.Image.URL != "" {
-		return host.Spec.Image.DeepCopy()
+	switch host.Status.Provisioning.State {
+	case metal3v1alpha1.StateProvisioning, metal3v1alpha1.StateExternallyProvisioned:
+		if host.Spec.Image != nil && host.Spec.Image.URL != "" {
+			return host.Spec.Image.DeepCopy()
+		}
 	}
 	return nil
 }

--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -1548,6 +1548,27 @@ func TestGetImageDeprovisioning(t *testing.T) {
 	assert.Exactly(t, host.Status.Provisioning.Image, *img)
 }
 
+func TestGetImageExternallyPprovisioned(t *testing.T) {
+	host := metal3v1alpha1.BareMetalHost{
+		Spec: metal3v1alpha1.BareMetalHostSpec{
+			Image: &metal3v1alpha1.Image{
+				URL: "http://example.test/image",
+			},
+		},
+		Status: metal3v1alpha1.BareMetalHostStatus{
+			Provisioning: metal3v1alpha1.ProvisionStatus{
+				State: metal3v1alpha1.StateExternallyProvisioned,
+			},
+		},
+	}
+
+	img := getCurrentImage(&host)
+
+	assert.NotNil(t, img)
+	assert.NotSame(t, host.Spec.Image, img)
+	assert.Exactly(t, *host.Spec.Image, *img)
+}
+
 func TestUpdateRAID(t *testing.T) {
 	host := metal3v1alpha1.BareMetalHost{
 		Spec: metal3v1alpha1.BareMetalHostSpec{


### PR DESCRIPTION
In 269ff1eef216af719251daa4a33bc294409d1945 we stopped potentially
making use of the image from the Spec in the provisioner when there is
no image in the Status, except for the Provisioning state where we want
to register with the image we are provisioning even though it hasn't
completed yet.

We also need to make an exception for the ExternallyProvisioned state,
because in that state the image details are never copied to the Status.

This relies on the change in c0373bbfa38d3169d1b994cf0f0429396f12e651,
which ensures that the image data can be added to the Node once the Host
reaches the ExternallyProvisioned state. Prior to this, the image data
was only added when the Node was created, so we would have had to pass
the image details starting with the first call to
ValidateManagementAccess() in the Registration state.