### PR TITLE
Add disk type field to BMH HardwareDetails

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -442,6 +442,16 @@ const (
 	TeraByte          = GigaByte * 1000
 )
 
+// DiskType is a disk type, i.e. HDD, SSD, NVME.
+type DiskType string
+
+// DiskType constants.
+const (
+	HDD  DiskType = "HDD"
+	SSD  DiskType = "SSD"
+	NVME DiskType = "NVME"
+)
+
 // CPU describes one processor on the host.
 type CPU struct {
 	Arch           string     `json:"arch,omitempty"`
@@ -457,8 +467,16 @@ type Storage struct {
 	// may not be stable across reboots.
 	Name string `json:"name,omitempty"`
 
-	// Whether this disk represents rotational storage
+	// Whether this disk represents rotational storage.
+	// This field is not recommended for usage, please
+	// prefer using 'Type' field instead, this field
+	// will be deprecated eventually.
 	Rotational bool `json:"rotational,omitempty"`
+
+	// Device type, one of: HDD, SSD, NVME.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=HDD;SSD;NVME;
+	Type DiskType `json:"type,omitempty"`
 
 	// The size of the disk in Bytes
 	SizeBytes Capacity `json:"sizeBytes,omitempty"`

--- a/config/crd/bases/metal3.io_baremetalhosts.yaml
+++ b/config/crd/bases/metal3.io_baremetalhosts.yaml
@@ -495,7 +495,7 @@ spec:
                           description: The Linux device name of the disk, e.g. "/dev/sda". Note that this may not be stable across reboots.
                           type: string
                         rotational:
-                          description: Whether this disk represents rotational storage
+                          description: Whether this disk represents rotational storage. This field is not recommended for usage, please prefer using 'Type' field instead, this field will be deprecated eventually.
                           type: boolean
                         serialNumber:
                           description: The serial number of the device
@@ -504,6 +504,13 @@ spec:
                           description: The size of the disk in Bytes
                           format: int64
                           type: integer
+                        type:
+                          description: 'Device type, one of: HDD, SSD, NVME.'
+                          enum:
+                          - HDD
+                          - SSD
+                          - NVME
+                          type: string
                         vendor:
                           description: The name of the vendor of the device
                           type: string

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -493,7 +493,7 @@ spec:
                           description: The Linux device name of the disk, e.g. "/dev/sda". Note that this may not be stable across reboots.
                           type: string
                         rotational:
-                          description: Whether this disk represents rotational storage
+                          description: Whether this disk represents rotational storage. This field is not recommended for usage, please prefer using 'Type' field instead, this field will be deprecated eventually.
                           type: boolean
                         serialNumber:
                           description: The serial number of the device
@@ -502,6 +502,13 @@ spec:
                           description: The size of the disk in Bytes
                           format: int64
                           type: integer
+                        type:
+                          description: 'Device type, one of: HDD, SSD, NVME.'
+                          enum:
+                          - HDD
+                          - SSD
+                          - NVME
+                          type: string
                         vendor:
                           description: The name of the vendor of the device
                           type: string

--- a/pkg/provisioner/ironic/hardwaredetails/hardwaredetails.go
+++ b/pkg/provisioner/ironic/hardwaredetails/hardwaredetails.go
@@ -95,12 +95,25 @@ func getNICDetails(ifdata []introspection.InterfaceType,
 	return nics
 }
 
+func getDiskType(diskdata introspection.RootDiskType) metal3v1alpha1.DiskType {
+	if diskdata.Rotational {
+		return metal3v1alpha1.HDD
+	}
+
+	if strings.HasPrefix(diskdata.Name, "/dev/nvme") {
+		return metal3v1alpha1.NVME
+	}
+
+	return metal3v1alpha1.SSD
+}
+
 func getStorageDetails(diskdata []introspection.RootDiskType) []metal3v1alpha1.Storage {
 	storage := make([]metal3v1alpha1.Storage, len(diskdata))
 	for i, disk := range diskdata {
 		storage[i] = metal3v1alpha1.Storage{
 			Name:               disk.Name,
 			Rotational:         disk.Rotational,
+			Type:               getDiskType(disk),
 			SizeBytes:          metal3v1alpha1.Capacity(disk.Size),
 			Vendor:             disk.Vendor,
 			Model:              disk.Model,


### PR DESCRIPTION
Motivation to add additional disk type is to allow custom storage provider assemble different types of storage based on needed storage profiles.

Something like:
 - `fast and expensive` storage on NVME
 - `general` storage on SSD
 - `backup`, `cold data` storage on HDD
 - `hybrid cache` storage with fast NVMEs backed by HDD
 - ...

Signed-off-by: s3rj1k <evasive.gyron@gmail.com>