### PR TITLE
Set external_http_url on the node when BMC is IPv6

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,10 @@ but overflows could happen in case of slow provisioners and / or higher number o
 concurrent reconciles. For such reasons, it is highly recommended to keep
 BMO_CONCURRENCY value lower than the requested PROVISIONING_LIMIT. Default is 20.
 
+`IRONIC_EXTERNAL_URL_V6` -- This is the URL where Ironic will find the image for
+nodes that use IPv6. In dual stack environments, this can be used to tell Ironic which IP
+version it should set on the BMC.
+
 Kustomization Configuration
 ---------------------------
 

--- a/pkg/provisioner/ironic/factory.go
+++ b/pkg/provisioner/ironic/factory.go
@@ -3,6 +3,7 @@ package ironic
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -151,6 +152,17 @@ func loadConfigFromEnv(havePreprovImgBuilder bool) (ironicConfig, error) {
 			return c, fmt.Errorf("Invalid value for variable LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE, must be one of Default, Always or Never")
 		}
 		c.liveISOForcePersistentBootDevice = forcePersistentBootDevice
+	}
+
+	c.externalURL = os.Getenv("IRONIC_EXTERNAL_URL_V6")
+
+	// Let's see if externalURL looks like a URL
+	if c.externalURL != "" {
+		_, externalURLParseErr := url.Parse(c.externalURL)
+
+		if externalURLParseErr != nil {
+			return c, externalURLParseErr
+		}
 	}
 
 	return c, nil


### PR DESCRIPTION
When the BMC address is IPv6, we need to set the `external_http_url`
value on the node so that the node can access the provisioning image.