### PR TITLE
Bug 2041765: irmc: change BootInterface to ipxe

### DIFF
--- a/pkg/hardwareutils/bmc/access_test.go
+++ b/pkg/hardwareutils/bmc/access_test.go
@@ -479,7 +479,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			needsMac:   true,
 			driver:     "irmc",
 			bios:       "",
-			boot:       "pxe",
+			boot:       "ipxe",
 			management: "",
 			power:      "",
 			raid:       "irmc",

--- a/pkg/hardwareutils/bmc/irmc.go
+++ b/pkg/hardwareutils/bmc/irmc.go
@@ -75,7 +75,7 @@ func (a *iRMCAccessDetails) BIOSInterface() string {
 }
 
 func (a *iRMCAccessDetails) BootInterface() string {
-	return "pxe"
+	return "ipxe"
 }
 
 func (a *iRMCAccessDetails) ManagementInterface() string {


### PR DESCRIPTION
Fixed iRMC server deployment failure during IPI.

See https://github.com/openshift/installer/issues/5504 for details.

Signed-off-by: Zhou Hao <zhouhao@fujitsu.com>