### PR TITLE
Allow writing 'null' for HardwareRAIDVolumes and SoftwareRAIDVolumes.

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -278,6 +278,7 @@ type RAIDConfig struct {
 	// The list of logical disks for hardware RAID, if rootDeviceHints isn't used, first volume is root volume.
 	// You can set the value of this field to `[]` to clear all the hardware RAID configurations.
 	// +optional
+	// +nullable
 	HardwareRAIDVolumes []HardwareRAIDVolume `json:"hardwareRAIDVolumes"`
 
 	// The list of logical disks for software RAID, if rootDeviceHints isn't used, first volume is root volume.
@@ -290,6 +291,7 @@ type RAIDConfig struct {
 	// Software RAID will always be deleted.
 	// +kubebuilder:validation:MaxItems=2
 	// +optional
+	// +nullable
 	SoftwareRAIDVolumes []SoftwareRAIDVolume `json:"softwareRAIDVolumes"`
 }
 

--- a/config/crd/bases/metal3.io_baremetalhosts.yaml
+++ b/config/crd/bases/metal3.io_baremetalhosts.yaml
@@ -316,6 +316,7 @@ spec:
                       required:
                       - level
                       type: object
+                    nullable: true
                     type: array
                   softwareRAIDVolumes:
                     description: The list of logical disks for software RAID, if rootDeviceHints
@@ -403,6 +404,7 @@ spec:
                       - level
                       type: object
                     maxItems: 2
+                    nullable: true
                     type: array
                 type: object
               rootDeviceHints:
@@ -903,6 +905,7 @@ spec:
                           required:
                           - level
                           type: object
+                        nullable: true
                         type: array
                       softwareRAIDVolumes:
                         description: The list of logical disks for software RAID,
@@ -992,6 +995,7 @@ spec:
                           - level
                           type: object
                         maxItems: 2
+                        nullable: true
                         type: array
                     type: object
                   rootDeviceHints:

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -314,6 +314,7 @@ spec:
                       required:
                       - level
                       type: object
+                    nullable: true
                     type: array
                   softwareRAIDVolumes:
                     description: The list of logical disks for software RAID, if rootDeviceHints
@@ -401,6 +402,7 @@ spec:
                       - level
                       type: object
                     maxItems: 2
+                    nullable: true
                     type: array
                 type: object
               rootDeviceHints:
@@ -901,6 +903,7 @@ spec:
                           required:
                           - level
                           type: object
+                        nullable: true
                         type: array
                       softwareRAIDVolumes:
                         description: The list of logical disks for software RAID,
@@ -990,6 +993,7 @@ spec:
                           - level
                           type: object
                         maxItems: 2
+                        nullable: true
                         type: array
                     type: object
                   rootDeviceHints:


### PR DESCRIPTION
BuildRAIDCleanSteps and saveHostProvisioningSettings rely on distinguishing between empty/missing and [].

Not allowing this causes errors like this:
```
Reconciler error,reconciler group:metal3.io,reconciler kind:BareMetalHost,name:sch05,namespace:cluster-sch,error:failed to save host status after "preparing": BareMetalHost.metal3.io "sch05" is invalid: status.provisioning.raid.hardwareRAIDVolumes: Invalid value: "null": status.provisioning.raid.hardwareRAIDVolumes in body must be of type array: "null",errorVerbose:BareMetalHost.metal3.io "sch05" is invalid: status.provisioning.raid.hardwareRAIDVolumes: Invalid value: "null": status.provisioning.raid.hardwareRAIDVolumes in body must be of type array: "null"
 failed to save host status after "preparing"
 github.com/metal3-io/baremetal-operator/controllers/metal3%2eio.(*BareMetalHostReconciler).Reconcile
 	/workspace/controllers/metal3.io/baremetalhost_controller.go:259
 sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:298
 sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:253
 sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:214
 runtime.goexit
 	/usr/local/go/src/runtime/asm_amd64.s:1371,stacktrace:sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:253
 sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:214

```