### PR TITLE
:seedling: redact the password info of image URL in logs

### DIFF
--- a/pkg/provisioner/ironic/update_opts.go
+++ b/pkg/provisioner/ironic/update_opts.go
@@ -88,6 +88,9 @@ func sanitisedValue(data interface{}) interface{} {
 		if strings.Contains(k.String(), "password") {
 			safeDatumValue = reflect.ValueOf("<redacted>")
 		}
+		if safeDatumValue.Interface() != nil && reflect.TypeOf(safeDatumValue.Interface()).Kind() == reflect.String {
+			safeDatumValue = reflect.ValueOf(redactedProbableURL(reflect.ValueOf(safeDatumValue.Interface()).String()))
+		}
 		safeValue.SetMapIndex(k, safeDatumValue)
 	}
 


### PR DESCRIPTION
When ironic downloads images from an external server that requires basic authentication, the user and password would be added to URL. The password info shall be hidden in the logs.

<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: baremetal operator log should not show any password info.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: N/A
Fixes #
