### PR TITLE
Remove apis module replacement in ironic module

### DIFF
--- a/pkg/ironic/go.mod
+++ b/pkg/ironic/go.mod
@@ -5,11 +5,9 @@ go 1.16
 require (
 	github.com/go-logr/logr v0.4.0
 	github.com/gophercloud/gophercloud v0.18.0
-	github.com/metal3-io/baremetal-operator/apis v0.0.0
+	github.com/metal3-io/baremetal-operator/apis v0.0.0-20211019071605-57305319bec4
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489
 	sigs.k8s.io/controller-runtime v0.9.7
 )
-
-replace github.com/metal3-io/baremetal-operator/apis => ../../apis

--- a/pkg/ironic/go.sum
+++ b/pkg/ironic/go.sum
@@ -265,6 +265,8 @@ github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/metal3-io/baremetal-operator/apis v0.0.0-20211019071605-57305319bec4 h1:fOvcf7v2tiPgHr7OriUWyUK79qh/C99zBVVWS7bAEt0=
+github.com/metal3-io/baremetal-operator/apis v0.0.0-20211019071605-57305319bec4/go.mod h1:/pror7LknTgduckyCOm/EhnjFKIZy3mXQHr2GdaQ3kQ=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=


### PR DESCRIPTION
This PR removes apis module replacement in ironic go module. Because
ironic go module still could not be imported, since it can not find
apis module inside.