### PR TITLE
Do not consider empty RAID and root device hints updated

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -918,6 +918,27 @@ func (r *BareMetalHostReconciler) registerHost(prov provisioner.Provisioner, inf
 	return nil
 }
 
+func updateRootDeviceHints(host *metal3v1alpha1.BareMetalHost, info *reconcileInfo) (dirty bool, err error) {
+	// Ensure the root device hints we're going to use are stored.
+	//
+	// If the user has provided explicit root device hints, they take
+	// precedence. Otherwise use the values from the hardware profile.
+	hintSource := host.Spec.RootDeviceHints
+	if hintSource == nil {
+		hwProf, err := hardware.GetProfile(host.HardwareProfile())
+		if err != nil {
+			return false, errors.Wrap(err, "failed to update root device hints")
+		}
+		hintSource = &hwProf.RootDeviceHints
+	}
+	if !reflect.DeepEqual(hintSource, host.Status.Provisioning.RootDeviceHints) {
+		info.log.Info("RootDeviceHints have changed", "old", host.Status.Provisioning.RootDeviceHints, "new", hintSource)
+		host.Status.Provisioning.RootDeviceHints = hintSource.DeepCopy()
+		dirty = true
+	}
+	return
+}
+
 // Ensure we have the information about the hardware on the host.
 func (r *BareMetalHostReconciler) actionInspecting(prov provisioner.Provisioner, info *reconcileInfo) actionResult {
 	info.log.Info("inspecting hardware")
@@ -1049,6 +1070,12 @@ func (r *BareMetalHostReconciler) matchProfile(info *reconcileInfo) (dirty bool,
 		info.publishEvent("ProfileSet", fmt.Sprintf("Hardware profile set: %s", hardwareProfile))
 	}
 
+	hintsDirty, err := updateRootDeviceHints(info.host, info)
+	if err != nil {
+		return
+	}
+
+	dirty = dirty || hintsDirty
 	return
 }
 
@@ -1414,23 +1441,10 @@ func getHostProvisioningSettings(host *metal3v1alpha1.BareMetalHost, info *recon
 // provisioning that do not trigger re-provisioning into the status
 // fields of the host.
 func saveHostProvisioningSettings(host *metal3v1alpha1.BareMetalHost, info *reconcileInfo) (dirty bool, err error) {
-
-	// Ensure the root device hints we're going to use are stored.
-	//
-	// If the user has provided explicit root device hints, they take
-	// precedence. Otherwise use the values from the hardware profile.
-	hintSource := host.Spec.RootDeviceHints.DeepCopy()
-	if hintSource == nil {
-		hwProf, err := hardware.GetProfile(host.HardwareProfile())
-		if err != nil {
-			return false, errors.Wrap(err, "Could not update root device hints")
-		}
-		hintSource = hwProf.RootDeviceHints.DeepCopy()
-	}
-	if !reflect.DeepEqual(hintSource, host.Status.Provisioning.RootDeviceHints) {
-		host.Status.Provisioning.RootDeviceHints = hintSource.DeepCopy()
-		info.log.Info("RootDeviceHints have changed")
-		dirty = true
+	// Root device hints may change as a result of RAID
+	dirty, err = updateRootDeviceHints(host, info)
+	if err != nil {
+		return
 	}
 
 	// Copy RAID settings
@@ -1438,20 +1452,23 @@ func saveHostProvisioningSettings(host *metal3v1alpha1.BareMetalHost, info *reco
 	// If RAID configure is nil or empty, means that we need to keep the current hardware RAID configuration
 	// or clear current software RAID configuration
 	if specRAID == nil || reflect.DeepEqual(specRAID, &metal3v1alpha1.RAIDConfig{}) {
-		// Set the default value of RAID configure:
-		// {
-		//     HardwareRAIDVolumes: nil or Status.Provisioning.RAID.HardwareRAIDVolumes(not empty),
-		//     SoftwareRAIDVolume: [],
-		// }
-		specRAID = &metal3v1alpha1.RAIDConfig{}
-		if host.Status.Provisioning.RAID != nil && len(host.Status.Provisioning.RAID.HardwareRAIDVolumes) != 0 {
-			specRAID.HardwareRAIDVolumes = host.Status.Provisioning.RAID.HardwareRAIDVolumes
+		// Short-circuit logic when no RAID is set and no RAID is requested
+		if host.Status.Provisioning.RAID != nil {
+			// Set the default value of RAID configure:
+			// {
+			//     HardwareRAIDVolumes: nil or Status.Provisioning.RAID.HardwareRAIDVolumes(not empty),
+			//     SoftwareRAIDVolume: [],
+			// }
+			specRAID = &metal3v1alpha1.RAIDConfig{}
+			if len(host.Status.Provisioning.RAID.HardwareRAIDVolumes) != 0 {
+				specRAID.HardwareRAIDVolumes = host.Status.Provisioning.RAID.HardwareRAIDVolumes
+			}
+			specRAID.SoftwareRAIDVolumes = []metal3v1alpha1.SoftwareRAIDVolume{}
 		}
-		specRAID.SoftwareRAIDVolumes = []metal3v1alpha1.SoftwareRAIDVolume{}
 	}
 	if !reflect.DeepEqual(host.Status.Provisioning.RAID, specRAID) {
+		info.log.Info("RAID settings have changed", "old", host.Status.Provisioning.RAID, "new", specRAID)
 		host.Status.Provisioning.RAID = specRAID
-		info.log.Info("RAID settings have changed")
 		dirty = true
 	}
 

--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -1955,6 +1955,10 @@ func TestUpdateRAID(t *testing.T) {
 		},
 		Status: metal3v1alpha1.BareMetalHostStatus{
 			Provisioning: metal3v1alpha1.ProvisionStatus{
+				RAID: &metal3v1alpha1.RAIDConfig{
+					HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{},
+					SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{},
+				},
 				RootDeviceHints: &metal3v1alpha1.RootDeviceHints{
 					DeviceName:         "userd_devicename",
 					HCTL:               "1:2:3:4",


### PR DESCRIPTION
Currently, due to the way we compare these fields in Spec and Status,
we always trigger an update at least once. Avoid it if the fields are
completely empty.

Extract the root device hints function and call it when matching the
profile to avoid a new update later on.

Improve logging around the diff handling.
