### PR TITLE
📖 Update CI status badges in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # Bare Metal Operator
 
-[![Ubuntu V1alpha4 build status](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a4_integration_test_ubuntu/badge/icon?subject=Ubuntu%20E2E%20V1alpha4)](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a4_integration_test_ubuntu/)
-[![CentOS V1alpha4 build status](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a4_integration_test_centos/badge/icon?subject=CentOS%20E2E%20V1alpha4)](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a4_integration_test_centos/)
+[![Ubuntu V1alpha5 build status](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a5_integration_test_ubuntu/badge/icon?subject=Ubuntu%20E2E%20V1alpha5)](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a5_integration_test_ubuntu/)
+[![CentOS V1alpha5 build status](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a5_integration_test_centos/badge/icon?subject=CentOS%20E2E%20V1alpha5)](https://jenkins.nordix.org/view/Airship/job/airship_master_v1a5_integration_test_centos/)
 
 The Bare Metal Operator implements a Kubernetes API for managing bare metal
-hosts.  It maintains an inventory of available hosts as instances of the
-`BareMetalHost` Custom Resource Definition.  The Bare Metal Operator knows how
+hosts. It maintains an inventory of available hosts as instances of the
+`BareMetalHost` Custom Resource Definition. The Bare Metal Operator knows how
 to:
 
 * Inspect the host’s hardware details and report them on the corresponding
-  `BareMetalHost`.  This includes information about CPUs, RAM, disks, NICs, and
+  `BareMetalHost`. This includes information about CPUs, RAM, disks, NICs, and
   more.
-* Provision hosts with a desired image
+* Provision hosts with a desired image.
 * Clean a host’s disk contents before or after provisioning.
 
-More capabilities are being added regularly.  See open issues and pull requests
+More capabilities are being added regularly. See open issues and pull requests
 for more information on work in progress.
 
 For more information about Metal³, the Bare Metal Operator, and other related


### PR DESCRIPTION
 Report `v1alpha5` CI job status instead of `v1alpha4` since that is the latest API version as of now.