### PR TITLE
Update error message when soft poweroff fails

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -59,6 +59,7 @@ const (
 	rebootAnnotationPrefix        = "reboot.metal3.io"
 	inspectAnnotationPrefix       = "inspect.metal3.io"
 	hardwareDetailsAnnotation     = inspectAnnotationPrefix + "/hardwaredetails"
+	clarifySoftPoweroffFailure    = "Continuing with hard poweroff after soft poweroff fails. More details: "
 )
 
 // BareMetalHostReconciler reconciles a BareMetalHost object
@@ -1218,6 +1219,10 @@ func (r *BareMetalHostReconciler) manageHostPower(prov provisioner.Provisioner, 
 	}
 
 	if provResult.ErrorMessage != "" {
+		if !desiredPowerOnState && desiredRebootMode == metal3v1alpha1.RebootModeSoft &&
+			info.host.Status.ErrorType != metal3v1alpha1.PowerManagementError {
+			provResult.ErrorMessage = clarifySoftPoweroffFailure + provResult.ErrorMessage
+		}
 		return recordActionFailure(info, metal3v1alpha1.PowerManagementError, provResult.ErrorMessage)
 	}
 


### PR DESCRIPTION
This PR updates the error message in case of soft poweroff failure. 
Currently, the workflow when turning off a machine, BMO tries soft poweroff first. If failed, it performs a hard poweroff. The problem is that after soft poweroff fails, BMO would publish an error message got from ironic conductor, something like: `Failed to change power state to 'power off' by 'soft power off'. Error: Redfish exception occurred. Error: Setting power state to soft power off failed for node <node id>...`. This message can make user confused and think that this is a serious error and it can interrupt the poweroff workflow. 
This PR aims to clarify a bit more about the workflow by informing user about the followed hard poweroff after the soft one failure. 