### PR TITLE
Set minReadySeconds for BMO and Ironic

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -11,6 +11,7 @@ spec:
     matchLabels:
       control-plane: controller-manager
   replicas: 1
+  minReadySeconds: 10
   template:
     metadata:
       labels:

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -1972,6 +1972,7 @@ metadata:
   name: baremetal-operator-controller-manager
   namespace: baremetal-operator-system
 spec:
+  minReadySeconds: 10
   replicas: 1
   selector:
     matchLabels:

--- a/ironic-deployment/ironic/ironic.yaml
+++ b/ironic-deployment/ironic/ironic.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ${NAMEPREFIX}-ironic
 spec:
   replicas: 1
+  minReadySeconds: 10
   strategy:
     # We cannot run Ironic with more than one replica at a time. The recreate
     # strategy makes sure that the old pod is gone before a new is started.


### PR DESCRIPTION
This is to make it easier to tell when the deployments are "available".
The default is to consider them available as soon as the pods have
started. But if there is some problem it is likely that the pods will
immediately crash. Therefore it makes sense to give them a few seconds
before we consider them available for real.

This is related to https://github.com/metal3-io/metal3-dev-env/issues/981 and https://github.com/metal3-io/metal3-dev-env/pull/983
It will be easier to check the health of the controllers when the deployments have `minReadySeconds` set.