### PR TITLE
Add NET_RAW capability for dnsmasq

### DIFF
--- a/ironic-deployment/ironic/ironic.yaml
+++ b/ironic-deployment/ironic/ironic.yaml
@@ -23,7 +23,7 @@ spec:
           imagePullPolicy: Always
           securityContext:
              capabilities:
-               add: ["NET_ADMIN"]
+               add: ["NET_ADMIN", "NET_RAW"]
           command:
             - /bin/rundnsmasq
           livenessProbe:


### PR DESCRIPTION
We are seeing failed jobs in the CI due to dnsmasq missing NET_RAW capability. This should solve the issue. But it would also be good to check with upstream what caused this change.