### PR TITLE
Add BareMetalHost validation

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_validation.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_validation.go
@@ -80,6 +80,10 @@ func validateBMCAccess(s BareMetalHostSpec, bmcAccess bmc.AccessDetails) []error
 		}
 	}
 
+	if bmcAccess.NeedsMAC() && s.BootMACAddress == "" {
+		errs = append(errs, fmt.Errorf("BMC driver %s requires a BootMACAddress value", bmcAccess.Type()))
+	}
+
 	return errs
 }
 

--- a/apis/metal3.io/v1alpha1/baremetalhost_validation.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_validation.go
@@ -74,6 +74,12 @@ func validateBMCAccess(s BareMetalHostSpec, bmcAccess bmc.AccessDetails) []error
 		}
 	}
 
+	if s.Firmware != nil {
+		if _, err := bmcAccess.BuildBIOSSettings((*bmc.FirmwareConfig)(s.Firmware)); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
 	return errs
 }
 

--- a/apis/metal3.io/v1alpha1/baremetalhost_validation.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_validation.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	_ "github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 )
 
 // log is for logging in this package.
@@ -17,6 +17,14 @@ var log = logf.Log.WithName("baremetalhost-validation")
 func (host *BareMetalHost) validateHost() []error {
 	log.Info("validate create", "name", host.Name)
 	var errs []error
+
+	if host.Spec.BMC.Address != "" {
+		var err error
+		_, err = bmc.NewAccessDetails(host.Spec.BMC.Address, host.Spec.BMC.DisableCertificateVerification)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
 
 	if err := validateRAID(host.Spec.RAID); err != nil {
 		errs = append(errs, err)

--- a/apis/metal3.io/v1alpha1/baremetalhost_validation.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_validation.go
@@ -84,6 +84,10 @@ func validateBMCAccess(s BareMetalHostSpec, bmcAccess bmc.AccessDetails) []error
 		errs = append(errs, fmt.Errorf("BMC driver %s requires a BootMACAddress value", bmcAccess.Type()))
 	}
 
+	if s.BootMode == UEFISecureBoot && !bmcAccess.SupportsSecureBoot() {
+		errs = append(errs, fmt.Errorf("BMC driver %s does not support secure boot", bmcAccess.Type()))
+	}
+
 	return errs
 }
 

--- a/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -107,6 +107,31 @@ func TestValidateCreate(t *testing.T) {
 			oldBMH:    nil,
 			wantedErr: "Unknown BMC type 'test' for address test:127.0.1.1",
 		},
+		{
+			name: "RAIDWithUnsupportBMC",
+			newBMH: &BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: BareMetalHostSpec{
+					RAID: &RAIDConfig{
+						HardwareRAIDVolumes: []HardwareRAIDVolume{
+							{
+								SizeGibibytes:         nil,
+								Level:                 "",
+								Name:                  "",
+								Rotational:            nil,
+								NumberOfPhysicalDisks: nil,
+							},
+						},
+					},
+					BMC: BMCDetails{
+						Address:         "ipmi://127.0.1.1",
+						CredentialsName: "test1",
+					},
+				}},
+			oldBMH:    nil,
+			wantedErr: "BMC driver ipmi does not support configuring RAID",
+		},
 	}
 
 	for _, tt := range tests {

--- a/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -150,6 +150,20 @@ func TestValidateCreate(t *testing.T) {
 			oldBMH:    nil,
 			wantedErr: "firmware settings for ipmi are not supported",
 		},
+		{
+			name: "BootMACAddressRequired",
+			newBMH: &BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: BareMetalHostSpec{
+					BMC: BMCDetails{
+						Address:         "libvirt://127.0.1.1",
+						CredentialsName: "test1",
+					},
+				}},
+			oldBMH:    nil,
+			wantedErr: "BMC driver libvirt requires a BootMACAddress value",
+		},
 	}
 
 	for _, tt := range tests {

--- a/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -164,6 +164,22 @@ func TestValidateCreate(t *testing.T) {
 			oldBMH:    nil,
 			wantedErr: "BMC driver libvirt requires a BootMACAddress value",
 		},
+		{
+			name: "BootMACAddressRequired",
+			newBMH: &BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: BareMetalHostSpec{
+					BMC: BMCDetails{
+						Address:         "libvirt://127.0.1.1",
+						CredentialsName: "test1",
+					},
+					BootMACAddress: "00:00:00:00:00:00",
+					BootMode:       UEFISecureBoot,
+				}},
+			oldBMH:    nil,
+			wantedErr: "BMC driver libvirt does not support secure boot",
+		},
 	}
 
 	for _, tt := range tests {

--- a/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -41,6 +41,7 @@ func TestValidateCreate(t *testing.T) {
 		Name:      "07564256-96ae-4315-ab03-8d34ece60fbb",
 		Namespace: "test-namespace",
 	}
+	enable := true
 
 	tests := []struct {
 		name      string
@@ -131,6 +132,23 @@ func TestValidateCreate(t *testing.T) {
 				}},
 			oldBMH:    nil,
 			wantedErr: "BMC driver ipmi does not support configuring RAID",
+		},
+		{
+			name: "FirmwareWithUnsupportBMC",
+			newBMH: &BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: BareMetalHostSpec{
+					Firmware: &FirmwareConfig{
+						VirtualizationEnabled: &enable,
+					},
+					BMC: BMCDetails{
+						Address:         "ipmi://127.0.1.1",
+						CredentialsName: "test1",
+					},
+				}},
+			oldBMH:    nil,
+			wantedErr: "firmware settings for ipmi are not supported",
 		},
 	}
 

--- a/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -93,6 +93,20 @@ func TestValidateCreate(t *testing.T) {
 			oldBMH:    nil,
 			wantedErr: "hardwareRAIDVolumes and softwareRAIDVolumes can not be set at the same time",
 		},
+		{
+			name: "unsupportBMCType",
+			newBMH: &BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: BareMetalHostSpec{
+					BMC: BMCDetails{
+						Address:         "test:127.0.1.1",
+						CredentialsName: "test1",
+					},
+				}},
+			oldBMH:    nil,
+			wantedErr: "Unknown BMC type 'test' for address test:127.0.1.1",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR adds some BareMetalHost validations as issued in #855.

* Invalid BMC Config
* RAID requested when not supported by driver
* Missing Boot MAC when required by driver
* BIOS requested when not supported by driver
* Add validations for BootMode