### PR TITLE
Fix bug with re-inspection due to Node in "available" state

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -667,7 +667,7 @@ func (r *BareMetalHostReconciler) actionInspecting(prov provisioner.Provisioner,
 	info.log.Info("inspecting hardware")
 
 	refresh := hasInspectAnnotation(info.host)
-	provResult, details, err := prov.InspectHardware(
+	provResult, started, details, err := prov.InspectHardware(
 		provisioner.InspectData{
 			BootMode: info.host.Status.Provisioning.BootMode,
 		},
@@ -682,7 +682,7 @@ func (r *BareMetalHostReconciler) actionInspecting(prov provisioner.Provisioner,
 	}
 
 	// Delete inspect annotation if exists
-	if hasInspectAnnotation(info.host) {
+	if started && hasInspectAnnotation(info.host) {
 		delete(info.host.Annotations, inspectAnnotationPrefix)
 		if err := r.Update(context.TODO(), info.host); err != nil {
 			return actionError{errors.Wrap(err, "failed to remove inspect annotation from host")}

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -920,9 +920,9 @@ func (m *mockProvisioner) ValidateManagementAccess(data provisioner.ManagementAc
 	return m.getNextResultByMethod("ValidateManagementAccess"), "", err
 }
 
-func (m *mockProvisioner) InspectHardware(data provisioner.InspectData, force, refresh bool) (result provisioner.Result, details *metal3v1alpha1.HardwareDetails, err error) {
+func (m *mockProvisioner) InspectHardware(data provisioner.InspectData, force, refresh bool) (result provisioner.Result, started bool, details *metal3v1alpha1.HardwareDetails, err error) {
 	details = &metal3v1alpha1.HardwareDetails{}
-	return m.getNextResultByMethod("InspectHardware"), details, err
+	return m.getNextResultByMethod("InspectHardware"), true, details, err
 }
 
 func (m *mockProvisioner) UpdateHardwareState() (hwState provisioner.HardwareState, err error) {

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -116,7 +116,8 @@ func (p *demoProvisioner) ValidateManagementAccess(data provisioner.ManagementAc
 // details of devices discovered on the hardware. It may be called
 // multiple times, and should return true for its dirty flag until the
 // inspection is completed.
-func (p *demoProvisioner) InspectHardware(data provisioner.InspectData, force, refresh bool) (result provisioner.Result, details *metal3v1alpha1.HardwareDetails, err error) {
+func (p *demoProvisioner) InspectHardware(data provisioner.InspectData, force, refresh bool) (result provisioner.Result, started bool, details *metal3v1alpha1.HardwareDetails, err error) {
+	started = true
 	hostName := p.objectMeta.Name
 
 	if hostName == InspectingHost {

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -119,12 +119,13 @@ func (p *fixtureProvisioner) ValidateManagementAccess(data provisioner.Managemen
 // details of devices discovered on the hardware. It may be called
 // multiple times, and should return true for its dirty flag until the
 // inspection is completed.
-func (p *fixtureProvisioner) InspectHardware(data provisioner.InspectData, force, refresh bool) (result provisioner.Result, details *metal3v1alpha1.HardwareDetails, err error) {
+func (p *fixtureProvisioner) InspectHardware(data provisioner.InspectData, force, refresh bool) (result provisioner.Result, started bool, details *metal3v1alpha1.HardwareDetails, err error) {
 	// The inspection is ongoing. We'll need to check the fixture
 	// status for the server here until it is ready for us to get the
 	// inspection details. Simulate that for now by creating the
 	// hardware details struct as part of a second pass.
 	p.log.Info("continuing inspection by setting details")
+	started = true
 	details =
 		&metal3v1alpha1.HardwareDetails{
 			RAMMebibytes: 128 * 1024,

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -100,7 +100,7 @@ type Provisioner interface {
 	// details of devices discovered on the hardware. It may be called
 	// multiple times, and should return true for its dirty flag until the
 	// inspection is completed.
-	InspectHardware(data InspectData, force, refresh bool) (result Result, details *metal3v1alpha1.HardwareDetails, err error)
+	InspectHardware(data InspectData, force, refresh bool) (result Result, started bool, details *metal3v1alpha1.HardwareDetails, err error)
 
 	// UpdateHardwareState fetches the latest hardware state of the
 	// server and updates the HardwareDetails field of the host with


### PR DESCRIPTION
When an annotation appears to force re-inspection, the Host returns to
the Inspecting state from the Ready/Available state. Originally the
ironic node would always be in the "manageable" state for a ready Host,
but we have usually been leaving it in the "available" state after
deprovisioning since 18465130c8f42bda4aa8191b5093656dcc029d90, and after
the initial preparation since 9a55ce5bc63a2f24916f1f604c736570836fdaea.

Handle the "available" node state during inspection by moving the node
to the "manageable" state. Since the first call to InspectHardware may
not start a new inspection, we have to return a new value to indicate
when inspection has actually started and thus it is safe to clear the
annotation. This also fixes a bug where failing to set the boot mode due
to a conflict would cause the inspection annotation to be removed
without starting a new inspection.