### PR TITLE
Always lazily update Node options in Ironic

### DIFF
--- a/pkg/provisioner/ironic/capabilities_test.go
+++ b/pkg/provisioner/ironic/capabilities_test.go
@@ -15,14 +15,12 @@ func TestBuildCapabilitiesValue(t *testing.T) {
 		Node          nodes.Node
 		Mode          metal3v1alpha1.BootMode
 		ExpectedValue string
-		ExpectedOp    nodes.UpdateOp
 	}{
 		{
 			Scenario:      "unset",
 			Node:          nodes.Node{},
 			Mode:          metal3v1alpha1.UEFI,
 			ExpectedValue: "boot_mode:uefi",
-			ExpectedOp:    nodes.AddOp,
 		},
 		{
 			Scenario: "empty",
@@ -33,7 +31,6 @@ func TestBuildCapabilitiesValue(t *testing.T) {
 			},
 			Mode:          metal3v1alpha1.UEFI,
 			ExpectedValue: "boot_mode:uefi",
-			ExpectedOp:    nodes.ReplaceOp,
 		},
 		{
 			Scenario: "not-there",
@@ -44,7 +41,6 @@ func TestBuildCapabilitiesValue(t *testing.T) {
 			},
 			Mode:          metal3v1alpha1.UEFI,
 			ExpectedValue: "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true,boot_mode:uefi",
-			ExpectedOp:    nodes.ReplaceOp,
 		},
 		{
 			Scenario: "add-secure-boot",
@@ -55,7 +51,6 @@ func TestBuildCapabilitiesValue(t *testing.T) {
 			},
 			Mode:          metal3v1alpha1.UEFISecureBoot,
 			ExpectedValue: "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true,boot_mode:uefi,secure_boot:true",
-			ExpectedOp:    nodes.ReplaceOp,
 		},
 		{
 			Scenario: "uefi-to-uefi",
@@ -66,7 +61,6 @@ func TestBuildCapabilitiesValue(t *testing.T) {
 			},
 			Mode:          metal3v1alpha1.UEFI,
 			ExpectedValue: "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true,boot_mode:uefi",
-			ExpectedOp:    nodes.ReplaceOp,
 		},
 		{
 			Scenario: "bios-to-bios",
@@ -77,7 +71,6 @@ func TestBuildCapabilitiesValue(t *testing.T) {
 			},
 			Mode:          metal3v1alpha1.Legacy,
 			ExpectedValue: "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true,boot_mode:bios",
-			ExpectedOp:    nodes.ReplaceOp,
 		},
 		{
 			Scenario: "bios-to-uefi",
@@ -88,7 +81,6 @@ func TestBuildCapabilitiesValue(t *testing.T) {
 			},
 			Mode:          metal3v1alpha1.UEFI,
 			ExpectedValue: "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true,boot_mode:uefi",
-			ExpectedOp:    nodes.ReplaceOp,
 		},
 		{
 			Scenario: "uefi-to-bios",
@@ -99,7 +91,6 @@ func TestBuildCapabilitiesValue(t *testing.T) {
 			},
 			Mode:          metal3v1alpha1.Legacy,
 			ExpectedValue: "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true,boot_mode:bios",
-			ExpectedOp:    nodes.ReplaceOp,
 		},
 		{
 			Scenario: "uefi-to-secure",
@@ -110,7 +101,6 @@ func TestBuildCapabilitiesValue(t *testing.T) {
 			},
 			Mode:          metal3v1alpha1.UEFISecureBoot,
 			ExpectedValue: "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true,boot_mode:uefi,secure_boot:true",
-			ExpectedOp:    nodes.ReplaceOp,
 		},
 		{
 			Scenario: "secure-to-uefi",
@@ -121,14 +111,12 @@ func TestBuildCapabilitiesValue(t *testing.T) {
 			},
 			Mode:          metal3v1alpha1.UEFI,
 			ExpectedValue: "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true,boot_mode:uefi",
-			ExpectedOp:    nodes.ReplaceOp,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.Scenario, func(t *testing.T) {
-			actualOp, actualVal := buildCapabilitiesValue(&tc.Node, tc.Mode)
-			assert.Equal(t, tc.ExpectedOp, actualOp)
+			actualVal := buildCapabilitiesValue(&tc.Node, tc.Mode)
 			assert.Equal(t, tc.ExpectedValue, actualVal)
 		})
 	}

--- a/pkg/provisioner/ironic/delete_test.go
+++ b/pkg/provisioner/ironic/delete_test.go
@@ -149,7 +149,7 @@ func deleteTest(t *testing.T, detach bool) {
 			expectedDirty:        true,
 			expectedRequestAfter: 0,
 			expectedUpdate: &nodes.UpdateOperation{
-				Op:    "replace",
+				Op:    nodes.AddOp,
 				Path:  "/maintenance",
 				Value: true,
 			},

--- a/pkg/provisioner/ironic/update_opts.go
+++ b/pkg/provisioner/ironic/update_opts.go
@@ -122,7 +122,10 @@ func (nu *nodeUpdater) logger(basepath, option string) logr.Logger {
 	if nu.log == nil {
 		return nil
 	}
-	log := nu.log.WithValues("option", option, "section", basepath[1:])
+	log := nu.log.WithValues("option", option)
+	if basepath != "" {
+		log = log.WithValues("section", basepath[1:])
+	}
 	return log
 }
 
@@ -138,6 +141,14 @@ func (nu *nodeUpdater) setSectionUpdateOpts(currentData map[string]interface{}, 
 			nu.Updates = append(nu.Updates, *updateOp)
 		}
 	}
+}
+
+func (nu *nodeUpdater) SetTopLevelOpt(name string, desiredValue, currentValue interface{}) *nodeUpdater {
+	currentData := map[string]interface{}{name: currentValue}
+	desiredData := optionsData{name: desiredValue}
+
+	nu.setSectionUpdateOpts(currentData, desiredData, "")
+	return nu
 }
 
 func (nu *nodeUpdater) SetPropertiesOpts(settings optionsData, node *nodes.Node) *nodeUpdater {

--- a/pkg/provisioner/ironic/update_opts.go
+++ b/pkg/provisioner/ironic/update_opts.go
@@ -1,0 +1,151 @@
+package ironic
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
+)
+
+type optionsData map[string]interface{}
+
+func optionValueEqual(current, value interface{}) bool {
+	if reflect.DeepEqual(current, value) {
+		return true
+	}
+	switch curVal := current.(type) {
+	case []interface{}:
+		// newType could reasonably be either []interface{} or e.g. []string,
+		// so we must use reflection.
+		newType := reflect.TypeOf(value)
+		switch newType.Kind() {
+		case reflect.Slice, reflect.Array:
+		default:
+			return false
+		}
+		newList := reflect.ValueOf(value)
+		if newList.Len() != len(curVal) {
+			return false
+		}
+		for i, v := range curVal {
+			if !optionValueEqual(newList.Index(i).Interface(), v) {
+				return false
+			}
+		}
+		return true
+	case map[string]interface{}:
+		// newType could reasonably be either map[string]interface{} or
+		// e.g. map[string]string, so we must use reflection.
+		newType := reflect.TypeOf(value)
+		if newType.Kind() != reflect.Map ||
+			newType.Key().Kind() != reflect.String {
+			return false
+		}
+		newMap := reflect.ValueOf(value)
+		if newMap.Len() != len(curVal) {
+			return false
+		}
+		for k, v := range curVal {
+			newV := newMap.MapIndex(reflect.ValueOf(k))
+			if !(newV.IsValid() && optionValueEqual(newV.Interface(), v)) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func deref(v interface{}) interface{} {
+	if v == nil {
+		return nil
+	}
+	if reflect.TypeOf(v).Kind() != reflect.Ptr {
+		return v
+	}
+	if ptrVal := reflect.ValueOf(v); ptrVal.IsNil() {
+		return nil
+	} else {
+		return ptrVal.Elem().Interface()
+	}
+}
+
+func getUpdateOperation(name string, currentData map[string]interface{}, desiredValue interface{}, path string, log logr.Logger) *nodes.UpdateOperation {
+	current, present := currentData[name]
+
+	desiredValue = deref(desiredValue)
+	if desiredValue != nil {
+		if !(present && optionValueEqual(deref(current), desiredValue)) {
+			if log != nil {
+				if present {
+					log.Info("updating option data",
+						"value", desiredValue, "old_value", current)
+				} else {
+					log.Info("adding option data",
+						"value", desiredValue)
+				}
+			}
+			return &nodes.UpdateOperation{
+				Op:    nodes.AddOp, // Add also does replace
+				Path:  path,
+				Value: desiredValue,
+			}
+		}
+	} else {
+		if present {
+			if log != nil {
+				log.Info("removing option data")
+			}
+			return &nodes.UpdateOperation{
+				Op:   nodes.RemoveOp,
+				Path: path,
+			}
+		}
+	}
+	return nil
+}
+
+type nodeUpdater struct {
+	Updates nodes.UpdateOpts
+	log     logr.Logger
+}
+
+func updateOptsBuilder(logger logr.Logger) *nodeUpdater {
+	return &nodeUpdater{
+		log: logger,
+	}
+}
+
+func (nu *nodeUpdater) logger(basepath, option string) logr.Logger {
+	if nu.log == nil {
+		return nil
+	}
+	log := nu.log.WithValues("option", option, "section", basepath[1:])
+	return log
+}
+
+func (nu *nodeUpdater) path(basepath, option string) string {
+	return fmt.Sprintf("%s/%s", basepath, option)
+}
+
+func (nu *nodeUpdater) setSectionUpdateOpts(currentData map[string]interface{}, settings optionsData, basepath string) {
+	for name, desiredValue := range settings {
+		updateOp := getUpdateOperation(name, currentData, desiredValue,
+			nu.path(basepath, name), nu.logger(basepath, name))
+		if updateOp != nil {
+			nu.Updates = append(nu.Updates, *updateOp)
+		}
+	}
+}
+
+func (nu *nodeUpdater) SetPropertiesOpts(settings optionsData, node *nodes.Node) *nodeUpdater {
+	nu.setSectionUpdateOpts(node.Properties, settings, "/properties")
+	return nu
+}
+
+func (nu *nodeUpdater) SetInstanceInfoOpts(settings optionsData, node *nodes.Node) *nodeUpdater {
+	nu.setSectionUpdateOpts(node.InstanceInfo, settings, "/instance_info")
+	return nu
+}

--- a/pkg/provisioner/ironic/updateopts_test.go
+++ b/pkg/provisioner/ironic/updateopts_test.go
@@ -391,6 +391,21 @@ func TestGetUpdateOperation(t *testing.T) {
 	}
 }
 
+func TestTopLevelUpdateOpt(t *testing.T) {
+	u := updateOptsBuilder(log)
+	u.SetTopLevelOpt("foo", "baz", "bar")
+	ops := u.Updates
+	assert.Len(t, ops, 1)
+	op := ops[0].(nodes.UpdateOperation)
+	assert.Equal(t, nodes.AddOp, op.Op)
+	assert.Equal(t, "baz", op.Value)
+	assert.Equal(t, "/foo", op.Path)
+
+	u = updateOptsBuilder(log)
+	u.SetTopLevelOpt("foo", "bar", "bar")
+	assert.Len(t, u.Updates, 0)
+}
+
 func TestPropertiesUpdateOpts(t *testing.T) {
 	newValues := optionsData{
 		"foo": "bar",
@@ -761,7 +776,7 @@ func TestGetUpdateOptsForNodeLiveIso(t *testing.T) {
 		{
 			Path:  "/deploy_interface",
 			Value: "ramdisk",
-			Op:    nodes.ReplaceOp,
+			Op:    nodes.AddOp,
 		},
 	}
 
@@ -829,7 +844,7 @@ func TestGetUpdateOptsForNodeImageToLiveIso(t *testing.T) {
 		{
 			Path:  "/deploy_interface",
 			Value: "ramdisk",
-			Op:    nodes.ReplaceOp,
+			Op:    nodes.AddOp,
 		},
 		{
 			Path: "/instance_info/image_source",
@@ -910,7 +925,7 @@ func TestGetUpdateOptsForNodeLiveIsoToImage(t *testing.T) {
 		{
 			Path:  "/deploy_interface",
 			Value: "direct",
-			Op:    nodes.ReplaceOp,
+			Op:    nodes.AddOp,
 		},
 		{
 			Path:  "/instance_info/image_source",

--- a/pkg/provisioner/ironic/updateopts_test.go
+++ b/pkg/provisioner/ironic/updateopts_test.go
@@ -467,7 +467,7 @@ func TestGetUpdateOptsForNodeWithRootHints(t *testing.T) {
 		BootMode:        metal3v1alpha1.DefaultBootMode,
 		RootDeviceHints: host.Status.Provisioning.RootDeviceHints,
 	}
-	patches := prov.getUpdateOptsForNode(ironicNode, provData)
+	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates
 
 	t.Logf("patches: %v", patches)
 
@@ -563,7 +563,7 @@ func TestGetUpdateOptsForNodeVirtual(t *testing.T) {
 		BootMode:        metal3v1alpha1.DefaultBootMode,
 		HardwareProfile: hwProf,
 	}
-	patches := prov.getUpdateOptsForNode(ironicNode, provData)
+	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates
 
 	t.Logf("patches: %v", patches)
 
@@ -670,7 +670,7 @@ func TestGetUpdateOptsForNodeDell(t *testing.T) {
 		BootMode:        metal3v1alpha1.DefaultBootMode,
 		HardwareProfile: hwProf,
 	}
-	patches := prov.getUpdateOptsForNode(ironicNode, provData)
+	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates
 
 	t.Logf("patches: %v", patches)
 
@@ -742,7 +742,7 @@ func TestGetUpdateOptsForNodeLiveIso(t *testing.T) {
 		Image:    *host.Spec.Image,
 		BootMode: metal3v1alpha1.DefaultBootMode,
 	}
-	patches := prov.getUpdateOptsForNode(ironicNode, provData)
+	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates
 
 	t.Logf("patches: %v", patches)
 
@@ -811,7 +811,7 @@ func TestGetUpdateOptsForNodeImageToLiveIso(t *testing.T) {
 		Image:    *host.Spec.Image,
 		BootMode: metal3v1alpha1.DefaultBootMode,
 	}
-	patches := prov.getUpdateOptsForNode(ironicNode, provData)
+	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates
 
 	t.Logf("patches: %v", patches)
 
@@ -890,7 +890,7 @@ func TestGetUpdateOptsForNodeLiveIsoToImage(t *testing.T) {
 		Image:    *host.Spec.Image,
 		BootMode: metal3v1alpha1.DefaultBootMode,
 	}
-	patches := prov.getUpdateOptsForNode(ironicNode, provData)
+	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates
 
 	t.Logf("patches: %v", patches)
 
@@ -992,7 +992,7 @@ func TestGetUpdateOptsForNodeSecureBoot(t *testing.T) {
 		BootMode:        metal3v1alpha1.UEFISecureBoot,
 		HardwareProfile: hwProf,
 	}
-	patches := prov.getUpdateOptsForNode(ironicNode, provData)
+	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates
 
 	t.Logf("patches: %v", patches)
 

--- a/pkg/provisioner/ironic/updateopts_test.go
+++ b/pkg/provisioner/ironic/updateopts_test.go
@@ -467,10 +467,7 @@ func TestGetUpdateOptsForNodeWithRootHints(t *testing.T) {
 		BootMode:        metal3v1alpha1.DefaultBootMode,
 		RootDeviceHints: host.Status.Provisioning.RootDeviceHints,
 	}
-	patches, err := prov.getUpdateOptsForNode(ironicNode, provData)
-	if err != nil {
-		t.Fatal(err)
-	}
+	patches := prov.getUpdateOptsForNode(ironicNode, provData)
 
 	t.Logf("patches: %v", patches)
 
@@ -566,10 +563,7 @@ func TestGetUpdateOptsForNodeVirtual(t *testing.T) {
 		BootMode:        metal3v1alpha1.DefaultBootMode,
 		HardwareProfile: hwProf,
 	}
-	patches, err := prov.getUpdateOptsForNode(ironicNode, provData)
-	if err != nil {
-		t.Fatal(err)
-	}
+	patches := prov.getUpdateOptsForNode(ironicNode, provData)
 
 	t.Logf("patches: %v", patches)
 
@@ -676,10 +670,7 @@ func TestGetUpdateOptsForNodeDell(t *testing.T) {
 		BootMode:        metal3v1alpha1.DefaultBootMode,
 		HardwareProfile: hwProf,
 	}
-	patches, err := prov.getUpdateOptsForNode(ironicNode, provData)
-	if err != nil {
-		t.Fatal(err)
-	}
+	patches := prov.getUpdateOptsForNode(ironicNode, provData)
 
 	t.Logf("patches: %v", patches)
 
@@ -751,10 +742,7 @@ func TestGetUpdateOptsForNodeLiveIso(t *testing.T) {
 		Image:    *host.Spec.Image,
 		BootMode: metal3v1alpha1.DefaultBootMode,
 	}
-	patches, err := prov.getUpdateOptsForNode(ironicNode, provData)
-	if err != nil {
-		t.Fatal(err)
-	}
+	patches := prov.getUpdateOptsForNode(ironicNode, provData)
 
 	t.Logf("patches: %v", patches)
 
@@ -823,10 +811,7 @@ func TestGetUpdateOptsForNodeImageToLiveIso(t *testing.T) {
 		Image:    *host.Spec.Image,
 		BootMode: metal3v1alpha1.DefaultBootMode,
 	}
-	patches, err := prov.getUpdateOptsForNode(ironicNode, provData)
-	if err != nil {
-		t.Fatal(err)
-	}
+	patches := prov.getUpdateOptsForNode(ironicNode, provData)
 
 	t.Logf("patches: %v", patches)
 
@@ -905,10 +890,7 @@ func TestGetUpdateOptsForNodeLiveIsoToImage(t *testing.T) {
 		Image:    *host.Spec.Image,
 		BootMode: metal3v1alpha1.DefaultBootMode,
 	}
-	patches, err := prov.getUpdateOptsForNode(ironicNode, provData)
-	if err != nil {
-		t.Fatal(err)
-	}
+	patches := prov.getUpdateOptsForNode(ironicNode, provData)
 
 	t.Logf("patches: %v", patches)
 
@@ -1010,10 +992,7 @@ func TestGetUpdateOptsForNodeSecureBoot(t *testing.T) {
 		BootMode:        metal3v1alpha1.UEFISecureBoot,
 		HardwareProfile: hwProf,
 	}
-	patches, err := prov.getUpdateOptsForNode(ironicNode, provData)
-	if err != nil {
-		t.Fatal(err)
-	}
+	patches := prov.getUpdateOptsForNode(ironicNode, provData)
 
 	t.Logf("patches: %v", patches)
 

--- a/pkg/provisioner/ironic/updateopts_test.go
+++ b/pkg/provisioner/ironic/updateopts_test.go
@@ -17,6 +17,422 @@ import (
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
 )
 
+func TestOptionValueEqual(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Before interface{}
+		After  interface{}
+		Equal  bool
+	}{
+		{
+			Name:   "nil interface",
+			Before: nil,
+			After:  "foo",
+			Equal:  false,
+		},
+		{
+			Name:   "equal string",
+			Before: "foo",
+			After:  "foo",
+			Equal:  true,
+		},
+		{
+			Name:   "unequal string",
+			Before: "foo",
+			After:  "bar",
+			Equal:  false,
+		},
+		{
+			Name:   "equal true",
+			Before: true,
+			After:  true,
+			Equal:  true,
+		},
+		{
+			Name:   "equal false",
+			Before: false,
+			After:  false,
+			Equal:  true,
+		},
+		{
+			Name:   "unequal true",
+			Before: true,
+			After:  false,
+			Equal:  false,
+		},
+		{
+			Name:   "unequal false",
+			Before: false,
+			After:  true,
+			Equal:  false,
+		},
+		{
+			Name:   "equal int",
+			Before: 42,
+			After:  42,
+			Equal:  true,
+		},
+		{
+			Name:   "unequal int",
+			Before: 27,
+			After:  42,
+			Equal:  false,
+		},
+		{
+			Name:   "string int",
+			Before: "42",
+			After:  42,
+			Equal:  false,
+		},
+		{
+			Name:   "int string",
+			Before: 42,
+			After:  "42",
+			Equal:  false,
+		},
+		{
+			Name:   "bool int",
+			Before: false,
+			After:  0,
+			Equal:  false,
+		},
+		{
+			Name:   "int bool",
+			Before: 1,
+			After:  true,
+			Equal:  false,
+		},
+		{
+			Name:   "string map",
+			Before: "foo",
+			After:  map[string]string{"foo": "foo"},
+			Equal:  false,
+		},
+		{
+			Name:   "map string",
+			Before: map[string]interface{}{"foo": "foo"},
+			After:  "foo",
+			Equal:  false,
+		},
+		{
+			Name:   "string list",
+			Before: "foo",
+			After:  []string{"foo"},
+			Equal:  false,
+		},
+		{
+			Name:   "list string",
+			Before: []string{"foo"},
+			After:  "foo",
+			Equal:  false,
+		},
+		{
+			Name:   "map list",
+			Before: map[string]interface{}{"foo": "foo"},
+			After:  []string{"foo"},
+			Equal:  false,
+		},
+		{
+			Name:   "list map",
+			Before: []string{"foo"},
+			After:  map[string]string{"foo": "foo"},
+			Equal:  false,
+		},
+		{
+			Name:   "equal map string-typed",
+			Before: map[string]interface{}{"foo": "bar"},
+			After:  map[string]string{"foo": "bar"},
+			Equal:  true,
+		},
+		{
+			Name:   "unequal map string-typed",
+			Before: map[string]interface{}{"foo": "bar"},
+			After:  map[string]string{"foo": "baz"},
+			Equal:  false,
+		},
+		{
+			Name:   "equal map int-typed",
+			Before: map[string]interface{}{"foo": 42},
+			After:  map[string]int{"foo": 42},
+			Equal:  true,
+		},
+		{
+			Name:   "unequal map int-typed",
+			Before: map[string]interface{}{"foo": "bar"},
+			After:  map[string]int{"foo": 42},
+			Equal:  false,
+		},
+		{
+			Name:   "equal map",
+			Before: map[string]interface{}{"foo": "bar", "42": 42},
+			After:  map[string]interface{}{"foo": "bar", "42": 42},
+			Equal:  true,
+		},
+		{
+			Name:   "unequal map",
+			Before: map[string]interface{}{"foo": "bar", "42": 42},
+			After:  map[string]interface{}{"foo": "bar", "42": 27},
+			Equal:  false,
+		},
+		{
+			Name:   "equal map empty string",
+			Before: map[string]interface{}{"foo": ""},
+			After:  map[string]interface{}{"foo": ""},
+			Equal:  true,
+		},
+		{
+			Name:   "unequal map replace empty string",
+			Before: map[string]interface{}{"foo": ""},
+			After:  map[string]interface{}{"foo": "bar"},
+			Equal:  false,
+		},
+		{
+			Name:   "unequal map replace with empty string",
+			Before: map[string]interface{}{"foo": "bar"},
+			After:  map[string]interface{}{"foo": ""},
+			Equal:  false,
+		},
+		{
+			Name:   "shorter map",
+			Before: map[string]interface{}{"foo": "bar", "42": 42},
+			After:  map[string]interface{}{"foo": "bar"},
+			Equal:  false,
+		},
+		{
+			Name:   "longer map",
+			Before: map[string]interface{}{"foo": "bar"},
+			After:  map[string]interface{}{"foo": "bar", "42": 42},
+			Equal:  false,
+		},
+		{
+			Name:   "different map",
+			Before: map[string]interface{}{"foo": "bar"},
+			After:  map[string]interface{}{"baz": "bar"},
+			Equal:  false,
+		},
+		{
+			Name:   "equal list string-typed",
+			Before: []interface{}{"foo", "bar"},
+			After:  []string{"foo", "bar"},
+			Equal:  true,
+		},
+		{
+			Name:   "unequal list string-typed",
+			Before: []interface{}{"foo", "bar"},
+			After:  []string{"foo", "baz"},
+			Equal:  false,
+		},
+		{
+			Name:   "equal list",
+			Before: []interface{}{"foo", 42},
+			After:  []interface{}{"foo", 42},
+			Equal:  true,
+		},
+		{
+			Name:   "unequal list",
+			Before: []interface{}{"foo", 42},
+			After:  []interface{}{"foo", 27},
+			Equal:  false,
+		},
+		{
+			Name:   "shorter list",
+			Before: []interface{}{"foo", 42},
+			After:  []interface{}{"foo"},
+			Equal:  false,
+		},
+		{
+			Name:   "longer list",
+			Before: []interface{}{"foo"},
+			After:  []interface{}{"foo", 42},
+			Equal:  false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			var ne = "="
+			if c.Equal {
+				ne = "!"
+			}
+			assert.Equal(t, c.Equal, optionValueEqual(c.Before, c.After),
+				fmt.Sprintf("%v %s= %v", c.Before, ne, c.After))
+		})
+	}
+}
+
+func TestGetUpdateOperation(t *testing.T) {
+	var nilp *string
+	bar_exist := "bar"
+	bar := "bar"
+	baz := "baz"
+	existingData := map[string]interface{}{
+		"foo":  "bar",
+		"foop": &bar_exist,
+		"nil":  nilp,
+	}
+	cases := []struct {
+		Name          string
+		Field         string
+		NewValue      interface{}
+		ExpectedOp    nodes.UpdateOp
+		ExpectedValue string
+	}{
+		{
+			Name:       "add value",
+			Field:      "baz",
+			NewValue:   "quux",
+			ExpectedOp: nodes.AddOp,
+		},
+		{
+			Name:          "add value pointer",
+			Field:         "baz",
+			NewValue:      &bar,
+			ExpectedValue: bar,
+			ExpectedOp:    nodes.AddOp,
+		},
+		{
+			Name:          "add pointer value pointer",
+			Field:         "nil",
+			NewValue:      &bar,
+			ExpectedValue: bar,
+			ExpectedOp:    nodes.AddOp,
+		},
+		{
+			Name:     "keep value",
+			Field:    "foo",
+			NewValue: "bar",
+		},
+		{
+			Name:     "keep pointer value",
+			Field:    "foop",
+			NewValue: "bar",
+		},
+		{
+			Name:     "keep value pointer",
+			Field:    "foo",
+			NewValue: &bar,
+		},
+		{
+			Name:     "keep pointer value pointer",
+			Field:    "foop",
+			NewValue: &bar,
+		},
+		{
+			Name:       "change value",
+			Field:      "foo",
+			NewValue:   "baz",
+			ExpectedOp: nodes.AddOp,
+		},
+		{
+			Name:       "change pointer value",
+			Field:      "foop",
+			NewValue:   "baz",
+			ExpectedOp: nodes.AddOp,
+		},
+		{
+			Name:          "change value pointer",
+			Field:         "foo",
+			NewValue:      &baz,
+			ExpectedValue: baz,
+			ExpectedOp:    nodes.AddOp,
+		},
+		{
+			Name:          "change pointer value pointer",
+			Field:         "foop",
+			NewValue:      &baz,
+			ExpectedValue: baz,
+			ExpectedOp:    nodes.AddOp,
+		},
+		{
+			Name:       "delete value",
+			Field:      "foo",
+			NewValue:   nil,
+			ExpectedOp: nodes.RemoveOp,
+		},
+		{
+			Name:       "delete value pointer",
+			Field:      "foo",
+			NewValue:   nilp,
+			ExpectedOp: nodes.RemoveOp,
+		},
+		{
+			Name:     "nonexistent value",
+			Field:    "bar",
+			NewValue: nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			path := fmt.Sprintf("test/%s", c.Field)
+			updateOp := getUpdateOperation(
+				c.Field, existingData,
+				c.NewValue,
+				path, nil)
+
+			switch c.ExpectedOp {
+			case nodes.AddOp, nodes.ReplaceOp:
+				assert.NotNil(t, updateOp)
+				ev := c.ExpectedValue
+				if ev == "" {
+					ev = c.NewValue.(string)
+				}
+				assert.Equal(t, c.ExpectedOp, updateOp.Op)
+				assert.Equal(t, ev, updateOp.Value)
+				assert.Equal(t, path, updateOp.Path)
+			case nodes.RemoveOp:
+				assert.NotNil(t, updateOp)
+				assert.Equal(t, c.ExpectedOp, updateOp.Op)
+				assert.Equal(t, path, updateOp.Path)
+			default:
+				assert.Nil(t, updateOp)
+			}
+		})
+	}
+}
+
+func TestPropertiesUpdateOpts(t *testing.T) {
+	newValues := optionsData{
+		"foo": "bar",
+		"baz": "quux",
+	}
+	node := nodes.Node{
+		Properties: map[string]interface{}{
+			"foo": "bar",
+		},
+	}
+
+	u := updateOptsBuilder(log)
+	u.SetPropertiesOpts(newValues, &node)
+	ops := u.Updates
+	assert.Len(t, ops, 1)
+	op := ops[0].(nodes.UpdateOperation)
+	assert.Equal(t, nodes.AddOp, op.Op)
+	assert.Equal(t, "quux", op.Value)
+	assert.Equal(t, "/properties/baz", op.Path)
+}
+
+func TestInstanceInfoUpdateOpts(t *testing.T) {
+	newValues := optionsData{
+		"foo": "bar",
+		"baz": "quux",
+	}
+	node := nodes.Node{
+		InstanceInfo: map[string]interface{}{
+			"foo": "bar",
+		},
+	}
+
+	u := updateOptsBuilder(log)
+	u.SetInstanceInfoOpts(newValues, &node)
+	ops := u.Updates
+	assert.Len(t, ops, 1)
+	op := ops[0].(nodes.UpdateOperation)
+	assert.Equal(t, nodes.AddOp, op.Op)
+	assert.Equal(t, "quux", op.Value)
+	assert.Equal(t, "/instance_info/baz", op.Path)
+}
+
 func TestGetUpdateOptsForNodeWithRootHints(t *testing.T) {
 
 	eventPublisher := func(reason, message string) {}


### PR DESCRIPTION
It became clear from #839 and #849 that in order to ensure consistent behaviour, we must ensure that the Ironic Node's image data is up to date on every reconcile, and this was implemented in #845 by unconditionally updating it. This will result in a write to Ironic on every reconcile, which is excessive.

We have the ability to check whether the data we want to set is already present, but we largely don't because of the huge amount of messy boilerplate currently required to update each option. This PR refactors the code so that we can just pass a map of the options we want to set to a function and lazy updates come for free, along with standardised logging.