### PR TITLE
🌱 Remove deprecated ioutil usage

### DIFF
--- a/pkg/provisioner/ironic/clients/auth.go
+++ b/pkg/provisioner/ironic/clients/auth.go
@@ -2,7 +2,6 @@ package clients
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -36,7 +35,7 @@ func authRoot() string {
 }
 
 func readAuthFile(filename string) (string, error) {
-	content, err := ioutil.ReadFile(filepath.Clean(filename))
+	content, err := os.ReadFile(filepath.Clean(filename))
 	return strings.TrimSpace(string(content)), err
 }
 

--- a/pkg/provisioner/ironic/testserver/ironic.go
+++ b/pkg/provisioner/ironic/testserver/ironic.go
@@ -3,7 +3,7 @@ package testserver
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -179,7 +179,7 @@ func (m *IronicMock) CreateNodes(callback NodeCreateCallback) *IronicMock {
 				http.StatusNotImplemented)
 		}
 
-		bodyRaw, err := ioutil.ReadAll(r.Body)
+		bodyRaw, err := io.ReadAll(r.Body)
 		if err != nil {
 			m.logRequest(r, fmt.Sprintf("ERROR: %s", err))
 			http.Error(w, fmt.Sprintf("%s", err), http.StatusInternalServerError)

--- a/pkg/provisioner/ironic/testserver/server.go
+++ b/pkg/provisioner/ironic/testserver/server.go
@@ -3,7 +3,7 @@ package testserver
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -72,7 +72,7 @@ func (m *MockServer) logRequest(r *http.Request, response string) {
 	m.t.Logf("%s: %s %s -> %s", m.name, r.Method, r.URL, response)
 	m.Requests += r.URL.Path + ";"
 
-	bodyRaw, _ := ioutil.ReadAll(r.Body)
+	bodyRaw, _ := io.ReadAll(r.Body)
 
 	m.FullRequests = append(m.FullRequests, simpleRequest{
 		pattern: r.URL.Path,


### PR DESCRIPTION
We are now targeting go1.16. Starting with this release, the ioutils
package is now deprecated [0]. This updates usage of ioutils calls for
the new recommended io and os equivalents.

[0] [doc/go1.16#ioutil](https://golang.org/doc/go1.16#ioutil)

Similar changes in CAPM3: [cluster-api-provider-metal3/pull/287](https://github.com/metal3-io/cluster-api-provider-metal3/pull/287)

