### PR TITLE
strip whitespace after decoding secret values

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -475,6 +475,10 @@ data:
   password: cGFzc3dvcmQ=
 ```
 
+NOTE: After decoding the secret content, whitespace is stripped from
+the beginning and end before the username and password values are
+used.
+
 ## Triggering Provisioning
 
 Several conditions must be met in order to initiate provisioning.


### PR DESCRIPTION
We have had several users report problems with credential management
that turned out to be caused by extra whitespace in the encoded values
placed into the secrets they created. Most often this is caused by
using command line tools to encode the values. For example,

$ echo -n root | base64
cm9vdA==
$ echo root | base64
cm9vdAo=

This change assumes that extraneous whitespace in the encoded values
is not part of the real username or password, and strips it before
trying to use the credentials. The logic to extract the credentials
from the secret is moved into its own function so that new unit tests
can be added.