### PR TITLE
Explicitly set node bios_interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/go-logr/logr v0.4.0
-	github.com/gophercloud/gophercloud v0.16.0
+	github.com/gophercloud/gophercloud v0.18.0
 	github.com/metal3-io/baremetal-operator/apis v0.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/googleapis/gnostic v0.5.5 h1:9fHAtK0uDfpveeqqo1hkEZJcFvYXAiCN3UutL8F9xHw=
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
-github.com/gophercloud/gophercloud v0.16.0 h1:sWjPfypuzxRxjVbk3/MsU4H8jS0NNlyauZtIUl78BPU=
-github.com/gophercloud/gophercloud v0.16.0/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
+github.com/gophercloud/gophercloud v0.18.0 h1:V6hcuMPmjXg+js9flU8T3RIHDCjV7F5CG5GD0MRhP/w=
+github.com/gophercloud/gophercloud v0.18.0/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/pkg/bmc/access.go
+++ b/pkg/bmc/access.go
@@ -54,6 +54,8 @@ type AccessDetails interface {
 	// (such as the kernel and ramdisk locations).
 	DriverInfo(bmcCreds Credentials) map[string]interface{}
 
+	BIOSInterface() string
+
 	// Boot interface to set
 	BootInterface() string
 

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -439,6 +439,7 @@ func TestStaticDriverInfo(t *testing.T) {
 		input      string
 		needsMac   bool
 		driver     string
+		bios       string
 		boot       string
 		management string
 		power      string
@@ -450,6 +451,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "ipmi://192.168.122.1:6233",
 			needsMac:   false,
 			driver:     "ipmi",
+			bios:       "",
 			boot:       "ipxe",
 			management: "",
 			power:      "",
@@ -462,6 +464,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "libvirt://192.168.122.1",
 			needsMac:   true,
 			driver:     "ipmi",
+			bios:       "",
 			boot:       "ipxe",
 			management: "",
 			power:      "",
@@ -474,6 +477,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "idrac://192.168.122.1",
 			needsMac:   false,
 			driver:     "idrac",
+			bios:       "",
 			boot:       "ipxe",
 			management: "",
 			power:      "",
@@ -486,6 +490,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "irmc://192.168.122.1",
 			needsMac:   false,
 			driver:     "irmc",
+			bios:       "",
 			boot:       "pxe",
 			management: "",
 			power:      "",
@@ -498,6 +503,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "redfish://192.168.122.1",
 			needsMac:   true,
 			driver:     "redfish",
+			bios:       "",
 			boot:       "ipxe",
 			management: "",
 			power:      "",
@@ -510,6 +516,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "redfish-virtualmedia://192.168.122.1",
 			needsMac:   true,
 			driver:     "redfish",
+			bios:       "",
 			boot:       "redfish-virtual-media",
 			management: "",
 			power:      "",
@@ -522,6 +529,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "redfish-virtualmedia+http://192.168.122.1",
 			needsMac:   true,
 			driver:     "redfish",
+			bios:       "",
 			boot:       "redfish-virtual-media",
 			management: "",
 			power:      "",
@@ -534,6 +542,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "redfish-virtualmedia+https://192.168.122.1",
 			needsMac:   true,
 			driver:     "redfish",
+			bios:       "",
 			boot:       "redfish-virtual-media",
 			management: "",
 			power:      "",
@@ -546,6 +555,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "idrac-redfish://192.168.122.1",
 			needsMac:   true,
 			driver:     "idrac",
+			bios:       "idrac-redfish",
 			boot:       "ipxe",
 			management: "idrac-redfish",
 			power:      "idrac-redfish",
@@ -558,6 +568,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:    "ilo5-virtualmedia://192.168.122.1",
 			needsMac: true,
 			driver:   "redfish",
+			bios:     "",
 			boot:     "redfish-virtual-media",
 		},
 
@@ -566,6 +577,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:    "ilo5-virtualmedia+http://192.168.122.1",
 			needsMac: true,
 			driver:   "redfish",
+			bios:     "",
 			boot:     "redfish-virtual-media",
 		},
 
@@ -574,6 +586,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:    "ilo5-virtualmedia+https://192.168.122.1",
 			needsMac: true,
 			driver:   "redfish",
+			bios:     "",
 			boot:     "redfish-virtual-media",
 		},
 
@@ -582,6 +595,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "idrac-virtualmedia://192.168.122.1",
 			needsMac:   true,
 			driver:     "idrac",
+			bios:       "idrac-redfish",
 			boot:       "idrac-redfish-virtual-media",
 			management: "idrac-redfish",
 			power:      "idrac-redfish",
@@ -594,6 +608,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "idrac-virtualmedia+http://192.168.122.1",
 			needsMac:   true,
 			driver:     "idrac",
+			bios:       "idrac-redfish",
 			boot:       "idrac-redfish-virtual-media",
 			management: "idrac-redfish",
 			power:      "idrac-redfish",
@@ -606,6 +621,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "idrac-virtualmedia+https://192.168.122.1",
 			needsMac:   true,
 			driver:     "idrac",
+			bios:       "idrac-redfish",
 			boot:       "idrac-redfish-virtual-media",
 			management: "idrac-redfish",
 			power:      "idrac-redfish",
@@ -618,6 +634,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "ibmc://192.168.122.1:6233",
 			needsMac:   true,
 			driver:     "ibmc",
+			bios:       "",
 			boot:       "pxe",
 			management: "ibmc",
 			power:      "ibmc",
@@ -630,6 +647,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "ilo4://192.168.122.1",
 			needsMac:   true,
 			driver:     "ilo",
+			bios:       "",
 			boot:       "ilo-ipxe",
 			management: "",
 			power:      "",
@@ -642,6 +660,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "ilo5://192.168.122.1",
 			needsMac:   true,
 			driver:     "ilo5",
+			bios:       "",
 			boot:       "ilo-ipxe",
 			management: "",
 			power:      "",
@@ -663,6 +682,10 @@ func TestStaticDriverInfo(t *testing.T) {
 			if acc.BootInterface() != tc.boot {
 				t.Fatalf("Unexpected boot interface %q, expected %q",
 					acc.BootInterface(), tc.boot)
+			}
+			if acc.BIOSInterface() != tc.bios {
+				t.Fatalf("Unexpected bios interface %q, expected %q",
+					acc.BIOSInterface(), tc.bios)
 			}
 		})
 	}

--- a/pkg/bmc/ibmc.go
+++ b/pkg/bmc/ibmc.go
@@ -81,6 +81,10 @@ func (a *ibmcAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 	return result
 }
 
+func (a *ibmcAccessDetails) BIOSInterface() string {
+	return ""
+}
+
 func (a *ibmcAccessDetails) BootInterface() string {
 	return "pxe"
 }

--- a/pkg/bmc/idrac.go
+++ b/pkg/bmc/idrac.go
@@ -76,6 +76,10 @@ func (a *iDracAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfa
 	return result
 }
 
+func (a *iDracAccessDetails) BIOSInterface() string {
+	return ""
+}
+
 func (a *iDracAccessDetails) BootInterface() string {
 	return "ipxe"
 }

--- a/pkg/bmc/idrac_virtualmedia.go
+++ b/pkg/bmc/idrac_virtualmedia.go
@@ -70,6 +70,10 @@ func (a *redfishiDracVirtualMediaAccessDetails) Driver() string {
 	return "idrac"
 }
 
+func (a *redfishiDracVirtualMediaAccessDetails) BIOSInterface() string {
+	return "idrac-redfish"
+}
+
 func (a *redfishiDracVirtualMediaAccessDetails) BootInterface() string {
 	return "idrac-redfish-virtual-media"
 }

--- a/pkg/bmc/ilo4.go
+++ b/pkg/bmc/ilo4.go
@@ -72,6 +72,10 @@ func (a *iLOAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interface
 	return result
 }
 
+func (a *iLOAccessDetails) BIOSInterface() string {
+	return ""
+}
+
 func (a *iLOAccessDetails) BootInterface() string {
 	return "ilo-ipxe"
 }

--- a/pkg/bmc/ilo5.go
+++ b/pkg/bmc/ilo5.go
@@ -72,6 +72,10 @@ func (a *iLO5AccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 	return result
 }
 
+func (a *iLO5AccessDetails) BIOSInterface() string {
+	return ""
+}
+
 func (a *iLO5AccessDetails) BootInterface() string {
 	return "ilo-ipxe"
 }

--- a/pkg/bmc/ipmi.go
+++ b/pkg/bmc/ipmi.go
@@ -91,6 +91,10 @@ func (a *ipmiAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 	return result
 }
 
+func (a *ipmiAccessDetails) BIOSInterface() string {
+	return ""
+}
+
 func (a *ipmiAccessDetails) BootInterface() string {
 	return "ipxe"
 }

--- a/pkg/bmc/irmc.go
+++ b/pkg/bmc/irmc.go
@@ -70,6 +70,10 @@ func (a *iRMCAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 	return result
 }
 
+func (a *iRMCAccessDetails) BIOSInterface() string {
+	return ""
+}
+
 func (a *iRMCAccessDetails) BootInterface() string {
 	return "pxe"
 }

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -100,6 +100,10 @@ func (a *redfishAccessDetails) DriverInfo(bmcCreds Credentials) map[string]inter
 	return result
 }
 
+func (a *redfishAccessDetails) BIOSInterface() string {
+	return ""
+}
+
 // That can be either pxe or redfish-virtual-media
 func (a *redfishAccessDetails) BootInterface() string {
 	return "ipxe"
@@ -133,9 +137,12 @@ func (a *redfishAccessDetails) BuildBIOSSettings(firmwareConfig *metal3v1alpha1.
 }
 
 // iDrac Redfish Overrides
-
 func (a *redfishiDracAccessDetails) Driver() string {
 	return "idrac"
+}
+
+func (a *redfishiDracAccessDetails) BIOSInterface() string {
+	return "idrac-redfish"
 }
 
 func (a *redfishiDracAccessDetails) BootInterface() string {

--- a/pkg/bmc/redfish_virtualmedia.go
+++ b/pkg/bmc/redfish_virtualmedia.go
@@ -69,6 +69,10 @@ func (a *redfishVirtualMediaAccessDetails) DriverInfo(bmcCreds Credentials) map[
 	return result
 }
 
+func (a *redfishVirtualMediaAccessDetails) BIOSInterface() string {
+	return ""
+}
+
 func (a *redfishVirtualMediaAccessDetails) BootInterface() string {
 	return "redfish-virtual-media"
 }

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -367,6 +367,7 @@ func (p *ironicProvisioner) ValidateManagementAccess(data provisioner.Management
 			p.client,
 			nodes.CreateOpts{
 				Driver:              bmcAccess.Driver(),
+				BIOSInterface:       bmcAccess.BIOSInterface(),
 				BootInterface:       bmcAccess.BootInterface(),
 				Name:                p.objectMeta.Name,
 				DriverInfo:          driverInfo,

--- a/pkg/provisioner/ironic/prepare_test.go
+++ b/pkg/provisioner/ironic/prepare_test.go
@@ -23,6 +23,7 @@ func (r *RAIDTestBMC) NeedsMAC() bool                                        { r
 func (r *RAIDTestBMC) Driver() string                                        { return "raid-test" }
 func (r *RAIDTestBMC) DisableCertificateVerification() bool                  { return false }
 func (r *RAIDTestBMC) DriverInfo(bmc.Credentials) (i map[string]interface{}) { return }
+func (r *RAIDTestBMC) BIOSInterface() string                                 { return "" }
 func (r *RAIDTestBMC) BootInterface() string                                 { return "" }
 func (r *RAIDTestBMC) ManagementInterface() string                           { return "" }
 func (r *RAIDTestBMC) PowerInterface() string                                { return "" }

--- a/pkg/provisioner/ironic/testbmc/testbmc.go
+++ b/pkg/provisioner/ironic/testbmc/testbmc.go
@@ -63,6 +63,10 @@ func (a *testAccessDetails) DriverInfo(bmcCreds bmc.Credentials) map[string]inte
 	return result
 }
 
+func (a *testAccessDetails) BIOSInterface() string {
+	return ""
+}
+
 func (a *testAccessDetails) BootInterface() string {
 	return "ipxe"
 }


### PR DESCRIPTION
Ironic sets the bios_interface by default for all drivers. For some drivers - particularly idrac-virtualmedia, the default should be overridden. If not explicitly set, Ironic will use the default.

This requires an upgrade to a Gophercloud release that supports BIOSInterface.