### PR TITLE
Create operator namespace with default kustomize config

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -13,6 +13,7 @@ namePrefix: baremetal-operator-
 #  someName: someValue
 
 bases:
+- ../namespace
 - ../crd
 - ../rbac
 - ../manager

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -6,12 +6,6 @@
 
    <https://kubernetes.io/docs/setup/minikube/>
 
-1. Create a namespace to host the operator
-
-    ```bash
-    kubectl create namespace baremetal-operator-system
-    ```
-
 1. Install cert-manager
 
     ```bash


### PR DESCRIPTION
Install `baremetal-operator-system` namespace and remove
the requirement for manual installation from dev setup doc.