### PR TITLE
move maelk to emeritus_approvers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,7 +5,6 @@ approvers:
  - dtantsur
  - fmuyassarov
  - hardys
- - maelk
  - zaneb
 
 reviewers:
@@ -16,3 +15,6 @@ reviewers:
  - furkatgofurov7
  - kashifest
  - s3rj1k
+
+emeritus_approvers:
+ - maelk


### PR DESCRIPTION
Maël's focus has shifted from this project to other tasks thus the
OWNERS list has to be modified accordingly.