### PR TITLE
Fix make target for setting Ironic image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ set-manifest-image-bmo: $(KUSTOMIZE) manifests
 .PHONY: set-manifest-image-ironic
 set-manifest-image-ironic: $(KUSTOMIZE) manifests
 	$(info Updating container image for Ironic to use ${MANIFEST_IMG}:${MANIFEST_TAG})
-	cd ironic-deployment/default && $(abspath $(KUSTOMIZE)) edit set image quay.io/metal3-io/ironic=${MANIFEST_IMG}:${MANIFEST_TAG}
+	cd ironic-deployment/ironic && $(abspath $(KUSTOMIZE)) edit set image quay.io/metal3-io/ironic=${MANIFEST_IMG}:${MANIFEST_TAG}
 
 .PHONY: set-manifest-image-mariadb
 set-manifest-image-mariadb: $(KUSTOMIZE) manifests


### PR DESCRIPTION
I mistakenly thought `default` was the base of all Ironic
kustomizations, but it turns out `ironic` is the base, so that is where
we should set the image.

Edit: The problem is that some kustomizations depends on `ironic` directly instead of `default`, meaning that any changes made in `default` will not be picked up. See for example keepalived: https://github.com/metal3-io/baremetal-operator/blob/main/ironic-deployment/keepalived/kustomization.yaml
