### PR TITLE
gitignore: Get rid of rules not associated with the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,55 +2,7 @@
 bin
 build/_output
 build/_test
-# Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
-### Emacs ###
-# -*- mode: gitignore; -*-
-*~
-\#*\#
-/.emacs.desktop
-/.emacs.desktop.lock
-*.elc
-auto-save-list
-tramp
-.\#*
-# Org-mode
-.org-id-locations
-*_archive
-# flymake-mode
-*_flymake.*
-# eshell files
-/eshell/history
-/eshell/lastdir
-# elpa packages
-/elpa/
-# reftex files
-*.rel
-# AUCTeX auto folder
-/auto/
-# cask packages
-.cask/
-dist/
-# Flycheck
-flycheck_*.el
-# server auth directory
-/server/
-# projectiles files
-.projectile
-projectile-bookmarks.eld
-# directory configuration
-.dir-locals.el
-# saveplace
-places
-# url cache
-url/cache/
-# cedet
-ede-projects.el
-# smex
-smex-items
-# company-statistics
-company-statistics-cache.el
-# anaconda-mode
-anaconda-mode/
+# Created by https://www.gitignore.io/api/go
 ### Go ###
 # Binaries for programs and plugins
 *.exe
@@ -62,20 +14,7 @@ anaconda-mode/
 *.test
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-### Vim ###
-# swap
-.sw[a-p]
-.*.sw[a-p]
-# session
-Session.vim
-# temporary
-.netrwhist
-# auto-generated tag files
-tags
-### VisualStudioCode ###
-.vscode/*
-.history
-# End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
+# End of https://www.gitignore.io/api/go
 
 
 # Tilt files.


### PR DESCRIPTION
Everybody has their own set of tools that generate different tempfiles
that should be ignored. The correct place to configure this is in the
global gitignore file "~/.config/git/ignore". Including ignore rules for
a select set of tools is an antipattern that encourages people to want
to add their own tools to the list in each of the hundreds of projects
they interact with instead of setting up their global rules once.