### PR TITLE
Rework run_local_ironic to use combined Ironic

### DIFF
--- a/tools/remove_local_ironic.sh
+++ b/tools/remove_local_ironic.sh
@@ -3,7 +3,8 @@
 set -xe
 
 # This script removes local ironic containers. 
-# It requires ${CONTAINER_RUNTIME} variable to be defined first
+
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
 for name in ironic ironic-api ironic-conductor ironic-inspector dnsmasq httpd mariadb ipa-downloader \
     ironic-endpoint-keepalived ironic-log-watch httpd-reverse-proxy ; do

--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -117,7 +117,7 @@ IPA_BASEURI=${IPA_BASEURI}
 IRONIC_USE_MARIADB=${IRONIC_USE_MARIADB}
 EOF
 
-if [ "$IRONIC_TLS_SETUP" == "true" ]; then
+if [ "$IRONIC_TLS_SETUP" == "true" ] && [ -n "$IRONIC_CA_CERT_B64" ]; then
 # shellcheck disable=SC2086
 cat << EOF | kubectl apply -f -
 apiVersion: v1

--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -15,7 +15,12 @@ CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 HTTP_PORT="6180"
 PROVISIONING_IP="${PROVISIONING_IP:-"172.22.0.1"}"
 CLUSTER_PROVISIONING_IP="${CLUSTER_PROVISIONING_IP:-"172.22.0.2"}"
-PROVISIONING_INTERFACE="${PROVISIONING_INTERFACE:-"ironicendpoint"}"
+# ironicendpoint is used in the CI setup
+if ip link show ironicendpoint > /dev/null; then
+    PROVISIONING_INTERFACE="${PROVISIONING_INTERFACE:-ironicendpoint}"
+else
+    PROVISIONING_INTERFACE="${PROVISIONING_INTERFACE:-}"
+fi
 CLUSTER_DHCP_RANGE="${CLUSTER_DHCP_RANGE:-"172.22.0.10,172.22.0.100"}"
 IRONIC_KERNEL_PARAMS="${IRONIC_KERNEL_PARAMS:-"console=ttyS0"}"
 IRONIC_BOOT_ISO_SOURCE="${IRONIC_BOOT_ISO_SOURCE:-"local"}"
@@ -55,7 +60,7 @@ if [ "$IRONIC_TLS_SETUP" = "true" ]; then
         IRONIC_KEY_FILE="${IRONIC_DATA_DIR}/tls/ironic.key"
         IRONIC_CACERT_FILE="${IRONIC_CERT_FILE}"
         sudo openssl req -x509 -newkey rsa:4096 -nodes -days 365 -subj "/CN=ironic" \
-            -addext "subjectAltName = IP:${CLUSTER_PROVISIONING_IP}" \
+            -addext "subjectAltName = IP:${CLUSTER_PROVISIONING_IP},IP:${PROVISIONING_IP}" \
             -out "${IRONIC_CERT_FILE}" -keyout "${IRONIC_KEY_FILE}"
     fi
 
@@ -64,7 +69,7 @@ if [ "$IRONIC_TLS_SETUP" = "true" ]; then
         IRONIC_INSPECTOR_KEY_FILE="${IRONIC_DATA_DIR}/tls/inspector.key"
         IRONIC_INSPECTOR_CACERT_FILE="${IRONIC_CERT_FILE}"
         sudo openssl req -x509 -newkey rsa:4096 -nodes -days 365 -subj "/CN=ironic" \
-            -addext "subjectAltName = IP:${CLUSTER_PROVISIONING_IP}" \
+            -addext "subjectAltName = IP:${CLUSTER_PROVISIONING_IP},IP:${PROVISIONING_IP}" \
             -out "${IRONIC_INSPECTOR_CERT_FILE}" -keyout "${IRONIC_INSPECTOR_KEY_FILE}"
     fi
 

--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -178,14 +178,16 @@ if [ -n "$IRONIC_USERNAME" ]; then
         "${IRONIC_DATA_DIR}/auth/ironic-rpc-auth-config"
      BASIC_AUTH_MOUNTS="-v ${IRONIC_DATA_DIR}/auth/ironic-auth-config:/auth/ironic/auth-config"
      BASIC_AUTH_MOUNTS="${BASIC_AUTH_MOUNTS} -v ${IRONIC_DATA_DIR}/auth/ironic-rpc-auth-config:/auth/ironic-rpc/auth-config"
-     IRONIC_HTPASSWD="--env HTTP_BASIC_HTPASSWD=$(htpasswd -n -b -B "${IRONIC_USERNAME}" "${IRONIC_PASSWORD}")"
+     IRONIC_HTPASSWD="$(htpasswd -n -b -B "${IRONIC_USERNAME}" "${IRONIC_PASSWORD}")"
+     IRONIC_HTPASSWD="--env HTTP_BASIC_HTPASSWD=${IRONIC_HTPASSWD} --env IRONIC_HTPASSWD=${IRONIC_HTPASSWD}"
 fi
 IRONIC_INSPECTOR_HTPASSWD=""
 if [ -n "$IRONIC_INSPECTOR_USERNAME" ]; then
      envsubst < "${SCRIPTDIR}/ironic-deployment/basic-auth/ironic-inspector-auth-config-tpl" > \
         "${IRONIC_DATA_DIR}/auth/ironic-inspector-auth-config"
      BASIC_AUTH_MOUNTS="${BASIC_AUTH_MOUNTS} -v ${IRONIC_DATA_DIR}/auth/ironic-inspector-auth-config:/auth/ironic-inspector/auth-config"
-     IRONIC_INSPECTOR_HTPASSWD="--env HTTP_BASIC_HTPASSWD=$(htpasswd -n -b -B "${IRONIC_INSPECTOR_USERNAME}" "${IRONIC_INSPECTOR_PASSWORD}")"
+     IRONIC_INSPECTOR_HTPASSWD="$(htpasswd -n -b -B "${IRONIC_INSPECTOR_USERNAME}" "${IRONIC_INSPECTOR_PASSWORD}")"
+     IRONIC_INSPECTOR_HTPASSWD="--env HTTP_BASIC_HTPASSWD=${IRONIC_INSPECTOR_HTPASSWD} --env INSPECTOR_HTPASSWD=${IRONIC_INSPECTOR_HTPASSWD}"
 fi
 
 sudo mkdir -p "$IRONIC_DATA_DIR/html/images"

--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -248,7 +248,8 @@ sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name dnsmasq \
 # https://github.com/metal3-io/ironic-image/blob/main/scripts/runhttpd
 # shellcheck disable=SC2086
 sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name httpd \
-     ${POD} --env-file "${IRONIC_DATA_DIR}/ironic-vars.env" \
+     ${POD} ${CERTS_MOUNTS} ${BASIC_AUTH_MOUNTS} ${IRONIC_HTPASSWD} \
+     --env-file "${IRONIC_DATA_DIR}/ironic-vars.env" \
      -v "$IRONIC_DATA_DIR:/shared" --entrypoint /bin/runhttpd "${IRONIC_IMAGE}"
 
 if [ "$IRONIC_USE_MARIADB" = "true" ]; then


### PR DESCRIPTION
This change also features significant simplifications to the way run_local_ironic works:
better defaults, automatic generation of TLS parameters, no requirement of kubectl.