### PR TITLE
Fix missing case of BuildRAIDCleanSteps

### DIFF
--- a/pkg/provisioner/ironic/raid.go
+++ b/pkg/provisioner/ironic/raid.go
@@ -210,10 +210,14 @@ func BuildRAIDCleanSteps(raidInterface string, target *metal3v1alpha1.RAIDConfig
 	}
 
 	// Hardware RAID
-	// Ignore SoftwareRAIDVolumes
-	if target != nil {
-		target.SoftwareRAIDVolumes = nil
+	// If hardware RAID configuration is nil,
+	// keep old hardware RAID configuration
+	if target == nil || target.HardwareRAIDVolumes == nil {
+		return
 	}
+
+	// Ignore SoftwareRAIDVolumes
+	target.SoftwareRAIDVolumes = nil
 	if actual != nil {
 		actual.SoftwareRAIDVolumes = nil
 	}
@@ -232,7 +236,7 @@ func BuildRAIDCleanSteps(raidInterface string, target *metal3v1alpha1.RAIDConfig
 	)
 
 	// If hardware raid configuration is empty, only need to clear old configuration
-	if target == nil || len(target.HardwareRAIDVolumes) == 0 {
+	if len(target.HardwareRAIDVolumes) == 0 {
 		return
 	}
 

--- a/pkg/provisioner/ironic/raid_test.go
+++ b/pkg/provisioner/ironic/raid_test.go
@@ -198,6 +198,16 @@ func TestBuildRAIDCleanSteps(t *testing.T) {
 		expectedError bool
 	}{
 		{
+			name:          "keep hardware RAID",
+			raidInterface: "irmc",
+			target:        nil,
+		},
+		{
+			name:          "keep hardware RAID",
+			raidInterface: "irmc",
+			target:        &metal3v1alpha1.RAIDConfig{},
+		},
+		{
 			name:          "configure hardware RAID",
 			raidInterface: "irmc",
 			target: &metal3v1alpha1.RAIDConfig{


### PR DESCRIPTION
Signed-off-by: Zou Yu <zouy.fnst@cn.fujitsu.com>

In #908, I missed a case in `BuildRAIDCleanSteps` from the beginning of that PR, so add the handling of the case in this PR.

In summary, it adds the case that when `hardwareRAIDVolumes` is nil, keep the actual RAID configuration. 