### PR TITLE
Use same settings for provisioner and controller logs 

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,15 +116,14 @@ func main() {
 		"The address the health endpoint binds to.")
 	flag.IntVar(&webhookPort, "webhook-port", 9443,
 		"Webhook Server port (set to 0 to disable)")
-	opts := zap.Options{
-		Development: devLogging,
-		TimeEncoder: zapcore.ISO8601TimeEncoder,
-	}
-	opts.BindFlags(flag.CommandLine)
-
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	logOpts := zap.Options{}
+	if devLogging {
+		logOpts.Development = true
+		logOpts.TimeEncoder = zapcore.ISO8601TimeEncoder
+	}
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&logOpts)))
 
 	printVersion()
 

--- a/main.go
+++ b/main.go
@@ -161,7 +161,8 @@ func main() {
 		ctrl.Log.Info("using demo provisioner")
 		provisionerFactory = &demo.Demo{}
 	} else {
-		provisionerFactory = ironic.NewProvisionerFactory(preprovImgEnable)
+		provLog := zap.New(zap.UseFlagOptions(&logOpts)).WithName("provisioner")
+		provisionerFactory = ironic.NewProvisionerFactory(provLog, preprovImgEnable)
 	}
 
 	if err = (&metal3iocontroller.BareMetalHostReconciler{

--- a/pkg/provisioner/ironic/factory.go
+++ b/pkg/provisioner/ironic/factory.go
@@ -10,9 +10,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/gophercloud/gophercloud"
-	"go.uber.org/zap/zapcore"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	logz "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
@@ -29,14 +26,10 @@ type ironicProvisionerFactory struct {
 	clientInspector *gophercloud.ServiceClient
 }
 
-func NewProvisionerFactory(havePreprovImgBuilder bool) provisioner.Factory {
-	factory := ironicProvisionerFactory{}
-
-	opts := zap.Options{
-		Development: true,
-		TimeEncoder: zapcore.ISO8601TimeEncoder,
+func NewProvisionerFactory(logger logr.Logger, havePreprovImgBuilder bool) provisioner.Factory {
+	factory := ironicProvisionerFactory{
+		log: logger.WithName("ironic"),
 	}
-	factory.log = logz.New(zap.UseFlagOptions(&opts)).WithName("provisioner").WithName("ironic")
 
 	err := factory.init(havePreprovImgBuilder)
 	if err != nil {


### PR DESCRIPTION
Previously the ironic provisioner log was created in a separate module,
and didn't have access to the CLI arguments. Originally the provisioner
was always in structured mode even when the -dev flag was passed to put
it into development mode, and then after #1175 vice-versa.

Create the provisioning logger in main.go using the same settings as the
controller logger, and pass it in to the provisioner factory. Only change the
timestamp formatting in development log mode.
