### PR TITLE
Add provisioner passthrough

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"time"
 
+    apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -364,6 +365,10 @@ type BareMetalHostSpec struct {
 	// +kubebuilder:default:=metadata
 	// +kubebuilder:validation:Optional
 	AutomatedCleaningMode AutomatedCleaningMode `json:"automatedCleaningMode,omitempty"`
+
+    // Provisioner passthrouth
+    // +optional
+    ProvisionerPassthrough apiextensions.JSON `json:"provisionerPassthrough,omitempty"`
 }
 
 // AutomatedCleaningMode is the interface to enable/disable automated cleaning

--- a/examples/example-host-ironic-ansible-extra.yaml
+++ b/examples/example-host-ironic-ansible-extra.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: example-baremetalhost-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: example-baremetalhost
+spec:
+  online: true
+  bmc:
+    address: ipmi://192.168.122.1:6233
+    credentialsName: example-baremetalhost-secret
+  provisionerPassthrough:
+    ironic:
+      deploy: ansible
+      ansible_extra:
+        foo: bar


### PR DESCRIPTION
Add provisioner agnostic field of type`apiextensions.JSON` to be able to implement any specific features in any underlying provisiner like the one described in #654 
