### PR TITLE
Stop relying on -modfile to allow vendorization

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -20,7 +20,6 @@ DEPLOY_BASIC_AUTH="${4,,}"
 DEPLOY_KEEPALIVED="${5,,}"
 MARIADB_HOST_IP="${MARIADB_HOST_IP:-"127.0.0.1"}"
 KUBECTL_ARGS="${KUBECTL_ARGS:-""}"
-KUSTOMIZE="go run -modfile=hack/tools/go.mod sigs.k8s.io/kustomize/kustomize/v3"
 RESTART_CONTAINER_CERTIFICATE_UPDATED=${RESTART_CONTAINER_CERTIFICATE_UPDATED:-"false"}
 export NAMEPREFIX=${NAMEPREFIX:-"capm3"}
 
@@ -43,6 +42,9 @@ IRONIC_DEPLOY_FILES="${SCRIPTDIR}/ironic-deployment/basic-auth/default/auth.yaml
 	${SCRIPTDIR}/ironic-deployment/tls/default/tls.yaml \
 	${SCRIPTDIR}/ironic-deployment/tls/keepalived/kustomization.yaml \
 	${SCRIPTDIR}/ironic-deployment/tls/keepalived/tls.yaml"
+
+KUSTOMIZE="tools/bin/kustomize"
+make -C "$(dirname "$0")/.." "${KUSTOMIZE}"
 
 for DEPLOY_FILE in ${IRONIC_DEPLOY_FILES}; do
   cp "$DEPLOY_FILE" "$DEPLOY_FILE".bak


### PR DESCRIPTION
The Makefile targets we use to build our tools rely on the `-modfile`
flag of the `go build` command.  Unfortunately, the golang build
toolchain doesn't respect the vendor directory relative to the `go.mod`
file specified by `-modfile`, and instead uses the vendor directory
relative to the current working directory.  Since each subdirectory in
this repository that contains a `go.mod` file needs to have its own
vendor directory in order to be built in vendorized scenarios, relying
on `-modfile` doesn't work.

The patch modifies the affected Makefile targets to instead change to
the directory of the tool being built instead of using the `-modfile`
flag.  This makes vendorization possible in downstream environments.

Finally, for consistency, we start building the kustomize tool in the
same way as controller-gen, and golangci-lint.