### PR TITLE
Add Kashif Khan as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,6 +4,7 @@ approvers:
  - andfasano
  - dtantsur
  - honza
+ - kashifest
  - zaneb
 
 reviewers:
@@ -12,7 +13,6 @@ reviewers:
  - elfosardo
  - dukov
  - furkatgofurov7
- - kashifest
  - s3rj1k
  - zhouhao3
 


### PR DESCRIPTION
After following the process described in our community [documents][1], there were no objections to adding Kashif as an approver.

[1]: https://github.com/metal3-io/metal3-docs/tree/master/maintainers
