### PR TITLE
Disable raid feature for iRMC server

### DIFF
--- a/pkg/bmc/irmc.go
+++ b/pkg/bmc/irmc.go
@@ -83,7 +83,7 @@ func (a *iRMCAccessDetails) PowerInterface() string {
 }
 
 func (a *iRMCAccessDetails) RAIDInterface() string {
-	return "irmc"
+	return "no-raid"
 }
 
 func (a *iRMCAccessDetails) VendorInterface() string {

--- a/pkg/provisioner/ironic/prepare_test.go
+++ b/pkg/provisioner/ironic/prepare_test.go
@@ -158,7 +158,7 @@ func TestPrepare(t *testing.T) {
 			host.Status.Provisioning.ID = nodeUUID
 			prepData := provisioner.PrepareData{}
 			if tc.existRaidConfig {
-				host.Spec.BMC.Address = "irmc://test.bmc/"
+				host.Spec.BMC.Address = "idrac://test.bmc/"
 				prepData.RAIDConfig = &metal3v1alpha1.RAIDConfig{
 					HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{
 						{


### PR DESCRIPTION
Signed-off-by: Zou Yu <zouy.fnst@cn.fujitsu.com>

In view of the need for further discussion on #908, we can first disable RAID settings for iRMC to avoid clean fail on iRMC servers that do not support hardware RAID. 