### PR TITLE
Add RequiresProvisioningNetwork check into AccessDetails

### DIFF
--- a/pkg/ironic/bmc/access.go
+++ b/pkg/ironic/bmc/access.go
@@ -70,6 +70,9 @@ type AccessDetails interface {
 	// Whether the driver supports booting a preprovisioning image in ISO format
 	SupportsISOPreprovisioningImage() bool
 
+	// RequiresProvisioningNetwork checks the driver requires provisioning network
+	RequiresProvisioningNetwork() bool
+
 	// Build bios clean steps for ironic
 	BuildBIOSSettings(firmwareConfig *metal3v1alpha1.FirmwareConfig) (settings []map[string]string, err error)
 }

--- a/pkg/ironic/bmc/ibmc.go
+++ b/pkg/ironic/bmc/ibmc.go
@@ -113,6 +113,10 @@ func (a *ibmcAccessDetails) SupportsISOPreprovisioningImage() bool {
 	return false
 }
 
+func (a *ibmcAccessDetails) RequiresProvisioningNetwork() bool {
+	return true
+}
+
 func (a *ibmcAccessDetails) BuildBIOSSettings(firmwareConfig *metal3v1alpha1.FirmwareConfig) (settings []map[string]string, err error) {
 	if firmwareConfig != nil {
 		return nil, fmt.Errorf("firmware settings for %s are not supported", a.Driver())

--- a/pkg/ironic/bmc/idrac.go
+++ b/pkg/ironic/bmc/idrac.go
@@ -110,6 +110,10 @@ func (a *iDracAccessDetails) SupportsISOPreprovisioningImage() bool {
 	return false
 }
 
+func (a *iDracAccessDetails) RequiresProvisioningNetwork() bool {
+	return true
+}
+
 func (a *iDracAccessDetails) BuildBIOSSettings(firmwareConfig *metal3v1alpha1.FirmwareConfig) (settings []map[string]string, err error) {
 	if firmwareConfig == nil {
 		return nil, nil

--- a/pkg/ironic/bmc/idrac_virtualmedia.go
+++ b/pkg/ironic/bmc/idrac_virtualmedia.go
@@ -103,6 +103,10 @@ func (a *redfishiDracVirtualMediaAccessDetails) SupportsISOPreprovisioningImage(
 	return true
 }
 
+func (a *redfishiDracVirtualMediaAccessDetails) RequiresProvisioningNetwork() bool {
+	return false
+}
+
 func (a *redfishiDracVirtualMediaAccessDetails) BuildBIOSSettings(firmwareConfig *metal3v1alpha1.FirmwareConfig) (settings []map[string]string, err error) {
 	if firmwareConfig != nil {
 		return nil, fmt.Errorf("firmware settings for %s are not supported", a.Driver())

--- a/pkg/ironic/bmc/ilo4.go
+++ b/pkg/ironic/bmc/ilo4.go
@@ -104,6 +104,10 @@ func (a *iLOAccessDetails) SupportsISOPreprovisioningImage() bool {
 	return false
 }
 
+func (a *iLOAccessDetails) RequiresProvisioningNetwork() bool {
+	return true
+}
+
 func (a *iLOAccessDetails) BuildBIOSSettings(firmwareConfig *metal3v1alpha1.FirmwareConfig) (settings []map[string]string, err error) {
 	if firmwareConfig == nil {
 		return nil, nil

--- a/pkg/ironic/bmc/ilo5.go
+++ b/pkg/ironic/bmc/ilo5.go
@@ -104,6 +104,10 @@ func (a *iLO5AccessDetails) SupportsISOPreprovisioningImage() bool {
 	return false
 }
 
+func (a *iLO5AccessDetails) RequiresProvisioningNetwork() bool {
+	return true
+}
+
 func (a *iLO5AccessDetails) BuildBIOSSettings(firmwareConfig *metal3v1alpha1.FirmwareConfig) (settings []map[string]string, err error) {
 	if firmwareConfig == nil {
 		return nil, nil

--- a/pkg/ironic/bmc/ipmi.go
+++ b/pkg/ironic/bmc/ipmi.go
@@ -123,6 +123,10 @@ func (a *ipmiAccessDetails) SupportsISOPreprovisioningImage() bool {
 	return false
 }
 
+func (a *ipmiAccessDetails) RequiresProvisioningNetwork() bool {
+	return true
+}
+
 func (a *ipmiAccessDetails) BuildBIOSSettings(firmwareConfig *metal3v1alpha1.FirmwareConfig) (settings []map[string]string, err error) {
 	if firmwareConfig != nil {
 		return nil, fmt.Errorf("firmware settings for %s are not supported", a.Driver())

--- a/pkg/ironic/bmc/irmc.go
+++ b/pkg/ironic/bmc/irmc.go
@@ -102,6 +102,10 @@ func (a *iRMCAccessDetails) SupportsISOPreprovisioningImage() bool {
 	return false
 }
 
+func (a *iRMCAccessDetails) RequiresProvisioningNetwork() bool {
+	return true
+}
+
 func (a *iRMCAccessDetails) BuildBIOSSettings(firmwareConfig *metal3v1alpha1.FirmwareConfig) (settings []map[string]string, err error) {
 	if firmwareConfig == nil {
 		return nil, nil

--- a/pkg/ironic/bmc/redfish.go
+++ b/pkg/ironic/bmc/redfish.go
@@ -133,6 +133,10 @@ func (a *redfishAccessDetails) SupportsISOPreprovisioningImage() bool {
 	return false
 }
 
+func (a *redfishAccessDetails) RequiresProvisioningNetwork() bool {
+	return true
+}
+
 func (a *redfishAccessDetails) BuildBIOSSettings(firmwareConfig *metal3v1alpha1.FirmwareConfig) (settings []map[string]string, err error) {
 	if firmwareConfig != nil {
 		return nil, fmt.Errorf("firmware settings for %s are not supported", a.Driver())

--- a/pkg/ironic/bmc/redfish_virtualmedia.go
+++ b/pkg/ironic/bmc/redfish_virtualmedia.go
@@ -101,6 +101,10 @@ func (a *redfishVirtualMediaAccessDetails) SupportsISOPreprovisioningImage() boo
 	return true
 }
 
+func (a *redfishVirtualMediaAccessDetails) RequiresProvisioningNetwork() bool {
+	return false
+}
+
 func (a *redfishVirtualMediaAccessDetails) BuildBIOSSettings(firmwareConfig *metal3v1alpha1.FirmwareConfig) (settings []map[string]string, err error) {
 	if firmwareConfig != nil {
 		return nil, fmt.Errorf("firmware settings for %s are not supported", a.Driver())

--- a/pkg/ironic/testbmc/testbmc.go
+++ b/pkg/ironic/testbmc/testbmc.go
@@ -96,6 +96,10 @@ func (a *testAccessDetails) SupportsISOPreprovisioningImage() bool {
 	return false
 }
 
+func (a *testAccessDetails) RequiresProvisioningNetwork() bool {
+	return true
+}
+
 func (a *testAccessDetails) BuildBIOSSettings(firmwareConfig *metal3v1alpha1.FirmwareConfig) (settings []map[string]string, err error) {
 
 	// Return sample BMC data for test purposes

--- a/pkg/provisioner/ironic/prepare_test.go
+++ b/pkg/provisioner/ironic/prepare_test.go
@@ -32,6 +32,7 @@ func (r *RAIDTestBMC) PowerInterface() string                                { r
 func (r *RAIDTestBMC) RAIDInterface() string                                 { return "" }
 func (r *RAIDTestBMC) VendorInterface() string                               { return "" }
 func (r *RAIDTestBMC) SupportsSecureBoot() bool                              { return false }
+func (r *RAIDTestBMC) RequiresProvisioningNetwork() bool                     { return true }
 func (r *RAIDTestBMC) BuildBIOSSettings(fwConf *metal3v1alpha1.FirmwareConfig) ([]map[string]string, error) {
 	return nil, nil
 }


### PR DESCRIPTION
This PR adds new function namely RequiresProvisioningNetwork into
AccessDetails. Thanks to that, when provisioning network is disabled
or not, it becomes possible to check which BMCs support this.