### PR TITLE
Rename certificate directory

### DIFF
--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -13,7 +13,7 @@ spec:
           name: webhook-server
           protocol: TCP
         volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
+        - mountPath: /tmp/baremetal-operator/serving-certs
           name: cert
           readOnly: true
       volumes:

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -1543,7 +1543,7 @@ spec:
           name: webhook-server
           protocol: TCP
         volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
+        - mountPath: /tmp/baremetal-operator/serving-certs
           name: cert
           readOnly: true
       terminationGracePeriodSeconds: 10

--- a/main.go
+++ b/main.go
@@ -41,6 +41,10 @@ import (
 	// +kubebuilder:scaffold:imports
 )
 
+const (
+	certDir = "/tmp/baremetal-operator/serving-certs"
+)
+
 var (
 	scheme     = k8sruntime.NewScheme()
 	setupLog   = ctrl.Log.WithName("setup")
@@ -135,6 +139,7 @@ func main() {
 		NewCache: cache.BuilderWithOptions(cache.Options{
 			SelectorsByObject: secretutils.AddSecretSelector(nil),
 		}),
+		CertDir: certDir,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
Kubebuilder uses `/tmp/k8s-webhook-server/serving-certs` as certificate
directory for webhook default. This PR renames this to more meaningful
`/tmp/baremetal-operator/serving-certs`