### PR TITLE
Run make fmt to fix issues

### DIFF
--- a/apis/metal3.io/v1alpha1/groupversion_info.go
+++ b/apis/metal3.io/v1alpha1/groupversion_info.go
@@ -14,8 +14,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the metal3.io v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=metal3.io
+// +kubebuilder:object:generate=true
+// +groupName=metal3.io
 package v1alpha1
 
 import (

--- a/pkg/provisioner/ironic/testserver/ironic.go
+++ b/pkg/provisioner/ironic/testserver/ironic.go
@@ -132,7 +132,7 @@ func (m *IronicMock) NodeUpdate(node nodes.Node) *IronicMock {
 	return m
 }
 
-//GetLastNodeUpdateRequestFor returns the content of the last update request for the specified node
+// GetLastNodeUpdateRequestFor returns the content of the last update request for the specified node
 func (m *IronicMock) GetLastNodeUpdateRequestFor(id string) (updates []nodes.UpdateOperation) {
 
 	if bodyRaw, ok := m.GetLastRequestFor("/v1/nodes/"+id, http.MethodPatch); ok {
@@ -236,10 +236,11 @@ func (m *IronicMock) WithNodeValidate(nodeUUID string) *IronicMock {
 }
 
 // Port configures the server with a valid response for
-//    [GET] /v1/nodes/<node uuid>/ports
-//    [GET] /v1/ports
-//    [GET] /v1/ports?address=<mac>
-//    [GET] /v1/ports?address=<mac>&fields=node_uuid
+//
+//	[GET] /v1/nodes/<node uuid>/ports
+//	[GET] /v1/ports
+//	[GET] /v1/ports?address=<mac>
+//	[GET] /v1/ports?address=<mac>&fields=node_uuid
 func (m *IronicMock) Port(port ports.Port) *IronicMock {
 	if port.NodeUUID == "" {
 		m.MockServer.t.Error("When using withPort(), the port must include a NodeUUID.")


### PR DESCRIPTION
No idea why the CI does not complain, but the local build fails with:

 pkg/provisioner/ironic/testserver/ironic.go:135: File is not `gofmt`-ed with `-s` (gofmt)