### PR TITLE
Don't use soon removed APIs

### DIFF
--- a/config/crd/patches/cainjection_in_firmwareschemas.yaml
+++ b/config/crd/patches/cainjection_in_firmwareschemas.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/cainjection_in_hostfirmwaresettings.yaml
+++ b/config/crd/patches/cainjection_in_hostfirmwaresettings.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/webhook_in_firmwareschemas.yaml
+++ b/config/crd/patches/webhook_in_firmwareschemas.yaml
@@ -1,6 +1,6 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: firmwareschemas.metal3.io

--- a/config/crd/patches/webhook_in_hostfirmwaresettings.yaml
+++ b/config/crd/patches/webhook_in_hostfirmwaresettings.yaml
@@ -1,6 +1,6 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hostfirmwaresettings.metal3.io


### PR DESCRIPTION
apiextensions.k8s.io/v1beta1 API of CustomResourceDefinition is going to be removed in 1.22 release of K8s. This patch replaces currently used beta APIs with already available v1.