### PR TITLE
Avoid logging BMC password when creds change

### DIFF
--- a/pkg/provisioner/ironic/updateopts_test.go
+++ b/pkg/provisioner/ironic/updateopts_test.go
@@ -1229,3 +1229,31 @@ func TestGetUpdateOptsForNodeSecureBoot(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitisedValue(t *testing.T) {
+	unchanged := []interface{}{
+		"foo",
+		42,
+		true,
+		[]string{"bar", "baz"},
+		map[string]string{"foo": "bar"},
+		map[string][]string{"foo": {"bar", "baz"}},
+		map[string]interface{}{"foo": []string{"bar", "baz"}, "bar": 42},
+	}
+
+	for _, u := range unchanged {
+		assert.Exactly(t, u, sanitisedValue(u))
+	}
+
+	unsafe := map[string]interface{}{
+		"foo":           "bar",
+		"password":      "secret",
+		"ipmi_password": "secret",
+	}
+	safe := map[string]interface{}{
+		"foo":           "bar",
+		"password":      "<redacted>",
+		"ipmi_password": "<redacted>",
+	}
+	assert.Exactly(t, safe, sanitisedValue(unsafe))
+}


### PR DESCRIPTION
Since b8dba2c016befacf2ff65004a2ff73008d5ab63a we use the nodeUpdater
with its built-in logging to update the ironic node when the credentials
change. This inadvertantly meant the BMC credentials will be logged in
this case (which is very rare; credentials don't often change).

To prevent this, sanitise new values as they are being logged. Ironic
does not return existing values for passwords, so there is no danger of
them being logged through that route. Currently password fields are only
redacted if they are set as part of a map; in practice this will be safe
for the foreseeable future as the bmc credentials are always set through
a map returned from the driver and not individually.

Fixes #980