### PR TITLE
Check for empty HFS status settings

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -1428,6 +1428,11 @@ func (r *BareMetalHostReconciler) getHostFirmwareSettings(info *reconcileInfo) (
 	// Check if there are settings in the Spec that are different than the Status
 	if meta.IsStatusConditionTrue(hfs.Status.Conditions, string(metal3v1alpha1.FirmwareSettingsChangeDetected)) {
 
+		// Check if the status settings have been populated
+		if len(hfs.Status.Settings) == 0 {
+			return false, nil, errors.New("host firmware status settings not available")
+		}
+
 		if meta.IsStatusConditionTrue(hfs.Status.Conditions, string(metal3v1alpha1.FirmwareSettingsValid)) {
 			info.log.Info("hostFirmwareSettings indicating ChangeDetected", "namespacename", info.request.NamespacedName)
 			return true, hfs, nil

--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -2736,9 +2736,51 @@ func TestHFSTransitionToPreparing(t *testing.T) {
 			{Type: "ChangeDetected", Status: "True", Reason: "Success"},
 			{Type: "Valid", Status: "True", Reason: "Success"},
 		},
+		Settings: metal3v1alpha1.SettingsMap{
+			"ProcVirtualization": "Enabled",
+			"SecureBoot":         "Enabled",
+		},
 	}
 
 	r.Update(goctx.TODO(), hfs)
 
 	waitForProvisioningState(t, r, host, metal3v1alpha1.StatePreparing)
+}
+
+// TestHFSEmptyStatusSettings ensures that BMH does not move to the next state in the
+// following two senarios:
+// 1. when a user provides the BIOS settings on a hardware server that does not
+// have the required license to configure BIOS
+// 2. when it is waiting to get data from Ironic
+func TestHFSEmptyStatusSettings(t *testing.T) {
+	host := newDefaultHost(t)
+	host.Spec.Online = true
+	host.Spec.ConsumerRef = &corev1.ObjectReference{}
+	host.Spec.ExternallyProvisioned = false
+	r := newTestReconciler(host)
+
+	waitForProvisioningState(t, r, host, metal3v1alpha1.StatePreparing)
+
+	// Update HFS so host will go through cleaning
+	hfs := &metal3v1alpha1.HostFirmwareSettings{}
+	key := client.ObjectKey{
+		Namespace: host.ObjectMeta.Namespace, Name: host.ObjectMeta.Name}
+	if err := r.Get(goctx.TODO(), key, hfs); err != nil {
+		t.Fatal(err)
+	}
+
+	hfs.Status = metal3v1alpha1.HostFirmwareSettingsStatus{
+		Conditions: []metav1.Condition{
+			{Type: "ChangeDetected", Status: "True", Reason: "Success"},
+			{Type: "Valid", Status: "True", Reason: "Success"},
+		},
+	}
+
+	r.Update(goctx.TODO(), hfs)
+
+	tryReconcile(t, r, host,
+		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
+			return host.Status.Provisioning.State == metal3v1alpha1.StatePreparing
+		},
+	)
 }

--- a/controllers/metal3.io/hostfirmwaresettings_controller.go
+++ b/controllers/metal3.io/hostfirmwaresettings_controller.go
@@ -247,8 +247,11 @@ func (r *HostFirmwareSettingsReconciler) updateStatus(info *rInfo, settings meta
 				dirty = true
 			}
 		} else {
-			for _, error := range errors {
-				info.publishEvent("ValidationFailed", fmt.Sprintf("Invalid BIOS setting: %v", error))
+			// If the status settings are empty, don't raise events
+			if len(newStatus.Settings) != 0 {
+				for _, error := range errors {
+					info.publishEvent("ValidationFailed", fmt.Sprintf("Invalid BIOS setting: %v", error))
+				}
 			}
 			reason = reasonConfigurationError
 			if setCondition(generation, &newStatus, info, metal3v1alpha1.FirmwareSettingsValid, metav1.ConditionFalse, reason, "Invalid BIOS setting") {


### PR DESCRIPTION
If the HFS status settings have not been populated, does not generate the
Invalid BIOS Setting events.

If the changes are detected, but the HFS status settings are empty, it waits
until hostFirmwareSettings are read.

Signed-off-by: tliu2021 <tali@redhat.com>