### PR TITLE
:bug: Always retry failed cleaning on deprovisioning (fixes #1182)

### DIFF
--- a/controllers/metal3.io/host_state_machine.go
+++ b/controllers/metal3.io/host_state_machine.go
@@ -517,6 +517,8 @@ func (hsm *hostStateMachine) handleDeprovisioning(info *reconcileInfo) actionRes
 			// If the provisioner gives up deprovisioning and
 			// deletion has been requested, continue to delete.
 			if hsm.Host.Status.ErrorCount > 3 {
+				info.log.Info("Giving up on host clean up after 3 attempts. The host may still be operational " +
+					"and cause issues in your clusters. You should clean it up manually now.")
 				return skipToDelete()
 			}
 		case actionError:

--- a/pkg/provisioner/ironic/provision_test.go
+++ b/pkg/provisioner/ironic/provision_test.go
@@ -237,16 +237,16 @@ func TestDeprovision(t *testing.T) {
 				ProvisionState: string(nodes.CleanFail),
 				UUID:           nodeUUID,
 			}),
-			expectedRequestAfter: 10,
-			expectedDirty:        true,
+			expectedErrorMessage: true,
 		},
 		{
 			name: "manageable state",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
 				ProvisionState: string(nodes.Manageable),
 				UUID:           nodeUUID,
 			}),
-			expectedDirty: false,
+			expectedRequestAfter: 10,
+			expectedDirty:        true,
 		},
 	}
 


### PR DESCRIPTION
Not running cleaning immediately after a failure may:

1. cause side effects when the machine powers back on into the old
   operating system (and e.g. rejoins the cluster as a worker);
2. confuse users with previous Ironic background since in Ironic a node
   cannot enter available without going through cleaning (unless disabled).

This change moves hosts manageable -> available immediately. Users who want
to opt-out have to set automatedCleanMode to disabled or detach the host.

As of this change, we still give up cleaning after 3 attempts, so it's
still possible to end up with an unclean host causing issues.