### PR TITLE
Always build a configdrive except for live ISO

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -438,6 +438,10 @@ type Image struct {
 	DiskFormat *string `json:"format,omitempty"`
 }
 
+func (image *Image) IsLiveISO() bool {
+	return image != nil && image.DiskFormat != nil && *image.DiskFormat == "live-iso"
+}
+
 // Custom deploy is a description of a customized deploy process.
 type CustomDeploy struct {
 	// Custom deploy method name.

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -795,7 +795,7 @@ func (p *ironicProvisioner) getImageUpdateOptsForNode(ironicNode *nodes.Node, im
 	if hasCustomDeploy {
 		// Custom deploy process
 		p.setCustomDeployUpdateOptsForNode(ironicNode, imageData, updater)
-	} else if imageData.DiskFormat != nil && *imageData.DiskFormat == "live-iso" {
+	} else if imageData.IsLiveISO() {
 		// Set live-iso format options
 		p.setLiveIsoUpdateOptsForNode(ironicNode, imageData, updater)
 	} else {
@@ -897,7 +897,7 @@ func (p *ironicProvisioner) setUpForProvisioning(ironicNode *nodes.Node, data pr
 
 func (p *ironicProvisioner) deployInterface(image *metal3v1alpha1.Image) (result string) {
 	result = "direct"
-	if image != nil && image.DiskFormat != nil && *image.DiskFormat == "live-iso" {
+	if image.IsLiveISO() {
 		result = "ramdisk"
 	}
 	return result
@@ -957,7 +957,7 @@ func (p *ironicProvisioner) Adopt(data provisioner.AdoptData, force bool) (resul
 func (p *ironicProvisioner) ironicHasSameImage(ironicNode *nodes.Node, image metal3v1alpha1.Image) (sameImage bool) {
 	// To make it easier to test if ironic is configured with
 	// the same image we are trying to provision to the host.
-	if image.DiskFormat != nil && *image.DiskFormat == "live-iso" {
+	if image.IsLiveISO() {
 		sameImage = (ironicNode.InstanceInfo["boot_iso"] == image.URL)
 		p.log.Info("checking image settings",
 			"boot_iso", ironicNode.InstanceInfo["boot_iso"],
@@ -1128,7 +1128,7 @@ func (p *ironicProvisioner) getConfigDrive(data provisioner.ProvisionData) (conf
 	// it to another virtual media slot. However, some hardware does not
 	// support two virtual media devices at the same time, so we shouldn't
 	// try it.
-	if data.Image.DiskFormat != nil && *data.Image.DiskFormat == "live-iso" {
+	if data.Image.IsLiveISO() {
 		p.log.Info("not providing config drive for live ISO")
 		return
 	}

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1124,6 +1124,15 @@ func (p *ironicProvisioner) Prepare(data provisioner.PrepareData, unprepared boo
 }
 
 func (p *ironicProvisioner) getConfigDrive(data provisioner.ProvisionData) (configDrive nodes.ConfigDrive, err error) {
+	// In theory, Ironic can support configdrive with live ISO by attaching
+	// it to another virtual media slot. However, some hardware does not
+	// support two virtual media devices at the same time, so we shouldn't
+	// try it.
+	if data.Image.DiskFormat != nil && *data.Image.DiskFormat == "live-iso" {
+		p.log.Info("not providing config drive for live ISO")
+		return
+	}
+
 	// Retrieve instance specific user data (cloud-init, ignition, etc).
 	userData, err := data.HostConfig.UserData()
 	if err != nil {
@@ -1147,7 +1156,7 @@ func (p *ironicProvisioner) getConfigDrive(data provisioner.ProvisionData) (conf
 	}
 
 	// Retrieve meta data with fallback to defaults from provisioner.
-	metaData := map[string]interface{}{
+	configDrive.MetaData = map[string]interface{}{
 		"uuid":             string(p.objectMeta.UID),
 		"metal3-namespace": p.objectMeta.Namespace,
 		"metal3-name":      p.objectMeta.Name,
@@ -1160,17 +1169,9 @@ func (p *ironicProvisioner) getConfigDrive(data provisioner.ProvisionData) (conf
 		return configDrive, errors.Wrap(err, "could not retrieve metadata")
 	}
 	if metaDataRaw != "" {
-		if err = yaml.Unmarshal([]byte(metaDataRaw), &metaData); err != nil {
+		if err = yaml.Unmarshal([]byte(metaDataRaw), &configDrive.MetaData); err != nil {
 			return configDrive, errors.Wrap(err, "failed to unmarshal metadata from secret")
 		}
-	}
-
-	// Set metaData if any field is populated by a user.
-	if metaDataRaw != "" || networkDataRaw != "" || userData != "" {
-		configDrive.MetaData = metaData
-		p.log.Info("triggering provisioning with config drive")
-	} else {
-		p.log.Info("triggering provisioning without config drive")
 	}
 
 	return


### PR DESCRIPTION
We have default meta data that we should pass in any case.

PR based on top of https://github.com/metal3-io/baremetal-operator/pull/900.