### PR TITLE
🌱 Fix mac address for demo and fixture provisioners

### DIFF
--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -142,7 +142,7 @@ func (p *demoProvisioner) InspectHardware(data provisioner.InspectData, force, r
 				{
 					Name:      "nic-1",
 					Model:     "virt-io",
-					MAC:       "some:mac:address",
+					MAC:       "ab:cd:12:34:56:78",
 					IP:        "192.168.100.1",
 					SpeedGbps: 1,
 					PXE:       true,
@@ -150,7 +150,7 @@ func (p *demoProvisioner) InspectHardware(data provisioner.InspectData, force, r
 				{
 					Name:      "nic-2",
 					Model:     "e1000",
-					MAC:       "some:other:mac:address",
+					MAC:       "12:34:56:78:ab:cd",
 					IP:        "192.168.100.2",
 					SpeedGbps: 1,
 					PXE:       false,

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -139,7 +139,7 @@ func (p *fixtureProvisioner) InspectHardware(data provisioner.InspectData, force
 				{
 					Name:      "nic-1",
 					Model:     "virt-io",
-					MAC:       "some:mac:address",
+					MAC:       "ab:cd:12:34:56:78",
 					IP:        "192.168.100.1",
 					SpeedGbps: 1,
 					PXE:       true,
@@ -147,7 +147,7 @@ func (p *fixtureProvisioner) InspectHardware(data provisioner.InspectData, force
 				{
 					Name:      "nic-2",
 					Model:     "e1000",
-					MAC:       "some:other:mac:address",
+					MAC:       "12:34:56:78:ab:cd",
 					IP:        "192.168.100.2",
 					SpeedGbps: 1,
 					PXE:       false,


### PR DESCRIPTION
**What this PR does / why we need it**:

The demo and fixture provisioners had invalid MAC addresses hard coded. Now that we have validation of them it is necessary to have proper addresses for things to work.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

