### PR TITLE
🌱 remove old unnecessary OWNERS files

### DIFF
--- a/config/OWNERS
+++ b/config/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
- - fmuyassarov
- - kashifest

--- a/ironic-deployment/OWNERS
+++ b/ironic-deployment/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
- - fmuyassarov
- - kashifest

--- a/resources/keepalived-docker/OWNERS
+++ b/resources/keepalived-docker/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
- - fmuyassarov
- - kashifest

--- a/tools/OWNERS
+++ b/tools/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
- - fmuyassarov
- - kashifest


### PR DESCRIPTION
As agreed with Kashif, these are obsolete OWNERS files, and they need to go. This way the review process falls to the root OWNERS.

fmyussarov is already emeritus approver on top-level.

/cc @kashifest @furkatgofurov7 