### PR TITLE
Copy labels from BaremetalHost to PreprovisioningImage

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -668,7 +668,7 @@ func (r *BareMetalHostReconciler) preprovImageAvailable(info *reconcileInfo, ima
 			"message", errCond.Message)
 		return false, imageBuildError{errCond.Message}
 	}
-	if meta.IsStatusConditionTrue(image.Status.Conditions, string(metal3v1alpha1.ConditionImageReady)) {
+	if readyCond := meta.FindStatusCondition(image.Status.Conditions, string(metal3v1alpha1.ConditionImageReady)); readyCond != nil && readyCond.Status == metav1.ConditionTrue && readyCond.ObservedGeneration == image.Generation {
 		return true, nil
 	}
 

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -663,7 +663,7 @@ func (r *BareMetalHostReconciler) preprovImageAvailable(info *reconcileInfo, ima
 		return false, nil
 	}
 
-	if errCond := meta.FindStatusCondition(image.Status.Conditions, string(metal3v1alpha1.ConditionImageError)); errCond.Status == metav1.ConditionTrue {
+	if errCond := meta.FindStatusCondition(image.Status.Conditions, string(metal3v1alpha1.ConditionImageError)); errCond != nil && errCond.Status == metav1.ConditionTrue {
 		info.log.Info("error building PreprovisioningImage",
 			"message", errCond.Message)
 		return false, imageBuildError{errCond.Message}

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -728,6 +728,9 @@ func (r *BareMetalHostReconciler) getPreprovImage(info *reconcileInfo, formats [
 	}
 
 	needsUpdate := false
+	if preprovImage.Labels == nil && len(info.host.Labels) > 0 {
+		preprovImage.Labels = make(map[string]string, len(info.host.Labels))
+	}
 	for k, v := range info.host.Labels {
 		if cur, ok := preprovImage.Labels[k]; !ok || cur != v {
 			preprovImage.Labels[k] = v

--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -2162,6 +2162,9 @@ func TestGetPreprovImageCreateUpdate(t *testing.T) {
 	secretName := "net_secret"
 	host := newDefaultHost(t)
 	host.Spec.PreprovisioningNetworkDataName = secretName
+	host.Labels = map[string]string{
+		"answer.metal3.io": "42",
+	}
 	r := newTestReconciler(host, newSecret(secretName, nil))
 	i := makeReconcileInfo(host)
 
@@ -2177,9 +2180,11 @@ func TestGetPreprovImageCreateUpdate(t *testing.T) {
 		&img))
 	assert.Equal(t, "x86_64", img.Spec.Architecture)
 	assert.Equal(t, secretName, img.Spec.NetworkDataName)
+	assert.Equal(t, "42", img.Labels["answer.metal3.io"])
 
 	newSecretName := "new_net_secret"
 	host.Spec.PreprovisioningNetworkDataName = newSecretName
+	host.Labels["cat.metal3.io"] = "meow"
 
 	imgData, err = r.getPreprovImage(i, []metal3v1alpha1.ImageFormat{"iso"})
 	assert.NoError(t, err)
@@ -2191,6 +2196,8 @@ func TestGetPreprovImageCreateUpdate(t *testing.T) {
 	},
 		&img))
 	assert.Equal(t, newSecretName, img.Spec.NetworkDataName)
+	assert.Equal(t, "42", img.Labels["answer.metal3.io"])
+	assert.Equal(t, "meow", img.Labels["cat.metal3.io"])
 }
 
 func TestGetPreprovImage(t *testing.T) {


### PR DESCRIPTION
This may be needed e.g. to find linked objects.