### PR TITLE
add honza pokorny as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,13 +4,13 @@ approvers:
  - andfasano
  - dtantsur
  - fmuyassarov
+ - honza
  - zaneb
 
 reviewers:
  - ardaguclu
  - bfournie
  - elfosardo
- - honza
  - dukov
  - furkatgofurov7
  - kashifest


### PR DESCRIPTION
After following the process described in our community documents [1], there were no objections in adding Honza as an approver

[1] https://github.com/metal3-io/metal3-docs/tree/master/maintainers