### PR TITLE
🌱 Separate mariadb kustomize component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ set-manifest-image-ironic: $(KUSTOMIZE) manifests
 .PHONY: set-manifest-image-mariadb
 set-manifest-image-mariadb: $(KUSTOMIZE) manifests
 	$(info Updating container image for Mariadb to use ${MANIFEST_IMG}:${MANIFEST_TAG})
-	cd ironic-deployment/base && $(abspath $(KUSTOMIZE)) edit set image quay.io/metal3-io/mariadb=${MANIFEST_IMG}:${MANIFEST_TAG}
+	cd ironic-deployment/components/mariadb && $(abspath $(KUSTOMIZE)) edit set image quay.io/metal3-io/mariadb=${MANIFEST_IMG}:${MANIFEST_TAG}
 
 .PHONY: set-manifest-image-keepalived
 set-manifest-image-keepalived: $(KUSTOMIZE) manifests

--- a/ironic-deployment/README.md
+++ b/ironic-deployment/README.md
@@ -4,6 +4,10 @@ This folder contains kustomizations for Ironic.
 They are mainly used through the [deploy.sh](../tools/deploy.sh) script, which takes care of generating the necessary config for basic-auth and TLS.
 
 - **base** - This is the kustomize base that we start from.
-- **components** - In here you will find re-usable kustomize components for running Ironic with TLS, basic-auth or keepalived. Note that the basic-auth component is missing the actual credentials. This is on purpose, to make sure that the user is setting the password. Similarly the TLS component needs to have the proper IP/SAN set for the certificates.
+- **components** - In here you will find re-usable kustomize components for running Ironic with TLS, basic-auth, keepalived or mariadb.
+   - **basic-auth** - Enable basic authentication. Note that the basic-auth component is missing the actual credentials. This is on purpose, to make sure that the user is setting the password.
+   - **tls** - Enable TLS. The TLS component needs to have the proper IP/SAN set for the certificates.
+   - **keepalived** - Add a keepalived container to the deployment. This is useful when using a VIP for exposing the Ironic endpoint, so that the IP can move with the pod.
+   - **mariadb** - Use MariaDB instead of SQLite. TLS required for this to work.
 - **default** - A minimal, fully working, Ironic kustomization including configmap and password. Use only for development! The DB password is hard coded in the repo and there is no TLS or basic-auth.
 - **overlays** - Here you will find ready made overlays that use the above mentioned components.

--- a/ironic-deployment/base/ironic.yaml
+++ b/ironic-deployment/base/ironic.yaml
@@ -49,39 +49,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: ironic-bmo-configmap
-        - name: mariadb
-          image: quay.io/metal3-io/mariadb
-          imagePullPolicy: Always
-          livenessProbe:
-           exec:
-             command: ["sh", "-c", "mysqladmin status -uironic -p$(printenv MARIADB_PASSWORD)"]
-           initialDelaySeconds: 30
-           periodSeconds: 30
-           timeoutSeconds: 10
-           successThreshold: 1
-           failureThreshold: 10
-          readinessProbe:
-           exec:
-             command: ["sh", "-c", "mysqladmin status -uironic -p$(printenv MARIADB_PASSWORD)"]
-           initialDelaySeconds: 30
-           periodSeconds: 30
-           timeoutSeconds: 10
-           successThreshold: 1
-           failureThreshold: 10
-          volumeMounts:
-            - mountPath: /shared
-              name: ironic-data-volume
-          env:
-            - name: MARIADB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: mariadb-password
-                  key: password
-            - name: RESTART_CONTAINER_CERTIFICATE_UPDATED
-              valueFrom:
-                 configMapKeyRef:
-                  name: ironic-bmo-configmap
-                  key: RESTART_CONTAINER_CERTIFICATE_UPDATED
         - name: ironic
           image: quay.io/metal3-io/ironic
           imagePullPolicy: Always
@@ -109,12 +76,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: ironic-bmo-configmap
-          env:
-            - name: MARIADB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: mariadb-password
-                  key: password
         - name: ironic-log-watch
           image: quay.io/metal3-io/ironic
           imagePullPolicy: Always

--- a/ironic-deployment/components/keepalived/ironic_bmo_configmap.env
+++ b/ironic-deployment/components/keepalived/ironic_bmo_configmap.env
@@ -9,5 +9,3 @@ IRONIC_INSPECTOR_ENDPOINT=http://172.22.0.2:5050/v1/
 CACHEURL=http://172.22.0.1/images
 IRONIC_FAST_TRACK=true
 IRONIC_KERNEL_PARAMS=console=ttyS0
-# TODO(dtantsur): this should probably not be the default
-IRONIC_USE_MARIADB=true

--- a/ironic-deployment/components/mariadb/certificate.yaml
+++ b/ironic-deployment/components/mariadb/certificate.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: mariadb-cert
+spec:
+  commonName: mariadb-cert
+  ipAddresses:
+  - MARIADB_HOST_IP
+  issuerRef:
+    kind: Issuer
+    name: ca-issuer
+  secretName: mariadb-cert

--- a/ironic-deployment/components/mariadb/kustomization.yaml
+++ b/ironic-deployment/components/mariadb/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+- certificate.yaml
+
+patchesStrategicMerge:
+- mariadb_patch.yaml
+
+secretGenerator:
+- literals:
+  - password=changeme
+  name: mariadb-password
+  type: Opaque

--- a/ironic-deployment/components/mariadb/mariadb_patch.yaml
+++ b/ironic-deployment/components/mariadb/mariadb_patch.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ironic
+spec:
+  template:
+    spec:
+      containers:
+        - name: mariadb
+          image: quay.io/metal3-io/mariadb
+          imagePullPolicy: Always
+          livenessProbe:
+           exec:
+             command: ["sh", "-c", "mysqladmin status -uironic -p$(printenv MARIADB_PASSWORD)"]
+           initialDelaySeconds: 30
+           periodSeconds: 30
+           timeoutSeconds: 10
+           successThreshold: 1
+           failureThreshold: 10
+          readinessProbe:
+           exec:
+             command: ["sh", "-c", "mysqladmin status -uironic -p$(printenv MARIADB_PASSWORD)"]
+           initialDelaySeconds: 30
+           periodSeconds: 30
+           timeoutSeconds: 10
+           successThreshold: 1
+           failureThreshold: 10
+          volumeMounts:
+            - mountPath: /shared
+              name: ironic-data-volume
+            - name: cert-mariadb
+              mountPath: "/certs/mariadb"
+              readOnly: true
+            - name: cert-mariadb-ca
+              mountPath: "/certs/ca/mariadb"
+              readOnly: true
+          env:
+            - name: MARIADB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mariadb-password
+                  key: password
+            - name: RESTART_CONTAINER_CERTIFICATE_UPDATED
+              valueFrom:
+                 configMapKeyRef:
+                  name: ironic-bmo-configmap
+                  key: RESTART_CONTAINER_CERTIFICATE_UPDATED
+        - name: ironic
+          env:
+            - name: MARIADB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mariadb-password
+                  key: password
+            - name: IRONIC_USE_MARIADB
+              value: "true"
+          volumeMounts:
+            - name: cert-mariadb-ca
+              mountPath: "/certs/ca/mariadb"
+              readOnly: true
+      volumes:
+      - name: cert-mariadb
+        secret:
+          secretName: mariadb-cert
+      - name: cert-mariadb-ca
+        secret:
+          secretName: ironic-cacert

--- a/ironic-deployment/components/tls/certificate.yaml
+++ b/ironic-deployment/components/tls/certificate.yaml
@@ -52,16 +52,3 @@ spec:
     kind: Issuer
     name: ca-issuer
   secretName: ironic-inspector-cert
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: mariadb-cert
-spec:
-  commonName: mariadb-cert
-  ipAddresses:
-  - MARIADB_HOST_IP
-  issuerRef:
-    kind: Issuer
-    name: ca-issuer
-  secretName: mariadb-cert

--- a/ironic-deployment/components/tls/tls.yaml
+++ b/ironic-deployment/components/tls/tls.yaml
@@ -25,9 +25,6 @@ spec:
         - name: cert-ironic-inspector-ca
           mountPath: "/certs/ca/ironic-inspector"
           readOnly: true
-        - name: cert-mariadb-ca
-          mountPath: "/certs/ca/mariadb"
-          readOnly: true
       - name: ironic-httpd
         livenessProbe:
          exec:
@@ -72,14 +69,6 @@ spec:
         - name: cert-ironic-inspector-ca
           mountPath: "/certs/ca/ironic-inspector"
           readOnly: true
-      - name: mariadb
-        volumeMounts:
-        - name: cert-mariadb
-          mountPath: "/certs/mariadb"
-          readOnly: true
-        - name: cert-mariadb-ca
-          mountPath: "/certs/ca/mariadb"
-          readOnly: true
       volumes:
       - name: cert-ironic-ca
         secret:
@@ -93,9 +82,3 @@ spec:
       - name: cert-ironic-inspector
         secret:
           secretName: ironic-inspector-cert
-      - name: cert-mariadb
-        secret:
-          secretName: mariadb-cert
-      - name: cert-mariadb-ca
-        secret:
-          secretName: ironic-cacert

--- a/ironic-deployment/default/ironic_bmo_configmap.env
+++ b/ironic-deployment/default/ironic_bmo_configmap.env
@@ -9,5 +9,3 @@ CACHEURL=http://172.22.0.1/images
 IRONIC_FAST_TRACK=true
 IRONIC_KERNEL_PARAMS=console=ttyS0
 IRONIC_INSPECTOR_VLAN_INTERFACES=all
-# TODO(dtantsur): this should probably not be the default
-IRONIC_USE_MARIADB=true

--- a/ironic-deployment/default/kustomization.yaml
+++ b/ironic-deployment/default/kustomization.yaml
@@ -8,8 +8,3 @@ configMapGenerator:
 - envs:
   - ironic_bmo_configmap.env
   name: ironic-bmo-configmap
-secretGenerator:
-- literals:
-  - password=changeme
-  name: mariadb-password
-  type: Opaque

--- a/ironic-deployment/overlays/basic-auth_tls_keepalived_mariadb/kustomization.yaml
+++ b/ironic-deployment/overlays/basic-auth_tls_keepalived_mariadb/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# namespace: baremetal-operator-system
+# namePrefix: baremetal-operator-
+
+resources:
+- ../basic-auth_tls_keepalived
+
+components:
+- ../../components/mariadb


### PR DESCRIPTION
This is the exact same as https://github.com/metal3-io/baremetal-operator/pull/1196 to try to make the tests run...

**What this PR does / why we need it:**

Make it optional to include the mariadb container. Split it into its of component that can be selected if needed.

NOTE: Running with MariaDB requires TLS to be enabled.

Supporting all the different combinations is becoming very hard since they affect each other. For example, if you want TLS + mariadb, then maraidb need patches for TLS and other components also need to know about these certificates. I don't see the point in supporting all different combinations and would suggest that we only support secure and well tested ones, i.e. those that we test in CI.
Alternatively, if we want a more "dynamic" way to handle things, we could consider going with helm charts instead. IMO there is not much point in doing that unless we actually test the combinations in some way. Instead I think we should provide a good base kustomization that works and users can build upon if needed.
