### PR TITLE
Remove reset_required from FirmwareSchema

### DIFF
--- a/apis/metal3.io/v1alpha1/firmwareschema_types.go
+++ b/apis/metal3.io/v1alpha1/firmwareschema_types.go
@@ -49,9 +49,6 @@ type SettingSchema struct {
 	// Whether or not this setting is read only.
 	ReadOnly *bool `json:"read_only,omitempty"`
 
-	// Whether or not a reset is required after changing this setting.
-	ResetRequired *bool `json:"reset_required,omitempty"`
-
 	// Whether or not this setting's value is unique to this node, e.g.
 	// a serial number.
 	Unique *bool `json:"unique,omitempty"`

--- a/apis/metal3.io/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/metal3.io/v1alpha1/zz_generated.deepcopy.go
@@ -964,11 +964,6 @@ func (in *SettingSchema) DeepCopyInto(out *SettingSchema) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.ResetRequired != nil {
-		in, out := &in.ResetRequired, &out.ResetRequired
-		*out = new(bool)
-		**out = **in
-	}
 	if in.Unique != nil {
 		in, out := &in.Unique, &out.Unique
 		*out = new(bool)

--- a/config/crd/bases/metal3.io_firmwareschemas.yaml
+++ b/config/crd/bases/metal3.io_firmwareschemas.yaml
@@ -72,10 +72,6 @@ spec:
                     read_only:
                       description: Whether or not this setting is read only.
                       type: boolean
-                    reset_required:
-                      description: Whether or not a reset is required after changing
-                        this setting.
-                      type: boolean
                     unique:
                       description: Whether or not this setting's value is unique to
                         this node, e.g. a serial number.

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -1170,10 +1170,6 @@ spec:
                     read_only:
                       description: Whether or not this setting is read only.
                       type: boolean
-                    reset_required:
-                      description: Whether or not a reset is required after changing
-                        this setting.
-                      type: boolean
                     unique:
                       description: Whether or not this setting's value is unique to
                         this node, e.g. a serial number.

--- a/pkg/provisioner/ironic/bios_test.go
+++ b/pkg/provisioner/ironic/bios_test.go
@@ -57,7 +57,6 @@ func TestGetFirmwareSettings(t *testing.T) {
 					MinLength:       &minLength,
 					MaxLength:       &maxLength,
 					ReadOnly:        &iTrue,
-					ResetRequired:   nil,
 					Unique:          nil,
 				},
 				"NumCores": {
@@ -68,7 +67,6 @@ func TestGetFirmwareSettings(t *testing.T) {
 					MinLength:       nil,
 					MaxLength:       nil,
 					ReadOnly:        &iTrue,
-					ResetRequired:   nil,
 					Unique:          nil,
 				},
 				"ProcVirtualization": {
@@ -79,7 +77,6 @@ func TestGetFirmwareSettings(t *testing.T) {
 					MinLength:       nil,
 					MaxLength:       nil,
 					ReadOnly:        &iFalse,
-					ResetRequired:   nil,
 					Unique:          nil,
 				},
 			},

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -971,7 +971,6 @@ func (p *ironicProvisioner) GetFirmwareSettings(includeSchema bool) (settings me
 				MinLength:       v.MinLength,
 				MaxLength:       v.MaxLength,
 				ReadOnly:        v.ReadOnly,
-				ResetRequired:   v.ResetRequired,
 				Unique:          v.Unique,
 			}
 		}


### PR DESCRIPTION
The reset_required field in the FirmwareSchema is both misleading and unnecessary. Changing HostFirmwareSettings is accomplished by resetting the host so this field doesn't provide any extra info; in addition not all vendors implement this field.