### PR TITLE
Exclude hosts with virtual media from PROVISIONING_LIMIT

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,7 +39,8 @@ client certificate SAN validation.
 Operator. Default is the number of CPUs, but no less than 2 and no more than 8.
 
 `PROVISIONING_LIMIT` -- The desired maximum number of hosts that could be (de)provisioned
-simultaneously by the Operator. The Operator will try to enforce this limit,
+simultaneously by the Operator. The limit does not apply to hosts that use
+virtual media for provisioning. The Operator will try to enforce this limit,
 but overflows could happen in case of slow provisioners and / or higher number of
 concurrent reconciles. For such reasons, it is highly recommended to keep
 BMO_CONCURRENCY value lower than the requested PROVISIONING_LIMIT. Default is 20.

--- a/pkg/provisioner/ironic/provisioncapacity_test.go
+++ b/pkg/provisioner/ironic/provisioncapacity_test.go
@@ -24,6 +24,8 @@ func TestHasCapacity(t *testing.T) {
 		provisioningLimit int
 		nodeStates        []nodes.ProvisionState
 		hostName          string
+		bootInterface     string
+		bmcAddress        string
 
 		expectedHasCapacity bool
 		expectedError       string
@@ -57,6 +59,22 @@ func TestHasCapacity(t *testing.T) {
 
 			expectedHasCapacity: true,
 		},
+		{
+			name:              "enough-capacity-due-virtual-media",
+			provisioningLimit: 1,
+			nodeStates:        states,
+			bmcAddress:        "redfish-virtualmedia://example.com/redfish/v1/Systems/1",
+
+			expectedHasCapacity: true,
+		},
+		{
+			name:              "enough-capacity-due-other-virtual-media",
+			provisioningLimit: 1,
+			nodeStates:        states,
+			bootInterface:     "redfish-virtual-media",
+
+			expectedHasCapacity: true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -67,6 +85,7 @@ func TestHasCapacity(t *testing.T) {
 				allNodes = append(allNodes, nodes.Node{
 					Name:           fmt.Sprintf("myns%snode-%d", nameSeparator, n),
 					ProvisionState: string(state),
+					BootInterface:  tc.bootInterface,
 				})
 			}
 
@@ -78,6 +97,9 @@ func TestHasCapacity(t *testing.T) {
 
 			host := makeHost()
 			host.Name = tc.hostName
+			if tc.bmcAddress != "" {
+				host.Spec.BMC.Address = tc.bmcAddress
+			}
 
 			auth := clients.AuthConfig{Type: clients.NoAuth}
 


### PR DESCRIPTION
The limit was designed to avoid glitches when too many hosts DHCP or
boot from PXE. Virtual media requires neither, and with a pre-built ISO
is actually quite efficient.