### PR TITLE
Delete controller flag for baremetalhost for secret

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -647,7 +647,7 @@ func (r *BareMetalHostReconciler) preprovImageAvailable(info *reconcileInfo, ima
 			Namespace: image.ObjectMeta.Namespace,
 		}
 		secretManager := r.secretManager(info.log)
-		networkData, err := secretManager.AcquireSecret(secretKey, info.host, false, false)
+		networkData, err := secretManager.AcquireSecret(secretKey, info.host, false)
 		if err != nil {
 			return false, err
 		}
@@ -1489,7 +1489,7 @@ func (r *BareMetalHostReconciler) getBMCSecretAndSetOwner(request ctrl.Request, 
 	reqLogger := r.Log.WithValues("baremetalhost", request.NamespacedName)
 	secretManager := r.secretManager(reqLogger)
 
-	bmcCredsSecret, err := secretManager.AcquireSecret(host.CredentialsKey(), host, false, host.Status.Provisioning.State != metal3v1alpha1.StateDeleting)
+	bmcCredsSecret, err := secretManager.AcquireSecret(host.CredentialsKey(), host, host.Status.Provisioning.State != metal3v1alpha1.StateDeleting)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil, &ResolveBMCSecretRefError{message: fmt.Sprintf("The BMC secret %s does not exist", host.CredentialsKey())}

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -1489,7 +1489,7 @@ func (r *BareMetalHostReconciler) getBMCSecretAndSetOwner(request ctrl.Request, 
 	reqLogger := r.Log.WithValues("baremetalhost", request.NamespacedName)
 	secretManager := r.secretManager(reqLogger)
 
-	bmcCredsSecret, err := secretManager.AcquireSecret(host.CredentialsKey(), host, true, host.Status.Provisioning.State != metal3v1alpha1.StateDeleting)
+	bmcCredsSecret, err := secretManager.AcquireSecret(host.CredentialsKey(), host, false, host.Status.Provisioning.State != metal3v1alpha1.StateDeleting)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil, &ResolveBMCSecretRefError{message: fmt.Sprintf("The BMC secret %s does not exist", host.CredentialsKey())}

--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -764,9 +764,8 @@ func TestSecretUpdateOwnerRefAndEnvironmentLabelOnStartup(t *testing.T) {
 	secret = getHostSecret(t, r, host)
 	assert.Equal(t, host.Name, secret.OwnerReferences[0].Name)
 	assert.Equal(t, "BareMetalHost", secret.OwnerReferences[0].Kind)
-	assert.True(t, *secret.OwnerReferences[0].Controller)
-	assert.True(t, *secret.OwnerReferences[0].BlockOwnerDeletion)
-
+	assert.Nil(t, secret.OwnerReferences[0].Controller)
+	assert.Nil(t, secret.OwnerReferences[0].BlockOwnerDeletion)
 	assert.Equal(t, "baremetal", secret.Labels["environment.metal3.io"])
 
 }

--- a/controllers/metal3.io/preprovisioningimage_controller.go
+++ b/controllers/metal3.io/preprovisioningimage_controller.go
@@ -244,7 +244,7 @@ func getNetworkData(secretManager secretutils.SecretManager, img *metal3.Preprov
 		Name:      networkDataSecret,
 		Namespace: img.ObjectMeta.Namespace,
 	}
-	secret, err := secretManager.AcquireSecret(secretKey, img, false, false)
+	secret, err := secretManager.AcquireSecret(secretKey, img, false)
 	if err != nil {
 		return nil, metal3.SecretStatus{}, err
 	}

--- a/pkg/secretutils/secret_manager.go
+++ b/pkg/secretutils/secret_manager.go
@@ -65,7 +65,7 @@ func (sm *SecretManager) findSecret(key types.NamespacedName) (secret *corev1.Se
 // claimSecret ensures that the Secret has a label that will ensure it is
 // present in the cache (and that we can watch for changes), and optionally
 // that it has a particular owner reference.
-func (sm *SecretManager) claimSecret(secret *corev1.Secret, owner client.Object, ownerIsController, addFinalizer bool) error {
+func (sm *SecretManager) claimSecret(secret *corev1.Secret, owner client.Object, addFinalizer bool) error {
 	log := sm.log.WithValues("secret", secret.Name, "secretNamespace", secret.Namespace)
 	needsUpdate := false
 	if !metav1.HasLabel(secret.ObjectMeta, LabelEnvironmentName) {
@@ -78,30 +78,24 @@ func (sm *SecretManager) claimSecret(secret *corev1.Secret, owner client.Object,
 			"ownerKind", owner.GetObjectKind().GroupVersionKind().Kind,
 			"owner", owner.GetNamespace()+"/"+owner.GetName(),
 			"ownerUID", owner.GetUID())
-		if ownerIsController {
-			if !metav1.IsControlledBy(secret, owner) {
-				ownerLog.Info("setting secret controller reference")
-				if err := controllerutil.SetControllerReference(owner, secret, sm.client.Scheme()); err != nil {
-					return errors.Wrap(err, "failed to set secret controller reference")
-				}
-				needsUpdate = true
+		alreadyOwned := false
+		ownerUID := owner.GetUID()
+		for _, ref := range secret.GetOwnerReferences() {
+			// We used to add controller references to BMC
+			// secrets. This was wrong, update.
+			if ref.UID == ownerUID && ref.Controller == nil {
+				alreadyOwned = true
+				break
+			} else if ref.Controller != nil && *ref.Controller {
+				ownerLog.Info("updating secret to no longer have an owner of type controller")
 			}
-		} else {
-			alreadyOwned := false
-			ownerUID := owner.GetUID()
-			for _, ref := range secret.GetOwnerReferences() {
-				if ref.UID == ownerUID {
-					alreadyOwned = true
-					break
-				}
+		}
+		if !alreadyOwned {
+			ownerLog.Info("setting secret owner reference")
+			if err := controllerutil.SetOwnerReference(owner, secret, sm.client.Scheme()); err != nil {
+				return errors.Wrap(err, "failed to set secret owner reference")
 			}
-			if !alreadyOwned {
-				ownerLog.Info("setting secret owner reference")
-				if err := controllerutil.SetOwnerReference(owner, secret, sm.client.Scheme()); err != nil {
-					return errors.Wrap(err, "failed to set secret owner reference")
-				}
-				needsUpdate = true
-			}
+			needsUpdate = true
 		}
 	}
 
@@ -124,12 +118,12 @@ func (sm *SecretManager) claimSecret(secret *corev1.Secret, owner client.Object,
 // will ensure it is present in the cache (and that we can watch for changes),
 // and optionally that it has a particular owner reference. The owner reference
 // may optionally be a controller reference.
-func (sm *SecretManager) obtainSecretForOwner(key types.NamespacedName, owner client.Object, ownerIsController, addFinalizer bool) (*corev1.Secret, error) {
+func (sm *SecretManager) obtainSecretForOwner(key types.NamespacedName, owner client.Object, addFinalizer bool) (*corev1.Secret, error) {
 	secret, err := sm.findSecret(key)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("failed to fetch secret %s in namespace %s", key.Name, key.Namespace))
 	}
-	err = sm.claimSecret(secret, owner, ownerIsController, addFinalizer)
+	err = sm.claimSecret(secret, owner, addFinalizer)
 
 	return secret, err
 }
@@ -138,18 +132,18 @@ func (sm *SecretManager) obtainSecretForOwner(key types.NamespacedName, owner cl
 // ensure it is present in the cache (and that we can watch for changes), and
 // that it has a particular owner reference. The owner reference may optionally
 // be a controller reference.
-func (sm *SecretManager) AcquireSecret(key types.NamespacedName, owner client.Object, ownerIsController, addFinalizer bool) (*corev1.Secret, error) {
+func (sm *SecretManager) AcquireSecret(key types.NamespacedName, owner client.Object, addFinalizer bool) (*corev1.Secret, error) {
 	if owner == nil {
 		panic("AcquireSecret called with no owner")
 	}
 
-	return sm.obtainSecretForOwner(key, owner, ownerIsController, addFinalizer)
+	return sm.obtainSecretForOwner(key, owner, addFinalizer)
 }
 
 // ObtainSecret retrieves a Secret and ensures that it has a label that will
 // ensure it is present in the cache (and that we can watch for changes).
 func (sm *SecretManager) ObtainSecret(key types.NamespacedName) (*corev1.Secret, error) {
-	return sm.obtainSecretForOwner(key, nil, false, false)
+	return sm.obtainSecretForOwner(key, nil, false)
 }
 
 // ReleaseSecret removes secrets manager finalizer from specified secret when needed.


### PR DESCRIPTION
Secret may be shared across the several baremetal hosts. Delete the
controller flag which have been resricted the share.

Replaces https://github.com/metal3-io/baremetal-operator/pull/1073
Fix https://github.com/metal3-io/baremetal-operator/issues/1045