### PR TITLE
Use deep copy/equal for host root device hints

### DIFF
--- a/controllers/metal3.io/host_state_machine.go
+++ b/controllers/metal3.io/host_state_machine.go
@@ -412,7 +412,7 @@ func (hsm *hostStateMachine) handleAvailable(info *reconcileInfo) actionResult {
 		return actionComplete{}
 	}
 
-	if dirty, _, err := getHostProvisioningSettings(info.host); err != nil {
+	if dirty, _, err := getHostProvisioningSettings(info.host, info); err != nil {
 		return actionError{err}
 	} else if dirty {
 		hsm.NextState = metal3v1alpha1.StatePreparing

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -1129,7 +1129,8 @@ func (hb *hostBuilder) build() *metal3v1alpha1.BareMetalHost {
 }
 
 func (hb *hostBuilder) SaveHostProvisioningSettings() *hostBuilder {
-	saveHostProvisioningSettings(&hb.BareMetalHost)
+	info := makeDefaultReconcileInfo(&hb.BareMetalHost)
+	saveHostProvisioningSettings(&hb.BareMetalHost, info)
 	return hb
 }
 


### PR DESCRIPTION
The root device hints have a rotational field which is a pointer to a bool. Use DeepCopy and DeepEqual to ensure its handled properly.