### PR TITLE
Fix missing case of BuildRAIDCleanSteps

### DIFF
--- a/pkg/provisioner/ironic/raid.go
+++ b/pkg/provisioner/ironic/raid.go
@@ -210,10 +210,14 @@ func BuildRAIDCleanSteps(raidInterface string, target *metal3v1alpha1.RAIDConfig
 	}
 
 	// Hardware RAID
-	// Ignore SoftwareRAIDVolumes
-	if target != nil {
-		target.SoftwareRAIDVolumes = nil
+	// If hardware RAID configuration is nil,
+	// keep old hardware RAID configuration
+	if target == nil || target.HardwareRAIDVolumes == nil {
+		return
 	}
+
+	// Ignore SoftwareRAIDVolumes
+	target.SoftwareRAIDVolumes = nil
 	if actual != nil {
 		actual.SoftwareRAIDVolumes = nil
 	}
@@ -232,7 +236,7 @@ func BuildRAIDCleanSteps(raidInterface string, target *metal3v1alpha1.RAIDConfig
 	)
 
 	// If hardware raid configuration is empty, only need to clear old configuration
-	if target == nil || len(target.HardwareRAIDVolumes) == 0 {
+	if len(target.HardwareRAIDVolumes) == 0 {
 		return
 	}
 

--- a/pkg/provisioner/ironic/raid_test.go
+++ b/pkg/provisioner/ironic/raid_test.go
@@ -198,6 +198,16 @@ func TestBuildRAIDCleanSteps(t *testing.T) {
 		expectedError bool
 	}{
 		{
+			name:          "keep hardware RAID",
+			raidInterface: "irmc",
+			target:        nil,
+		},
+		{
+			name:          "keep hardware RAID",
+			raidInterface: "irmc",
+			target:        &metal3v1alpha1.RAIDConfig{},
+		},
+		{
 			name:          "configure hardware RAID",
 			raidInterface: "irmc",
 			target: &metal3v1alpha1.RAIDConfig{


### PR DESCRIPTION
Signed-off-by: Zou Yu <zouy.fnst@cn.fujitsu.com>

This PR replaces #941. I closed PR941 to avoid affecting openshift [PR165](https://github.com/openshift/baremetal-operator/pull/165).
PR165 should only track #908, rather than includes PR941, since it is a bug fix.
Unfortunately, PR941 and PR908 was on the same branch, so I have to close PR941 and open this one, sorry about that.

This PR aims to address a case in BuildRAIDCleanSteps which I missed in PR908.

In summary, it add the handling of the case when hardwareRAIDVolumes is nil and the target node doesn't have a RAID controller.  We shouldn't delete the RAID configuration on that node in that case, otherwise the `ironic` node will enter the clean failed state because of  `delete_configuration` clean step failure.
