### PR TITLE
Enable RAID for Redfish-based iDRAC driver flavor

### DIFF
--- a/pkg/hardwareutils/bmc/idrac_virtualmedia.go
+++ b/pkg/hardwareutils/bmc/idrac_virtualmedia.go
@@ -85,7 +85,7 @@ func (a *redfishiDracVirtualMediaAccessDetails) PowerInterface() string {
 }
 
 func (a *redfishiDracVirtualMediaAccessDetails) RAIDInterface() string {
-	return "no-raid"
+	return "idrac-redfish"
 }
 
 func (a *redfishiDracVirtualMediaAccessDetails) VendorInterface() string {

--- a/pkg/hardwareutils/bmc/redfish.go
+++ b/pkg/hardwareutils/bmc/redfish.go
@@ -164,7 +164,7 @@ func (a *redfishiDracAccessDetails) PowerInterface() string {
 }
 
 func (a *redfishiDracAccessDetails) RAIDInterface() string {
-	return "no-raid"
+	return "idrac-redfish"
 }
 
 func (a *redfishiDracAccessDetails) VendorInterface() string {


### PR DESCRIPTION
It's already enabled for the WSMAN flavor via the idrac driver.
We even document it in docs/api as supported.
