### PR TITLE
Fix ironic httpd readness & liveness Probe

### DIFF
--- a/ironic-deployment/ironic/ironic.yaml
+++ b/ironic-deployment/ironic/ironic.yaml
@@ -154,7 +154,7 @@ spec:
             - /bin/runhttpd
           livenessProbe:
            exec:
-             command: ["sh", "-c", "curl -sSfk https://127.0.0.1:6180"]
+             command: ["sh", "-c", "curl -sSfk http://127.0.0.1:6180/images"]
            initialDelaySeconds: 30
            periodSeconds: 30
            timeoutSeconds: 10
@@ -162,7 +162,7 @@ spec:
            failureThreshold: 10
           readinessProbe:
            exec:
-             command: ["sh", "-c", "curl -sSfk https://127.0.0.1:6180"]
+             command: ["sh", "-c", "curl -sSfk http://127.0.0.1:6180/images"]
            initialDelaySeconds: 30
            periodSeconds: 30
            timeoutSeconds: 10


### PR DESCRIPTION
It will be restarted because it is a path not in liveness probe
The default ironic deploy without ssl requires an http call.

```
# https error log
[core:debug] [pid 26:tid 45] protocol.c(1447): [client 127.0.0.1:34436] AH00566: request failed: malformed request line
127.0.0.1 - - [23/Jul/2022:14:44:06 +0000] "\x16\x03\x01\x02" 400 226 "-" "-"
```