### PR TITLE
🐛 Fix endless requeue of HostFirmwareSettings

### DIFF
--- a/controllers/metal3.io/hostfirmwaresettings_controller.go
+++ b/controllers/metal3.io/hostfirmwaresettings_controller.go
@@ -120,6 +120,9 @@ func (r *HostFirmwareSettingsReconciler) Reconcile(ctx context.Context, req ctrl
 	bmh := &metal3v1alpha1.BareMetalHost{}
 	if err = r.Get(context.TODO(), req.NamespacedName, bmh); err != nil {
 		reqLogger.Info("could not get baremetalhost, not running reconciler")
+		if k8serrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{Requeue: true, RequeueAfter: resourceNotAvailableRetryDelay}, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The reconciler was endlessly re-queuing HostFirmwareSettings after the BMH was deleted. For BMH we treat missing resource as a special case that we don't re-queue to avoid this endless loop. This PR makes it the same for HostFirmwareSettings.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1190 
