### PR TITLE
Fixes CentOS build failure on CentOS master

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -43,13 +43,19 @@ spec:
           httpGet:
             path: /healthz
             port: 9440
-          initialDelaySeconds: 15
-          periodSeconds: 20
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 2
+          successThreshold: 1
+          failureThreshold: 10
         readinessProbe:
           httpGet:
             path: /readyz
             port: 9440
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 10
+          timeoutSeconds: 2
+          successThreshold: 1
+          failureThreshold: 10
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -1884,22 +1884,28 @@ spec:
         image: quay.io/metal3-io/baremetal-operator
         imagePullPolicy: Always
         livenessProbe:
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: 9440
-          initialDelaySeconds: 15
-          periodSeconds: 20
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2
         name: manager
         ports:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
         readinessProbe:
+          failureThreshold: 10
           httpGet:
             path: /readyz
             port: 9440
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:

--- a/ironic-deployment/ironic/ironic.yaml
+++ b/ironic-deployment/ironic/ironic.yaml
@@ -29,19 +29,19 @@ spec:
           livenessProbe:
            exec:
              command: ["sh", "-c", "ss -lun | grep :67 && ss -lun | grep :69"]
-           initialDelaySeconds: 120
-           periodSeconds: 10
-           timeoutSeconds: 1
+           initialDelaySeconds: 30
+           periodSeconds: 30
+           timeoutSeconds: 10
            successThreshold: 1
-           failureThreshold: 3
+           failureThreshold: 10
           readinessProbe:
            exec:
              command: ["sh", "-c", "ss -lun | grep :67 && ss -lun | grep :69"]
            initialDelaySeconds: 30
-           periodSeconds: 10
-           timeoutSeconds: 1
+           periodSeconds: 30
+           timeoutSeconds: 10
            successThreshold: 1
-           failureThreshold: 3
+           failureThreshold: 10
           volumeMounts:
             - mountPath: /shared
               name: ironic-data-volume
@@ -56,19 +56,19 @@ spec:
           livenessProbe:
            exec:
              command: ["sh", "-c", "mysqladmin status -uironic -p$(printenv MARIADB_PASSWORD)"]
-           initialDelaySeconds: 120
-           periodSeconds: 10
-           timeoutSeconds: 1
+           initialDelaySeconds: 30
+           periodSeconds: 30
+           timeoutSeconds: 10
            successThreshold: 1
-           failureThreshold: 3
+           failureThreshold: 10
           readinessProbe:
            exec:
              command: ["sh", "-c", "mysqladmin status -uironic -p$(printenv MARIADB_PASSWORD)"]
            initialDelaySeconds: 30
-           periodSeconds: 10
-           timeoutSeconds: 1
+           periodSeconds: 30
+           timeoutSeconds: 10
            successThreshold: 1
-           failureThreshold: 3
+           failureThreshold: 10
           volumeMounts:
             - mountPath: /shared
               name: ironic-data-volume
@@ -91,19 +91,19 @@ spec:
           livenessProbe:
            exec:
              command: ["sh", "-c", "curl -sSf http://127.0.0.1:6385 || curl -sSfk https://127.0.0.1:6385"]
-           initialDelaySeconds: 120
-           periodSeconds: 10
-           timeoutSeconds: 1
+           initialDelaySeconds: 30
+           periodSeconds: 30
+           timeoutSeconds: 10
            successThreshold: 1
-           failureThreshold: 3
+           failureThreshold: 10
           readinessProbe:
            exec:
              command: ["sh", "-c", "curl -sSf http://127.0.0.1:6385 || curl -sSfk https://127.0.0.1:6385"]
            initialDelaySeconds: 30
-           periodSeconds: 10
-           timeoutSeconds: 1
+           periodSeconds: 30
+           timeoutSeconds: 10
            successThreshold: 1
-           failureThreshold: 3
+           failureThreshold: 10
           volumeMounts:
             - mountPath: /shared
               name: ironic-data-volume
@@ -124,18 +124,19 @@ spec:
           readinessProbe:
             exec:
               command: ["sh", "-c", "curl -sd '{}' -o – -k https://127.0.0.1:8089 || curl -sd '{}' -o – http://127.0.0.1:8089"]
-            failureThreshold: 3
-            periodSeconds: 10
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 1
+            failureThreshold: 10
           livenessProbe:
-            failureThreshold: 3
             exec:
               command: ["sh", "-c", "curl -sd '{}' -o – -k https://127.0.0.1:8089 || curl -sd '{}' -o – http://127.0.0.1:8089"]
-            failureThreshold: 3
-            periodSeconds: 10
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 1
+            failureThreshold: 10
           volumeMounts:
             - mountPath: /shared
               name: ironic-data-volume
@@ -162,17 +163,19 @@ spec:
           readinessProbe:
             exec:
               command: ["sh", "-c", "curl -sSf http://127.0.0.1:5050 || curl -sSf -k https://127.0.0.1:5050"]
-            failureThreshold: 3
-            periodSeconds: 10
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 1
+            failureThreshold: 10
           livenessProbe:
-            failureThreshold: 3
             exec:
               command: ["sh", "-c", "curl -sSf http://127.0.0.1:5050 || curl -sSf -k https://127.0.0.1:5050"]
-            periodSeconds: 10
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 1
+            failureThreshold: 10
           command:
             - /bin/runironic-inspector
           envFrom:


### PR DESCRIPTION
Fixes CentOS build failure on CentOS master/main by setting appropriate delays for health probes.
The ironic pod contains 7 containers and takes some time full start. The time it takes for all the containers to be up and running was measured and the delays in the PR were chosen accordingly. 

```
#!/bin/bash
echo "--------------start measurement: $(date)-------------------"
echo
# Create and deploy bmo without health probes
# run the following in advance
# kubectl scale deploy -n baremetal-operator-system baremetal-operator-ironic --replicas=0

kubectl scale deploy -n baremetal-operator-system baremetal-operator-ironic --replicas=1

while true; do
 error=false
 minikube ssh -- curl -sSfk https://127.0.0.1:6385 > /dev/null && echo "success, $(date), port: 6385" || error=true;echo "failure, $(date), port: 6385"
 minikube ssh -- curl -sd '{}' -o ?~@~S -k https://127.0.0.1:8089 > /dev/null  && echo "success, $(date), port:8089" || error=true;echo "failure, $(date), port: 8089"
 minikube ssh -- curl -sSf -k https://127.0.0.1:5050 > /dev/null  && echo "success, $(date), port:5050" || error=true;echo "failure, $(date), port: 5050"
 minikube ssh -- ss -lun | grep -E ":67|:69" > /dev/null  && echo "success, $(date), port:67:69" || error=true;echo "failure, $(date), port: 67:69"
 if [ "$error" == false ];then
   break
 fi
done
echo
echo "--------------end measurement: $(date)-------------------"
```
Running the script as follows
`bash measure.sh | tee result.txt `