### PR TITLE
:bug: Revert live-iso validation as it is blocking pxe boot when non-virtualmedia drivers are used

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_validation.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_validation.go
@@ -76,7 +76,6 @@ func (host *BareMetalHost) validateChanges(old *BareMetalHost) []error {
 
 func validateBMCAccess(s BareMetalHostSpec, bmcAccess bmc.AccessDetails) []error {
 	var errs []error
-	diskFormat := "live-iso"
 
 	if bmcAccess == nil {
 		return errs
@@ -107,10 +106,6 @@ func validateBMCAccess(s BareMetalHostSpec, bmcAccess bmc.AccessDetails) []error
 
 	if s.BootMode == UEFISecureBoot && !bmcAccess.SupportsSecureBoot() {
 		errs = append(errs, fmt.Errorf("BMC driver %s does not support secure boot", bmcAccess.Type()))
-	}
-
-	if s.Image != nil && s.Image.DiskFormat != nil && *s.Image.DiskFormat == diskFormat && !bmcAccess.SupportsISOPreprovisioningImage() {
-		errs = append(errs, fmt.Errorf("BMC driver %s does not support live-iso image", bmcAccess.Type()))
 	}
 
 	return errs

--- a/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -46,7 +46,6 @@ func TestValidateCreate(t *testing.T) {
 
 	// for RAID validation test cases
 	numberOfPhysicalDisks := 3
-	diskFormat := "live-iso"
 
 	tests := []struct {
 		name      string
@@ -455,25 +454,6 @@ func TestValidateCreate(t *testing.T) {
 			},
 			oldBMH:    nil,
 			wantedErr: "Image URL test1 is an invalid URL",
-		},
-		{
-			name: "liveISOImageWithUnsupportedBMC",
-			newBMH: &BareMetalHost{
-				TypeMeta:   tm,
-				ObjectMeta: om,
-				Spec: BareMetalHostSpec{
-					BMC: BMCDetails{
-						Address:         "idrac://127.0.0.1",
-						CredentialsName: "test1",
-					},
-					Image: &Image{
-						URL:        "http://127.0.0.1",
-						DiskFormat: &diskFormat,
-					},
-				}, // end of BMH spec
-			},
-			oldBMH:    nil,
-			wantedErr: "BMC driver idrac does not support live-iso image",
 		},
 	}
 


### PR DESCRIPTION
This reverts commit 40986755ad389c5edc51e4feef045d3a6fb19e65 part of this PR - [https://github.com/metal3-io/baremetal-operator/pull/1107/commits](https://github.com/metal3-io/baremetal-operator/pull/1107/commits)

<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This validation is blocking pxe booting when live-iso image format is used along with non-virtualmedia drivers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
