### PR TITLE
🐛 Do not abandon cleaning after 3 failures

### DIFF
--- a/controllers/metal3.io/host_state_machine.go
+++ b/controllers/metal3.io/host_state_machine.go
@@ -517,6 +517,8 @@ func (hsm *hostStateMachine) handleDeprovisioning(info *reconcileInfo) actionRes
 			// If the provisioner gives up deprovisioning and
 			// deletion has been requested, continue to delete.
 			if hsm.Host.Status.ErrorCount > 3 {
+				info.log.Info("Giving up on host clean up after 3 attempts. The host may still be operational " +
+					"and cause issues in your clusters. You should clean it up manually now.")
 				return skipToDelete()
 			}
 		case actionError:

--- a/pkg/provisioner/ironic/provision_test.go
+++ b/pkg/provisioner/ironic/provision_test.go
@@ -237,16 +237,16 @@ func TestDeprovision(t *testing.T) {
 				ProvisionState: string(nodes.CleanFail),
 				UUID:           nodeUUID,
 			}),
-			expectedRequestAfter: 10,
-			expectedDirty:        true,
+			expectedErrorMessage: true,
 		},
 		{
 			name: "manageable state",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
 				ProvisionState: string(nodes.Manageable),
 				UUID:           nodeUUID,
 			}),
-			expectedDirty: false,
+			expectedRequestAfter: 10,
+			expectedDirty:        true,
 		},
 	}
 


### PR DESCRIPTION
This behavior is arbitrary, opaque and violates the assumption that
cleaning results in actual cleaning. It hides infrastructure problems
and may cause deleted Kubernetes nodes reappear in the cluster.
Users that don't care about nodes being cleaned should opt out of
cleaning instead of relying on implicit behavior.

The issue that hosts cannot be deleted in the unmanages state has to be
addressed separately since it also affects hosts with cleaning disabled.

Follow-up to #1184 