### PR TITLE
Enable Client certificate authorization for Ironic TLS client.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,17 @@ Ironic Inspector.
 `IRONIC_INSECURE` -- ("True", "False") Whether to skip the ironic certificate
 validation. It is highly recommend to not set it to True.
 
+`IRONIC_CLIENT_CERT_FILE` -- The path of the Client certificate file of Ironic,
+if needed. Both Client certificate and Client private key must be defined for
+client certificate authentication (mTLS) to be enabled.
+
+`IRONIC_CLIENT_PRIVATE_KEY_FILE` -- The path of the Client private key file of Ironic,
+if needed. Both Client certificate and Client private key must be defined for
+client certificate authentication (mTLS) to be enabled.
+
+`IRONIC_SKIP_CLIENT_SAN_VERIFY` -- ("True", "False") Whether to skip the ironic
+client certificate SAN validation.
+
 `BMO_CONCURRENCY` -- The number of concurrent reconciles performed by the
 Operator. Default is 3.
 


### PR DESCRIPTION
Add ability to pass Client Certificate and Private Key to `ironic/ironic-inspector` client configuration.
Code is modeled after `TrustedCAFile` realization.

This enables to have Ironic behind TLS offload proxy with no-password authentication (mTLS).

Signed-off-by: s3rj1k <evasive.gyron@gmail.com>