### PR TITLE
⚠️ 🐛 Update mariadb_patch.yaml

### DIFF
--- a/ironic-deployment/components/mariadb/mariadb_patch.yaml
+++ b/ironic-deployment/components/mariadb/mariadb_patch.yaml
@@ -25,6 +25,9 @@ spec:
            timeoutSeconds: 10
            successThreshold: 1
            failureThreshold: 10
+          securityContext:
+            runAsGroup: 27
+            runAsUser: 27
           volumeMounts:
             - mountPath: /shared
               name: ironic-data-volume


### PR DESCRIPTION
Add securityContext to ensure compliance with other recent securityContext improvements

<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
It fixes an issue with mariadb being deployed in a pod where securityContext is set elsewhere.

Without it, it'll throw errors for config - And if you try set the same ironic ID as the other deployments, it will fail to write mariadb logs and refuse to start.

This sets the id to the mysql user (27), allowing it to start up accordingly.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
