### PR TITLE
:bug: Remove provisioning IP from ironic-dnsmasq checks

### DIFF
--- a/ironic-deployment/ironic/ironic.yaml
+++ b/ironic-deployment/ironic/ironic.yaml
@@ -28,7 +28,7 @@ spec:
             - /bin/rundnsmasq
           livenessProbe:
            exec:
-             command: ["sh", "-c", "ss -lun | grep :67 && ss -lun | grep $PROVISIONING_IP:69"]
+             command: ["sh", "-c", "ss -lun | grep :67 && ss -lun | grep :69"]
            initialDelaySeconds: 120
            periodSeconds: 10
            timeoutSeconds: 1
@@ -36,7 +36,7 @@ spec:
            failureThreshold: 3
           readinessProbe:
            exec:
-             command: ["sh", "-c", "ss -lun | grep :67 && ss -lun | grep $PROVISIONING_IP:69"]
+             command: ["sh", "-c", "ss -lun | grep :67 && ss -lun | grep :69"]
            initialDelaySeconds: 30
            periodSeconds: 10
            timeoutSeconds: 1


### PR DESCRIPTION
The liveness and readiness healthchecks for the ironic-dnsmasq container were using the $PROVISIONING_IP to determine whether the dnsmasq process was up and running properly. However, experimentally we've verified that the dnsmasq service can serve on port 69 bound to a different IP on the same subnet. This has caused flakes in the CI tests. It should be sufficient to check that some service is listening on port 69 for a sanity readiness / liveness check.