### PR TITLE
Remove amd64 and linux to ensure multiarch container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY pkg/hardwareutils/go.sum pkg/hardwareutils/go.sum
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o baremetal-operator main.go
+RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o baremetal-operator main.go
 
 # Copy the controller-manager into a thin image
 # BMO has a dependency preventing us to use the static one,

--- a/Tiltfile
+++ b/Tiltfile
@@ -98,7 +98,7 @@ def enable_provider(name):
     # manager_build_path or the main.go must be provided via go_main option. The binary is written to .tiltbuild/manager.
     local_resource(
         name + "_manager",
-        cmd = "cd " + context + ';mkdir -p .tiltbuild;CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags \'-extldflags "-static"\' -o .tiltbuild/manager ' + go_main,
+        cmd = "cd " + context + ';mkdir -p .tiltbuild;CGO_ENABLED=0 go build -ldflags \'-extldflags "-static"\' -o .tiltbuild/manager ' + go_main,
         deps = live_reload_deps,
     )
 


### PR DESCRIPTION
Hello, I am testing the baremetal-operator on arm, and noticed that this builds an arm container with an x86 image. I'd like to remove the hard-coded arch so the image builds based on the os arch.