### PR TITLE
Check if bmc hostname follows DNS Standard

### DIFF
--- a/pkg/hardwareutils/bmc/access.go
+++ b/pkg/hardwareutils/bmc/access.go
@@ -173,7 +173,7 @@ func checkDNSValid(address string) error {
 	// Check if BMC address hostname follows DNS Standard
 	valid, _ := regexp.MatchString(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]{0,61}[A-Za-z0-9])$`, address)
 	if !valid {
-		return fmt.Errorf("BMC address hostname [%s] invalid, expected format : Type://DNS_Standard_Hostname:Port", address)
+		return fmt.Errorf("BMC address hostname/IP : [%s] is invalid", address)
 	}
 	return nil
 }

--- a/pkg/hardwareutils/bmc/access.go
+++ b/pkg/hardwareutils/bmc/access.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -86,8 +87,12 @@ type AccessDetails interface {
 	BuildBIOSSettings(firmwareConfig *FirmwareConfig) (settings []map[string]string, err error)
 }
 
-func getParsedURL(address string) (parsedURL *url.URL, err error) {
-	// Start by assuming "type://host:port"
+func GetParsedURL(address string) (parsedURL *url.URL, err error) {
+	// Check for expected format
+	if err := checkDNSValid(address); err != nil {
+		return nil, errors.Wrap(err, "failed to parse BMC address information")
+	}
+
 	parsedURL, err = url.Parse(address)
 	if err != nil {
 		// We failed to parse the URL, but it may just be a host or
@@ -138,7 +143,7 @@ func NewAccessDetails(address string, disableCertificateVerification bool) (Acce
 		return nil, errors.New("missing BMC address")
 	}
 
-	parsedURL, err := getParsedURL(address)
+	parsedURL, err := GetParsedURL(address)
 	if err != nil {
 		return nil, err
 	}
@@ -149,4 +154,21 @@ func NewAccessDetails(address string, disableCertificateVerification bool) (Acce
 	}
 
 	return factory(parsedURL, disableCertificateVerification)
+}
+
+func checkDNSValid(address string) error {
+
+	// Allowing empty BMC address
+	if address == "" {
+		return nil
+	}
+
+	// Check if BMC address follows the format: Type://DNS_Standard_Hostname:Port
+	// Type and Port are optional
+	valid, _ := regexp.MatchString(`^([a-zA-Z]+\:\/\/)?(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]{0,61}[A-Za-z0-9])(\:[0-9]+)?$`, address)
+	if !valid {
+		return fmt.Errorf("BMC address invalid, expected format : Type://DNS_Standard_Hostname:Port")
+	}
+
+	return nil
 }

--- a/pkg/hardwareutils/bmc/access_test.go
+++ b/pkg/hardwareutils/bmc/access_test.go
@@ -51,6 +51,38 @@ func TestParse(t *testing.T) {
 		},
 
 		{
+			Scenario: "valid dns hostname",
+			Address:  "my.examplehost.com",
+			Type:     "ipmi",
+			Port:     "",
+			Host:     "my.examplehost.com",
+			Hostname: "my.examplehost.com",
+			Path:     "",
+		},
+
+		{
+			Scenario:    "invalid dns hostname",
+			Address:     "my-.examplehost.com",
+			Type:        "ipmi",
+			Port:        "",
+			Host:        "my-.examplehost.com",
+			Hostname:    "my-.examplehost.com",
+			Path:        "",
+			ExpectError: true,
+		},
+
+		{
+			Scenario:    "invalid ipv6 host address",
+			Address:     "[fe80::fc33:62ff:fe33:8xff]:6223",
+			Type:        "ipmi",
+			Port:        "6223",
+			Host:        "fe80::fc33:62ff:fe33.8xff",
+			Hostname:    "[fe80::fc33:62ff:fe33:8xff]:6223",
+			Path:        "",
+			ExpectError: true,
+		},
+
+		{
 			Scenario: "host and port",
 			Address:  "192.168.122.1:6233",
 			Type:     "ipmi",

--- a/pkg/hardwareutils/bmc/access_test.go
+++ b/pkg/hardwareutils/bmc/access_test.go
@@ -368,7 +368,7 @@ func TestParse(t *testing.T) {
 		},
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
-			url, err := getParsedURL(tc.Address)
+			url, err := GetParsedURL(tc.Address)
 
 			if tc.ExpectError {
 				if err == nil {


### PR DESCRIPTION
Adds a function to check if the bmc.address follows DNS standard and exports the GetParsedURL function to make it available in other validations.