### PR TITLE
Point ironic-inspector to the ironic image in quay

### DIFF
--- a/ironic-deployment/ironic/ironic.yaml
+++ b/ironic-deployment/ironic/ironic.yaml
@@ -90,7 +90,7 @@ spec:
             - mountPath: /shared
               name: ironic-data-volume
         - name: ironic-inspector
-          image: quay.io/metal3-io/ironic-inspector
+          image: quay.io/metal3-io/ironic
           imagePullPolicy: Always
           command:
             - /bin/runironic-inspector
@@ -98,7 +98,7 @@ spec:
             - configMapRef:
                 name: ironic-bmo-configmap
         - name: ironic-inspector-log-watch
-          image: quay.io/metal3-io/ironic-inspector
+          image: quay.io/metal3-io/ironic
           imagePullPolicy: Always
           command:
             - /bin/runlogwatch.sh

--- a/ironic-deployment/tls/default/tls.yaml
+++ b/ironic-deployment/tls/default/tls.yaml
@@ -51,7 +51,7 @@ spec:
           mountPath: "/certs/ca/mariadb"
           readOnly: true
       - name: httpd-reverse-proxy
-        image: quay.io/metal3-io/ironic-inspector
+        image: quay.io/metal3-io/ironic
         imagePullPolicy: Always
         envFrom:
           - configMapRef:

--- a/ironic-deployment/tls/default/tls.yaml
+++ b/ironic-deployment/tls/default/tls.yaml
@@ -17,6 +17,9 @@ spec:
         - name: cert-ironic-inspector-ca
           mountPath: "/certs/ca/ironic-inspector"
           readOnly: true
+        - name: cert-ironic-inspector
+          mountPath: "/certs/ironic-inspector"
+          readOnly: true
         - name: cert-mariadb-ca
           mountPath: "/certs/ca/mariadb"
           readOnly: true
@@ -49,21 +52,6 @@ spec:
           readOnly: true
         - name: cert-mariadb-ca
           mountPath: "/certs/ca/mariadb"
-          readOnly: true
-      - name: httpd-reverse-proxy
-        image: quay.io/metal3-io/ironic
-        imagePullPolicy: Always
-        envFrom:
-          - configMapRef:
-              name: ironic-bmo-configmap
-        command: 
-          - /bin/runhttpd
-        volumeMounts:
-        - name: cert-ironic-ca
-          mountPath: "/certs/ca/ironic"
-          readOnly: true
-        - name: cert-ironic-inspector
-          mountPath: "/certs/ironic-inspector"
           readOnly: true
       volumes:
       - name: cert-ironic-ca

--- a/ironic-deployment/tls/keepalived/tls.yaml
+++ b/ironic-deployment/tls/keepalived/tls.yaml
@@ -51,7 +51,7 @@ spec:
           mountPath: "/certs/ca/mariadb"
           readOnly: true
       - name: httpd-reverse-proxy
-        image: quay.io/metal3-io/ironic-inspector
+        image: quay.io/metal3-io/ironic
         imagePullPolicy: Always
         envFrom:
           - configMapRef:

--- a/ironic-deployment/tls/keepalived/tls.yaml
+++ b/ironic-deployment/tls/keepalived/tls.yaml
@@ -17,6 +17,9 @@ spec:
         - name: cert-ironic-inspector-ca
           mountPath: "/certs/ca/ironic-inspector"
           readOnly: true
+        - name: cert-ironic-inspector
+          mountPath: "/certs/ironic-inspector"
+          readOnly: true
         - name: cert-mariadb-ca
           mountPath: "/certs/ca/mariadb"
           readOnly: true
@@ -49,21 +52,6 @@ spec:
           readOnly: true
         - name: cert-mariadb-ca
           mountPath: "/certs/ca/mariadb"
-          readOnly: true
-      - name: httpd-reverse-proxy
-        image: quay.io/metal3-io/ironic
-        imagePullPolicy: Always
-        envFrom:
-          - configMapRef:
-              name: ironic-bmo-configmap
-        command: 
-          - /bin/runhttpd
-        volumeMounts:
-        - name: cert-ironic-ca
-          mountPath: "/certs/ca/ironic"
-          readOnly: true
-        - name: cert-ironic-inspector
-          mountPath: "/certs/ironic-inspector"
           readOnly: true
       volumes:
       - name: cert-ironic-ca

--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -239,17 +239,6 @@ sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name ironic-inspect
      --entrypoint /bin/runironic-inspector \
      -v "$IRONIC_DATA_DIR:/shared" "${IRONIC_INSPECTOR_IMAGE}"
 
-# Start httpd reverse proxy for Ironic Inspector
-# shellcheck disable=SC2086
-if [[ $INSPECTOR_REVERSE_PROXY_SETUP == "true" ]]
-then
-    sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name httpd-reverse-proxy \
-         ${POD} ${CERTS_MOUNTS} ${BASIC_AUTH_MOUNTS} ${IRONIC_INSPECTOR_HTPASSWD} \
-         --env-file "${IRONIC_DATA_DIR}/ironic-vars.env" \
-         --entrypoint /bin/runhttpd \
-         -v "$IRONIC_DATA_DIR:/shared" "${IRONIC_INSPECTOR_IMAGE}"
-fi
-
 # Start ironic-inspector-log-watch
 # shellcheck disable=SC2086
 sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name ironic-inspector-log-watch \

--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -5,7 +5,7 @@ set -ex
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic:master"}
-IRONIC_INSPECTOR_IMAGE=${IRONIC_INSPECTOR_IMAGE:-"quay.io/metal3-io/ironic-inspector"}
+IRONIC_INSPECTOR_IMAGE=${IRONIC_INSPECTOR_IMAGE:-"quay.io/metal3-io/ironic"}
 IRONIC_KEEPALIVED_IMAGE=${IRONIC_KEEPALIVED_IMAGE:-"quay.io/metal3-io/keepalived"}
 IPA_DOWNLOADER_IMAGE=${IPA_DOWNLOADER_IMAGE:-"quay.io/metal3-io/ironic-ipa-downloader:master"}
 IPA_BASEURI=${IPA_BASEURI:-}


### PR DESCRIPTION
This PR picks a commit of @elfosardo. The purpose of this commit is: After ironic-inspector merges with ironic image, we need to change the reference of the ironic-inspector container to point to the ironic image in quay.
This commit has been revert in the PR:https://github.com/metal3-io/baremetal-operator/pull/873. Now it can go in after the PR  https://github.com/metal3-io/ironic-image/pull/264/ which solves the problem that two httpd instances try to open the same port. 