### PR TITLE
✨Use grouping feature of Tilt to add BMO label

### DIFF
--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -1,10 +1,18 @@
 {
     "name": "metal3-bmo",
     "config": {
-        "kustomize_config": false,
         "image": "quay.io/metal3-io/baremetal-operator",
         "live_reload_deps": [
-            "apis", "cmd", "pkg", "config", "controllers", "go.mod", "go.sum", "main.go"
-        ]
+            "apis",
+            "cmd",
+            "pkg",
+            "config",
+            "controllers",
+            "go.mod",
+            "go.sum",
+            "main.go"
+        ],
+        "label": "BMO",
+        "manager_name": "baremetal-operator-controller-manager"
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Update tilt-provider.json to add BMO label in Tilt UX. This [grouping feature](https://blog.tilt.dev/2021/08/09/resource-grouping.html) is supported in tilt version >= v0.22.2.
This patch provides two different grouping strategies:

- by controllers
- and local binaries

Also, the corresponding controller and binary will be grouped under 'BMO' group label as shown in the local Tilt setup using BMO,CAPM3&IPAM controllers.

![bmo](https://user-images.githubusercontent.com/40443040/147971287-8b2338b2-622e-444c-8fe7-4dc2d882f06e.png)

Related patches in: [CAPM3](https://github.com/metal3-io/cluster-api-provider-metal3/pull/385)&[IPAM](https://github.com/metal3-io/ip-address-manager/pull/83).
