### PR TITLE
Add ardaguclu and bfournie to reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,6 +10,8 @@ approvers:
  - zaneb
 
 reviewers:
+ - ardaguclu
+ - bfournie
  - honza
  - dukov
  - furkatgofurov7


### PR DESCRIPTION
Arda and Bob have both contributed substantial pieces of code and are
regular reviewers. Thus, they should have reviewer permissions as
documented at:

https://github.com/metal3-io/metal3-docs/blob/master/processes/managing-reviewers.md#proposal