### PR TITLE
Add an interface for the image builder to report a failure

### DIFF
--- a/pkg/imageprovider/default.go
+++ b/pkg/imageprovider/default.go
@@ -49,7 +49,7 @@ func (eip envImageProvider) BuildImage(data ImageData, networkData NetworkData, 
 		url = eip.initrdURL
 	}
 	if url == "" {
-		err = fmt.Errorf("Unsupported image format \"%s\"", data.Format)
+		err = BuildInvalidError(fmt.Errorf("Unsupported image format \"%s\"", data.Format))
 	}
 	return
 }

--- a/pkg/imageprovider/invalid.go
+++ b/pkg/imageprovider/invalid.go
@@ -1,0 +1,19 @@
+package imageprovider
+
+import "fmt"
+
+type ImageBuildInvalid struct {
+	err error
+}
+
+func (ibf ImageBuildInvalid) Error() string {
+	return fmt.Sprintf("Cannot generate image: %s", ibf.err.Error())
+}
+
+func (ibf ImageBuildInvalid) Unwrap() error {
+	return ibf.err
+}
+
+func BuildInvalidError(err error) ImageBuildInvalid {
+	return ImageBuildInvalid{err: err}
+}


### PR DESCRIPTION
Some failures to build images may be permanent, as opposed to transient
errors. Define a special error type that allows the imageprovider to
indicate a permanent failure, that is then reported in the CR.

Other errors are assumed to be transient and will continue to cause a
retry.