### PR TITLE
🌱 Dockerfile: use apt-get instead of apt

### DIFF
--- a/resources/keepalived-docker/Dockerfile
+++ b/resources/keepalived-docker/Dockerfile
@@ -2,8 +2,13 @@
 ARG BASE_IMAGE=ubuntu
 
 FROM $BASE_IMAGE
-ENV DEBIAN_FRONTEND=noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
+
 COPY sample.keepalived.conf /etc/keepalived/keepalived.conf
-COPY  manage-keepalived.sh manage-keepalived.sh
-RUN apt update -y && apt install keepalived -y
+COPY manage-keepalived.sh manage-keepalived.sh
+
+RUN apt-get update -y && \
+    apt-get install keepalived -y && \
+    apt-get clean
+
 ENTRYPOINT ["/bin/bash", "manage-keepalived.sh"]

--- a/resources/keepalived-docker/Dockerfile
+++ b/resources/keepalived-docker/Dockerfile
@@ -1,5 +1,5 @@
 # Support FROM override
-ARG BASE_IMAGE=ubuntu
+ARG BASE_IMAGE=ubuntu:22.04
 
 FROM $BASE_IMAGE
 ARG DEBIAN_FRONTEND=noninteractive
@@ -7,8 +7,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 COPY sample.keepalived.conf /etc/keepalived/keepalived.conf
 COPY manage-keepalived.sh manage-keepalived.sh
 
-RUN apt-get update -y && \
-    apt-get install keepalived -y && \
-    apt-get clean
+RUN apt-get -y update && \
+    apt-get -y install keepalived && \
+    apt-get -y clean
 
 ENTRYPOINT ["/bin/bash", "manage-keepalived.sh"]


### PR DESCRIPTION
Proposing following improvements to keepalived Docker image build:

- Apt doesn't have stable CLI interface and it gives out warnings about it during build. Change `apt` to `apt-get`.
- Add `apt-get` clean to minimize image size.
- Change DEBIAN_FRONTEND from ENV to ARG to limit it to build time.
- Lock used base image to specific version of ubuntu (`ubuntu` -> `ubuntu:"22.04`) to avoid unexpected base OS upgrades + allows correct rebuilds later on