### PR TITLE
baremetal: Add privLevel to bmc data

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -32,6 +32,9 @@ communicate with them.
 * IPMI
   * `ipmi://<host>:<port>`, an unadorned `<host>:<port>` is also accepted
     and the port is optional, if using the default one (623).
+  * The ipmi privilege level can be set from the default(`ADMINISTRATOR`)
+    to `OPERATOR` with an option URL parameter `privilegelevel`.
+    `ipmi://<host>:<port>?privilegelevel=OPERATOR`
 * Dell iDRAC
   * `idrac://` (or `idrac+http://` to disable TLS).
   * `idrac-virtualmedia://` to use virtual media instead of PXE

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -678,11 +678,25 @@ func TestDriverInfo(t *testing.T) {
 			Scenario: "ipmi default port",
 			input:    "ipmi://192.168.122.1",
 			expects: map[string]interface{}{
-				"ipmi_port":      ipmiDefaultPort,
-				"ipmi_password":  "",
-				"ipmi_username":  "",
-				"ipmi_address":   "192.168.122.1",
-				"ipmi_verify_ca": false,
+				"ipmi_port":       ipmiDefaultPort,
+				"ipmi_password":   "",
+				"ipmi_username":   "",
+				"ipmi_address":    "192.168.122.1",
+				"ipmi_verify_ca":  false,
+				"ipmi_priv_level": "ADMINISTRATOR",
+			},
+		},
+
+		{
+			Scenario: "ipmi setting privilege level",
+			input:    "ipmi://192.168.122.1?privilegelevel=OPERATOR",
+			expects: map[string]interface{}{
+				"ipmi_port":       ipmiDefaultPort,
+				"ipmi_password":   "",
+				"ipmi_username":   "",
+				"ipmi_address":    "192.168.122.1",
+				"ipmi_verify_ca":  false,
+				"ipmi_priv_level": "OPERATOR",
 			},
 		},
 


### PR DESCRIPTION
Add a new parameter to optionaly set the ipmi privilage
level used when connected to BMC's over ipmi, the default
"ADMINISTRATOR" isn't always available (e.g. in ibmcloud).

Currently works on bootstrap node but not in the metal3 pod, so I'm missing something
tested with
openshift/installer#4845