### PR TITLE
Use finalizer for BMC secret.

### DIFF
--- a/controllers/metal3.io/preprovisioningimage_controller.go
+++ b/controllers/metal3.io/preprovisioningimage_controller.go
@@ -151,7 +151,7 @@ func getNetworkDataStatus(secretManager secretutils.SecretManager, img *metal3.P
 		Name:      networkDataSecret,
 		Namespace: img.ObjectMeta.Namespace,
 	}
-	secret, err := secretManager.AcquireSecret(secretKey, img, false)
+	secret, err := secretManager.AcquireSecret(secretKey, img, false, false)
 	if err != nil {
 		return metal3.SecretStatus{}, err
 	}


### PR DESCRIPTION
There is a race condition when deleting namespace using API/CLI that contains BMH and BMC Secrets.
Secrets can be deleting before actual de-provisioning of BMH has started and this leads to broken state with registration error.

By using finalizer that is set for secrets that are OwnerRef`ed this change ensures proper objects deletion order by un-setting secrets finalizer only after deprovisioning has ended, k8s will then be allowed to clean-up remaining BMC secrets.

Signed-off-by: s3rj1k <evasive.gyron@gmail.com>