### PR TITLE
Switch the deployment to use a single ironic process

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -107,7 +107,6 @@ ironic-deployment/
 │   │   └── kustomization.yaml
 │   ├── ironic-auth-config-tpl
 │   ├── ironic-inspector-auth-config-tpl
-│   ├── ironic-rpc-auth-config-tpl
 │   ├── keepalived
 │   │   ├── auth.yaml
 │   │   └── kustomization.yaml

--- a/ironic-deployment/basic-auth/default/auth.yaml
+++ b/ironic-deployment/basic-auth/default/auth.yaml
@@ -6,27 +6,19 @@ spec:
   template:
     spec:
       containers:
-      - name: ironic-api
+      - name: ironic
         volumeMounts:
-        - name: ironic-rpc-auth-config
-          mountPath: "/auth/ironic-rpc"
+        - name: ironic-auth-config
+          mountPath: "/auth/ironic"
           readOnly: true
-        envFrom:
-        - configMapRef:
-            name: ironic-htpasswd
-        - configMapRef:
-            name: ironic-bmo-configmap
-      - name: ironic-conductor
-        volumeMounts:
         - name: ironic-inspector-auth-config
           mountPath: "/auth/ironic-inspector"
           readOnly: true
-        - name: ironic-rpc-auth-config
-          mountPath: "/auth/ironic-rpc"
-          readOnly: true
         envFrom:
         - configMapRef:
             name: ironic-htpasswd
+        - configMapRef:
+            name: ironic-inspector-htpasswd
         - configMapRef:
             name: ironic-bmo-configmap
       - name: ironic-inspector
@@ -34,7 +26,12 @@ spec:
         - name: ironic-auth-config
           mountPath: "/auth/ironic"
           readOnly: true
+        - name: ironic-inspector-auth-config
+          mountPath: "/auth/ironic-inspector"
+          readOnly: true
         envFrom:
+        - configMapRef:
+            name: ironic-htpasswd
         - configMapRef:
             name: ironic-inspector-htpasswd
         - configMapRef:
@@ -46,6 +43,3 @@ spec:
       - name: ironic-inspector-auth-config
         secret:
           secretName: ironic-inspector-auth-config
-      - name: ironic-rpc-auth-config
-        secret:
-          secretName: ironic-rpc-auth-config

--- a/ironic-deployment/basic-auth/default/kustomization.yaml
+++ b/ironic-deployment/basic-auth/default/kustomization.yaml
@@ -21,9 +21,6 @@ secretGenerator:
 - name: ironic-inspector-auth-config
   files:
   - auth-config=ironic-inspector-auth-config
-- name: ironic-rpc-auth-config
-  files:
-  - auth-config=ironic-rpc-auth-config
 
 patchesStrategicMerge:
 - auth.yaml

--- a/ironic-deployment/basic-auth/keepalived/auth.yaml
+++ b/ironic-deployment/basic-auth/keepalived/auth.yaml
@@ -6,27 +6,19 @@ spec:
   template:
     spec:
       containers:
-      - name: ironic-api
+      - name: ironic
         volumeMounts:
-        - name: ironic-rpc-auth-config
-          mountPath: "/auth/ironic-rpc"
+        - name: ironic-auth-config
+          mountPath: "/auth/ironic"
           readOnly: true
-        envFrom:
-        - configMapRef:
-            name: ironic-htpasswd
-        - configMapRef:
-            name: ironic-bmo-configmap
-      - name: ironic-conductor
-        volumeMounts:
         - name: ironic-inspector-auth-config
           mountPath: "/auth/ironic-inspector"
           readOnly: true
-        - name: ironic-rpc-auth-config
-          mountPath: "/auth/ironic-rpc"
-          readOnly: true
         envFrom:
         - configMapRef:
             name: ironic-htpasswd
+        - configMapRef:
+            name: ironic-inspector-htpasswd
         - configMapRef:
             name: ironic-bmo-configmap
       - name: ironic-inspector
@@ -34,7 +26,12 @@ spec:
         - name: ironic-auth-config
           mountPath: "/auth/ironic"
           readOnly: true
+        - name: ironic-inspector-auth-config
+          mountPath: "/auth/ironic-inspector"
+          readOnly: true
         envFrom:
+        - configMapRef:
+            name: ironic-htpasswd
         - configMapRef:
             name: ironic-inspector-htpasswd
         - configMapRef:
@@ -46,6 +43,3 @@ spec:
       - name: ironic-inspector-auth-config
         secret:
           secretName: ironic-inspector-auth-config
-      - name: ironic-rpc-auth-config
-        secret:
-          secretName: ironic-rpc-auth-config

--- a/ironic-deployment/basic-auth/keepalived/kustomization.yaml
+++ b/ironic-deployment/basic-auth/keepalived/kustomization.yaml
@@ -21,9 +21,6 @@ secretGenerator:
 - name: ironic-inspector-auth-config
   files:
   - auth-config=ironic-inspector-auth-config
-- name: ironic-rpc-auth-config
-  files:
-  - auth-config=ironic-rpc-auth-config
 
 patchesStrategicMerge:
 - auth.yaml

--- a/ironic-deployment/basic-auth/tls/default/auth.yaml
+++ b/ironic-deployment/basic-auth/tls/default/auth.yaml
@@ -6,27 +6,29 @@ spec:
   template:
     spec:
       containers:
-      - name: ironic-api
+      - name: ironic
         volumeMounts:
-        - name: ironic-rpc-auth-config
-          mountPath: "/auth/ironic-rpc"
+        - name: ironic-inspector-auth-config
+          mountPath: "/auth/ironic-inspector"
           readOnly: true
         envFrom:
         - configMapRef:
             name: ironic-htpasswd
         - configMapRef:
             name: ironic-bmo-configmap
-      - name: ironic-conductor
+      - name: ironic-httpd
         volumeMounts:
+        - name: ironic-auth-config
+          mountPath: "/auth/ironic"
+          readOnly: true
         - name: ironic-inspector-auth-config
           mountPath: "/auth/ironic-inspector"
-          readOnly: true
-        - name: ironic-rpc-auth-config
-          mountPath: "/auth/ironic-rpc"
           readOnly: true
         envFrom:
         - configMapRef:
             name: ironic-htpasswd
+        - configMapRef:
+            name: ironic-inspector-htpasswd
         - configMapRef:
             name: ironic-bmo-configmap
       - name: ironic-inspector
@@ -46,6 +48,3 @@ spec:
       - name: ironic-inspector-auth-config
         secret:
           secretName: ironic-inspector-auth-config
-      - name: ironic-rpc-auth-config
-        secret:
-          secretName: ironic-rpc-auth-config

--- a/ironic-deployment/basic-auth/tls/default/kustomization.yaml
+++ b/ironic-deployment/basic-auth/tls/default/kustomization.yaml
@@ -21,9 +21,6 @@ secretGenerator:
 - name: ironic-inspector-auth-config
   files:
   - auth-config=ironic-inspector-auth-config
-- name: ironic-rpc-auth-config
-  files:
-  - auth-config=ironic-rpc-auth-config
 
 patchesStrategicMerge:
 - auth.yaml

--- a/ironic-deployment/basic-auth/tls/keepalived/auth.yaml
+++ b/ironic-deployment/basic-auth/tls/keepalived/auth.yaml
@@ -6,27 +6,29 @@ spec:
   template:
     spec:
       containers:
-      - name: ironic-api
+      - name: ironic
         volumeMounts:
-        - name: ironic-rpc-auth-config
-          mountPath: "/auth/ironic-rpc"
+        - name: ironic-inspector-auth-config
+          mountPath: "/auth/ironic-inspector"
           readOnly: true
         envFrom:
         - configMapRef:
             name: ironic-htpasswd
         - configMapRef:
             name: ironic-bmo-configmap
-      - name: ironic-conductor
+      - name: ironic-httpd
         volumeMounts:
+        - name: ironic-auth-config
+          mountPath: "/auth/ironic"
+          readOnly: true
         - name: ironic-inspector-auth-config
           mountPath: "/auth/ironic-inspector"
-          readOnly: true
-        - name: ironic-rpc-auth-config
-          mountPath: "/auth/ironic-rpc"
           readOnly: true
         envFrom:
         - configMapRef:
             name: ironic-htpasswd
+        - configMapRef:
+            name: ironic-inspector-htpasswd
         - configMapRef:
             name: ironic-bmo-configmap
       - name: ironic-inspector
@@ -46,6 +48,3 @@ spec:
       - name: ironic-inspector-auth-config
         secret:
           secretName: ironic-inspector-auth-config
-      - name: ironic-rpc-auth-config
-        secret:
-          secretName: ironic-rpc-auth-config

--- a/ironic-deployment/basic-auth/tls/keepalived/kustomization.yaml
+++ b/ironic-deployment/basic-auth/tls/keepalived/kustomization.yaml
@@ -21,9 +21,6 @@ secretGenerator:
 - name: ironic-inspector-auth-config
   files:
   - auth-config=ironic-inspector-auth-config
-- name: ironic-rpc-auth-config
-  files:
-  - auth-config=ironic-rpc-auth-config
 
 patchesStrategicMerge:
 - auth.yaml

--- a/ironic-deployment/default/ironic_bmo_configmap.env
+++ b/ironic-deployment/default/ironic_bmo_configmap.env
@@ -9,3 +9,5 @@ CACHEURL=http://172.22.0.1/images
 IRONIC_FAST_TRACK=true
 IRONIC_KERNEL_PARAMS=console=ttyS0
 IRONIC_INSPECTOR_VLAN_INTERFACES=all
+# TODO(dtantsur): this should probably not be the default
+IRONIC_USE_MARIADB=true

--- a/ironic-deployment/ironic/ironic.yaml
+++ b/ironic-deployment/ironic/ironic.yaml
@@ -81,11 +81,11 @@ spec:
                  configMapKeyRef:
                   name: ironic-bmo-configmap
                   key: RESTART_CONTAINER_CERTIFICATE_UPDATED
-        - name: ironic-api
+        - name: ironic
           image: quay.io/metal3-io/ironic
           imagePullPolicy: Always
           command:
-            - /bin/runironic-api
+            - /bin/runironic
           livenessProbe:
            exec:
              command: ["sh", "-c", "curl -sSf http://127.0.0.1:6385 || curl -sSfk https://127.0.0.1:6385"]
@@ -102,39 +102,6 @@ spec:
            timeoutSeconds: 10
            successThreshold: 1
            failureThreshold: 10
-          volumeMounts:
-            - mountPath: /shared
-              name: ironic-data-volume
-          envFrom:
-            - configMapRef:
-                name: ironic-bmo-configmap
-          env:
-            - name: MARIADB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: mariadb-password
-                  key: password
-        - name: ironic-conductor
-          image: quay.io/metal3-io/ironic
-          imagePullPolicy: Always
-          command:
-            - /bin/runironic-conductor
-          readinessProbe:
-            exec:
-              command: ["sh", "-c", "curl -sd '{}' -o – -k https://127.0.0.1:8089 || curl -sd '{}' -o – http://127.0.0.1:8089"]
-            initialDelaySeconds: 30
-            periodSeconds: 30
-            timeoutSeconds: 10
-            successThreshold: 1
-            failureThreshold: 10
-          livenessProbe:
-            exec:
-              command: ["sh", "-c", "curl -sd '{}' -o – -k https://127.0.0.1:8089 || curl -sd '{}' -o – http://127.0.0.1:8089"]
-            initialDelaySeconds: 30
-            periodSeconds: 30
-            timeoutSeconds: 10
-            successThreshold: 1
-            failureThreshold: 10
           volumeMounts:
             - mountPath: /shared
               name: ironic-data-volume
@@ -176,6 +143,33 @@ spec:
             failureThreshold: 10
           command:
             - /bin/runironic-inspector
+          envFrom:
+            - configMapRef:
+                name: ironic-bmo-configmap
+        - name: ironic-httpd
+          image: quay.io/metal3-io/ironic
+          imagePullPolicy: Always
+          command:
+            - /bin/runhttpd
+          livenessProbe:
+           exec:
+             command: ["sh", "-c", "curl -sSfk https://127.0.0.1:6180"]
+           initialDelaySeconds: 30
+           periodSeconds: 30
+           timeoutSeconds: 10
+           successThreshold: 1
+           failureThreshold: 10
+          readinessProbe:
+           exec:
+             command: ["sh", "-c", "curl -sSfk https://127.0.0.1:6180"]
+           initialDelaySeconds: 30
+           periodSeconds: 30
+           timeoutSeconds: 10
+           successThreshold: 1
+           failureThreshold: 10
+          volumeMounts:
+            - mountPath: /shared
+              name: ironic-data-volume
           envFrom:
             - configMapRef:
                 name: ironic-bmo-configmap

--- a/ironic-deployment/keepalived/ironic_bmo_configmap.env
+++ b/ironic-deployment/keepalived/ironic_bmo_configmap.env
@@ -9,3 +9,5 @@ IRONIC_INSPECTOR_ENDPOINT=http://172.22.0.2:5050/v1/
 CACHEURL=http://172.22.0.1/images
 IRONIC_FAST_TRACK=true
 IRONIC_KERNEL_PARAMS=console=ttyS0
+# TODO(dtantsur): this should probably not be the default
+IRONIC_USE_MARIADB=true

--- a/ironic-deployment/tls/default/tls.yaml
+++ b/ironic-deployment/tls/default/tls.yaml
@@ -6,44 +6,71 @@ spec:
   template:
     spec:
       containers:
-      - name: ironic-api
+      - name: ironic
+        readinessProbe:
+         exec:
+           command: ["sh", "-c", "curl -sSf http://127.0.0.1:6388"]
+        livenessProbe:
+         exec:
+           command: ["sh", "-c", "curl -sSf http://127.0.0.1:6388"]
+        env:
+        - name: IRONIC_REVERSE_PROXY_SETUP
+          value: "true"
+        - name: INSPECTOR_REVERSE_PROXY_SETUP
+          value: "true"
         volumeMounts:
-        - name: cert-ironic
-          mountPath: "/certs/ironic"
-          readOnly: true
         - name: cert-ironic-ca
           mountPath: "/certs/ca/ironic"
           readOnly: true
         - name: cert-ironic-inspector-ca
           mountPath: "/certs/ca/ironic-inspector"
+          readOnly: true
+        - name: cert-mariadb-ca
+          mountPath: "/certs/ca/mariadb"
+          readOnly: true
+      - name: ironic-httpd
+        livenessProbe:
+         exec:
+           command: ["sh", "-c", "curl -sSfk https://127.0.0.1:6385"]
+        readinessProbe:
+         exec:
+           command: ["sh", "-c", "curl -sSfk https://127.0.0.1:6385"]
+        env:
+        - name: IRONIC_REVERSE_PROXY_SETUP
+          value: "true"
+        - name: INSPECTOR_REVERSE_PROXY_SETUP
+          value: "true"
+        volumeMounts:
+        - name: cert-ironic
+          mountPath: "/certs/ironic"
           readOnly: true
         - name: cert-ironic-inspector
           mountPath: "/certs/ironic-inspector"
           readOnly: true
-        - name: cert-mariadb-ca
-          mountPath: "/certs/ca/mariadb"
-          readOnly: true
-      - name: ironic-conductor
-        volumeMounts:
-        - name: cert-ironic
-          mountPath: "/certs/ironic"
-          readOnly: true
         - name: cert-ironic-ca
           mountPath: "/certs/ca/ironic"
           readOnly: true
         - name: cert-ironic-inspector-ca
           mountPath: "/certs/ca/ironic-inspector"
-          readOnly: true
-        - name: cert-mariadb-ca
-          mountPath: "/certs/ca/mariadb"
           readOnly: true
       - name: ironic-inspector
+        readinessProbe:
+          exec:
+            command: ["sh", "-c", "curl -sSf http://127.0.0.1:5049"]
+        livenessProbe:
+          exec:
+            command: ["sh", "-c", "curl -sSf http://127.0.0.1:5049"]
+        env:
+        - name: IRONIC_REVERSE_PROXY_SETUP
+          value: "true"
+        - name: INSPECTOR_REVERSE_PROXY_SETUP
+          value: "true"
         volumeMounts:
         - name: cert-ironic-ca
           mountPath: "/certs/ca/ironic"
           readOnly: true
-        - name: cert-ironic-inspector
-          mountPath: "/certs/ironic-inspector"
+        - name: cert-ironic-inspector-ca
+          mountPath: "/certs/ca/ironic-inspector"
           readOnly: true
       - name: mariadb
         volumeMounts:

--- a/ironic-deployment/tls/keepalived/tls.yaml
+++ b/ironic-deployment/tls/keepalived/tls.yaml
@@ -6,44 +6,71 @@ spec:
   template:
     spec:
       containers:
-      - name: ironic-api
+      - name: ironic
+        readinessProbe:
+         exec:
+           command: ["sh", "-c", "curl -sSf http://127.0.0.1:6388"]
+        livenessProbe:
+         exec:
+           command: ["sh", "-c", "curl -sSf http://127.0.0.1:6388"]
+        env:
+        - name: IRONIC_REVERSE_PROXY_SETUP
+          value: "true"
+        - name: INSPECTOR_REVERSE_PROXY_SETUP
+          value: "true"
         volumeMounts:
-        - name: cert-ironic
-          mountPath: "/certs/ironic"
-          readOnly: true
         - name: cert-ironic-ca
           mountPath: "/certs/ca/ironic"
           readOnly: true
         - name: cert-ironic-inspector-ca
           mountPath: "/certs/ca/ironic-inspector"
+          readOnly: true
+        - name: cert-mariadb-ca
+          mountPath: "/certs/ca/mariadb"
+          readOnly: true
+      - name: ironic-httpd
+        livenessProbe:
+         exec:
+           command: ["sh", "-c", "curl -sSfk https://127.0.0.1:6385"]
+        readinessProbe:
+         exec:
+           command: ["sh", "-c", "curl -sSfk https://127.0.0.1:6385"]
+        env:
+        - name: IRONIC_REVERSE_PROXY_SETUP
+          value: "true"
+        - name: INSPECTOR_REVERSE_PROXY_SETUP
+          value: "true"
+        volumeMounts:
+        - name: cert-ironic
+          mountPath: "/certs/ironic"
           readOnly: true
         - name: cert-ironic-inspector
           mountPath: "/certs/ironic-inspector"
           readOnly: true
-        - name: cert-mariadb-ca
-          mountPath: "/certs/ca/mariadb"
-          readOnly: true
-      - name: ironic-conductor
-        volumeMounts:
-        - name: cert-ironic
-          mountPath: "/certs/ironic"
-          readOnly: true
         - name: cert-ironic-ca
           mountPath: "/certs/ca/ironic"
           readOnly: true
         - name: cert-ironic-inspector-ca
           mountPath: "/certs/ca/ironic-inspector"
-          readOnly: true
-        - name: cert-mariadb-ca
-          mountPath: "/certs/ca/mariadb"
           readOnly: true
       - name: ironic-inspector
+        readinessProbe:
+          exec:
+            command: ["sh", "-c", "curl -sSf http://127.0.0.1:5049"]
+        livenessProbe:
+          exec:
+            command: ["sh", "-c", "curl -sSf http://127.0.0.1:5049"]
+        env:
+        - name: IRONIC_REVERSE_PROXY_SETUP
+          value: "true"
+        - name: INSPECTOR_REVERSE_PROXY_SETUP
+          value: "true"
         volumeMounts:
         - name: cert-ironic-ca
           mountPath: "/certs/ca/ironic"
           readOnly: true
-        - name: cert-ironic-inspector
-          mountPath: "/certs/ironic-inspector"
+        - name: cert-ironic-inspector-ca
+          mountPath: "/certs/ca/ironic-inspector"
           readOnly: true
       - name: mariadb
         volumeMounts:

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -194,12 +194,10 @@ if [ "${DEPLOY_BASIC_AUTH}" == "true" ]; then
         "${IRONIC_SCENARIO}/ironic-auth-config"
         envsubst < "${SCRIPTDIR}/ironic-deployment/basic-auth/ironic-inspector-auth-config-tpl" > \
         "${IRONIC_SCENARIO}/ironic-inspector-auth-config"
-        envsubst < "${SCRIPTDIR}/ironic-deployment/basic-auth/ironic-rpc-auth-config-tpl" > \
-        "${IRONIC_SCENARIO}/ironic-rpc-auth-config"
 
-        echo "HTTP_BASIC_HTPASSWD=$(htpasswd -n -b -B "${IRONIC_USERNAME}" "${IRONIC_PASSWORD}")" > \
+        echo "IRONIC_HTPASSWD=$(htpasswd -n -b -B "${IRONIC_USERNAME}" "${IRONIC_PASSWORD}")" > \
         "${IRONIC_SCENARIO}/ironic-htpasswd"
-        echo "HTTP_BASIC_HTPASSWD=$(htpasswd -n -b -B "${IRONIC_INSPECTOR_USERNAME}" \
+        echo "INSPECTOR_HTPASSWD=$(htpasswd -n -b -B "${IRONIC_INSPECTOR_USERNAME}" \
         "${IRONIC_INSPECTOR_PASSWORD}")" > "${IRONIC_SCENARIO}/ironic-inspector-htpasswd"
     fi
 fi
@@ -254,7 +252,6 @@ if [ "${DEPLOY_BASIC_AUTH}" == "true" ]; then
     if [ "${DEPLOY_IRONIC}" == "true" ]; then
         rm "${IRONIC_SCENARIO}/ironic-auth-config"
         rm "${IRONIC_SCENARIO}/ironic-inspector-auth-config"
-        rm "${IRONIC_SCENARIO}/ironic-rpc-auth-config"
 
         rm "${IRONIC_SCENARIO}/ironic-htpasswd"
         rm "${IRONIC_SCENARIO}/ironic-inspector-htpasswd"

--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -179,10 +179,7 @@ IRONIC_HTPASSWD=""
 if [ -n "$IRONIC_USERNAME" ]; then
      envsubst < "${SCRIPTDIR}/ironic-deployment/basic-auth/ironic-auth-config-tpl" > \
         "${IRONIC_DATA_DIR}/auth/ironic-auth-config"
-     envsubst < "${SCRIPTDIR}/ironic-deployment/basic-auth/ironic-rpc-auth-config-tpl" > \
-        "${IRONIC_DATA_DIR}/auth/ironic-rpc-auth-config"
      BASIC_AUTH_MOUNTS="-v ${IRONIC_DATA_DIR}/auth/ironic-auth-config:/auth/ironic/auth-config"
-     BASIC_AUTH_MOUNTS="${BASIC_AUTH_MOUNTS} -v ${IRONIC_DATA_DIR}/auth/ironic-rpc-auth-config:/auth/ironic-rpc/auth-config"
      IRONIC_HTPASSWD="$(htpasswd -n -b -B "${IRONIC_USERNAME}" "${IRONIC_PASSWORD}")"
      IRONIC_HTPASSWD="--env HTTP_BASIC_HTPASSWD=${IRONIC_HTPASSWD} --env IRONIC_HTPASSWD=${IRONIC_HTPASSWD}"
 fi


### PR DESCRIPTION
This change reduces the resource footprint of the installation and paves
the way to dropping MariaDB by default (not a part of this patch).
