### PR TITLE
Use recreate strategy for ironic deployment

### DIFF
--- a/ironic-deployment/ironic/ironic.yaml
+++ b/ironic-deployment/ironic/ironic.yaml
@@ -4,6 +4,10 @@ metadata:
   name: capm3-ironic
 spec:
   replicas: 1
+  strategy:
+    # We cannot run Ironic with more than one replica at a time. The recreate
+    # strategy makes sure that the old pod is gone before a new is started.
+    type: Recreate
   selector:
     matchLabels:
       name: capm3-ironic
@@ -46,7 +50,7 @@ spec:
               valueFrom:
                  configMapKeyRef:
                   name: ironic-bmo-configmap
-                  key: RESTART_CONTAINER_CERTIFICATE_UPDATED 
+                  key: RESTART_CONTAINER_CERTIFICATE_UPDATED
         - name: ironic-api
           image: quay.io/metal3-io/ironic
           imagePullPolicy: Always


### PR DESCRIPTION
Ironic cannot run with more than 1 replica (the second crashes immediately) but the default rolling update strategy will try to get a second replica up and running before it removes the old one. This means that the rollout always gets stuck unless we first manually scale down the deployment to 0, then update, and finally scale it up again.

The recreate strategy is a better fit since it does the scale down
automatically.

For reference, here is how we currently upgrade ironic in the upgrade tests:
https://github.com/Nordix/metal3-dev-env/blob/1ab2dda79c717083f8ced21cdaeb885c93559dc6/vm-setup/roles/v1aX_integration_test/tasks/upgrade.yml#L217-L257