### PR TITLE
🌱 Update versioning to match new package release versions

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/google/uuid v1.1.2
-	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.0.0
+	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.23.5

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.17
 require (
 	github.com/go-logr/logr v1.2.0
 	github.com/gophercloud/gophercloud v0.22.0
-	github.com/metal3-io/baremetal-operator/apis v0.0.0
-	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.0.0
+	github.com/metal3-io/baremetal-operator/apis v0.1.0
+	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.1
 	github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
Please see #1082 for more information.

This PR seeks to resolve import errors when importing version `v0.1.0`
Resolves:

```sh
docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.32.2 golangci-lint run - 
level=error msg="Running error: context loading failed: failed to load packages: failed to load with go/packages: err: exit status 1: stderr: go: github.com/metal3-io/baremetal-operator/apis@v0.1.0 requires\n\tgithub.com/metal3-io/baremetal-operator/pkg/hardwareutils@v0.0.0: reading github.com/metal3-io/baremetal-operator/pkg/hardwareutils/pkg/hardwareutils/go.mod at revision pkg/hardwareutils/v0.0.0: unknown revision pkg/hardwareutils/v0.0.0\n"
```