### PR TITLE
Refactoring: make ProvisionData.Image a pointer

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -813,7 +813,7 @@ func (r *BareMetalHostReconciler) actionProvisioning(prov provisioner.Provisione
 	}
 
 	provResult, err := prov.Provision(provisioner.ProvisionData{
-		Image:           *info.host.Spec.Image.DeepCopy(),
+		Image:           info.host.Spec.Image.DeepCopy(),
 		HostConfig:      hostConf,
 		BootMode:        info.host.Status.Provisioning.BootMode,
 		HardwareProfile: hwProf,
@@ -840,7 +840,10 @@ func (r *BareMetalHostReconciler) actionProvisioning(prov provisioner.Provisione
 	}
 
 	// If the provisioner had no work, ensure the image settings match.
-	if info.host.Status.Provisioning.Image != *(info.host.Spec.Image) {
+	if info.host.Spec.Image == nil && info.host.Status.Provisioning.Image.URL != "" {
+		info.log.Info("removing deployed image in status")
+		info.host.Status.Provisioning.Image = metal3v1alpha1.Image{}
+	} else if info.host.Spec.Image != nil && info.host.Status.Provisioning.Image != *(info.host.Spec.Image) {
 		info.log.Info("updating deployed image in status")
 		info.host.Status.Provisioning.Image = *(info.host.Spec.Image)
 	}

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -210,7 +210,7 @@ func (p *fixtureProvisioner) Provision(data provisioner.ProvisionData) (result p
 	if p.state.image.URL == "" {
 		p.publisher("ProvisioningComplete", "Image provisioning completed")
 		p.log.Info("moving to done")
-		p.state.image = data.Image
+		p.state.image = *data.Image
 		result.Dirty = true
 		result.RequeueAfter = provisionRequeueDelay
 	}

--- a/pkg/provisioner/ironic/provision_test.go
+++ b/pkg/provisioner/ironic/provision_test.go
@@ -112,6 +112,7 @@ func TestProvision(t *testing.T) {
 			result, err := prov.Provision(provisioner.ProvisionData{
 				HostConfig: fixture.NewHostConfigData("testUserData", "test: NetworkData", "test: Meta"),
 				BootMode:   v1alpha1.DefaultBootMode,
+				Image:      host.Spec.Image.DeepCopy(),
 			})
 
 			assert.Equal(t, tc.expectedDirty, result.Dirty)
@@ -387,7 +388,7 @@ func TestIronicHasSameImage(t *testing.T) {
 				t.Fatalf("could not create provisioner: %s", err)
 			}
 
-			sameImage := prov.ironicHasSameImage(&tc.node, *host.Spec.Image)
+			sameImage := prov.ironicHasSameImage(&tc.node, host.Spec.Image)
 			assert.Equal(t, tc.expected, sameImage)
 		})
 	}

--- a/pkg/provisioner/ironic/updateopts_test.go
+++ b/pkg/provisioner/ironic/updateopts_test.go
@@ -463,7 +463,7 @@ func TestGetUpdateOptsForNodeWithRootHints(t *testing.T) {
 	ironicNode := &nodes.Node{}
 
 	provData := provisioner.ProvisionData{
-		Image:           *host.Spec.Image,
+		Image:           host.Spec.Image,
 		BootMode:        metal3v1alpha1.DefaultBootMode,
 		RootDeviceHints: host.Status.Provisioning.RootDeviceHints,
 	}
@@ -559,7 +559,7 @@ func TestGetUpdateOptsForNodeVirtual(t *testing.T) {
 
 	hwProf, _ := hardware.GetProfile("libvirt")
 	provData := provisioner.ProvisionData{
-		Image:           *host.Spec.Image,
+		Image:           host.Spec.Image,
 		BootMode:        metal3v1alpha1.DefaultBootMode,
 		HardwareProfile: hwProf,
 	}
@@ -666,7 +666,7 @@ func TestGetUpdateOptsForNodeDell(t *testing.T) {
 
 	hwProf, _ := hardware.GetProfile("dell")
 	provData := provisioner.ProvisionData{
-		Image:           *host.Spec.Image,
+		Image:           host.Spec.Image,
 		BootMode:        metal3v1alpha1.DefaultBootMode,
 		HardwareProfile: hwProf,
 	}
@@ -739,7 +739,7 @@ func TestGetUpdateOptsForNodeLiveIso(t *testing.T) {
 	ironicNode := &nodes.Node{}
 
 	provData := provisioner.ProvisionData{
-		Image:    *host.Spec.Image,
+		Image:    host.Spec.Image,
 		BootMode: metal3v1alpha1.DefaultBootMode,
 	}
 	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates
@@ -808,7 +808,7 @@ func TestGetUpdateOptsForNodeImageToLiveIso(t *testing.T) {
 	}
 
 	provData := provisioner.ProvisionData{
-		Image:    *host.Spec.Image,
+		Image:    host.Spec.Image,
 		BootMode: metal3v1alpha1.DefaultBootMode,
 	}
 	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates
@@ -887,7 +887,7 @@ func TestGetUpdateOptsForNodeLiveIsoToImage(t *testing.T) {
 	}
 
 	provData := provisioner.ProvisionData{
-		Image:    *host.Spec.Image,
+		Image:    host.Spec.Image,
 		BootMode: metal3v1alpha1.DefaultBootMode,
 	}
 	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates
@@ -988,7 +988,7 @@ func TestGetUpdateOptsForNodeSecureBoot(t *testing.T) {
 
 	hwProf, _ := hardware.GetProfile("libvirt")
 	provData := provisioner.ProvisionData{
-		Image:           *host.Spec.Image,
+		Image:           host.Spec.Image,
 		BootMode:        metal3v1alpha1.UEFISecureBoot,
 		HardwareProfile: hwProf,
 	}

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -78,7 +78,7 @@ type PrepareData struct {
 }
 
 type ProvisionData struct {
-	Image           metal3v1alpha1.Image
+	Image           *metal3v1alpha1.Image
 	HostConfig      HostConfigData
 	BootMode        metal3v1alpha1.BootMode
 	HardwareProfile hardware.Profile


### PR DESCRIPTION
This is preparation for having Image optional on deployment, as is the
case with custom deploy procedure. See this design for details:
https://github.com/metal3-io/metal3-docs/pull/180/
