### PR TITLE
ironic: Always add ImageFormatInitRD to supported formats

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -564,12 +564,9 @@ func (p *ironicProvisioner) PreprovisioningImageFormats() ([]metal3v1alpha1.Imag
 		return nil, err
 	}
 
-	var formats []metal3v1alpha1.ImageFormat
+	formats := []metal3v1alpha1.ImageFormat{metal3v1alpha1.ImageFormatInitRD}
 	if accessDetails.SupportsISOPreprovisioningImage() {
 		formats = append(formats, metal3v1alpha1.ImageFormatISO)
-	}
-	if p.config.deployKernelURL != "" {
-		formats = append(formats, metal3v1alpha1.ImageFormatInitRD)
 	}
 
 	return formats, nil


### PR DESCRIPTION
In short: There is no way to use the Preprovisioning API with format InitRD with an external controller.

Ironic should always support initrd format for PreProvisioning API.

Right now this depends on DEPLOY_KERNEL_URL being set, which requires DEPLOY_RAMDISK_URL to be set, which enables the internal PreprovisioningImageReconciler, which we do not want with an external reconciler.
