### PR TITLE
🌱 Separate updating images from ValidateManagementAccess

### DIFF
--- a/pkg/provisioner/ironic/raid.go
+++ b/pkg/provisioner/ironic/raid.go
@@ -45,7 +45,7 @@ func setTargetRAIDCfg(p *ironicProvisioner, raidInterface string, ironicNode *no
 
 	updater := updateOptsBuilder(p.debugLog)
 	updater.SetTopLevelOpt("raid_interface", targetRaidInterface, ironicNode.RAIDInterface)
-	success, result, err := p.tryUpdateNode(ironicNode, updater)
+	ironicNode, success, result, err := p.tryUpdateNode(ironicNode, updater)
 	if !success {
 		return result, err
 	}


### PR DESCRIPTION
Contrary to its name, ValidateManagementAccess also enrolls the node and
configures various deploy-related parameters. This change splits
cleaning, image, custom deploy and ramdisk settings to a new function
with a goal to eventually delineate them.

Fix tryUpdateNode to return the updated node.
