### PR TITLE
📖 Update docs and add more context concerning new deployment folders

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -17,62 +17,76 @@ Operator(BMO) with or without Ironic as well as deploying only Ironic scenario.
 tree config/
 config/
 ├── basic-auth
-│   ├── default
-│   │   ├── credentials_patch.yaml
-│   │   └── kustomization.yaml
-│   └── tls
-│       ├── credentials_patch.yaml
-│       └── kustomization.yaml
+│   ├── default
+│   │   ├── credentials_patch.yaml
+│   │   └── kustomization.yaml
+│   └── tls
+│       ├── credentials_patch.yaml
+│       └── kustomization.yaml
 ├── certmanager
-│   ├── certificate.yaml
-│   ├── kustomization.yaml
-│   └── kustomizeconfig.yaml
+│   ├── certificate.yaml
+│   ├── kustomization.yaml
+│   └── kustomizeconfig.yaml
 ├── crd
-│   ├── bases
-│   │   └── metal3.io_baremetalhosts.yaml
-│   ├── kustomization.yaml
-│   ├── kustomizeconfig.yaml
-│   └── patches
-│       ├── cainjection_in_baremetalhosts.yaml
-│       └── webhook_in_baremetalhosts.yaml
+│   ├── bases
+│   │   ├── metal3.io_baremetalhosts.yaml
+│   │   ├── metal3.io_firmwareschemas.yaml
+│   │   └── metal3.io_hostfirmwaresettings.yaml
+│   ├── kustomization.yaml
+│   ├── kustomizeconfig.yaml
+│   └── patches
+│       ├── cainjection_in_baremetalhosts.yaml
+│       ├── cainjection_in_firmwareschemas.yaml
+│       ├── cainjection_in_hostfirmwaresettings.yaml
+│       ├── webhook_in_baremetalhosts.yaml
+│       ├── webhook_in_firmwareschemas.yaml
+│       └── webhook_in_hostfirmwaresettings.yaml
 ├── default
-│   ├── ironic.env
-│   ├── kustomization.yaml
-│   ├── manager_auth_proxy_patch.yaml
-│   ├── manager_webhook_patch.yaml
-│   └── webhookcainjection_patch.yaml
+│   ├── ironic.env
+│   ├── kustomization.yaml
+│   ├── manager_auth_proxy_patch.yaml
+│   ├── manager_webhook_patch.yaml
+│   └── webhookcainjection_patch.yaml
 ├── kustomization.yaml
 ├── manager
-│   ├── kustomization.yaml
-│   └── manager.yaml
+│   ├── kustomization.yaml
+│   └── manager.yaml
 ├── namespace
-│   ├── kustomization.yaml
-│   └── namespace.yaml
+│   ├── kustomization.yaml
+│   └── namespace.yaml
+├── OWNERS
 ├── prometheus
-│   ├── kustomization.yaml
-│   └── monitor.yaml
+│   ├── kustomization.yaml
+│   └── monitor.yaml
 ├── rbac
-│   ├── auth_proxy_client_clusterrole.yaml
-│   ├── auth_proxy_role_binding.yaml
-│   ├── auth_proxy_role.yaml
-│   ├── auth_proxy_service.yaml
-│   ├── baremetalhost_editor_role.yaml
-│   ├── baremetalhost_viewer_role.yaml
-│   ├── kustomization.yaml
-│   ├── leader_election_role_binding.yaml
-│   ├── leader_election_role.yaml
-│   ├── role_binding.yaml
-│   └── role.yaml
+│   ├── auth_proxy_client_clusterrole.yaml
+│   ├── auth_proxy_role_binding.yaml
+│   ├── auth_proxy_role.yaml
+│   ├── auth_proxy_service.yaml
+│   ├── baremetalhost_editor_role.yaml
+│   ├── baremetalhost_viewer_role.yaml
+│   ├── firmwareschema_editor_role.yaml
+│   ├── firmwareschema_viewer_role.yaml
+│   ├── hostfirmwaresettings_editor_role.yaml
+│   ├── hostfirmwaresettings_viewer_role.yaml
+│   ├── kustomization.yaml
+│   ├── leader_election_role_binding.yaml
+│   ├── leader_election_role.yaml
+│   ├── role_binding.yaml
+│   └── role.yaml
 ├── render
-│   └── capm3.yaml
+│   └── capm3.yaml
 ├── samples
-│   └── metal3.io_v1alpha1_baremetalhost.yaml
+│   ├── metal3.io_v1alpha1_baremetalhost.yaml
+│   ├── metal3.io_v1alpha1_firmwareschema.yaml
+│   └── metal3.io_v1alpha1_hostfirmwaresettings.yaml
 ├── tls
-│   ├── kustomization.yaml
-│   └── tls_ca_patch.yaml
+│   ├── kustomization.yaml
+│   └── tls_ca_patch.yaml
 └── webhook
     ├── kustomization.yaml
     ├── kustomizeconfig.yaml
+    ├── manifests.yaml
     └── service_patch.yaml
 ```
 
@@ -80,7 +94,7 @@ The `config` directory has one top level folder for deployment, namely `default`
 and it deploys only baremetal-operator through kustomization file calling
 `manager` folder. In addition, `basic-auth`, `certmanager`, `crd`, `namespace`,
 `prometheus`, `rbac`, `tls` and `webhook`folders have their own kustomization
-and yaml files.
+and yaml files. `samples` folder includes yaml representation of sample CRDs.
 
 ## Current structure of ironic-deployment directory
 
@@ -88,47 +102,53 @@ and yaml files.
 tree ironic-deployment/
 ironic-deployment/
 ├── basic-auth
-│   ├── default
-│   │   ├── auth.yaml
-│   │   └── kustomization.yaml
-│   ├── ironic-auth-config-tpl
-│   ├── ironic-inspector-auth-config-tpl
-│   ├── ironic-rpc-auth-config-tpl
-│   ├── keepalived
-│   │   ├── auth.yaml
-│   │   └── kustomization.yaml
-│   └── tls
-│       ├── default
-│       │   ├── auth.yaml
-│       │   └── kustomization.yaml
-│       └── keepalived
-│           ├── auth.yaml
-│           └── kustomization.yaml
+│   ├── default
+│   │   ├── auth.yaml
+│   │   └── kustomization.yaml
+│   ├── ironic-auth-config-tpl
+│   ├── ironic-inspector-auth-config-tpl
+│   ├── ironic-rpc-auth-config-tpl
+│   ├── keepalived
+│   │   ├── auth.yaml
+│   │   └── kustomization.yaml
+│   └── tls
+│       ├── default
+│       │   ├── auth.yaml
+│       │   └── kustomization.yaml
+│       └── keepalived
+│           ├── auth.yaml
+│           └── kustomization.yaml
+├── certmanager
+│   ├── certificate.yaml
+│   └── kustomization.yaml
 ├── default
-│   ├── ironic_bmo_configmap.env
-│   └── kustomization.yaml
+│   ├── ironic_bmo_configmap.env
+│   └── kustomization.yaml
 ├── ironic
-│   ├── ironic.yaml
-│   └── kustomization.yaml
+│   ├── ironic.yaml
+│   └── kustomization.yaml
 ├── keepalived
-│   ├── ironic_bmo_configmap.env
-│   ├── keepalived_patch.yaml
-│   └── kustomization.yaml
+│   ├── ironic_bmo_configmap.env
+│   ├── keepalived_patch.yaml
+│   └── kustomization.yaml
+├── OWNERS
 └── tls
     ├── default
-    │   ├── kustomization.yaml
-    │   └── tls.yaml
+    │   ├── kustomization.yaml
+    │   └── tls.yaml
     └── keepalived
         ├── kustomization.yaml
         └── tls.yaml
 ```
 
-Ironic-deployment folder has three top level folder for deployments,
-namely `default`,  `ironic` and `keepalived`. `default` and `ironic` deploy
-only ironic, `keepalived` deploys the ironic with keepalived. As the name
-implies, `keepalived/keepalived_patch.yaml` patches the default image URL
-through kustomization. `tls` and `basic-auth` folders contain deployment files
-to add TLS and Basic Auth support between baremetal-operator and ironic.
+Ironic-deployment folder has few folders for different deployments, `default`
+and `ironic` folders contain kustomization and deployment files for ironic, while
+`keepalived` folder keeps deploy files for the ironic with keepalived. As the name
+implies, `keepalived/keepalived_patch.yaml` patches the default image URL through
+kustomization. `tls` and `basic-auth` folders contain deployment files to add TLS
+and Basic Auth support between baremetal-operator and ironic. Similarly,
+`basic-auth` folder holds a manifest to add a cert-manager setup for Ironic TLS
+deployment.
 
 ## Deployment commands
 

--- a/docs/ironic-endpoint-keepalived-configuration.md
+++ b/docs/ironic-endpoint-keepalived-configuration.md
@@ -30,6 +30,7 @@ tree resources/keepalived-docker/
 
 ├── Dockerfile
 ├── manage-keepalived.sh
+├── OWNERS
 └── sample.keepalived.conf
 
 ```


### PR DESCRIPTION
Updates tree structure for `config/`, `ironic-deployment/` and `resources/keepalived-docker/` folders. Also adds some more information re: what and why do we need those new folders/deployment files.