### PR TITLE
:bug: Revert "Delay deprovision/delete when multiple finalizers exist"

### DIFF
--- a/controllers/metal3.io/host_state_machine.go
+++ b/controllers/metal3.io/host_state_machine.go
@@ -223,10 +223,6 @@ func (hsm *hostStateMachine) checkInitiateDelete() bool {
 	default:
 		hsm.NextState = metal3v1alpha1.StateDeleting
 	case metal3v1alpha1.StateProvisioning, metal3v1alpha1.StateProvisioned:
-		if len(hsm.Host.Finalizers) > 1 {
-			// Allow other finalizers to run before changing state
-			return false
-		}
 		if hsm.Host.OperationalStatus() == metal3v1alpha1.OperationalStatusDetached {
 			hsm.NextState = metal3v1alpha1.StateDeleting
 		} else {

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -1075,60 +1075,6 @@ func TestErrorClean(t *testing.T) {
 	}
 }
 
-func TestDeleteWaitsForFinalizers(t *testing.T) {
-	tests := []struct {
-		Scenario      string
-		Host          *metal3v1alpha1.BareMetalHost
-		ExpectedState metal3v1alpha1.ProvisioningState
-	}{
-		{
-			Scenario: "provisioning-2-finalizers",
-			Host: host(metal3v1alpha1.StateProvisioning).
-				setDeletion().
-				setFinalizers([]string{metal3v1alpha1.BareMetalHostFinalizer, "other-finalizer"}).
-				build(),
-			ExpectedState: metal3v1alpha1.StateProvisioned,
-		},
-		{
-			Scenario: "provisioned-2-finalizers",
-			Host: host(metal3v1alpha1.StateProvisioned).
-				setDeletion().
-				setFinalizers([]string{metal3v1alpha1.BareMetalHostFinalizer, "other-finalizer"}).
-				build(),
-			ExpectedState: metal3v1alpha1.StateProvisioned,
-		},
-		{
-			Scenario: "provisioning-1-finalizer",
-			Host: host(metal3v1alpha1.StateProvisioning).
-				setDeletion().
-				setFinalizers([]string{metal3v1alpha1.BareMetalHostFinalizer}).
-				build(),
-			ExpectedState: metal3v1alpha1.StateDeprovisioning,
-		},
-		{
-			Scenario: "provisioned-1-finalizer",
-			Host: host(metal3v1alpha1.StateProvisioned).
-				setDeletion().
-				setFinalizers([]string{metal3v1alpha1.BareMetalHostFinalizer}).
-				build(),
-			ExpectedState: metal3v1alpha1.StateDeprovisioning,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.Scenario, func(t *testing.T) {
-			prov := newMockProvisioner()
-			hsm := newHostStateMachine(tt.Host, &BareMetalHostReconciler{
-				Client: fakeclient.NewFakeClient(),
-			}, prov, true)
-
-			info := makeDefaultReconcileInfo(tt.Host)
-			hsm.ReconcileState(info)
-
-			assert.Equal(t, tt.ExpectedState, tt.Host.Status.Provisioning.State)
-		})
-	}
-}
-
 type hostBuilder struct {
 	metal3v1alpha1.BareMetalHost
 }
@@ -1245,11 +1191,6 @@ func (hb *hostBuilder) DisableInspection() *hostBuilder {
 func (hb *hostBuilder) setDeletion() *hostBuilder {
 	date := metav1.Date(2021, time.January, 18, 10, 18, 0, 0, time.UTC)
 	hb.DeletionTimestamp = &date
-	return hb
-}
-
-func (hb *hostBuilder) setFinalizers(finalizers []string) *hostBuilder {
-	hb.Finalizers = finalizers
 	return hb
 }
 


### PR DESCRIPTION
This reverts #1230.

Finalizers are a signal to the k8s API, not to controllers. Controllers should ignore finalizers other than their own. This change overloaded the semantics of the finalizer to communicate between controllers. Annotations are the way to do this.