### PR TITLE
🐛 .github: secure github actions

### DIFF
--- a/.github/workflows/kubesec.yml
+++ b/.github/workflows/kubesec.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '30 7 * * 4'
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     runs-on: ubuntu-20.04
@@ -13,7 +16,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 # v2.6.0
 
       - name: Collect all yaml
         id: list_yaml
@@ -36,7 +39,7 @@ jobs:
         value: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 # v2.6.0
 
       - name: Run kubesec scanner
         uses: controlplaneio/kubesec-action@43d0ddff5ffee89a6bb9f29b64cd865411137b14
@@ -53,6 +56,6 @@ jobs:
 
       - name: Upload Kubesec scan results to GitHub Security tab
         if: ${{ steps.save_result.outputs.result != '[]' }}
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@4b3fd9198891cf782111537728021ffc6ae722ba # v1.1.37
         with:
           sarif_file: ${{ matrix.value }}.sarif

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,25 +6,30 @@ on:
 
 name: release
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Export RELEASE_TAG var
         run:  echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 # v2.6.0
         with:
           fetch-depth: 0
       - name: Install go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2.2.0
         with:
           go-version: '1.19'
       - name: Generate release notes
         run: |
           make release-notes
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           draft: true
           files: out/*


### PR DESCRIPTION
Set top-level permission to read, and allow write only where applicable.

Pin actions to a sha to prevent unwanted changes.
