### PR TITLE
Add main branch reference instead of master

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -431,20 +431,20 @@ metadata:
   finalizers:
   - baremetalhost.metal3.io
   generation: 2
-  name: bmo-master-0
+  name: bmo-controlplane-0
   namespace: bmo-project
   resourceVersion: "22642"
-  selfLink: /apis/metal3.io/v1alpha1/namespaces/bmo-project/baremetalhosts/bmo-master-0
+  selfLink: /apis/metal3.io/v1alpha1/namespaces/bmo-project/baremetalhosts/bmo-controlplane-0
   uid: 92b2f77a-db70-11e9-9db1-525400764849
 spec:
   bmc:
     address: ipmi://10.10.57.19
-    credentialsName: bmo-master-0-bmc-secret
+    credentialsName: bmo-controlplane-0-bmc-secret
   bootMACAddress: 98:03:9b:61:80:48
   consumerRef:
     apiVersion: machine.openshift.io/v1beta1
     kind: Machine
-    name: bmo-master-0
+    name: bmo-controlplane-0
     namespace: bmo-project
   externallyProvisioned: true
   hardwareProfile: default
@@ -460,19 +460,19 @@ spec:
   firmware:
     virtualizationEnabled: true
   userData:
-    name: bmo-master-user-data
+    name: bmo-controlplane-user-data
     namespace: bmo-project
   networkData:
-    name: bmo-master-network-data
+    name: bmo-controlplane-network-data
     namespace: bmo-project
   metaData:
-    name: bmo-master-meta-data
+    name: bmo-controlplane-meta-data
     namespace: bmo-project
 status:
   errorMessage: ""
   goodCredentials:
     credentials:
-      name: bmo-master-0-bmc-secret
+      name: bmo-controlplane-0-bmc-secret
       namespace: bmo-project
     credentialsVersion: "5562"
   hardware:
@@ -487,7 +487,7 @@ status:
         date: 12/17/2018
         vendor: Dell Inc.
         version: 1.6.13
-    hostname: bmo-master-0.localdomain
+    hostname: bmo-controlplane-0.localdomain
     nics:
     - ip: 172.22.135.105
       mac: "00:00:00:00:00:00"
@@ -514,12 +514,12 @@ status:
     state: externally provisioned
   triedCredentials:
     credentials:
-      name: bmo-master-0-bmc-secret
+      name: bmo-controlplane-0-bmc-secret
       namespace: bmo-project
     credentialsVersion: "5562"
 ```
 
-And here is the secret `bmo-master-0-bmc-secret` holding the host's
+And here is the secret `bmo-controlplane-0-bmc-secret` holding the host's
 BMC credentials, base64 encoded:
 
 ```console
@@ -540,7 +540,7 @@ paste it into the yaml as mentioned below.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: bmo-master-0-bmc-secret
+  name: bmo-controlplane-0-bmc-secret
 type: Opaque
 data:
   username: YWRtaW4=
@@ -760,7 +760,7 @@ items:
     ownerReferences:
     - apiVersion: metal3.io/v1alpha1
       kind: HostFirmwareSettings
-      name: ostest-master-0
+      name: ostest-controlplane-0
       uid: 8c315c33-29b0-4863-a61d-ce5ddde58498
     resourceVersion: "19133"
     uid: d169cd94-4d6e-4567-a1b9-d5f4962a8dee
@@ -778,7 +778,7 @@ items:
     ownerReferences:
     - apiVersion: metal3.io/v1alpha1
       kind: HostFirmwareSettings
-      name: ostest-master-1
+      name: ostest-controlplane-1
       uid: a991875d-9897-49f1-9d86-16ea9ed6c84f
     resourceVersion: "19141"
     uid: b442e01f-3724-4f14-a578-f0b99d296c95

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -233,18 +233,18 @@ The output can be passed directly to `kubectl apply` like this:
 go run cmd/make-virt-host/main.go openshift_worker_1 | kubectl apply -f -
 ```
 
-When the host is a *master*, include the `-consumer` and
+When the host is a *controlplane host*, include the `-consumer` and
 `-consumer-namespace` options to associate the host with the existing
 `Machine` object.
 
 ```bash
-$ go run cmd/make-virt-host/main.go -consumer ostest-master-1 \
-  -consumer-namespace openshift-machine-api  openshift_master_1
+$ go run cmd/make-virt-host/main.go -consumer ostest-controlplane-1 \
+  -consumer-namespace openshift-machine-api  openshift_controlplane_1
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: openshift-master-1-bmc-secret
+  name: openshift-controlplane-1-bmc-secret
 type: Opaque
 data:
   username: YWRtaW4=
@@ -254,15 +254,15 @@ data:
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
-  name: openshift-master-1
+  name: openshift-controlplane-1
 spec:
   online: true
   bmc:
     address: libvirt://192.168.122.1:6231/
-    credentialsName: openshift-master-1-bmc-secret
+    credentialsName: openshift-controlplane-1-bmc-secret
   bootMACAddress: 00:c9:a0:f2:e0:59
   consumerRef:
-    name: ostest-master-1
+    name: ostest-controlplane-1
     namespace: openshift-machine-api
 ```
 

--- a/docs/publishing-images.md
+++ b/docs/publishing-images.md
@@ -1,7 +1,7 @@
 Publishing Images
 =================
 
-Images for changes merged into master are automatically built through
+Images for changes merged into main are automatically built through
 the [metal3-io org on
 quay.io](https://quay.io/repository/metal3-io/baremetal-operator). It
 is also easy to set up your own builds to test images from branches in
@@ -43,7 +43,7 @@ your development fork.
 
    1. Click "Start New Build"
    2. Click "Run Trigger Now" in the modal popup
-   3. Select "master" from the list of branches.
+   3. Select "main" from the list of branches.
    4. Click "Start Build"
    5. At this point you may have to refresh your browser to see the
       build because the UI seems to cache pretty aggressively.
@@ -53,7 +53,7 @@ your development fork.
 
    1. Copy `deploy/operator.yaml` to `deploy/dev-operator.yaml`.
    2. Edit `deploy/dev-operator.yaml` and change the `image` setting
-      so it points to your account on quay.io. Builds from master will
+      so it points to your account on quay.io. Builds from main will
       have the default "latest" tag, but in order to test from a
       branch you will need to modify the image name to include the
       branch at the end, like this:

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -507,7 +507,7 @@ func (p *ironicProvisioner) ValidateManagementAccess(data provisioner.Management
 		return
 
 	case nodes.Active:
-		// The host is already running, maybe it's a master?
+		// The host is already running, maybe it's a controlplane host?
 		p.debugLog.Info("have active host", "image_source", ironicNode.InstanceInfo["image_source"])
 		fallthrough
 

--- a/pkg/provisioner/ironic/testserver/ironic.go
+++ b/pkg/provisioner/ironic/testserver/ironic.go
@@ -67,7 +67,7 @@ func (m *IronicMock) WithDrivers() *IronicMock {
 	{
 		"drivers": [{
 			"hosts": [
-			  "master-2.ostest.test.metalkube.org"
+			  "controlplane-2.ostest.test.metalkube.org"
 			],
 			"links": [
 			  {


### PR DESCRIPTION
BMO's default branch is now `main`. This PR removes/updates any reference to `master` branch previously. 