### PR TITLE
irmc: change the return value of NeedsMAC() to true

### DIFF
--- a/pkg/hardwareutils/bmc/access_test.go
+++ b/pkg/hardwareutils/bmc/access_test.go
@@ -476,7 +476,7 @@ func TestStaticDriverInfo(t *testing.T) {
 		{
 			Scenario:   "irmc",
 			input:      "irmc://192.168.122.1",
-			needsMac:   false,
+			needsMac:   true,
 			driver:     "irmc",
 			bios:       "",
 			boot:       "pxe",

--- a/pkg/hardwareutils/bmc/irmc.go
+++ b/pkg/hardwareutils/bmc/irmc.go
@@ -31,7 +31,9 @@ func (a *iRMCAccessDetails) Type() string {
 // NeedsMAC returns true when the host is going to need a separate
 // port created rather than having it discovered.
 func (a *iRMCAccessDetails) NeedsMAC() bool {
-	return false
+	// For the inspection to work, we need a MAC address
+	// https://github.com/metal3-io/baremetal-operator/pull/284#discussion_r317579040
+	return true
 }
 
 func (a *iRMCAccessDetails) Driver() string {


### PR DESCRIPTION
When adding iRMC type BMH in OCP environment, if `bootMACAddress` is not specified, the following error will occur:
```
Events:                              
  Type    Reason             Age   From                         Message
  ----    ------             ----  ----                         -------
  Normal  RegistrationError  47s   metal3-baremetal-controller  MAC address  conflicts with existing node openshift-machine-api~master-0
  Normal  RegistrationError  47s   metal3-baremetal-controller  MAC address  conflicts with existing node openshift-machine-api~master-0

```
So modify the return value of `NeedsMAC` so that `bootMACAddress` must be specified when creating a BMH.


Signed-off-by: Zhou Hao <zhouhao@fujitsu.com>