### PR TITLE
Add cert-manager setup for TLS in ironic deployment.

### DIFF
--- a/ironic-deployment/basic-auth/default/auth.yaml
+++ b/ironic-deployment/basic-auth/default/auth.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: metal3-ironic
+  name: capm3-ironic
 spec:
   template:
     spec:

--- a/ironic-deployment/basic-auth/default/kustomization.yaml
+++ b/ironic-deployment/basic-auth/default/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: metal3
+namespace: capm3-system
 resources:
 - ../../default
 

--- a/ironic-deployment/basic-auth/keepalived/auth.yaml
+++ b/ironic-deployment/basic-auth/keepalived/auth.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: metal3-ironic
+  name: capm3-ironic
 spec:
   template:
     spec:

--- a/ironic-deployment/basic-auth/keepalived/kustomization.yaml
+++ b/ironic-deployment/basic-auth/keepalived/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: metal3
+namespace: capm3-system
 resources:
 - ../../keepalived
 

--- a/ironic-deployment/basic-auth/tls/default/auth.yaml
+++ b/ironic-deployment/basic-auth/tls/default/auth.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: metal3-ironic
+  name: capm3-ironic
 spec:
   template:
     spec:

--- a/ironic-deployment/basic-auth/tls/default/kustomization.yaml
+++ b/ironic-deployment/basic-auth/tls/default/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: metal3
+namespace: capm3-system
 resources:
 - ../../../tls/default
 

--- a/ironic-deployment/basic-auth/tls/keepalived/auth.yaml
+++ b/ironic-deployment/basic-auth/tls/keepalived/auth.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: metal3-ironic
+  name: capm3-ironic
 spec:
   template:
     spec:

--- a/ironic-deployment/basic-auth/tls/keepalived/kustomization.yaml
+++ b/ironic-deployment/basic-auth/tls/keepalived/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: metal3
+namespace: capm3-system
 resources:
 - ../../../tls/keepalived
 

--- a/ironic-deployment/certmanager/certificate.yaml
+++ b/ironic-deployment/certmanager/certificate.yaml
@@ -1,0 +1,69 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: capm3-system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ironic-cacert
+  namespace: capm3-system
+spec:
+  isCA: true
+  ipAddresses:
+  - IRONIC_HOST_IP
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: ironic-cacert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: ca-issuer
+  namespace: capm3-system
+spec:
+  ca:
+    secretName: ironic-cacert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ironic-cert
+  namespace: capm3-system
+spec:
+  ipAddresses:
+  - IRONIC_HOST_IP
+  issuerRef:
+    kind: Issuer
+    name: ca-issuer
+  secretName: ironic-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ironic-inspector-cert
+  namespace: capm3-system
+spec:
+  ipAddresses:
+  - IRONIC_HOST_IP
+  issuerRef:
+    kind: Issuer
+    name: ca-issuer
+  secretName: ironic-inspector-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: mariadb-cert
+  namespace: capm3-system
+spec:
+  ipAddresses:
+  - MARIADB_HOST_IP
+  issuerRef:
+    kind: Issuer
+    name: ca-issuer
+  secretName: mariadb-cert

--- a/ironic-deployment/certmanager/kustomization.yaml
+++ b/ironic-deployment/certmanager/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- certificate.yaml

--- a/ironic-deployment/default/kustomization.yaml
+++ b/ironic-deployment/default/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: metal3
+namespace: capm3-system
 resources:
 - ../ironic
 configMapGenerator:

--- a/ironic-deployment/ironic/ironic.yaml
+++ b/ironic-deployment/ironic/ironic.yaml
@@ -1,16 +1,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: metal3-ironic
+  name: capm3-ironic
 spec:
   replicas: 1
   selector:
     matchLabels:
-      name: metal3-ironic
+      name: capm3-ironic
   template:
     metadata:
       labels:
-        name: metal3-ironic
+        name: capm3-ironic
     spec:
       hostNetwork: true
       containers:

--- a/ironic-deployment/keepalived/keepalived_patch.yaml
+++ b/ironic-deployment/keepalived/keepalived_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: metal3-ironic
+  name: capm3-ironic
 spec:
   template:
     spec:

--- a/ironic-deployment/keepalived/kustomization.yaml
+++ b/ironic-deployment/keepalived/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: metal3
+namespace: capm3-system
 resources:
 - ../../config/namespace
 - ../ironic

--- a/ironic-deployment/tls/default/kustomization.yaml
+++ b/ironic-deployment/tls/default/kustomization.yaml
@@ -1,35 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: metal3
+namespace: capm3-system
 resources:
 - ../../default
-
-secretGenerator:
-- name: ironic-ca-cert
-  files:
-  - tls.crt=ironic-ca.crt
-- name: ironic-inspector-ca-cert
-  files:
-  - tls.crt=ironic-inspector-ca.crt
-- name: ironic-cert
-  files:
-  - tls.crt=ironic.crt
-  - tls.key=ironic.key
-  type: "kubernetes.io/tls"
-- name: ironic-inspector-cert
-  files:
-  - tls.crt=ironic-inspector.crt
-  - tls.key=ironic-inspector.key
-  type: "kubernetes.io/tls"
-- name: mariadb-ca-cert
-  files:
-  - tls.crt=mariadb-ca.crt
-- name: mariadb-cert
-  files:
-  - tls.crt=mariadb.crt
-  - tls.key=mariadb.key
-  type: "kubernetes.io/tls"
+- ../../certmanager
 
 patchesStrategicMerge:
 - tls.yaml
-

--- a/ironic-deployment/tls/default/tls.yaml
+++ b/ironic-deployment/tls/default/tls.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: metal3-ironic
+  name: capm3-ironic
 spec:
   template:
     spec:
@@ -68,10 +68,10 @@ spec:
       volumes:
       - name: cert-ironic-ca
         secret:
-          secretName: ironic-ca-cert
+          secretName: ironic-cacert
       - name: cert-ironic-inspector-ca
         secret:
-          secretName: ironic-inspector-ca-cert
+          secretName: ironic-cacert
       - name: cert-ironic
         secret:
           secretName: ironic-cert
@@ -83,4 +83,4 @@ spec:
           secretName: mariadb-cert
       - name: cert-mariadb-ca
         secret:
-          secretName: mariadb-ca-cert
+          secretName: ironic-cacert

--- a/ironic-deployment/tls/keepalived/kustomization.yaml
+++ b/ironic-deployment/tls/keepalived/kustomization.yaml
@@ -1,34 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: metal3
+namespace: capm3-system
 resources:
 - ../../keepalived
-
-secretGenerator:
-- name: ironic-ca-cert
-  files:
-  - tls.crt=ironic-ca.crt
-- name: ironic-inspector-ca-cert
-  files:
-  - tls.crt=ironic-inspector-ca.crt
-- name: ironic-cert
-  files:
-  - tls.crt=ironic.crt
-  - tls.key=ironic.key
-  type: "kubernetes.io/tls"
-- name: ironic-inspector-cert
-  files:
-  - tls.crt=ironic-inspector.crt
-  - tls.key=ironic-inspector.key
-  type: "kubernetes.io/tls"
-- name: mariadb-ca-cert
-  files:
-  - tls.crt=mariadb-ca.crt
-- name: mariadb-cert
-  files:
-  - tls.crt=mariadb.crt
-  - tls.key=mariadb.key
-  type: "kubernetes.io/tls"
+- ../../certmanager
 
 patchesStrategicMerge:
 - tls.yaml

--- a/ironic-deployment/tls/keepalived/tls.yaml
+++ b/ironic-deployment/tls/keepalived/tls.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: metal3-ironic
+  name: capm3-ironic
 spec:
   template:
     spec:
@@ -68,10 +68,10 @@ spec:
       volumes:
       - name: cert-ironic-ca
         secret:
-          secretName: ironic-ca-cert
+          secretName: ironic-cacert
       - name: cert-ironic-inspector-ca
         secret:
-          secretName: ironic-inspector-ca-cert
+          secretName: ironic-cacert
       - name: cert-ironic
         secret:
           secretName: ironic-cert
@@ -83,4 +83,4 @@ spec:
           secretName: mariadb-cert
       - name: cert-mariadb-ca
         secret:
-          secretName: mariadb-ca-cert
+          secretName: ironic-cacert

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -115,15 +115,15 @@ func init() {
 	}
 	ironicTrustedCAFile = os.Getenv("IRONIC_CACERT_FILE")
 	if ironicTrustedCAFile == "" {
-		ironicTrustedCAFile = "/opt/metal3/certs/ca/crt"
+		ironicTrustedCAFile = "/opt/metal3/certs/ca/tls.crt"
 	}
 	ironicClientCertFile = os.Getenv("IRONIC_CLIENT_CERT_FILE")
 	if ironicClientCertFile == "" {
-		ironicClientCertFile = "/opt/metal3/certs/client/crt"
+		ironicClientCertFile = "/opt/metal3/certs/client/tls.crt"
 	}
 	ironicClientPrivKeyFile = os.Getenv("IRONIC_CLIENT_PRIVATE_KEY_FILE")
 	if ironicClientPrivKeyFile == "" {
-		ironicClientPrivKeyFile = "/opt/metal3/certs/client/key"
+		ironicClientPrivKeyFile = "/opt/metal3/certs/client/tls.key"
 	}
 	ironicInsecureStr := os.Getenv("IRONIC_INSECURE")
 	if strings.ToLower(ironicInsecureStr) == "true" {

--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -82,6 +82,18 @@ IRONIC_INSPECTOR_VLAN_INTERFACES=${IRONIC_INSPECTOR_VLAN_INTERFACES}
 IPA_BASEURI=${IPA_BASEURI}
 EOF
 
+# shellcheck disable=SC2086
+cat << EOF | kubectl apply -f -
+apiVersion: v1
+data:
+  tls.crt: ${IRONIC_CA_CERT_B64:-""}
+kind: Secret
+metadata:
+   name: ironic-cacert
+   namespace: capm3-system
+type: Opaque
+EOF
+
 sudo "${CONTAINER_RUNTIME}" pull "$IRONIC_IMAGE"
 sudo "${CONTAINER_RUNTIME}" pull "$IRONIC_INSPECTOR_IMAGE"
 sudo "${CONTAINER_RUNTIME}" pull "$IRONIC_KEEPALIVED_IMAGE"


### PR DESCRIPTION
Ironic deployment doesn't have cert-manager setup for TLS and this PR will add the cert-manager for  TLS.