### PR TITLE
Extend docs for "baremetalhost.metal3.io/detached" annotation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -520,3 +520,6 @@ to be updated unlike the `paused` anotation. While in this state the
 OperationalStatus field will be `detached` but the provisioning state will
 be unmodified.  This API only has any effect for BareMetalHost resources
 that are in either `Provisioned` or `ExternallyProvisioned` state.
+
+Please note only the existence of the annotation is important to treat the BMH
+as detached and the value of the annotation is always ignored.


### PR DESCRIPTION
Currently it's not clear that the `baremetalhost.metal3.io/detached`
annotation ignores the value. This PR makes it clear in the API
documentation that the annotation is not a boolean value so that setting
it as `"false"` may not have an expected result.

Supersedes: #912 