### PR TITLE
Correctly deprovision nodes in DeployWait and Deploying

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1450,7 +1450,12 @@ func (p *ironicProvisioner) Deprovision(force bool) (result provisioner.Result, 
 		p.log.Info("cleaning")
 		return operationContinuing(deprovisionRequeueDelay)
 
-	case nodes.Active, nodes.DeployFail:
+	case nodes.Deploying:
+		p.log.Info("previous deploy running")
+		// Deploying cannot be stopped, wait for DeployWait or Active
+		return operationContinuing(deprovisionRequeueDelay)
+
+	case nodes.Active, nodes.DeployFail, nodes.DeployWait:
 		p.log.Info("starting deprovisioning")
 		p.publisher("DeprovisioningStarted", "Image deprovisioning started")
 		return p.changeNodeProvisionState(


### PR DESCRIPTION
Currently these states are unhandled. From DeployWait we can immediately
start undeploying, for Deploying we have to wait for another state.