### PR TITLE
give hardwareutils a pinned version so it may be imported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ build/_test
 *.out
 # End of https://www.gitignore.io/api/go
 
+.vscode 
 
 # Tilt files.
 .tiltbuild

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/google/uuid v1.1.2
-	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.0.0
+	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v1.1.2
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.23.5

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-logr/logr v1.2.0
 	github.com/gophercloud/gophercloud v0.22.0
 	github.com/metal3-io/baremetal-operator/apis v0.0.0
-	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.0.0
+	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v1.1.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/stretchr/testify v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/go-logr/logr v1.2.0
 	github.com/gophercloud/gophercloud v0.22.0
-	github.com/metal3-io/baremetal-operator/apis v0.0.0
+	github.com/metal3-io/baremetal-operator/apis v1.1.2
 	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v1.1.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0


### PR DESCRIPTION
This PR aims to resolve #1082 so that `v1alpha1` may be imported from other packages.

