### PR TITLE
Get rid of envsubst for nameprefix

### DIFF
--- a/ironic-deployment/basic-auth/default/auth.yaml
+++ b/ironic-deployment/basic-auth/default/auth.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ${NAMEPREFIX}-ironic
+  name: ironic
 spec:
   template:
     spec:

--- a/ironic-deployment/basic-auth/default/kustomization.yaml
+++ b/ironic-deployment/basic-auth/default/kustomization.yaml
@@ -1,8 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ${NAMEPREFIX}-system
+namespace: baremetal-operator-system
 resources:
 - ../../default
+- ../../../config/namespace
 
 configMapGenerator:
 - behavior: create

--- a/ironic-deployment/basic-auth/keepalived/auth.yaml
+++ b/ironic-deployment/basic-auth/keepalived/auth.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ${NAMEPREFIX}-ironic
+  name: ironic
 spec:
   template:
     spec:

--- a/ironic-deployment/basic-auth/keepalived/kustomization.yaml
+++ b/ironic-deployment/basic-auth/keepalived/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ${NAMEPREFIX}-system
+namespace: baremetal-operator-system
 resources:
 - ../../keepalived
 

--- a/ironic-deployment/basic-auth/tls/default/auth.yaml
+++ b/ironic-deployment/basic-auth/tls/default/auth.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ${NAMEPREFIX}-ironic
+  name: ironic
 spec:
   template:
     spec:

--- a/ironic-deployment/basic-auth/tls/default/kustomization.yaml
+++ b/ironic-deployment/basic-auth/tls/default/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ${NAMEPREFIX}-system
+namespace: baremetal-operator-system
 resources:
 - ../../../tls/default
 

--- a/ironic-deployment/basic-auth/tls/keepalived/auth.yaml
+++ b/ironic-deployment/basic-auth/tls/keepalived/auth.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ${NAMEPREFIX}-ironic
+  name: ironic
 spec:
   template:
     spec:

--- a/ironic-deployment/basic-auth/tls/keepalived/kustomization.yaml
+++ b/ironic-deployment/basic-auth/tls/keepalived/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ${NAMEPREFIX}-system
+namespace: baremetal-operator-system
 resources:
 - ../../../tls/keepalived
 

--- a/ironic-deployment/certmanager/certificate.yaml
+++ b/ironic-deployment/certmanager/certificate.yaml
@@ -2,7 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
-  namespace: ${NAMEPREFIX}-system
 spec:
   selfSigned: {}
 ---
@@ -10,7 +9,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ironic-cacert
-  namespace: ${NAMEPREFIX}-system
 spec:
   commonName: ironic-ca
   isCA: true
@@ -25,7 +23,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: ca-issuer
-  namespace: ${NAMEPREFIX}-system
 spec:
   ca:
     secretName: ironic-cacert
@@ -34,7 +31,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ironic-cert
-  namespace: ${NAMEPREFIX}-system
 spec:
   commonName: ironic-cert
   ipAddresses:
@@ -48,7 +44,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ironic-inspector-cert
-  namespace: ${NAMEPREFIX}-system
 spec:
   commonName: ironic-inspector-cert
   ipAddresses:
@@ -62,7 +57,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: mariadb-cert
-  namespace: ${NAMEPREFIX}-system
 spec:
   commonName: mariadb-cert
   ipAddresses:

--- a/ironic-deployment/default/kustomization.yaml
+++ b/ironic-deployment/default/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ${NAMEPREFIX}-system
+namespace: baremetal-operator-system
+namePrefix: baremetal-operator-
 resources:
 - ../ironic
 configMapGenerator:

--- a/ironic-deployment/ironic/ironic.yaml
+++ b/ironic-deployment/ironic/ironic.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ${NAMEPREFIX}-ironic
+  name: ironic
 spec:
   replicas: 1
   minReadySeconds: 10
@@ -11,11 +11,11 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      name: ${NAMEPREFIX}-ironic
+      name: ironic
   template:
     metadata:
       labels:
-        name: ${NAMEPREFIX}-ironic
+        name: ironic
     spec:
       hostNetwork: true
       containers:

--- a/ironic-deployment/keepalived/keepalived_patch.yaml
+++ b/ironic-deployment/keepalived/keepalived_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ${NAMEPREFIX}-ironic
+  name: ironic
 spec:
   template:
     spec:

--- a/ironic-deployment/keepalived/kustomization.yaml
+++ b/ironic-deployment/keepalived/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ${NAMEPREFIX}-system
+namespace: baremetal-operator-system
+namePrefix: baremetal-operator-
 resources:
 - ../../config/namespace
 - ../ironic

--- a/ironic-deployment/tls/default/kustomization.yaml
+++ b/ironic-deployment/tls/default/kustomization.yaml
@@ -1,8 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ${NAMEPREFIX}-system
+namespace: baremetal-operator-system
 resources:
 - ../../default
+- ../../config/namespace
 - ../../certmanager
 
 patchesStrategicMerge:

--- a/ironic-deployment/tls/default/tls.yaml
+++ b/ironic-deployment/tls/default/tls.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ${NAMEPREFIX}-ironic
+  name: ironic
 spec:
   template:
     spec:

--- a/ironic-deployment/tls/keepalived/kustomization.yaml
+++ b/ironic-deployment/tls/keepalived/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ${NAMEPREFIX}-system
+namespace: baremetal-operator-system
 resources:
 - ../../keepalived
 - ../../certmanager

--- a/ironic-deployment/tls/keepalived/tls.yaml
+++ b/ironic-deployment/tls/keepalived/tls.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ${NAMEPREFIX}-ironic
+  name: ironic
 spec:
   template:
     spec:


### PR DESCRIPTION
The Ironic kustomizations used envsubst to set the nameprefix, while BMO
was using the built in feature in kustomize. To unify them and simplify
the deploy script a bit, the Ironix kustomizations were changed to also
use the kustomize feature.

There is a slight change in the manifests since the namePrefix is
applied also to secrets, configmaps and label selectors that didn't have
the prefix set before.

The namespace is now also created as part of the kustomizations for
Ironic (same as for BMO).

Fixes #1072

Edit:

This breaks CAPM3 v1alpha4 (which is deprecated). The issue is that Ironic ends up in the wrong namespace. It is easily solve by copying the `ironic-cacert` secret to the namespace where BMO is running (`capm3-system`) or making changes to the Ironic manifests. However, v1alpha4 is no longer supported so I'm a bit hesitant to add something specific to that version.

In addition to this, v1alpha4 uses Kubernetes v1.21, which is [EOL in just a few weeks](https://kubernetes.io/releases/#release-v1-21). So it makes sense to not focus on this old version in my opinion. But of course, let me know if there are objections!