### PR TITLE
Fix software RAID

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -213,19 +213,19 @@ spec:
 
 **NOTE:** Currently the 'raid' field is only supported by ilo5/idrac/irmc.
 
-**NOTE:** Software RAID will always be deleted.
+**NOTE:** Do not try to simultaneously delete hardware RAID volumes and add
+software RAID volumes. Delete hardware RAID first, wait for the host to settle
+down, add software volumes afterwards.
 
 **NOTE:** If you got following error message:
 
 1. raid settings are defined, but the node's driver %s does not support RAID.
 2. node's driver %s does not support hardware RAID.
-3. node's driver %s does not support software RAID.
 
 You can solve it by:
 
 1. Keep raid field is nil.
 2. Keep hardwareRAIDVolumes field is nil.
-3. Keep softwareRAIDVolumes field is nil.
 
 If the error message you get isn't included the above, you may need to check
 whether the BM has a RAID controller and keep the raid field blank.

--- a/pkg/hardwareutils/bmc/access_test.go
+++ b/pkg/hardwareutils/bmc/access_test.go
@@ -434,7 +434,6 @@ func TestStaticDriverInfo(t *testing.T) {
 		boot       string
 		management string
 		power      string
-		raid       string
 		vendor     string
 	}{
 		{
@@ -446,7 +445,6 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "ipxe",
 			management: "",
 			power:      "",
-			raid:       "no-raid",
 		},
 
 		{
@@ -458,7 +456,6 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "ipxe",
 			management: "",
 			power:      "",
-			raid:       "no-raid",
 		},
 
 		{
@@ -470,7 +467,6 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "ipxe",
 			management: "",
 			power:      "",
-			raid:       "no-raid",
 		},
 
 		{
@@ -482,7 +478,6 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "ipxe",
 			management: "",
 			power:      "",
-			raid:       "irmc",
 		},
 
 		{
@@ -494,7 +489,6 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "ipxe",
 			management: "",
 			power:      "",
-			raid:       "no-raid",
 		},
 
 		{
@@ -506,7 +500,6 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "redfish-virtual-media",
 			management: "",
 			power:      "",
-			raid:       "no-raid",
 		},
 
 		{
@@ -518,7 +511,6 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "redfish-virtual-media",
 			management: "",
 			power:      "",
-			raid:       "no-raid",
 		},
 
 		{
@@ -530,7 +522,6 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "redfish-virtual-media",
 			management: "",
 			power:      "",
-			raid:       "no-raid",
 		},
 
 		{
@@ -542,7 +533,6 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "ipxe",
 			management: "idrac-redfish",
 			power:      "idrac-redfish",
-			raid:       "no-raid",
 			vendor:     "idrac-redfish",
 		},
 
@@ -582,7 +572,6 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "idrac-redfish-virtual-media",
 			management: "idrac-redfish",
 			power:      "idrac-redfish",
-			raid:       "no-raid",
 			vendor:     "idrac-redfish",
 		},
 
@@ -595,7 +584,6 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "idrac-redfish-virtual-media",
 			management: "idrac-redfish",
 			power:      "idrac-redfish",
-			raid:       "no-raid",
 			vendor:     "idrac-redfish",
 		},
 
@@ -608,7 +596,6 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "idrac-redfish-virtual-media",
 			management: "idrac-redfish",
 			power:      "idrac-redfish",
-			raid:       "no-raid",
 			vendor:     "idrac-redfish",
 		},
 
@@ -621,7 +608,6 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "pxe",
 			management: "ibmc",
 			power:      "ibmc",
-			raid:       "no-raid",
 		},
 
 		{
@@ -633,7 +619,6 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "ilo-ipxe",
 			management: "",
 			power:      "",
-			raid:       "no-raid",
 		},
 
 		{
@@ -645,7 +630,6 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "ilo-virtual-media",
 			management: "",
 			power:      "",
-			raid:       "no-raid",
 		},
 
 		{
@@ -657,7 +641,6 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "ilo-ipxe",
 			management: "",
 			power:      "",
-			raid:       "ilo5",
 		},
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {

--- a/pkg/provisioner/ironic/raid.go
+++ b/pkg/provisioner/ironic/raid.go
@@ -19,7 +19,7 @@ const (
 
 // setTargetRAIDCfg set the RAID settings to the ironic Node for RAID configuration steps
 func setTargetRAIDCfg(p *ironicProvisioner, raidInterface string, ironicNode *nodes.Node, data provisioner.PrepareData) (provisioner.Result, error) {
-	err := CheckRAIDInterface(raidInterface, data.TargetRAIDConfig)
+	targetRaidInterface, err := CheckRAIDInterface(raidInterface, data.TargetRAIDConfig, data.ActualRAIDConfig)
 	if err != nil {
 		return operationFailed(err.Error())
 	}
@@ -41,6 +41,13 @@ func setTargetRAIDCfg(p *ironicProvisioner, raidInterface string, ironicNode *no
 		*logicalDisks[0].IsRootVolume = true
 	} else {
 		p.log.Info("rootDeviceHints is used, the first volume of raid will not be set to root")
+	}
+
+	updater := updateOptsBuilder(p.debugLog)
+	updater.SetTopLevelOpt("raid_interface", targetRaidInterface, ironicNode.RAIDInterface)
+	success, result, err := p.tryUpdateNode(ironicNode, updater)
+	if !success {
+		return result, err
 	}
 
 	// Set target for RAID configuration steps
@@ -178,26 +185,22 @@ func buildTargetSoftwareRAIDCfg(volumes []metal3v1alpha1.SoftwareRAIDVolume) (lo
 
 // BuildRAIDCleanSteps build the clean steps for RAID configuration from BaremetalHost spec
 func BuildRAIDCleanSteps(raidInterface string, target *metal3v1alpha1.RAIDConfig, actual *metal3v1alpha1.RAIDConfig) (cleanSteps []nodes.CleanStep, err error) {
-	err = CheckRAIDInterface(raidInterface, target)
+	_, err = CheckRAIDInterface(raidInterface, target, actual)
 	if err != nil {
 		return nil, err
 	}
 
-	// No RAID
-	if raidInterface == noRAIDInterface {
-		return
-	}
-
 	// Software RAID
-	if raidInterface == softwareRAIDInterface {
+	if target != nil && target.SoftwareRAIDVolumes != nil {
 		// Ignore HardwareRAIDVolumes
-		if target != nil {
-			target.HardwareRAIDVolumes = nil
-		}
+		target.HardwareRAIDVolumes = nil
 		if actual != nil {
 			actual.HardwareRAIDVolumes = nil
 		}
 		if reflect.DeepEqual(target, actual) {
+			return
+		}
+		if len(target.SoftwareRAIDVolumes) == 0 && (actual == nil || len(actual.SoftwareRAIDVolumes) == 0) {
 			return
 		}
 
@@ -216,7 +219,7 @@ func BuildRAIDCleanSteps(raidInterface string, target *metal3v1alpha1.RAIDConfig
 		)
 
 		// If software raid configuration is empty, only need to clear old configuration
-		if target == nil || len(target.SoftwareRAIDVolumes) == 0 {
+		if len(target.SoftwareRAIDVolumes) == 0 {
 			return
 		}
 
@@ -233,7 +236,7 @@ func BuildRAIDCleanSteps(raidInterface string, target *metal3v1alpha1.RAIDConfig
 	// Hardware RAID
 	// If hardware RAID configuration is nil,
 	// keep old hardware RAID configuration
-	if target == nil || target.HardwareRAIDVolumes == nil {
+	if raidInterface == noRAIDInterface || target == nil || target.HardwareRAIDVolumes == nil {
 		return
 	}
 
@@ -274,22 +277,31 @@ func BuildRAIDCleanSteps(raidInterface string, target *metal3v1alpha1.RAIDConfig
 }
 
 // CheckRAIDInterface checks the current RAID interface against the requested configuration
-func CheckRAIDInterface(raidInterface string, target *metal3v1alpha1.RAIDConfig) error {
-	// FIXME(dtantsur): the software RAID logic is completely broken: no driver sets raidInterface to "agent".
-	// This value must be used when software RAID volumes are requested or deleted.
-	switch raidInterface {
-	case noRAIDInterface:
-		if target != nil && (len(target.HardwareRAIDVolumes) != 0 || len(target.SoftwareRAIDVolumes) != 0) {
-			return fmt.Errorf("target settings are defined, but the node's driver %s does not support RAID", raidInterface)
-		}
-	case softwareRAIDInterface:
-		if target != nil && len(target.HardwareRAIDVolumes) != 0 {
-			return fmt.Errorf("node's driver %s does not support hardware RAID", raidInterface)
-		}
-	default:
-		if target != nil && len(target.HardwareRAIDVolumes) == 0 && len(target.SoftwareRAIDVolumes) != 0 {
-			return fmt.Errorf("node's driver %s does not support software RAID", raidInterface)
-		}
+func CheckRAIDInterface(raidInterface string, target, actual *metal3v1alpha1.RAIDConfig) (string, error) {
+	if target == nil {
+		return raidInterface, nil
 	}
-	return nil
+
+	if raidInterface == noRAIDInterface && len(target.HardwareRAIDVolumes) != 0 {
+		return "", fmt.Errorf("RAID settings are defined, but the node's driver %s does not support RAID", raidInterface)
+	}
+
+	// This is not a real case since no BMC driver defaults to agent, but we add it for consistency
+	if raidInterface == softwareRAIDInterface && len(target.HardwareRAIDVolumes) != 0 {
+		return "", fmt.Errorf("hardware RAID settings are defined, but the node's driver %s only supports software RAID", raidInterface)
+	}
+
+	// If software RAID is requested, change the RAID interface.
+	// FIXME(dtantsur): if a user tries to simultaneously remove hardware RAID volumes and add software RAID volumes, it will not work.
+	// The matter is complicated because Ironic cannot change the RAID interface in the middle of cleaning. We better just document it.
+	if len(target.SoftwareRAIDVolumes) != 0 {
+		return softwareRAIDInterface, nil
+	}
+
+	// If software RAID is being deleted, also change the interface.
+	if actual != nil && len(actual.SoftwareRAIDVolumes) != 0 {
+		return softwareRAIDInterface, nil
+	}
+
+	return raidInterface, nil
 }

--- a/pkg/provisioner/ironic/raid_test.go
+++ b/pkg/provisioner/ironic/raid_test.go
@@ -491,7 +491,7 @@ func TestCheckRAIDConfigure(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.raidInterface, func(t *testing.T) {
-			err := checkRAIDConfigure(c.raidInterface, c.RAID)
+			err := CheckRAIDInterface(c.raidInterface, c.RAID)
 			if (err != nil) != c.expectedError {
 				t.Errorf("Got unexpected error: %v", err)
 			}

--- a/pkg/provisioner/ironic/raid_test.go
+++ b/pkg/provisioner/ironic/raid_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
+	"github.com/stretchr/testify/assert"
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 )
@@ -259,11 +260,6 @@ func TestBuildRAIDCleanSteps(t *testing.T) {
 						Level: "1",
 					},
 				},
-				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{
-					{
-						Level: "1",
-					},
-				},
 			},
 			expected: []nodes.CleanStep{
 				{
@@ -283,11 +279,6 @@ func TestBuildRAIDCleanSteps(t *testing.T) {
 				HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{
 					{
 						Name:  "root",
-						Level: "1",
-					},
-				},
-				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{
-					{
 						Level: "1",
 					},
 				},
@@ -366,6 +357,21 @@ func TestBuildRAIDCleanSteps(t *testing.T) {
 			},
 		},
 		{
+			name:          "keep missing software RAID",
+			raidInterface: "agent",
+			target: &metal3v1alpha1.RAIDConfig{
+				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{},
+			},
+		},
+		{
+			name:          "keep empty software RAID",
+			raidInterface: "agent",
+			target: &metal3v1alpha1.RAIDConfig{
+				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{},
+			},
+			actual: &metal3v1alpha1.RAIDConfig{},
+		},
+		{
 			name:          "clear software RAID",
 			raidInterface: "agent",
 			target: &metal3v1alpha1.RAIDConfig{
@@ -406,9 +412,11 @@ func TestBuildRAIDCleanSteps(t *testing.T) {
 
 func TestCheckRAIDConfigure(t *testing.T) {
 	cases := []struct {
-		raidInterface string
-		RAID          *metal3v1alpha1.RAIDConfig
-		expectedError bool
+		raidInterface        string
+		RAID                 *metal3v1alpha1.RAIDConfig
+		expectedError        bool
+		expectedNewInterface string
+		currentRAID          *metal3v1alpha1.RAIDConfig
 	}{
 		{
 			raidInterface: "no-raid",
@@ -430,6 +438,17 @@ func TestCheckRAIDConfigure(t *testing.T) {
 			expectedError: true,
 		},
 		{
+			raidInterface: "no-raid",
+			RAID: &metal3v1alpha1.RAIDConfig{
+				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{
+					{
+						Level: "1",
+					},
+				},
+			},
+			expectedNewInterface: "agent",
+		},
+		{
 			raidInterface: "agent",
 		},
 		{
@@ -485,15 +504,36 @@ func TestCheckRAIDConfigure(t *testing.T) {
 					},
 				},
 			},
-			expectedError: true,
+			expectedNewInterface: "agent",
+		},
+		{
+			raidInterface: "hardware",
+			RAID: &metal3v1alpha1.RAIDConfig{
+				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{},
+			},
+			currentRAID: &metal3v1alpha1.RAIDConfig{
+				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{
+					{
+						Level: "1",
+					},
+				},
+			},
+			expectedNewInterface: "agent",
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.raidInterface, func(t *testing.T) {
-			err := CheckRAIDInterface(c.raidInterface, c.RAID)
+			newInterface, err := CheckRAIDInterface(c.raidInterface, c.RAID, c.currentRAID)
 			if (err != nil) != c.expectedError {
 				t.Errorf("Got unexpected error: %v", err)
+			}
+			if !c.expectedError {
+				if c.expectedNewInterface != "" {
+					assert.Equal(t, c.expectedNewInterface, newInterface)
+				} else {
+					assert.Equal(t, c.raidInterface, newInterface)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
The current code treats software RAID similarly to hardware RAID and
expects the driver's RAIDInterface value to be "agent" to use it.
This is never the case, as software RAID is not driver-specific.

This change adjusts the procedure to set the expected RAIDInterface
before setting the target configuration. This makes software RAID work
with any values of the driver's RAIDInterface.