### PR TITLE
🐛BMH add architecture before inspection 

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -408,6 +408,12 @@ type BareMetalHostSpec struct {
 	// A custom deploy procedure.
 	// +optional
 	CustomDeploy *CustomDeploy `json:"customDeploy,omitempty"`
+
+	// Architecture means CPU architecture.
+	// Allowed values are x86_64, aarch64, ppc64le, &c.
+	// It's passed to the preprovisioningimage.
+	// +optional
+	Architecture string `json:"architecture,omitempty"`
 }
 
 // AutomatedCleaningMode is the interface to enable/disable automated cleaning

--- a/config/crd/bases/metal3.io_baremetalhosts.yaml
+++ b/config/crd/bases/metal3.io_baremetalhosts.yaml
@@ -74,6 +74,10 @@ spec:
           spec:
             description: BareMetalHostSpec defines the desired state of BareMetalHost
             properties:
+              architecture:
+                description: Architecture means CPU architecture. Allowed values are
+                  x86_64, aarch64, ppc64le, &c. It's passed to the preprovisioningimage.
+                type: string
               automatedCleaningMode:
                 default: metadata
                 description: When set to disabled, automated cleaning will be avoided

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -73,6 +73,10 @@ spec:
           spec:
             description: BareMetalHostSpec defines the desired state of BareMetalHost
             properties:
+              architecture:
+                description: Architecture means CPU architecture. Allowed values are
+                  x86_64, aarch64, ppc64le, &c. It's passed to the preprovisioningimage.
+                type: string
               automatedCleaningMode:
                 default: metadata
                 description: When set to disabled, automated cleaning will be avoided

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -659,6 +659,9 @@ func getHostArchitecture(host *metal3v1alpha1.BareMetalHost) string {
 		host.Status.HardwareDetails.CPU.Arch != "" {
 		return host.Status.HardwareDetails.CPU.Arch
 	}
+	if host.Spec.Architecture != "" {
+		return host.Spec.Architecture
+	}
 	if hwprof, err := profile.GetProfile(host.Status.HardwareProfile); err == nil {
 		return hwprof.CPUArch
 	}


### PR DESCRIPTION

<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

In a multi-architecture scenario, can an annotation be added to bmh to represent the architecture? Through the new annotation field, it is used to generate the kernel and add kernel params in the preprovisioning image for bmh of different architectures