### PR TITLE
Don't register in Inspecting if inspection disabled

### DIFF
--- a/controllers/metal3.io/host_state_machine.go
+++ b/controllers/metal3.io/host_state_machine.go
@@ -298,6 +298,12 @@ func (hsm *hostStateMachine) ensureRegistered(info *reconcileInfo) (result actio
 		// In the deleting state the whole idea is to de-register the host
 		return
 	case metal3v1alpha1.StateRegistering:
+	case metal3v1alpha1.StateInspecting:
+		if inspectionDisabled(hsm.Host) {
+			// No need to register if we are not actually going to inspect
+			return
+		}
+		fallthrough
 	default:
 		if hsm.Host.Status.ErrorType == metal3v1alpha1.RegistrationError ||
 			!hsm.Host.Status.GoodCredentials.Match(*info.bmcCredsSecret) {


### PR DESCRIPTION
When inspection is disabled, the host still passes through the
inspecting state. Previously, we would still try to register the host in
this state, which would mean that it would require a valid
PreprovisioningImage to continue. Since no image is needed if we are not
actually going to inspect, skip registration in this case.