### PR TITLE
Make PreprovisioningImage controller more generic

### DIFF
--- a/apis/metal3.io/v1alpha1/preprovisioningimage_types.go
+++ b/apis/metal3.io/v1alpha1/preprovisioningimage_types.go
@@ -22,6 +22,8 @@ import (
 // +kubebuilder:validation:Enum=iso;initrd
 type ImageFormat string
 
+const PreprovisioningImageFinalizer = "preprovisioningimage.metal3.io"
+
 const (
 	ImageFormatISO    ImageFormat = "iso"
 	ImageFormatInitRD ImageFormat = "initrd"

--- a/controllers/metal3.io/preprovisioningimage_controller.go
+++ b/controllers/metal3.io/preprovisioningimage_controller.go
@@ -175,7 +175,7 @@ func (r *PreprovisioningImageReconciler) update(img *metal3.PreprovisioningImage
 		Format:            format,
 		Architecture:      img.Spec.Architecture,
 		NetworkDataStatus: secretStatus,
-	}, networkDataContent)
+	}, networkDataContent, log)
 	if err != nil {
 		return false, err
 	}

--- a/controllers/metal3.io/preprovisioningimage_controller.go
+++ b/controllers/metal3.io/preprovisioningimage_controller.go
@@ -94,6 +94,11 @@ func (r *PreprovisioningImageReconciler) Reconcile(ctx context.Context, req ctrl
 func (r *PreprovisioningImageReconciler) update(img *metal3.PreprovisioningImage, log logr.Logger) (bool, error) {
 	generation := img.GetGeneration()
 
+	if !r.ImageProvider.SupportsArchitecture(img.Spec.Architecture) {
+		log.Info("image architecture not supported", "architecture", img.Spec.Architecture)
+		return setError(generation, &img.Status, reasonImageConfigurationError, "Architecture not supported"), nil
+	}
+
 	format := r.getImageFormat(img.Spec, log)
 	if format == "" {
 		return setError(generation, &img.Status, reasonImageConfigurationError, "No acceptable image format supported"), nil

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ import (
 
 	metal3iov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	metal3iocontroller "github.com/metal3-io/baremetal-operator/controllers/metal3.io"
+	"github.com/metal3-io/baremetal-operator/pkg/imageprovider"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/demo"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/fixture"
@@ -165,10 +166,11 @@ func main() {
 
 	if preprovImgEnable {
 		imgReconciler := metal3iocontroller.PreprovisioningImageReconciler{
-			Client:    mgr.GetClient(),
-			Log:       ctrl.Log.WithName("controllers").WithName("PreprovisioningImage"),
-			APIReader: mgr.GetAPIReader(),
-			Scheme:    mgr.GetScheme(),
+			Client:        mgr.GetClient(),
+			Log:           ctrl.Log.WithName("controllers").WithName("PreprovisioningImage"),
+			APIReader:     mgr.GetAPIReader(),
+			Scheme:        mgr.GetScheme(),
+			ImageProvider: imageprovider.NewDefaultImageProvider(),
 		}
 		if imgReconciler.CanStart() {
 			if err = (&imgReconciler).SetupWithManager(mgr); err != nil {

--- a/pkg/imageprovider/default.go
+++ b/pkg/imageprovider/default.go
@@ -1,0 +1,59 @@
+package imageprovider
+
+import (
+	"os"
+
+	metal3 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+)
+
+type envImageProvider struct {
+	isoURL    string
+	initrdURL string
+}
+
+func NewDefaultImageProvider() ImageProvider {
+	return envImageProvider{
+		isoURL:    os.Getenv("DEPLOY_ISO_URL"),
+		initrdURL: os.Getenv("DEPLOY_RAMDISK_URL"),
+	}
+}
+
+func (eip envImageProvider) SupportsFormat(format metal3.ImageFormat) bool {
+	switch format {
+	case metal3.ImageFormatISO:
+		return eip.isoURL != ""
+	case metal3.ImageFormatInitRD:
+		// Assume we are running inside the same process as the BMH controller -
+		// if there is no kernel URL then it will be unable to use the initrd.
+		if os.Getenv("DEPLOY_KERNEL_URL") == "" {
+			return false
+		}
+		return eip.initrdURL != ""
+	default:
+		return false
+	}
+}
+
+func (eip envImageProvider) BuildImage(acceptFormats []metal3.ImageFormat) (url string, format metal3.ImageFormat, errorMessage string) {
+	for _, fmt := range acceptFormats {
+		switch fmt {
+		case metal3.ImageFormatISO:
+			if iso := eip.isoURL; iso != "" {
+				return iso, fmt, ""
+			}
+			if errorMessage == "" {
+				format = fmt
+				errorMessage = "No DEPLOY_ISO_URL specified"
+			}
+		case metal3.ImageFormatInitRD:
+			if initrd := eip.initrdURL; initrd != "" {
+				return initrd, fmt, ""
+			}
+			if errorMessage == "" {
+				format = fmt
+				errorMessage = "No DEPLOY_RAMDISK_URL specified"
+			}
+		}
+	}
+	return
+}

--- a/pkg/imageprovider/default.go
+++ b/pkg/imageprovider/default.go
@@ -1,6 +1,7 @@
 package imageprovider
 
 import (
+	"fmt"
 	"os"
 
 	metal3 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
@@ -34,26 +35,15 @@ func (eip envImageProvider) SupportsFormat(format metal3.ImageFormat) bool {
 	}
 }
 
-func (eip envImageProvider) BuildImage(acceptFormats []metal3.ImageFormat) (url string, format metal3.ImageFormat, errorMessage string) {
-	for _, fmt := range acceptFormats {
-		switch fmt {
-		case metal3.ImageFormatISO:
-			if iso := eip.isoURL; iso != "" {
-				return iso, fmt, ""
-			}
-			if errorMessage == "" {
-				format = fmt
-				errorMessage = "No DEPLOY_ISO_URL specified"
-			}
-		case metal3.ImageFormatInitRD:
-			if initrd := eip.initrdURL; initrd != "" {
-				return initrd, fmt, ""
-			}
-			if errorMessage == "" {
-				format = fmt
-				errorMessage = "No DEPLOY_RAMDISK_URL specified"
-			}
-		}
+func (eip envImageProvider) BuildImage(format metal3.ImageFormat) (url string, err error) {
+	switch format {
+	case metal3.ImageFormatISO:
+		url = eip.isoURL
+	case metal3.ImageFormatInitRD:
+		url = eip.initrdURL
+	}
+	if url == "" {
+		err = fmt.Errorf("Unsupported image format \"%s\"", format)
 	}
 	return
 }

--- a/pkg/imageprovider/default.go
+++ b/pkg/imageprovider/default.go
@@ -39,15 +39,15 @@ func (eip envImageProvider) SupportsFormat(format metal3.ImageFormat) bool {
 	}
 }
 
-func (eip envImageProvider) BuildImage(format metal3.ImageFormat) (url string, err error) {
-	switch format {
+func (eip envImageProvider) BuildImage(data ImageData, networkData NetworkData) (url string, err error) {
+	switch data.Format {
 	case metal3.ImageFormatISO:
 		url = eip.isoURL
 	case metal3.ImageFormatInitRD:
 		url = eip.initrdURL
 	}
 	if url == "" {
-		err = fmt.Errorf("Unsupported image format \"%s\"", format)
+		err = fmt.Errorf("Unsupported image format \"%s\"", data.Format)
 	}
 	return
 }

--- a/pkg/imageprovider/default.go
+++ b/pkg/imageprovider/default.go
@@ -19,6 +19,10 @@ func NewDefaultImageProvider() ImageProvider {
 	}
 }
 
+func (eip envImageProvider) SupportsArchitecture(arch string) bool {
+	return true
+}
+
 func (eip envImageProvider) SupportsFormat(format metal3.ImageFormat) bool {
 	switch format {
 	case metal3.ImageFormatISO:

--- a/pkg/imageprovider/default.go
+++ b/pkg/imageprovider/default.go
@@ -51,3 +51,7 @@ func (eip envImageProvider) BuildImage(data ImageData, networkData NetworkData) 
 	}
 	return
 }
+
+func (eip envImageProvider) DiscardImage(data ImageData) error {
+	return nil
+}

--- a/pkg/imageprovider/default.go
+++ b/pkg/imageprovider/default.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/go-logr/logr"
+
 	metal3 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 )
 
@@ -39,7 +41,7 @@ func (eip envImageProvider) SupportsFormat(format metal3.ImageFormat) bool {
 	}
 }
 
-func (eip envImageProvider) BuildImage(data ImageData, networkData NetworkData) (url string, err error) {
+func (eip envImageProvider) BuildImage(data ImageData, networkData NetworkData, log logr.Logger) (url string, err error) {
 	switch data.Format {
 	case metal3.ImageFormatISO:
 		url = eip.isoURL

--- a/pkg/imageprovider/imageprovider.go
+++ b/pkg/imageprovider/imageprovider.go
@@ -1,9 +1,11 @@
 package imageprovider
 
 import (
-	metal3 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/go-logr/logr"
+
+	metal3 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 )
 
 // ImageData contains information about the image type being requested, and
@@ -28,7 +30,7 @@ type ImageProvider interface {
 
 	// BuildImage requests the ImageProvider to build an image with the
 	// supplied network data and return a URL where it can be accessed.
-	BuildImage(ImageData, NetworkData) (string, error)
+	BuildImage(ImageData, NetworkData, logr.Logger) (string, error)
 
 	// DiscardImage notifies the ImageProvider that a previously built image
 	// is no longer required.

--- a/pkg/imageprovider/imageprovider.go
+++ b/pkg/imageprovider/imageprovider.go
@@ -9,5 +9,5 @@ type ImageProvider interface {
 
 	// BuildImage requests the ImageProvider to build an image in the given
 	// format.
-	BuildImage([]metal3.ImageFormat) (string, metal3.ImageFormat, string)
+	BuildImage(metal3.ImageFormat) (string, error)
 }

--- a/pkg/imageprovider/imageprovider.go
+++ b/pkg/imageprovider/imageprovider.go
@@ -1,6 +1,21 @@
 package imageprovider
 
-import metal3 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+import (
+	metal3 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ImageData contains information about the image type being requested, and
+// metadata about the request.
+type ImageData struct {
+	ImageMetadata     *metav1.ObjectMeta
+	Format            metal3.ImageFormat
+	Architecture      string
+	NetworkDataStatus metal3.SecretStatus
+}
+
+type NetworkData map[string][]byte
 
 type ImageProvider interface {
 	// SupportsArchitecture returns whether the ImageProvider can provide
@@ -11,7 +26,7 @@ type ImageProvider interface {
 	// the given format.
 	SupportsFormat(metal3.ImageFormat) bool
 
-	// BuildImage requests the ImageProvider to build an image in the given
-	// format.
-	BuildImage(metal3.ImageFormat) (string, error)
+	// BuildImage requests the ImageProvider to build an image with the
+	// supplied network data and return a URL where it can be accessed.
+	BuildImage(ImageData, NetworkData) (string, error)
 }

--- a/pkg/imageprovider/imageprovider.go
+++ b/pkg/imageprovider/imageprovider.go
@@ -3,6 +3,10 @@ package imageprovider
 import metal3 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 
 type ImageProvider interface {
+	// SupportsArchitecture returns whether the ImageProvider can provide
+	// images for the given processor architecture.
+	SupportsArchitecture(string) bool
+
 	// SupportsFormat returns whether the ImageProvider can provide images in
 	// the given format.
 	SupportsFormat(metal3.ImageFormat) bool

--- a/pkg/imageprovider/imageprovider.go
+++ b/pkg/imageprovider/imageprovider.go
@@ -1,0 +1,13 @@
+package imageprovider
+
+import metal3 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+
+type ImageProvider interface {
+	// SupportsFormat returns whether the ImageProvider can provide images in
+	// the given format.
+	SupportsFormat(metal3.ImageFormat) bool
+
+	// BuildImage requests the ImageProvider to build an image in the given
+	// format.
+	BuildImage([]metal3.ImageFormat) (string, metal3.ImageFormat, string)
+}

--- a/pkg/imageprovider/imageprovider.go
+++ b/pkg/imageprovider/imageprovider.go
@@ -29,4 +29,8 @@ type ImageProvider interface {
 	// BuildImage requests the ImageProvider to build an image with the
 	// supplied network data and return a URL where it can be accessed.
 	BuildImage(ImageData, NetworkData) (string, error)
+
+	// DiscardImage notifies the ImageProvider that a previously built image
+	// is no longer required.
+	DiscardImage(ImageData) error
 }


### PR DESCRIPTION
Create a new ImageProvider interface that the controller uses to obtain the image. The default implementation just obtains the URLs from environment variables as before, but is much easier to swap out for a new implementation than writing a separate controller.

Since custom controllers may need to cache data for each image, the controller needs to notify the image provider when a possibly cached image is no longer required. To this end, add a finalizer so that a cached image is cleared before a resource is deleted, and also mark the resource not ready when the config changes so that the existing image cache can be dropped.