### PR TITLE
Fix auto clean failure in preparing state

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1217,10 +1217,7 @@ func (p *ironicProvisioner) Prepare(data provisioner.PrepareData, unprepared boo
 			started = true
 		}
 		// Manual clean finished
-		result, err = p.changeNodeProvisionState(
-			ironicNode,
-			nodes.ProvisionStateOpts{Target: nodes.TargetProvide},
-		)
+		result, err = operationComplete()
 
 	case nodes.CleanFail:
 		// When clean failed, we need to clean host provisioning settings.


### PR DESCRIPTION
Auto cleaning step(erase_devices_metadata) in Prepare will fail with the following error:

```
Agent returned error for clean step {'step': 'erase_devices_metadata',
'priority': 10, 'interface': 'deploy', 'reboot_requested': False, 'abortable':
True, 'requires_ramdisk': True} on node 09174110-95b3-4bd0-99a9-839df8794139 :
Error performing clean_step erase_devices_metadata: Error erasing block device:
Failed to erase the metadata on the device(s): \"/dev/sda\": Unexpected error
while running command.\nCommand: dd bs=512 if=/dev/zero of=/dev/sda count=33\n
Exit code: 1\nStdout: ''\nStderr: \"dd: error writing '/dev/sda': Input/output
error\\n1+0 records in\\n0+0 records out\\n0 bytes copied, 0.00108204 s, 0.0 kB/s\\n\"
```

Since RAID cannot be used immediately after the configuration is completed, it takes a
certain amount of time to initialize. At this time, data cannot be written to the disk,
and the above error occurs.

This will result in entering the clean fail state and re-executing manual clean and
auto clean, then it causes the above error again.

Signed-off-by: Zou Yu <zouy.fnst@cn.fujitsu.com>