### PR TITLE
🌱 Refine ironic provisioner log data format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.13.0
 	github.com/stretchr/testify v1.7.1
 	go.etcd.io/etcd/client/pkg/v3 v3.5.6
+	go.uber.org/zap v1.21.0
 	k8s.io/api v0.25.0
 	k8s.io/apimachinery v0.25.0
 	k8s.io/client-go v0.25.0
@@ -56,7 +57,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/net v0.4.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/sys v0.3.0 // indirect

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"runtime"
 
+	"go.uber.org/zap/zapcore"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -115,9 +116,15 @@ func main() {
 		"The address the health endpoint binds to.")
 	flag.IntVar(&webhookPort, "webhook-port", 9443,
 		"Webhook Server port (set to 0 to disable)")
+	opts := zap.Options{
+		Development: devLogging,
+		TimeEncoder: zapcore.ISO8601TimeEncoder,
+	}
+	opts.BindFlags(flag.CommandLine)
+
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(devLogging)))
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	printVersion()
 

--- a/pkg/provisioner/ironic/factory.go
+++ b/pkg/provisioner/ironic/factory.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/gophercloud/gophercloud"
+	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	logz "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
@@ -30,7 +32,11 @@ type ironicProvisionerFactory struct {
 func NewProvisionerFactory(havePreprovImgBuilder bool) provisioner.Factory {
 	factory := ironicProvisionerFactory{}
 
-	factory.log = logz.New().WithName("provisioner").WithName("ironic")
+	opts := zap.Options{
+		Development: true,
+		TimeEncoder: zapcore.ISO8601TimeEncoder,
+	}
+	factory.log = logz.New(zap.UseFlagOptions(&opts)).WithName("provisioner").WithName("ironic")
 
 	err := factory.init(havePreprovImgBuilder)
 	if err != nil {


### PR DESCRIPTION
Refine the log data format from "1666158340.7038972" to "2022-10-19T05:45:40.674Z"

The original format is badly readable.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
