### PR TITLE
Uplift kube-rbac-proxy to v0.8.0

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8085/"

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -1032,7 +1032,7 @@ spec:
         - --upstream=http://127.0.0.1:8085/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Taking in changes as CAPI release-0.3 kubernetes-sigs/cluster-api#4639 
Eventually this means only to take a newer version of kube-rbac-proxy  into effect. 