### PR TITLE
Fix the bug when not using reverse proxy for Ironic-inspector

### DIFF
--- a/ironic-deployment/tls/default/tls.yaml
+++ b/ironic-deployment/tls/default/tls.yaml
@@ -53,6 +53,9 @@ spec:
         - name: cert-mariadb-ca
           mountPath: "/certs/ca/mariadb"
           readOnly: true
+        - name: cert-ironic-inspector-ca
+          mountPath: "/certs/ca/ironic-inspector"
+          readOnly: true
       volumes:
       - name: cert-ironic-ca
         secret:

--- a/ironic-deployment/tls/keepalived/tls.yaml
+++ b/ironic-deployment/tls/keepalived/tls.yaml
@@ -45,6 +45,9 @@ spec:
         - name: cert-ironic-inspector
           mountPath: "/certs/ironic-inspector"
           readOnly: true
+        - name: cert-ironic-inspector-ca
+          mountPath: "/certs/ca/ironic-inspector"
+          readOnly: true
       - name: mariadb
         volumeMounts:
         - name: cert-mariadb


### PR DESCRIPTION
This PR adds an option to disable the ironic inspector reverse proxy when we enable TLS on Ironic communication. 
Edit: Instead of adding an option, this PR just fixes a bug in the non-proxy case. 