### PR TITLE
✨ add explicit securitycontexts to controller

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,44 +19,54 @@ spec:
         webhook: metal3-io-v1alpha1-baremetalhost
     spec:
       containers:
-      - command:
-        - /baremetal-operator
-        args:
-        - --enable-leader-election
-        image: quay.io/metal3-io/baremetal-operator
-        imagePullPolicy: Always
-        env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-        envFrom:
-          - configMapRef:
-              name: ironic
-        name: manager
-        securityContext:
-          allowPrivilegeEscalation: false
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 9440
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 2
-          successThreshold: 1
-          failureThreshold: 10
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 9440
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 2
-          successThreshold: 1
-          failureThreshold: 10
-      serviceAccountName: controller-manager
+        - command:
+            - /baremetal-operator
+          args:
+            - --enable-leader-election
+          image: quay.io/metal3-io/baremetal-operator
+          imagePullPolicy: Always
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - configMapRef:
+                name: ironic
+          name: manager
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            runAsUser: 65532
+            runAsGroup: 65532
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9440
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 2
+            successThreshold: 1
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 9440
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 2
+            successThreshold: 1
+            failureThreshold: 10
       terminationGracePeriodSeconds: 10
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: controller-manager

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -2232,6 +2232,12 @@ spec:
           timeoutSeconds: 2
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsUser: 65532
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
@@ -2246,6 +2252,10 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: baremetal-operator-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:


### PR DESCRIPTION
It is always good to not rely on the defaults, but be explicit. Set explicit, secure securityContext for the BMO controller manager deployment and containers.

CAPI has the same starting from upcoming v1.4.0 and cert-manager etc has them already.

Setting explicit securityContext has its downsides as well, for tilt. Tilt's live update cannot handle securityContext which sets the user as non-root, as it requires root to deploy the binaries on rebuild. To workaround this, strip function is added to Tiltfile to handle BMO securityContexts.

Also, reindent the manifest properly.