### PR TITLE
:seedling: Delay deprovision/delete when multiple finalizers exist

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -838,7 +838,7 @@ func (r *BareMetalHostReconciler) registerHost(prov provisioner.Provisioner, inf
 	// Create the hostFirmwareSettings resource with same host name/namespace if it doesn't exist
 	if info.host.Name != "" {
 		if !info.host.DeletionTimestamp.IsZero() {
-			r.Log.Info(fmt.Sprintf("will not attempt to create new hostFirmwareSettings in %s", info.host.Namespace))
+			info.log.Info(fmt.Sprintf("will not attempt to create new hostFirmwareSettings in %s", info.host.Namespace))
 		} else {
 			if err = r.createHostFirmwareSettings(info); err != nil {
 				info.log.Info("failed creating hostfirmwaresettings")

--- a/controllers/metal3.io/host_state_machine.go
+++ b/controllers/metal3.io/host_state_machine.go
@@ -223,6 +223,10 @@ func (hsm *hostStateMachine) checkInitiateDelete() bool {
 	default:
 		hsm.NextState = metal3v1alpha1.StateDeleting
 	case metal3v1alpha1.StateProvisioning, metal3v1alpha1.StateProvisioned:
+		if len(hsm.Host.Finalizers) > 1 {
+			// Allow other finalizers to run before changing state
+			return false
+		}
 		if hsm.Host.OperationalStatus() == metal3v1alpha1.OperationalStatusDetached {
 			hsm.NextState = metal3v1alpha1.StateDeleting
 		} else {


### PR DESCRIPTION
Delaying moving the host to deprovisioning or deleting allows other components to do whatever logic they need to do before BMO decides if the host should be deprovisioned or deleted.

In one specific case a finalizer could be added to a detached host which will attach the host to allow it to be cleaned at the time it is deleted. This logic needs to happen before BMO proceeds with its own delete logic.

@dtantsur PTAL