### PR TITLE
Replace package "text" with "google/safetext"

### DIFF
--- a/cmd/make-bm-worker/templates/templates.go
+++ b/cmd/make-bm-worker/templates/templates.go
@@ -3,7 +3,8 @@ package templates
 import (
 	"bytes"
 	"encoding/base64"
-	"text/template"
+
+	"github.com/google/safetext/yamltemplate"
 )
 
 var templateBody = `---
@@ -102,7 +103,7 @@ func encodeToSecret(input string) string {
 // was a problem rendering it.
 func (t Template) Render() (string, error) {
 	buf := new(bytes.Buffer)
-	tmpl := template.Must(template.New("yaml_out").Parse(templateBody))
+	tmpl := yamltemplate.Must(yamltemplate.New("yaml_out").Parse(templateBody))
 	err := tmpl.Execute(buf, t)
 	return buf.String(), err
 }

--- a/cmd/make-virt-host/main.go
+++ b/cmd/make-virt-host/main.go
@@ -9,7 +9,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"text/template"
+
+	"github.com/google/safetext/yamltemplate"
 )
 
 const (
@@ -212,7 +213,7 @@ func main() {
 		Consumer:          strings.TrimSpace(*consumer),
 		ConsumerNamespace: strings.TrimSpace(*consumerNamespace),
 	}
-	t := template.Must(template.New("yaml_out").Parse(templateBody))
+	t := yamltemplate.Must(yamltemplate.New("yaml_out").Parse(templateBody))
 	err = t.Execute(os.Stdout, args)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/go-logr/logr v1.2.3
+	github.com/google/safetext v0.0.0-20230106111101-7156a760e523
 	github.com/gophercloud/gophercloud v1.2.0
 	github.com/metal3-io/baremetal-operator/apis v0.1.2
 	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/safetext v0.0.0-20230106111101-7156a760e523 h1:i4NsbmB9pD5+Ggp5GZKyvYY6MkjvPE8CIMlkvXFF8gA=
+github.com/google/safetext v0.0.0-20230106111101-7156a760e523/go.mod h1:mJNEy0r5YPHC7ChQffpOszlGB4L1iqjXWpIEKcFpr9s=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -736,8 +738,8 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=


### PR DESCRIPTION
The library "text/template" is syntax-unaware and at risk of injection vulnerabilities. [More context](https://github.com/google/safetext).

Signed-off-by: Jie Yang <jieyangnku@gmail.com>

<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
