### PR TITLE
Fix non-existing fmt target usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,10 @@ generate-check-local:
 fmt-check: ## Run gofmt and report an error if any changes are made
 	./hack/gofmt.sh
 
+.PHONY: fmt
+fmt: ## Run gofmt and fix files with formatting issues
+	gofmt -s -w .
+
 ## --------------------------------------
 ## Documentation
 ## --------------------------------------

--- a/hack/gofmt.sh
+++ b/hack/gofmt.sh
@@ -13,7 +13,7 @@ if [ "${IS_CONTAINER}" != "false" ]; then
 
   # shellcheck disable=SC2086
   if [ -n "$(gofmt -l .)" ]; then
-      make fmt
+      gofmt -s -d -e .
       exit 1
   fi
 else


### PR DESCRIPTION
This fixed non-existing `fmt` target in the Makefile. Also, updates `fmt-check` target to actually do the formatting.
Currently, if there is formatting issue running `./hack/gofmt.sh` would print
```
fmuyassarov@est:~/go/src/github/baremetal-operator$ ./hack/gofmt.sh 
+ IS_CONTAINER=false
+ CONTAINER_RUNTIME=docker
+ [ false != false ]
+ docker run --rm --env IS_CONTAINER=TRUE --volume /home/fmuyassarov/go/src/github/baremetal-operator:/workdir:rw,z --entrypoint sh --workdir /workdir registry.hub.docker.com/library/golang:1.16 /workdir/hack/gofmt.sh
+ IS_CONTAINER=TRUE
+ CONTAINER_RUNTIME=podman
+ [ TRUE != false ]
+ TOP_DIR=.
+ export XDG_CACHE_HOME=/tmp/.cache
+ cd .
+ gofmt -l .
+ [ -n apis/metal3.io/v1alpha1/baremetalhost_types.go ]
+ make fmt
make: *** No rule to make target 'fmt'.  Stop.
```

and after this patch, 
```
fmuyassarov@est:~/go/src/github/baremetal-operator$ ./hack/gofmt.sh 
+ IS_CONTAINER=false
+ CONTAINER_RUNTIME=docker
+ [ false != false ]
+ docker run --rm --env IS_CONTAINER=TRUE --volume /home/fmuyassarov/go/src/github/baremetal-operator:/workdir:rw,z --entrypoint sh --workdir /workdir registry.hub.docker.com/library/golang:1.16 /workdir/hack/gofmt.sh
+ IS_CONTAINER=TRUE
+ CONTAINER_RUNTIME=podman
+ [ TRUE != false ]
+ TOP_DIR=.
+ export XDG_CACHE_HOME=/tmp/.cache
+ cd .
+ gofmt -l .
+ [ -n apis/metal3.io/v1alpha1/baremetalhost_types.go ]
+ echo Please run make fmt-check to fix formatting issues
+ exit 1
Please run make fmt-check to fix formatting issues
```
and I'm informed that I need to run make `fmt-check` to fix formatting.



