### PR TITLE
Modify namespace prefix in ironic deployment to support TLS

### DIFF
--- a/config/tls/kustomization.yaml
+++ b/config/tls/kustomization.yaml
@@ -5,10 +5,5 @@ resources:
 - ../default
 - ../namespace
 
-secretGenerator:
-  - name: ironic-cacert
-    files:
-    - crt=ca.crt
-
 patchesStrategicMerge:
 - tls_ca_patch.yaml

--- a/ironic-deployment/basic-auth/default/auth.yaml
+++ b/ironic-deployment/basic-auth/default/auth.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: capm3-ironic
+  name: ${NAMEPREFIX}-ironic
 spec:
   template:
     spec:

--- a/ironic-deployment/basic-auth/default/kustomization.yaml
+++ b/ironic-deployment/basic-auth/default/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: capm3-system
+namespace: ${NAMEPREFIX}-system
 resources:
 - ../../default
 

--- a/ironic-deployment/basic-auth/keepalived/auth.yaml
+++ b/ironic-deployment/basic-auth/keepalived/auth.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: capm3-ironic
+  name: ${NAMEPREFIX}-ironic
 spec:
   template:
     spec:

--- a/ironic-deployment/basic-auth/keepalived/kustomization.yaml
+++ b/ironic-deployment/basic-auth/keepalived/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: capm3-system
+namespace: ${NAMEPREFIX}-system
 resources:
 - ../../keepalived
 

--- a/ironic-deployment/basic-auth/tls/default/auth.yaml
+++ b/ironic-deployment/basic-auth/tls/default/auth.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: capm3-ironic
+  name: ${NAMEPREFIX}-ironic
 spec:
   template:
     spec:

--- a/ironic-deployment/basic-auth/tls/default/kustomization.yaml
+++ b/ironic-deployment/basic-auth/tls/default/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: capm3-system
+namespace: ${NAMEPREFIX}-system
 resources:
 - ../../../tls/default
 

--- a/ironic-deployment/basic-auth/tls/keepalived/auth.yaml
+++ b/ironic-deployment/basic-auth/tls/keepalived/auth.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: capm3-ironic
+  name: ${NAMEPREFIX}-ironic
 spec:
   template:
     spec:

--- a/ironic-deployment/basic-auth/tls/keepalived/kustomization.yaml
+++ b/ironic-deployment/basic-auth/tls/keepalived/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: capm3-system
+namespace: ${NAMEPREFIX}-system
 resources:
 - ../../../tls/keepalived
 

--- a/ironic-deployment/certmanager/certificate.yaml
+++ b/ironic-deployment/certmanager/certificate.yaml
@@ -2,7 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
-  namespace: capm3-system
+  namespace: ${NAMEPREFIX}-system
 spec:
   selfSigned: {}
 ---
@@ -10,7 +10,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ironic-cacert
-  namespace: capm3-system
+  namespace: ${NAMEPREFIX}-system
 spec:
   isCA: true
   ipAddresses:
@@ -24,7 +24,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: ca-issuer
-  namespace: capm3-system
+  namespace: ${NAMEPREFIX}-system
 spec:
   ca:
     secretName: ironic-cacert
@@ -33,7 +33,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ironic-cert
-  namespace: capm3-system
+  namespace: ${NAMEPREFIX}-system
 spec:
   ipAddresses:
   - IRONIC_HOST_IP
@@ -46,7 +46,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ironic-inspector-cert
-  namespace: capm3-system
+  namespace: ${NAMEPREFIX}-system
 spec:
   ipAddresses:
   - IRONIC_HOST_IP
@@ -59,7 +59,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: mariadb-cert
-  namespace: capm3-system
+  namespace: ${NAMEPREFIX}-system
 spec:
   ipAddresses:
   - MARIADB_HOST_IP

--- a/ironic-deployment/default/kustomization.yaml
+++ b/ironic-deployment/default/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: capm3-system
+namespace: ${NAMEPREFIX}-system
 resources:
 - ../ironic
 configMapGenerator:

--- a/ironic-deployment/ironic/ironic.yaml
+++ b/ironic-deployment/ironic/ironic.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: capm3-ironic
+  name: ${NAMEPREFIX}-ironic
 spec:
   replicas: 1
   strategy:
@@ -10,11 +10,11 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      name: capm3-ironic
+      name: ${NAMEPREFIX}-ironic
   template:
     metadata:
       labels:
-        name: capm3-ironic
+        name: ${NAMEPREFIX}-ironic
     spec:
       hostNetwork: true
       containers:

--- a/ironic-deployment/keepalived/keepalived_patch.yaml
+++ b/ironic-deployment/keepalived/keepalived_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: capm3-ironic
+  name: ${NAMEPREFIX}-ironic
 spec:
   template:
     spec:

--- a/ironic-deployment/keepalived/kustomization.yaml
+++ b/ironic-deployment/keepalived/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: capm3-system
+namespace: ${NAMEPREFIX}-system
 resources:
 - ../../config/namespace
 - ../ironic

--- a/ironic-deployment/tls/default/kustomization.yaml
+++ b/ironic-deployment/tls/default/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: capm3-system
+namespace: ${NAMEPREFIX}-system
 resources:
 - ../../default
 - ../../certmanager

--- a/ironic-deployment/tls/default/tls.yaml
+++ b/ironic-deployment/tls/default/tls.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: capm3-ironic
+  name: ${NAMEPREFIX}-ironic
 spec:
   template:
     spec:

--- a/ironic-deployment/tls/keepalived/kustomization.yaml
+++ b/ironic-deployment/tls/keepalived/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: capm3-system
+namespace: ${NAMEPREFIX}-system
 resources:
 - ../../keepalived
 - ../../certmanager

--- a/ironic-deployment/tls/keepalived/tls.yaml
+++ b/ironic-deployment/tls/keepalived/tls.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: capm3-ironic
+  name: ${NAMEPREFIX}-ironic
 spec:
   template:
     spec:

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -25,6 +25,32 @@ RESTART_CONTAINER_CERTIFICATE_UPDATED=${RESTART_CONTAINER_CERTIFICATE_UPDATED:-"
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
+IRONIC_DEPLOY_FILES="${SCRIPTDIR}/ironic-deployment/basic-auth/default/auth.yaml \
+	${SCRIPTDIR}/ironic-deployment/basic-auth/default/kustomization.yaml \
+	${SCRIPTDIR}/ironic-deployment/basic-auth/keepalived/auth.yaml \
+	${SCRIPTDIR}/ironic-deployment/basic-auth/keepalived/kustomization.yaml \
+	${SCRIPTDIR}/ironic-deployment/basic-auth/tls/default/auth.yaml \
+	${SCRIPTDIR}/ironic-deployment/basic-auth/tls/default/kustomization.yaml \
+	${SCRIPTDIR}/ironic-deployment/basic-auth/tls/keepalived/auth.yaml \
+	${SCRIPTDIR}/ironic-deployment/basic-auth/tls/keepalived/kustomization.yaml \
+	${SCRIPTDIR}/ironic-deployment/certmanager/certificate.yaml \
+	${SCRIPTDIR}/ironic-deployment/default/kustomization.yaml \
+	${SCRIPTDIR}/ironic-deployment/ironic/ironic.yaml \
+	${SCRIPTDIR}/ironic-deployment/keepalived/keepalived_patch.yaml \
+	${SCRIPTDIR}/ironic-deployment/keepalived/kustomization.yaml \
+	${SCRIPTDIR}/ironic-deployment/tls/default/kustomization.yaml \
+	${SCRIPTDIR}/ironic-deployment/tls/default/tls.yaml \
+	${SCRIPTDIR}/ironic-deployment/tls/keepalived/kustomization.yaml \
+	${SCRIPTDIR}/ironic-deployment/tls/keepalived/tls.yaml"
+
+for DEPLOY_FILE in ${IRONIC_DEPLOY_FILES}; do
+  cp "$DEPLOY_FILE" "$DEPLOY_FILE".orig
+  # shellcheck disable=SC2094
+  envsubst <"$DEPLOY_FILE".orig> "$DEPLOY_FILE"
+  # To use sed need to change ${NAMEPREFIX} to NAMEPREFIX to every IRONIC_DEPLOY_FILES
+  #sed -i "s/NAMEPREFIX/${NAMEPREFIX}/g" "${DEPLOY_FILE}"
+done
+
 if [ "${DEPLOY_BASIC_AUTH}" == "true" ]; then
     BMO_SCENARIO="${SCRIPTDIR}/config/basic-auth"
     IRONIC_SCENARIO="${SCRIPTDIR}/ironic-deployment/basic-auth"
@@ -143,6 +169,11 @@ if [ "${DEPLOY_IRONIC}" == "true" ]; then
     mv /tmp/ironic_bmo_configmap.env "${IRONIC_BMO_CONFIGMAP}"
     popd
 fi
+
+# Move back the original IRONIC_DEPLOY_FILES
+ for DEPLOY_FILE in ${IRONIC_DEPLOY_FILES}; do
+    mv "$DEPLOY_FILE".orig "$DEPLOY_FILE"
+ done
 
 if [ "${DEPLOY_BASIC_AUTH}" == "true" ]; then
     if [ "${DEPLOY_BMO}" == "true" ]; then

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -22,6 +22,7 @@ MARIADB_HOST_IP="${MARIADB_HOST_IP:-"127.0.0.1"}"
 KUBECTL_ARGS="${KUBECTL_ARGS:-""}"
 KUSTOMIZE="go run sigs.k8s.io/kustomize/kustomize/v3"
 RESTART_CONTAINER_CERTIFICATE_UPDATED=${RESTART_CONTAINER_CERTIFICATE_UPDATED:-"false"}
+export NAMEPREFIX=${NAMEPREFIX:-"capm3"}
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
@@ -44,11 +45,9 @@ IRONIC_DEPLOY_FILES="${SCRIPTDIR}/ironic-deployment/basic-auth/default/auth.yaml
 	${SCRIPTDIR}/ironic-deployment/tls/keepalived/tls.yaml"
 
 for DEPLOY_FILE in ${IRONIC_DEPLOY_FILES}; do
-  cp "$DEPLOY_FILE" "$DEPLOY_FILE".orig
+  cp "$DEPLOY_FILE" "$DEPLOY_FILE".bak
   # shellcheck disable=SC2094
-  envsubst <"$DEPLOY_FILE".orig> "$DEPLOY_FILE"
-  # To use sed need to change ${NAMEPREFIX} to NAMEPREFIX to every IRONIC_DEPLOY_FILES
-  #sed -i "s/NAMEPREFIX/${NAMEPREFIX}/g" "${DEPLOY_FILE}"
+  envsubst <"$DEPLOY_FILE".bak> "$DEPLOY_FILE"
 done
 
 if [ "${DEPLOY_BASIC_AUTH}" == "true" ]; then
@@ -172,7 +171,7 @@ fi
 
 # Move back the original IRONIC_DEPLOY_FILES
  for DEPLOY_FILE in ${IRONIC_DEPLOY_FILES}; do
-    mv "$DEPLOY_FILE".orig "$DEPLOY_FILE"
+    mv "$DEPLOY_FILE".bak "$DEPLOY_FILE"
  done
 
 if [ "${DEPLOY_BASIC_AUTH}" == "true" ]; then

--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -93,7 +93,7 @@ data:
 kind: Secret
 metadata:
    name: ironic-cacert
-   namespace: capm3-system
+   namespace: ${IRONIC_NAMESPACE}
 type: Opaque
 EOF
 fi

--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -18,7 +18,7 @@ PROVISIONING_INTERFACE="${PROVISIONING_INTERFACE:-"ironicendpoint"}"
 CLUSTER_DHCP_RANGE="${CLUSTER_DHCP_RANGE:-"172.22.0.10,172.22.0.100"}"
 IRONIC_KERNEL_PARAMS="${IRONIC_KERNEL_PARAMS:-"console=ttyS0"}"
 IRONIC_BOOT_ISO_SOURCE="${IRONIC_BOOT_ISO_SOURCE:-"local"}"
-
+export NAMEPREFIX=${NAMEPREFIX:-"capm3"}
 
 IRONIC_CACERT_FILE="${IRONIC_CACERT_FILE:-}"
 IRONIC_CERT_FILE="${IRONIC_CERT_FILE:-}"
@@ -93,7 +93,7 @@ data:
 kind: Secret
 metadata:
    name: ironic-cacert
-   namespace: ${IRONIC_NAMESPACE}
+   namespace: ${NAMEPREFIX}-system
 type: Opaque
 EOF
 fi


### PR DESCRIPTION
The changes in this PR will help to support TLS with CAPM3 v1a4(BMO part of CAPM3) and v1a5(BMO outside of CAPM3). This changes is needed to cope with v1a4 and v1a5 separately.