### PR TITLE
Allow image provider to override kernel and add kernel params

### DIFF
--- a/apis/metal3.io/v1alpha1/preprovisioningimage_types.go
+++ b/apis/metal3.io/v1alpha1/preprovisioningimage_types.go
@@ -65,6 +65,16 @@ type PreprovisioningImageStatus struct {
 	// imageUrl is the URL from which the built image can be downloaded.
 	ImageUrl string `json:"imageUrl,omitempty"`
 
+	// kernelUrl is the URL from which the kernel of the image can be downloaded.
+	// Only makes sense for initrd images.
+	// +optional
+	KernelUrl string `json:"kernelUrl,omitempty"`
+
+	// extraKernelParams is a string with extra parameters to pass to the
+	// kernel when booting the image over network. Only makes sense for initrd images.
+	// +optional
+	ExtraKernelParams string `json:"extraKernelParams,omitempty"`
+
 	// format is the type of image that is available at the download url:
 	// either iso or initrd.
 	// +optional

--- a/config/crd/bases/metal3.io_preprovisioningimages.yaml
+++ b/config/crd/bases/metal3.io_preprovisioningimages.yaml
@@ -147,6 +147,11 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              extraKernelParams:
+                description: extraKernelParams is a string with extra parameters to
+                  pass to the kernel when booting the image over network. Only makes
+                  sense for initrd images.
+                type: string
               format:
                 description: 'format is the type of image that is available at the
                   download url: either iso or initrd.'
@@ -157,6 +162,10 @@ spec:
               imageUrl:
                 description: imageUrl is the URL from which the built image can be
                   downloaded.
+                type: string
+              kernelUrl:
+                description: kernelUrl is the URL from which the kernel of the image
+                  can be downloaded. Only makes sense for initrd images.
                 type: string
               networkData:
                 description: networkData is a reference to the version of the Secret

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -1621,6 +1621,11 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              extraKernelParams:
+                description: extraKernelParams is a string with extra parameters to
+                  pass to the kernel when booting the image over network. Only makes
+                  sense for initrd images.
+                type: string
               format:
                 description: 'format is the type of image that is available at the
                   download url: either iso or initrd.'
@@ -1631,6 +1636,10 @@ spec:
               imageUrl:
                 description: imageUrl is the URL from which the built image can be
                   downloaded.
+                type: string
+              kernelUrl:
+                description: kernelUrl is the URL from which the kernel of the image
+                  can be downloaded. Only makes sense for initrd images.
                 type: string
               networkData:
                 description: networkData is a reference to the version of the Secret

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -45,6 +45,7 @@ import (
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/hardware"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/imageprovider"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/secretutils"
 	"github.com/metal3-io/baremetal-operator/pkg/utils"
@@ -753,8 +754,12 @@ func (r *BareMetalHostReconciler) getPreprovImage(info *reconcileInfo, formats [
 	}
 
 	image := provisioner.PreprovisioningImage{
-		ImageURL: preprovImage.Status.ImageUrl,
-		Format:   preprovImage.Status.Format,
+		GeneratedImage: imageprovider.GeneratedImage{
+			ImageURL:          preprovImage.Status.ImageUrl,
+			KernelURL:         preprovImage.Status.KernelUrl,
+			ExtraKernelParams: preprovImage.Status.ExtraKernelParams,
+		},
+		Format: preprovImage.Status.Format,
 	}
 	info.log.Info("using PreprovisioningImage")
 	return &image, nil

--- a/pkg/imageprovider/default.go
+++ b/pkg/imageprovider/default.go
@@ -41,14 +41,13 @@ func (eip envImageProvider) SupportsFormat(format metal3.ImageFormat) bool {
 	}
 }
 
-func (eip envImageProvider) BuildImage(data ImageData, networkData NetworkData, log logr.Logger) (url string, err error) {
+func (eip envImageProvider) BuildImage(data ImageData, networkData NetworkData, log logr.Logger) (image GeneratedImage, err error) {
 	switch data.Format {
 	case metal3.ImageFormatISO:
-		url = eip.isoURL
+		image.ImageURL = eip.isoURL
 	case metal3.ImageFormatInitRD:
-		url = eip.initrdURL
-	}
-	if url == "" {
+		image.ImageURL = eip.initrdURL
+	default:
 		err = BuildInvalidError(fmt.Errorf("Unsupported image format \"%s\"", data.Format))
 	}
 	return

--- a/pkg/imageprovider/imageprovider.go
+++ b/pkg/imageprovider/imageprovider.go
@@ -17,6 +17,14 @@ type ImageData struct {
 	NetworkDataStatus metal3.SecretStatus
 }
 
+// GeneratedImage contains information about the generated image. At least the
+// URL must be populated.
+type GeneratedImage struct {
+	ImageURL          string
+	KernelURL         string
+	ExtraKernelParams string
+}
+
 type NetworkData map[string][]byte
 
 type ImageProvider interface {
@@ -30,7 +38,7 @@ type ImageProvider interface {
 
 	// BuildImage requests the ImageProvider to build an image with the
 	// supplied network data and return a URL where it can be accessed.
-	BuildImage(ImageData, NetworkData, logr.Logger) (string, error)
+	BuildImage(ImageData, NetworkData, logr.Logger) (GeneratedImage, error)
 
 	// DiscardImage notifies the ImageProvider that a previously built image
 	// is no longer required.

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -9,6 +9,7 @@ import (
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/hardware"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/imageprovider"
 )
 
 /*
@@ -68,8 +69,8 @@ type HostConfigData interface {
 }
 
 type PreprovisioningImage struct {
-	ImageURL string
-	Format   metal3v1alpha1.ImageFormat
+	imageprovider.GeneratedImage
+	Format metal3v1alpha1.ImageFormat
 }
 
 type ManagementAccessData struct {


### PR DESCRIPTION
Currently, we assume that the same kernel can be used for all images.
This is not the case in multi-arch scenarios. Add a new optional field
to pass a kernel from the provider.

Also add support for extra kernel parameters. These are required by
CoreOS to link to the correct rootfs.

Requires: https://review.opendev.org/c/openstack/ironic/+/837379
