### PR TITLE
Add CommonName to Ironic and Mariadb certificates

### DIFF
--- a/ironic-deployment/certmanager/certificate.yaml
+++ b/ironic-deployment/certmanager/certificate.yaml
@@ -12,6 +12,7 @@ metadata:
   name: ironic-cacert
   namespace: ${NAMEPREFIX}-system
 spec:
+  commonName: ironic-ca
   isCA: true
   ipAddresses:
   - IRONIC_HOST_IP
@@ -35,6 +36,7 @@ metadata:
   name: ironic-cert
   namespace: ${NAMEPREFIX}-system
 spec:
+  commonName: ironic-cert
   ipAddresses:
   - IRONIC_HOST_IP
   issuerRef:
@@ -48,6 +50,7 @@ metadata:
   name: ironic-inspector-cert
   namespace: ${NAMEPREFIX}-system
 spec:
+  commonName: ironic-inspector-cert
   ipAddresses:
   - IRONIC_HOST_IP
   issuerRef:
@@ -61,6 +64,7 @@ metadata:
   name: mariadb-cert
   namespace: ${NAMEPREFIX}-system
 spec:
+  commonName: mariadb-cert
   ipAddresses:
   - MARIADB_HOST_IP
   issuerRef:


### PR DESCRIPTION
This PR fixes the issue when cert-manager cannot generate ironic and mariadb certificates:
```
kubectl get certificate -n baremetal-operator-system
NAME                    READY   SECRET                  AGE
ironic-cacert           True    ironic-cacert           2m52s
ironic-cert             False   ironic-cert             2m51s
ironic-inspector-cert   False   ironic-inspector-cert   2m51s
mariadb-cert            False   mariadb-cert            2m51s
```
Which leads to the problem that all the nodes cannot reach the ready state: https://jenkins.nordix.org/view/Metal3/job/airship_master_v1a5_integration_test_centos/114/console