### PR TITLE
Create namespace for ironic and ignore any errors

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -163,6 +163,7 @@ if [ "${DEPLOY_IRONIC}" == "true" ]; then
     fi
     IRONIC_CERTIFICATE_FILE="${SCRIPTDIR}/ironic-deployment/certmanager/certificate.yaml"
     sed -i "s/IRONIC_HOST_IP/${IRONIC_HOST_IP}/g; s/MARIADB_HOST_IP/${MARIADB_HOST_IP}/g" "${IRONIC_CERTIFICATE_FILE}"
+    kubectl create ns "${NAMEPREFIX}-system" || true
     # shellcheck disable=SC2086
     ${KUSTOMIZE} build "${IRONIC_SCENARIO}" | kubectl apply ${KUBECTL_ARGS} -f -
     mv /tmp/ironic_bmo_configmap.env "${IRONIC_BMO_CONFIGMAP}"


### PR DESCRIPTION
Deploy BMO&ironic with `deploy.sh` for the first time, the following errors have occurred.

```
Error from server (NotFound): error when creating "STDIN": namespaces "capm3-system" not found
Error from server (NotFound): error when creating "STDIN": namespaces "capm3-system" not found
Error from server (NotFound): error when creating "STDIN": namespaces "capm3-system" not found
```

This PR creates namespace for ironic and ignore any errors.
`shellcheck` passed.