### PR TITLE
Increase the default $BMO_CONCURRENCY for scale

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -1312,7 +1313,13 @@ func (r *BareMetalHostReconciler) updateEventHandler(e event.UpdateEvent) bool {
 // SetupWithManager reigsters the reconciler to be run by the manager
 func (r *BareMetalHostReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
-	maxConcurrentReconciles := 3
+	maxConcurrentReconciles := runtime.NumCPU()
+	if maxConcurrentReconciles > 8 {
+		maxConcurrentReconciles = 8
+	}
+	if maxConcurrentReconciles < 2 {
+		maxConcurrentReconciles = 2
+	}
 	if mcrEnv, ok := os.LookupEnv("BMO_CONCURRENCY"); ok {
 		mcr, err := strconv.Atoi(mcrEnv)
 		if err != nil {

--- a/controllers/metal3.io/host_state_machine.go
+++ b/controllers/metal3.io/host_state_machine.go
@@ -291,6 +291,10 @@ func (hsm *hostStateMachine) ensureRegistered(info *reconcileInfo) (result actio
 		// We haven't yet reached the Registration state, so don't attempt
 		// to register the Host.
 		return
+	case metal3v1alpha1.StateMatchProfile:
+		// We don't call the provisioner in this state, so there is no point
+		// in checking the registration.
+		return
 	case metal3v1alpha1.StateDeleting:
 		// In the deleting state the whole idea is to de-register the host
 		return

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,7 @@ client certificate authentication (mTLS) to be enabled.
 client certificate SAN validation.
 
 `BMO_CONCURRENCY` -- The number of concurrent reconciles performed by the
-Operator. Default is 3.
+Operator. Default is the number of CPUs, but no less than 2 and no more than 8.
 
 `PROVISIONING_LIMIT` -- The desired maximum number of hosts that could be (de)provisioned
 simultaneously by the Operator. The Operator will try to enforce this limit,


### PR DESCRIPTION
Instead of defaulting the $BMO_CONCURRENCY value (the maximum number of
Hosts to reconcile concurrently) to a hard-coded value of 3, set it
instead to the number of CPU threads available, but constrained to a
range between 2 and 8.

We never default to 1 so that we don't inadvertantly rely on
single-threadedness in tests. 8 seems to be a reasonable value for a
large scale deployment, while still being substantially below the
default $PROVISIONING_LIMIT of 20.

There remains no restriction on the value that can be passed in the
environment variable.

Fixes #905