### PR TITLE
Revert: Point ironic-inspector to the ironic image in quay

### DIFF
--- a/ironic-deployment/ironic/ironic.yaml
+++ b/ironic-deployment/ironic/ironic.yaml
@@ -85,7 +85,7 @@ spec:
             - mountPath: /shared
               name: ironic-data-volume
         - name: ironic-inspector
-          image: quay.io/metal3-io/ironic
+          image: quay.io/metal3-io/ironic-inspector
           imagePullPolicy: Always
           command:
             - /bin/runironic-inspector
@@ -93,7 +93,7 @@ spec:
             - configMapRef:
                 name: ironic-bmo-configmap
         - name: ironic-inspector-log-watch
-          image: quay.io/metal3-io/ironic
+          image: quay.io/metal3-io/ironic-inspector
           imagePullPolicy: Always
           command:
             - /bin/runlogwatch.sh

--- a/ironic-deployment/tls/default/tls.yaml
+++ b/ironic-deployment/tls/default/tls.yaml
@@ -51,7 +51,7 @@ spec:
           mountPath: "/certs/ca/mariadb"
           readOnly: true
       - name: httpd-reverse-proxy
-        image: quay.io/metal3-io/ironic
+        image: quay.io/metal3-io/ironic-inspector
         imagePullPolicy: Always
         envFrom:
           - configMapRef:

--- a/ironic-deployment/tls/keepalived/tls.yaml
+++ b/ironic-deployment/tls/keepalived/tls.yaml
@@ -51,7 +51,7 @@ spec:
           mountPath: "/certs/ca/mariadb"
           readOnly: true
       - name: httpd-reverse-proxy
-        image: quay.io/metal3-io/ironic
+        image: quay.io/metal3-io/ironic-inspector
         imagePullPolicy: Always
         envFrom:
           - configMapRef:

--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -5,7 +5,7 @@ set -ex
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic:master"}
-IRONIC_INSPECTOR_IMAGE=${IRONIC_INSPECTOR_IMAGE:-"quay.io/metal3-io/ironic"}
+IRONIC_INSPECTOR_IMAGE=${IRONIC_INSPECTOR_IMAGE:-"quay.io/metal3-io/ironic-inspector"}
 IRONIC_KEEPALIVED_IMAGE=${IRONIC_KEEPALIVED_IMAGE:-"quay.io/metal3-io/keepalived"}
 IPA_DOWNLOADER_IMAGE=${IPA_DOWNLOADER_IMAGE:-"quay.io/metal3-io/ironic-ipa-downloader:master"}
 IPA_BASEURI=${IPA_BASEURI:-}


### PR DESCRIPTION
Some of the CI jobs (especially Centos based integration tests) are failing with a common issue as below. This reverts https://github.com/metal3-io/baremetal-operator/pull/861.
to unblock CI and keep it running without failure. It seems there is a conflict in the httpd port and this probably needs to be fixed in Ironic image. See the [slack discussion](https://kubernetes.slack.com/archives/CHD49TLE7/p1620663788347600).
```
ERROR 1146 (42S02) at line 1: Table 'ironic.conductor_hardware_interfaces' doesn't exist
AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using fc00:f853:ccd:e793::1. Set the 'ServerName' directive globally to suppress this message
(98)Address already in use: AH00072: make_sock: could not bind to address [::]:6180
no listening sockets available, shutting down
AH00015: Unable to open logs

```