### PR TITLE
delete minor unreachable code in test caused by t.Fatal

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -171,14 +171,13 @@ func tryReconcile(t *testing.T, r *BareMetalHostReconciler, host *metal3v1alpha1
 	for i := 0; ; i++ {
 		t.Logf("tryReconcile: top of loop %d", i)
 		if i >= 25 {
-			t.Fatal(fmt.Errorf("Exceeded 25 iterations"))
+			t.Fatal("Exceeded 25 iterations")
 		}
 
 		result, err := r.Reconcile(context.Background(), request)
 
 		if err != nil {
 			t.Fatal(err)
-			break
 		}
 
 		// The FakeClient keeps a copy of the object we update, so we
@@ -198,8 +197,7 @@ func tryReconcile(t *testing.T, r *BareMetalHostReconciler, host *metal3v1alpha1
 
 		t.Logf("tryReconcile: loop bottom %d result=%v", i, result)
 		if !result.Requeue && result.RequeueAfter == 0 {
-			t.Fatal(fmt.Errorf("Ended reconcile at iteration %d without test condition being true", i))
-			break
+			t.Fatalf("Ended reconcile at iteration %d without test condition being true", i)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

t.Fatal* will report test failures and stop the test immediately.
**So some of the code is actually unreachable**

An example:
https://go.dev/play/p/5K3KZ5RzHhR
```go
package main

import (
	"testing"
)

// LastIndex returns the index of the last instance of x in list, or
// -1 if x is not present.
func LastIndex(list []int, x int) int {
	for i := len(list) - 1; i >= 0; i-- {
		if list[i] == x {
			return i
		}
	}
	return -1
}

func TestLastIndex(t *testing.T) {
	tests := []struct {
		list []int
		x    int
		want int
	}{
		{list: []int{1}, x: 1, want: 0},
		{list: []int{1, 1}, x: 1, want: 3}, // change want:1 to want:3, should fail
		{list: []int{2, 1}, x: 2, want: 0},
		{list: []int{1, 2, 1, 1}, x: 2, want: 1},
		{list: []int{1, 1, 1, 2, 2, 1}, x: 3, want: -1},
		{list: []int{3, 1, 2, 2, 1, 1}, x: 3, want: 111}, // change want:0 to want:111, should fail
	}
	for i, tt := range tests {
		t.Logf("index:%d", i)
		if got := LastIndex(tt.list, tt.x); got != tt.want {
			t.Errorf("LastIndex(%v, %v) = %v, want %v", tt.list, tt.x, got, tt.want)
		}
	}
}

func TestLastIndex2(t *testing.T) {
	tests := []struct {
		list []int
		x    int
		want int
	}{
		{list: []int{1}, x: 1, want: 0},
		{list: []int{1, 1}, x: 1, want: 3}, // change want:1 to want:3, should fail
		{list: []int{2, 1}, x: 2, want: 0},
		{list: []int{1, 2, 1, 1}, x: 2, want: 1},
		{list: []int{1, 1, 1, 2, 2, 1}, x: 3, want: -1},
		{list: []int{3, 1, 2, 2, 1, 1}, x: 3, want: 111}, // change want:0 to want:111, should fail
	}
	for i, tt := range tests {
		t.Logf("index:%d", i)
		if got := LastIndex(tt.list, tt.x); got != tt.want {
			t.Fatalf("LastIndex(%v, %v) = %v, want %v", tt.list, tt.x, got, tt.want) // Fatalf is equivalent to Logf followed by FailNow, so the following code will be unreachable
			continue  // unreachable
		}
	}
}

/* output:

=== RUN   TestLastIndex
    prog.go:32: index:0
    prog.go:32: index:1
    prog.go:34: LastIndex([1 1], 1) = 1, want 3
    prog.go:32: index:2
    prog.go:32: index:3
    prog.go:32: index:4
    prog.go:32: index:5
    prog.go:34: LastIndex([3 1 2 2 1 1], 3) = 0, want 111
--- FAIL: TestLastIndex (0.00s)
=== RUN   TestLastIndex2
    prog.go:53: index:0
    prog.go:53: index:1
    prog.go:55: LastIndex([1 1], 1) = 1, want 3
--- FAIL: TestLastIndex2 (0.00s)
FAIL

*/
```