### PR TITLE
:bug: Delete unmanaged host when deletion timestamp is non-zero

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -529,6 +529,17 @@ func (r *BareMetalHostReconciler) actionUnmanaged(prov provisioner.Provisioner, 
 	if info.host.HasBMCDetails() {
 		return actionComplete{}
 	}
+
+	if !info.host.DeletionTimestamp.IsZero() {
+		provResult, err := prov.Delete()
+		if err != nil {
+			return actionError{errors.Wrap(err, "failed to delete")}
+		}
+		if provResult.Dirty {
+			return actionContinue{provResult.RequeueAfter}
+		}
+	}
+
 	return actionContinue{unmanagedRetryDelay}
 }
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
When we try to delete an unmanaged BMH, it gets stuck since there is no deletion workflow right now. This Pr adds the workflow to delete an unmanaged BMH when the deletionTimestamp is non-zero.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
