### PR TITLE
remove_local_ironic.sh: update the list of containers

### DIFF
--- a/tools/remove_local_ironic.sh
+++ b/tools/remove_local_ironic.sh
@@ -6,8 +6,8 @@ set -xe
 
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
-for name in ironic ironic-api ironic-conductor ironic-inspector dnsmasq httpd mariadb ipa-downloader \
-    ironic-endpoint-keepalived ironic-log-watch httpd-reverse-proxy ; do
+for name in ironic ironic-inspector dnsmasq httpd mariadb ipa-downloader ironic-endpoint-keepalived \
+    ironic-log-watch ; do
     sudo "${CONTAINER_RUNTIME}" ps | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" kill "$name"
     sudo "${CONTAINER_RUNTIME}" ps --all | grep -w "$name$" && sudo "${CONTAINER_RUNTIME}" rm "$name" -f
 done


### PR DESCRIPTION
Some containers are no longer created in the run_local_ironic.sh script, so remove them from the list.

Signed-off-by: Zhou Hao <zhouhao@fujitsu.com>