### PR TITLE
Remove ironic-inspector-log-watch

### DIFF
--- a/tools/remove_local_ironic.sh
+++ b/tools/remove_local_ironic.sh
@@ -6,7 +6,7 @@ set -xe
 # It requires ${CONTAINER_RUNTIME} variable to be defined first
 
 for name in ironic ironic-api ironic-conductor ironic-inspector dnsmasq httpd mariadb ipa-downloader \
-    ironic-endpoint-keepalived ironic-log-watch ironic-inspector-log-watch httpd-reverse-proxy ; do
+    ironic-endpoint-keepalived ironic-log-watch httpd-reverse-proxy ; do
     sudo "${CONTAINER_RUNTIME}" ps | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" kill "$name"
     sudo "${CONTAINER_RUNTIME}" ps --all | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" rm "$name" -f
 done


### PR DESCRIPTION
This is a leftover work of #945 which has removed ironic-inspector-log-watch.