### PR TITLE
Create a SecretManager type to manage Secrets

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -815,10 +815,9 @@ func (r *BareMetalHostReconciler) actionPreparing(prov provisioner.Provisioner, 
 // Start/continue provisioning if we need to.
 func (r *BareMetalHostReconciler) actionProvisioning(prov provisioner.Provisioner, info *reconcileInfo) actionResult {
 	hostConf := &hostConfigData{
-		host:      info.host,
-		log:       info.log.WithName("host_config_data"),
-		client:    r,
-		apiReader: r.APIReader,
+		host:          info.host,
+		log:           info.log.WithName("host_config_data"),
+		secretManager: r.secretManager(info.log),
 	}
 	info.log.Info("provisioning")
 

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -54,9 +54,6 @@ const (
 	rebootAnnotationPrefix        = "reboot.metal3.io"
 	inspectAnnotationPrefix       = "inspect.metal3.io"
 	hardwareDetailsAnnotation     = inspectAnnotationPrefix + "/hardwaredetails"
-
-	LabelEnvironmentName  = secretutils.LabelEnvironmentName
-	LabelEnvironmentValue = secretutils.LabelEnvironmentValue
 )
 
 // BareMetalHostReconciler reconciles a BareMetalHost object

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -1228,7 +1228,10 @@ func (r *BareMetalHostReconciler) getBMCSecretAndSetOwner(request ctrl.Request, 
 
 	bmcCredsSecret, err = getSecret(r.Client, r.APIReader, host.CredentialsKey())
 	if err != nil {
-		return nil, &ResolveBMCSecretRefError{message: fmt.Sprintf("The BMC secret %s does not exist", host.CredentialsKey())}
+		if k8serrors.IsNotFound(err) {
+			return nil, &ResolveBMCSecretRefError{message: fmt.Sprintf("The BMC secret %s does not exist", host.CredentialsKey())}
+		}
+		return nil, err
 	}
 
 	// Make sure the secret has the correct owner as soon as we can.

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -44,6 +44,7 @@ import (
 	"github.com/metal3-io/baremetal-operator/pkg/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/hardware"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
+	"github.com/metal3-io/baremetal-operator/pkg/secretutils"
 	"github.com/metal3-io/baremetal-operator/pkg/utils"
 )
 
@@ -55,8 +56,8 @@ const (
 	inspectAnnotationPrefix       = "inspect.metal3.io"
 	hardwareDetailsAnnotation     = inspectAnnotationPrefix + "/hardwaredetails"
 
-	LabelEnvironmentName  = "environment.metal3.io"
-	LabelEnvironmentValue = "baremetal"
+	LabelEnvironmentName  = secretutils.LabelEnvironmentName
+	LabelEnvironmentValue = secretutils.LabelEnvironmentValue
 )
 
 // BareMetalHostReconciler reconciles a BareMetalHost object

--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -705,7 +705,7 @@ func TestSecretUpdateOwnerRefAndEnvironmentLabelOnStartup(t *testing.T) {
 	assert.True(t, *secret.OwnerReferences[0].Controller)
 	assert.True(t, *secret.OwnerReferences[0].BlockOwnerDeletion)
 
-	assert.Equal(t, LabelEnvironmentValue, secret.Labels[LabelEnvironmentName])
+	assert.Equal(t, "baremetal", secret.Labels["environment.metal3.io"])
 
 }
 

--- a/controllers/metal3.io/errors.go
+++ b/controllers/metal3.io/errors.go
@@ -37,17 +37,6 @@ func (e ResolveBMCSecretRefError) Error() string {
 		e.message)
 }
 
-// SaveBMCSecretOwnerError is returned when we
-// fail to set the owner of a secret
-type SaveBMCSecretOwnerError struct {
-	message string
-}
-
-func (e SaveBMCSecretOwnerError) Error() string {
-	return fmt.Sprintf("Failed to set owner of BMC secret %s",
-		e.message)
-}
-
 // NoDataInSecretError is returned when host configuration
 // data were not found in referenced secret
 type NoDataInSecretError struct {

--- a/controllers/metal3.io/host_config_data.go
+++ b/controllers/metal3.io/host_config_data.go
@@ -42,9 +42,6 @@ func getSecret(client client.Client, apiReader client.Reader, secretKey types.Na
 	// Secret not in cache; check API directly for unlabelled Secret
 	err = apiReader.Get(context.TODO(), secretKey, secret)
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil, err
-		}
 		return nil, err
 	}
 

--- a/controllers/metal3.io/host_config_data.go
+++ b/controllers/metal3.io/host_config_data.go
@@ -1,51 +1,19 @@
 package controllers
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/secretutils"
 )
 
 // hostConfigData is an implementation of host configuration data interface.
 // Object is able to retrive data from secrets referenced in a host spec
 type hostConfigData struct {
-	host      *metal3v1alpha1.BareMetalHost
-	log       logr.Logger
-	client    client.Client
-	apiReader client.Reader
-}
-
-// Generic method for retrieving a secret. If the secret is not found in the
-// filtered cache, then the object is retrieved directly from the API
-func getSecret(client client.Client, apiReader client.Reader, secretKey types.NamespacedName) (secret *corev1.Secret, err error) {
-
-	secret = &corev1.Secret{}
-
-	// Look for secret in the filtered cache
-	err = client.Get(context.TODO(), secretKey, secret)
-	if err == nil {
-		return secret, nil
-	}
-	if !k8serrors.IsNotFound(err) {
-		return nil, err
-	}
-
-	// Secret not in cache; check API directly for unlabelled Secret
-	err = apiReader.Get(context.TODO(), secretKey, secret)
-	if err != nil {
-		return nil, err
-	}
-
-	return secret, nil
+	host          *metal3v1alpha1.BareMetalHost
+	log           logr.Logger
+	secretManager secretutils.SecretManager
 }
 
 // Generic method for data extraction from a Secret. Function uses dataKey
@@ -57,19 +25,9 @@ func (hcd *hostConfigData) getSecretData(name, namespace, dataKey string) (strin
 		Namespace: namespace,
 	}
 
-	secret, err := getSecret(hcd.client, hcd.apiReader, key)
+	secret, err := hcd.secretManager.ObtainSecret(key)
 	if err != nil {
-		return "", errors.Wrap(err, fmt.Sprintf("failed to fetch user data from secret %s defined in namespace %s", name, namespace))
-	}
-
-	if !metav1.HasLabel(secret.ObjectMeta, LabelEnvironmentName) {
-		hcd.log.Info("updating secret environment label", "secret", secret.Name, "namespace", secret.Namespace)
-		metav1.SetMetaDataLabel(&secret.ObjectMeta, LabelEnvironmentName, LabelEnvironmentValue)
-
-		err = hcd.client.Update(context.TODO(), secret)
-		if err != nil {
-			return "", errors.Wrap(err, fmt.Sprintf("failed to updated secret %s defined in namespace %s", name, namespace))
-		}
+		return "", err
 	}
 
 	data, ok := secret.Data[dataKey]

--- a/controllers/metal3.io/host_config_data_test.go
+++ b/controllers/metal3.io/host_config_data_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/secretutils"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -66,11 +67,11 @@ func TestLabelSecrets(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			host := newHost("host", tc.hostSpec)
 			c := fakeclient.NewClientBuilder().Build()
+			baselog := ctrl.Log.WithName("controllers").WithName("BareMetalHost")
 			hcd := &hostConfigData{
-				host:      host,
-				log:       ctrl.Log.WithName("controllers").WithName("BareMetalHost").WithName("host_config_data"),
-				client:    c,
-				apiReader: c,
+				host:          host,
+				log:           baselog.WithName("host_config_data"),
+				secretManager: secretutils.NewSecretManager(baselog, c, c),
 			}
 
 			secret := newSecret(tc.name, map[string]string{"value": "somedata"})
@@ -298,11 +299,11 @@ func TestProvisionWithHostConfig(t *testing.T) {
 			c.Create(goctx.TODO(), testBMCSecret)
 			c.Create(goctx.TODO(), tc.UserDataSecret)
 			c.Create(goctx.TODO(), tc.NetworkDataSecret)
+			baselog := ctrl.Log.WithName("controllers").WithName("BareMetalHost")
 			hcd := &hostConfigData{
-				host:      tc.Host,
-				log:       ctrl.Log.WithName("controllers").WithName("BareMetalHost").WithName("host_config_data"),
-				client:    c,
-				apiReader: c,
+				host:          tc.Host,
+				log:           baselog.WithName("host_config_data"),
+				secretManager: secretutils.NewSecretManager(baselog, c, c),
 			}
 
 			actualUserData, err := hcd.UserData()

--- a/controllers/metal3.io/host_config_data_test.go
+++ b/controllers/metal3.io/host_config_data_test.go
@@ -82,7 +82,7 @@ func TestLabelSecrets(t *testing.T) {
 
 			actualSecret := &corev1.Secret{}
 			c.Get(context.TODO(), types.NamespacedName{Name: tc.name, Namespace: namespace}, actualSecret)
-			assert.Equal(t, actualSecret.Labels[LabelEnvironmentName], LabelEnvironmentValue)
+			assert.Equal(t, "baremetal", actualSecret.Labels["environment.metal3.io"])
 		})
 	}
 

--- a/main.go
+++ b/main.go
@@ -22,8 +22,6 @@ import (
 	"os"
 	"runtime"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -33,12 +31,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	metal3iov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	controllers "github.com/metal3-io/baremetal-operator/controllers/metal3.io"
 	metal3iocontroller "github.com/metal3-io/baremetal-operator/controllers/metal3.io"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/demo"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/fixture"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic"
+	"github.com/metal3-io/baremetal-operator/pkg/secretutils"
 	"github.com/metal3-io/baremetal-operator/pkg/version"
 	// +kubebuilder:scaffold:imports
 )
@@ -123,11 +121,7 @@ func main() {
 		HealthProbeBindAddress:  healthAddr,
 
 		NewCache: cache.BuilderWithOptions(cache.Options{
-			SelectorsByObject: cache.SelectorsByObject{
-				&corev1.Secret{}: {
-					Label: labels.SelectorFromSet(labels.Set{controllers.LabelEnvironmentName: controllers.LabelEnvironmentValue}),
-				},
-			},
+			SelectorsByObject: secretutils.AddSecretSelector(nil),
 		}),
 	})
 	if err != nil {

--- a/pkg/secretutils/label.go
+++ b/pkg/secretutils/label.go
@@ -1,0 +1,6 @@
+package secretutils
+
+const (
+	LabelEnvironmentName  = "environment.metal3.io"
+	LabelEnvironmentValue = "baremetal"
+)

--- a/pkg/secretutils/label.go
+++ b/pkg/secretutils/label.go
@@ -1,6 +1,32 @@
 package secretutils
 
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+)
+
 const (
 	LabelEnvironmentName  = "environment.metal3.io"
 	LabelEnvironmentValue = "baremetal"
 )
+
+// AddSecretSelector adds a selector to a cache.SelectorsByObject that filters
+// Secrets so that only those labelled as part of the baremetal environment get
+// cached. The input may be nil.
+func AddSecretSelector(selectors cache.SelectorsByObject) cache.SelectorsByObject {
+	secret := &corev1.Secret{}
+	newSelectors := cache.SelectorsByObject{
+		secret: {
+			Label: labels.SelectorFromSet(
+				labels.Set{
+					LabelEnvironmentName: LabelEnvironmentValue,
+				}),
+		},
+	}
+	if selectors == nil {
+		return newSelectors
+	}
+	selectors[secret] = newSelectors[secret]
+	return selectors
+}

--- a/pkg/secretutils/secret_manager.go
+++ b/pkg/secretutils/secret_manager.go
@@ -1,0 +1,140 @@
+package secretutils
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// SecretManager is a type for fetching Secrets whether or not they are in the
+// client cache, labelling so that they will be included in the client cache,
+// and optionally setting an owner reference.
+type SecretManager struct {
+	log       logr.Logger
+	client    client.Client
+	apiReader client.Reader
+}
+
+// NewSecretManager returns a new SecretManager
+func NewSecretManager(log logr.Logger, cacheClient client.Client, apiReader client.Reader) SecretManager {
+	return SecretManager{
+		log:       log.WithName("secret_manager"),
+		client:    cacheClient,
+		apiReader: apiReader,
+	}
+}
+
+// findSecret retrieves a Secret from the cache if it is available, and from the
+// k8s API if not.
+func (sm *SecretManager) findSecret(key types.NamespacedName) (secret *corev1.Secret, err error) {
+	secret = &corev1.Secret{}
+
+	// Look for secret in the filtered cache
+	err = sm.client.Get(context.TODO(), key, secret)
+	if err == nil {
+		return secret, nil
+	}
+	if !k8serrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	// Secret not in cache; check API directly for unlabelled Secret
+	err = sm.apiReader.Get(context.TODO(), key, secret)
+	if err != nil {
+		return nil, err
+	}
+
+	return secret, nil
+}
+
+// claimSecret ensures that the Secret has a label that will ensure it is
+// present in the cache (and that we can watch for changes), and optionally
+// that it has a particular owner reference.
+func (sm *SecretManager) claimSecret(secret *corev1.Secret, owner client.Object, ownerIsController bool) error {
+	log := sm.log.WithValues("secret", secret.Name, "secretNamespace", secret.Namespace)
+	needsUpdate := false
+	if !metav1.HasLabel(secret.ObjectMeta, LabelEnvironmentName) {
+		log.Info("settting secret environment label")
+		metav1.SetMetaDataLabel(&secret.ObjectMeta, LabelEnvironmentName, LabelEnvironmentValue)
+		needsUpdate = true
+	}
+	if owner != nil {
+		ownerLog := log.WithValues(
+			"ownerKind", owner.GetObjectKind().GroupVersionKind().Kind,
+			"owner", owner.GetNamespace()+"/"+owner.GetName(),
+			"ownerUID", owner.GetUID())
+		if ownerIsController {
+			if !metav1.IsControlledBy(secret, owner) {
+				ownerLog.Info("setting secret controller reference")
+				if err := controllerutil.SetControllerReference(owner, secret, sm.client.Scheme()); err != nil {
+					return errors.Wrap(err, "failed to set secret controller reference")
+				}
+				needsUpdate = true
+			}
+		} else {
+			alreadyOwned := false
+			ownerUID := owner.GetUID()
+			for _, ref := range secret.GetOwnerReferences() {
+				if ref.UID == ownerUID {
+					alreadyOwned = true
+					break
+				}
+			}
+			if !alreadyOwned {
+				ownerLog.Info("setting secret owner reference")
+				if err := controllerutil.SetOwnerReference(owner, secret, sm.client.Scheme()); err != nil {
+					return errors.Wrap(err, "failed to set secret owner reference")
+				}
+				needsUpdate = true
+			}
+		}
+	}
+
+	if needsUpdate {
+		if err := sm.client.Update(context.TODO(), secret); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("failed to update secret %s in namespace %s", secret.ObjectMeta.Name, secret.ObjectMeta.Namespace))
+		}
+	}
+
+	return nil
+}
+
+// obtainSecretForOwner retrieves a Secret and ensures that it has a label that
+// will ensure it is present in the cache (and that we can watch for changes),
+// and optionally that it has a particular owner reference. The owner reference
+// may optionally be a controller reference.
+func (sm *SecretManager) obtainSecretForOwner(key types.NamespacedName, owner client.Object, ownerIsController bool) (*corev1.Secret, error) {
+	secret, err := sm.findSecret(key)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to fetch secret %s in namespace %s", key.Name, key.Namespace))
+	}
+	err = sm.claimSecret(secret, owner, ownerIsController)
+
+	return secret, err
+}
+
+// AcquireSecret retrieves a Secret and ensures that it has a label that will
+// ensure it is present in the cache (and that we can watch for changes), and
+// that it has a particular owner reference. The owner reference may optionally
+// be a controller reference.
+func (sm *SecretManager) AcquireSecret(key types.NamespacedName, owner client.Object, ownerIsController bool) (*corev1.Secret, error) {
+	if owner == nil {
+		panic("AcquireSecret called with no owner")
+	}
+
+	return sm.obtainSecretForOwner(key, owner, ownerIsController)
+}
+
+// ObtainSecret retrieves a Secret and ensures that it has a label that will
+// ensure it is present in the cache (and that we can watch for changes).
+func (sm *SecretManager) ObtainSecret(key types.NamespacedName) (*corev1.Secret, error) {
+	return sm.obtainSecretForOwner(key, nil, false)
+}


### PR DESCRIPTION
De-duplicate the labelling implementations for BMC creds and user data, into a single SecretManager type in a new secretutils package. Also adds the flexibility to add owner references that are not controller references. As much code as possible related to caching/watching of Secrets is moved into this new package.