### PR TITLE
Add readiness and liveness probes

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -37,10 +37,16 @@ spec:
           - configMapRef:
               name: ironic
         name: manager
-        livenessProbe:
+        readinessProbe:
           httpGet:
             path: /healthz
             port: 9440
           initialDelaySeconds: 3
+          periodSeconds: 3
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9440
+          initialDelaySeconds: 10
           periodSeconds: 3
       terminationGracePeriodSeconds: 10

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -1853,13 +1853,19 @@ spec:
           httpGet:
             path: /healthz
             port: 9440
-          initialDelaySeconds: 3
+          initialDelaySeconds: 10
           periodSeconds: 3
         name: manager
         ports:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 9440
+          initialDelaySeconds: 3
+          periodSeconds: 3
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert

--- a/ironic-deployment/ironic/ironic.yaml
+++ b/ironic-deployment/ironic/ironic.yaml
@@ -26,6 +26,22 @@ spec:
                add: ["NET_ADMIN"]
           command:
             - /bin/rundnsmasq
+          livenessProbe:
+           exec:
+             command: ["sh", "-c", "ss -lun | grep :67 && ss -lun | grep $PROVISIONING_IP:69"]
+           initialDelaySeconds: 120
+           periodSeconds: 10
+           timeoutSeconds: 1
+           successThreshold: 1
+           failureThreshold: 3
+          readinessProbe:
+           exec:
+             command: ["sh", "-c", "ss -lun | grep :67 && ss -lun | grep $PROVISIONING_IP:69"]
+           initialDelaySeconds: 30
+           periodSeconds: 10
+           timeoutSeconds: 1
+           successThreshold: 1
+           failureThreshold: 3
           volumeMounts:
             - mountPath: /shared
               name: ironic-data-volume
@@ -37,6 +53,22 @@ spec:
           imagePullPolicy: Always
           command:
             - /bin/runmariadb
+          livenessProbe:
+           exec:
+             command: ["sh", "-c", "mysqladmin status -uironic -p$(printenv MARIADB_PASSWORD)"]
+           initialDelaySeconds: 120
+           periodSeconds: 10
+           timeoutSeconds: 1
+           successThreshold: 1
+           failureThreshold: 3
+          readinessProbe:
+           exec:
+             command: ["sh", "-c", "mysqladmin status -uironic -p$(printenv MARIADB_PASSWORD)"]
+           initialDelaySeconds: 30
+           periodSeconds: 10
+           timeoutSeconds: 1
+           successThreshold: 1
+           failureThreshold: 3
           volumeMounts:
             - mountPath: /shared
               name: ironic-data-volume
@@ -56,6 +88,22 @@ spec:
           imagePullPolicy: Always
           command:
             - /bin/runironic-api
+          livenessProbe:
+           exec:
+             command: ["sh", "-c", "curl -sSf http://127.0.0.1:6385 || curl -sSfk https://127.0.0.1:6385"]
+           initialDelaySeconds: 120
+           periodSeconds: 10
+           timeoutSeconds: 1
+           successThreshold: 1
+           failureThreshold: 3
+          readinessProbe:
+           exec:
+             command: ["sh", "-c", "curl -sSf http://127.0.0.1:6385 || curl -sSfk https://127.0.0.1:6385"]
+           initialDelaySeconds: 30
+           periodSeconds: 10
+           timeoutSeconds: 1
+           successThreshold: 1
+           failureThreshold: 3
           volumeMounts:
             - mountPath: /shared
               name: ironic-data-volume
@@ -73,6 +121,21 @@ spec:
           imagePullPolicy: Always
           command:
             - /bin/runironic-conductor
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "curl -sd '{}' -o – -k https://127.0.0.1:8089 || curl -sd '{}' -o – http://127.0.0.1:8089"]
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          livenessProbe:
+            failureThreshold: 3
+            exec:
+              command: ["sh", "-c", "curl -sd '{}' -o – -k https://127.0.0.1:8089 || curl -sd '{}' -o – http://127.0.0.1:8089"]
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           volumeMounts:
             - mountPath: /shared
               name: ironic-data-volume
@@ -96,6 +159,20 @@ spec:
         - name: ironic-inspector
           image: quay.io/metal3-io/ironic
           imagePullPolicy: Always
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "curl -sSf http://127.0.0.1:5050 || curl -sSf -k https://127.0.0.1:5050"]
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          livenessProbe:
+            failureThreshold: 3
+            exec:
+              command: ["sh", "-c", "curl -sSf http://127.0.0.1:5050 || curl -sSf -k https://127.0.0.1:5050"]
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           command:
             - /bin/runironic-inspector
           envFrom:


### PR DESCRIPTION
Add readiness and readiness/liveness probes for the following pods:

```
Ironic-pod:
  mariadb
  ironic-api
  ironic-inspector
  runironic-conductor
  ironic-dnsmasq
capm3
  manager
bmo
  manager
```