### PR TITLE
Do not encode empty hardwareRAIDVolumes

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -278,7 +278,7 @@ type RAIDConfig struct {
 	// The list of logical disks for hardware RAID, if rootDeviceHints isn't used, first volume is root volume.
 	// You can set the value of this field to `[]` to clear all the hardware RAID configurations.
 	// +optional
-	HardwareRAIDVolumes []HardwareRAIDVolume `json:"hardwareRAIDVolumes"`
+	HardwareRAIDVolumes []HardwareRAIDVolume `json:"hardwareRAIDVolumes,omitempty"`
 
 	// The list of logical disks for software RAID, if rootDeviceHints isn't used, first volume is root volume.
 	// If HardwareRAIDVolumes is set this item will be invalid.


### PR DESCRIPTION
hardwareRAIDVolumes is nil in some cases (probably when the platform of a host supports hardware raid but does not have any volumes configured). This translates to "null" in json representation and causes validation error because 'nil' and '[]' is not the same in Go:

```
Reconciler error,reconciler group:metal3.io,reconciler kind:BareMetalHost,name:sch05,namespace:cluster-sch,error:failed to save host status after "preparing": BareMetalHost.metal3.io "sch05" is invalid: status.provisioning.raid.hardwareRAIDVolumes: Invalid value: "null": status.provisioning.raid.hardwareRAIDVolumes in body must be of type array: "null",errorVerbose:BareMetalHost.metal3.io "sch05" is invalid: status.provisioning.raid.hardwareRAIDVolumes: Invalid value: "null": status.provisioning.raid.hardwareRAIDVolumes in body must be of type array: "null"
 failed to save host status after "preparing"
 github.com/metal3-io/baremetal-operator/controllers/metal3%2eio.(*BareMetalHostReconciler).Reconcile
 	/workspace/controllers/metal3.io/baremetalhost_controller.go:259
 sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:298
 sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:253
 sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:214
 runtime.goexit
 	/usr/local/go/src/runtime/asm_amd64.s:1371,stacktrace:sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:253
 sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:214

```

Omitting empty values fixes this error.
The field had "omitempty" previously, but it was removed in https://github.com/metal3-io/baremetal-operator/pull/908/files#diff-0f3e356f6156566888fdbc0e7c0fa713ee054933106059fc29f702f8d1a554f2L289