### PR TITLE
✨ Supported forced reboot of preprovisioning images

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -657,7 +657,8 @@ const (
 
 // RebootAnnotationArguments defines the arguments of the RebootAnnotation type
 type RebootAnnotationArguments struct {
-	Mode RebootMode `json:"mode"`
+	Mode  RebootMode `json:"mode"`
+	Force bool       `json:"force"`
 }
 
 // Match compares the saved status information with the name and

--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -602,9 +602,9 @@ func TestHasRebootAnnotation(t *testing.T) {
 	testCases := []struct {
 		Scenario       string
 		Annotations    map[string]string
+		expectForce    bool
 		expectedReboot bool
 		expectedMode   metal3v1alpha1.RebootMode
-		expectedForce  bool
 	}{
 		{
 			Scenario: "No annotations",
@@ -668,8 +668,16 @@ func TestHasRebootAnnotation(t *testing.T) {
 			Annotations: map[string]string{
 				rebootAnnotationPrefix + "/foo": "{\"force\": true}",
 			},
+			expectForce:    true,
 			expectedReboot: true,
-			expectedForce:  true,
+		},
+		{
+			Scenario: "Expect force",
+			Annotations: map[string]string{
+				rebootAnnotationPrefix + "/foo": "{\"mode\": \"hard\"}",
+			},
+			expectForce:    true,
+			expectedReboot: false,
 		},
 	}
 
@@ -683,10 +691,9 @@ func TestHasRebootAnnotation(t *testing.T) {
 				tc.expectedMode = metal3v1alpha1.RebootModeSoft
 			}
 
-			hasReboot, rebootMode, force := hasRebootAnnotation(info)
+			hasReboot, rebootMode := hasRebootAnnotation(info, tc.expectForce)
 			assert.Equal(t, tc.expectedReboot, hasReboot)
 			assert.Equal(t, tc.expectedMode, rebootMode)
-			assert.Equal(t, tc.expectedForce, force)
 		})
 	}
 }

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -1338,7 +1338,7 @@ func (m *mockProvisioner) Adopt(data provisioner.AdoptData, force bool) (result 
 	return m.getNextResultByMethod("Adopt"), err
 }
 
-func (m *mockProvisioner) Provision(data provisioner.ProvisionData) (result provisioner.Result, err error) {
+func (m *mockProvisioner) Provision(data provisioner.ProvisionData, forceReboot bool) (result provisioner.Result, err error) {
 	return m.getNextResultByMethod("Provision"), err
 }
 

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -1321,7 +1321,7 @@ func (m *mockProvisioner) PreprovisioningImageFormats() ([]metal3v1alpha1.ImageF
 	return nil, nil
 }
 
-func (m *mockProvisioner) InspectHardware(data provisioner.InspectData, force, refresh bool) (result provisioner.Result, started bool, details *metal3v1alpha1.HardwareDetails, err error) {
+func (m *mockProvisioner) InspectHardware(data provisioner.InspectData, restartOnFailure, refresh, forceReboot bool) (result provisioner.Result, started bool, details *metal3v1alpha1.HardwareDetails, err error) {
 	details = &metal3v1alpha1.HardwareDetails{}
 	return m.getNextResultByMethod("InspectHardware"), true, details, err
 }

--- a/controllers/metal3.io/hostfirmwaresettings_test.go
+++ b/controllers/metal3.io/hostfirmwaresettings_test.go
@@ -83,7 +83,7 @@ func (m *hsfMockProvisioner) Adopt(data provisioner.AdoptData, force bool) (resu
 	return
 }
 
-func (m *hsfMockProvisioner) Provision(data provisioner.ProvisionData) (result provisioner.Result, err error) {
+func (m *hsfMockProvisioner) Provision(data provisioner.ProvisionData, forceReboot bool) (result provisioner.Result, err error) {
 	return
 }
 

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -85,7 +85,7 @@ func (p *demoProvisioner) HasCapacity() (result bool, err error) {
 
 // ValidateManagementAccess tests the connection information for the
 // host to verify that the location and credentials work.
-func (p *demoProvisioner) ValidateManagementAccess(data provisioner.ManagementAccessData, credentialsChanged, force bool) (result provisioner.Result, provID string, err error) {
+func (p *demoProvisioner) ValidateManagementAccess(data provisioner.ManagementAccessData, credentialsChanged, restartOnFailure bool) (result provisioner.Result, provID string, err error) {
 	p.log.Info("testing management access")
 
 	hostName := p.objectMeta.Name
@@ -193,7 +193,7 @@ func (p *demoProvisioner) UpdateHardwareState() (hwState provisioner.HardwareSta
 }
 
 // Prepare remove existing configuration and set new configuration
-func (p *demoProvisioner) Prepare(data provisioner.PrepareData, unprepared bool, force bool) (result provisioner.Result, started bool, err error) {
+func (p *demoProvisioner) Prepare(data provisioner.PrepareData, unprepared bool, restartOnFailure bool) (result provisioner.Result, started bool, err error) {
 	hostName := p.objectMeta.Name
 
 	switch hostName {
@@ -218,7 +218,7 @@ func (p *demoProvisioner) Prepare(data provisioner.PrepareData, unprepared bool,
 
 // Adopt notifies the provisioner that the state machine believes the host
 // to be currently provisioned, and that it should be managed as such.
-func (p *demoProvisioner) Adopt(data provisioner.AdoptData, force bool) (result provisioner.Result, err error) {
+func (p *demoProvisioner) Adopt(data provisioner.AdoptData, restartOnFailure bool) (result provisioner.Result, err error) {
 	p.log.Info("adopting host")
 	result.Dirty = false
 	return
@@ -253,7 +253,7 @@ func (p *demoProvisioner) Provision(data provisioner.ProvisionData, forceReboot 
 // Deprovision removes the host from the image. It may be called
 // multiple times, and should return true for its dirty flag until the
 // deprovisioning operation is completed.
-func (p *demoProvisioner) Deprovision(force bool) (result provisioner.Result, err error) {
+func (p *demoProvisioner) Deprovision(restartOnFailure bool) (result provisioner.Result, err error) {
 
 	hostName := p.objectMeta.Name
 	switch hostName {

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -122,7 +122,7 @@ func (p *demoProvisioner) PreprovisioningImageFormats() ([]metal3v1alpha1.ImageF
 // details of devices discovered on the hardware. It may be called
 // multiple times, and should return true for its dirty flag until the
 // inspection is completed.
-func (p *demoProvisioner) InspectHardware(data provisioner.InspectData, force, refresh bool) (result provisioner.Result, started bool, details *metal3v1alpha1.HardwareDetails, err error) {
+func (p *demoProvisioner) InspectHardware(data provisioner.InspectData, restartOnFailure, refresh, forceReboot bool) (result provisioner.Result, started bool, details *metal3v1alpha1.HardwareDetails, err error) {
 	started = true
 	hostName := p.objectMeta.Name
 

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -227,7 +227,7 @@ func (p *demoProvisioner) Adopt(data provisioner.AdoptData, force bool) (result 
 // Provision writes the image from the host spec to the host. It may
 // be called multiple times, and should return true for its dirty flag
 // until the provisioning operation is completed.
-func (p *demoProvisioner) Provision(data provisioner.ProvisionData) (result provisioner.Result, err error) {
+func (p *demoProvisioner) Provision(data provisioner.ProvisionData, forceReboot bool) (result provisioner.Result, err error) {
 
 	hostName := p.objectMeta.Name
 	p.log.Info("provisioning image to host")

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -97,7 +97,7 @@ func (p *fixtureProvisioner) HasCapacity() (result bool, err error) {
 
 // ValidateManagementAccess tests the connection information for the
 // host to verify that the location and credentials work.
-func (p *fixtureProvisioner) ValidateManagementAccess(data provisioner.ManagementAccessData, credentialsChanged, force bool) (result provisioner.Result, provID string, err error) {
+func (p *fixtureProvisioner) ValidateManagementAccess(data provisioner.ManagementAccessData, credentialsChanged, restartOnFailure bool) (result provisioner.Result, provID string, err error) {
 	p.log.Info("testing management access")
 
 	if p.state.validateError != "" {
@@ -191,7 +191,7 @@ func (p *fixtureProvisioner) UpdateHardwareState() (hwState provisioner.Hardware
 }
 
 // Prepare remove existing configuration and set new configuration
-func (p *fixtureProvisioner) Prepare(data provisioner.PrepareData, unprepared bool, force bool) (result provisioner.Result, started bool, err error) {
+func (p *fixtureProvisioner) Prepare(data provisioner.PrepareData, unprepared bool, restartOnFailure bool) (result provisioner.Result, started bool, err error) {
 	p.log.Info("preparing host")
 	started = unprepared
 	return
@@ -199,7 +199,7 @@ func (p *fixtureProvisioner) Prepare(data provisioner.PrepareData, unprepared bo
 
 // Adopt notifies the provisioner that the state machine believes the host
 // to be currently provisioned, and that it should be managed as such.
-func (p *fixtureProvisioner) Adopt(data provisioner.AdoptData, force bool) (result provisioner.Result, err error) {
+func (p *fixtureProvisioner) Adopt(data provisioner.AdoptData, restartOnFailure bool) (result provisioner.Result, err error) {
 	p.log.Info("adopting host")
 	if !p.state.adopted {
 		p.state.adopted = true
@@ -238,7 +238,7 @@ func (p *fixtureProvisioner) Provision(data provisioner.ProvisionData, forceRebo
 // Deprovision removes the host from the image. It may be called
 // multiple times, and should return true for its dirty flag until the
 // deprovisioning operation is completed.
-func (p *fixtureProvisioner) Deprovision(force bool) (result provisioner.Result, err error) {
+func (p *fixtureProvisioner) Deprovision(restartOnFailure bool) (result provisioner.Result, err error) {
 	p.log.Info("ensuring host is deprovisioned")
 
 	result.RequeueAfter = deprovisionRequeueDelay

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -212,7 +212,7 @@ func (p *fixtureProvisioner) Adopt(data provisioner.AdoptData, force bool) (resu
 // Provision writes the image from the host spec to the host. It may
 // be called multiple times, and should return true for its dirty flag
 // until the provisioning operation is completed.
-func (p *fixtureProvisioner) Provision(data provisioner.ProvisionData) (result provisioner.Result, err error) {
+func (p *fixtureProvisioner) Provision(data provisioner.ProvisionData, forceReboot bool) (result provisioner.Result, err error) {
 	p.log.Info("provisioning image to host")
 
 	if data.CustomDeploy != nil && p.state.customDeploy == nil {

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -125,7 +125,7 @@ func (p *fixtureProvisioner) PreprovisioningImageFormats() ([]metal3v1alpha1.Ima
 // details of devices discovered on the hardware. It may be called
 // multiple times, and should return true for its dirty flag until the
 // inspection is completed.
-func (p *fixtureProvisioner) InspectHardware(data provisioner.InspectData, force, refresh bool) (result provisioner.Result, started bool, details *metal3v1alpha1.HardwareDetails, err error) {
+func (p *fixtureProvisioner) InspectHardware(data provisioner.InspectData, restartOnFailure, refresh, forceReboot bool) (result provisioner.Result, started bool, details *metal3v1alpha1.HardwareDetails, err error) {
 	// The inspection is ongoing. We'll need to check the fixture
 	// status for the server here until it is ready for us to get the
 	// inspection details. Simulate that for now by creating the

--- a/pkg/provisioner/ironic/provision_test.go
+++ b/pkg/provisioner/ironic/provision_test.go
@@ -124,6 +124,17 @@ func TestProvision(t *testing.T) {
 			expectedDirty:        true,
 		},
 		{
+			name: "forceReboot: Deploy Wait",
+			ironic: testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
+				ProvisionState: string(nodes.DeployWait),
+				UUID:           nodeUUID,
+			}),
+			forceReboot:            true,
+			expectedRequestAfter:   10,
+			expectedDirty:          true,
+			expectedProvisionState: nodes.TargetDeleted,
+		},
+		{
 			name: "fault state",
 			ironic: testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
 				ProvisionState: string(nodes.Manageable),
@@ -176,7 +187,7 @@ func TestProvision(t *testing.T) {
 				Image:      testImage,
 				HostConfig: fixture.NewHostConfigData("testUserData", "test: NetworkData", "test: Meta"),
 				BootMode:   v1alpha1.DefaultBootMode,
-			})
+			}, tc.forceReboot)
 
 			assert.Equal(t, tc.expectedDirty, result.Dirty)
 			assert.Equal(t, time.Second*time.Duration(tc.expectedRequestAfter), result.RequeueAfter)

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -125,7 +125,7 @@ type Provisioner interface {
 	// of credentials it has are different from the credentials it has
 	// previously been using, without implying that either set of
 	// credentials is correct.
-	ValidateManagementAccess(data ManagementAccessData, credentialsChanged, force bool) (result Result, provID string, err error)
+	ValidateManagementAccess(data ManagementAccessData, credentialsChanged, restartOnFailure bool) (result Result, provID string, err error)
 
 	// PreprovisioningImageFormats returns a list of acceptable formats for a
 	// pre-provisioning image to be built by a PreprovisioningImage object. The
@@ -146,10 +146,10 @@ type Provisioner interface {
 
 	// Adopt brings an externally-provisioned host under management by
 	// the provisioner.
-	Adopt(data AdoptData, force bool) (result Result, err error)
+	Adopt(data AdoptData, restartOnFailure bool) (result Result, err error)
 
 	// Prepare remove existing configuration and set new configuration
-	Prepare(data PrepareData, unprepared bool, force bool) (result Result, started bool, err error)
+	Prepare(data PrepareData, unprepared bool, restartOnFailure bool) (result Result, started bool, err error)
 
 	// Provision writes the image from the host spec to the host. It
 	// may be called multiple times, and should return true for its
@@ -159,7 +159,7 @@ type Provisioner interface {
 	// Deprovision removes the host from the image. It may be called
 	// multiple times, and should return true for its dirty flag until
 	// the deprovisioning operation is completed.
-	Deprovision(force bool) (result Result, err error)
+	Deprovision(restartOnFailure bool) (result Result, err error)
 
 	// Delete removes the host from the provisioning system. It may be
 	// called multiple times, and should return true for its dirty

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -136,7 +136,7 @@ type Provisioner interface {
 	// details of devices discovered on the hardware. It may be called
 	// multiple times, and should return true for its dirty flag until the
 	// inspection is completed.
-	InspectHardware(data InspectData, force, refresh bool) (result Result, started bool, details *metal3v1alpha1.HardwareDetails, err error)
+	InspectHardware(data InspectData, restartOnFailure, refresh, forceReboot bool) (result Result, started bool, details *metal3v1alpha1.HardwareDetails, err error)
 
 	// UpdateHardwareState fetches the latest hardware state of the
 	// server and updates the HardwareDetails field of the host with

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -154,7 +154,7 @@ type Provisioner interface {
 	// Provision writes the image from the host spec to the host. It
 	// may be called multiple times, and should return true for its
 	// dirty flag until the provisioning operation is completed.
-	Provision(data ProvisionData) (result Result, err error)
+	Provision(data ProvisionData, forceReboot bool) (result Result, err error)
 
 	// Deprovision removes the host from the image. It may be called
 	// multiple times, and should return true for its dirty flag until


### PR DESCRIPTION
This change adds a new reboot variant:
```yaml
reboot.metal3.io: '{"force": true}'
```

This reboot mode works in available, provisioning and inspecting states.

Includes:
- https://github.com/metal3-io/baremetal-operator/pull/1240