### PR TITLE
:bug: Don't check for ironic capacity in 'deleting' state

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -334,10 +334,9 @@ func recordActionFailure(info *reconcileInfo, errorType metal3v1alpha1.ErrorType
 func recordActionDelayed(info *reconcileInfo, state metal3v1alpha1.ProvisioningState) actionResult {
 	var counter prometheus.Counter
 
-	switch state {
-	case metal3v1alpha1.StateDeprovisioning, metal3v1alpha1.StateDeleting:
+	if state == metal3v1alpha1.StateDeprovisioning {
 		counter = delayedDeprovisioningHostCounters.With(hostMetricLabels(info.request))
-	default:
+	} else {
 		counter = delayedProvisioningHostCounters.With(hostMetricLabels(info.request))
 	}
 

--- a/controllers/metal3.io/host_state_machine.go
+++ b/controllers/metal3.io/host_state_machine.go
@@ -104,7 +104,7 @@ func (hsm *hostStateMachine) updateHostStateFrom(initialState metal3v1alpha1.Pro
 		// avoid putting an excessive pressure on the provisioner
 		switch hsm.NextState {
 		case metal3v1alpha1.StateInspecting, metal3v1alpha1.StateProvisioning,
-			metal3v1alpha1.StateDeprovisioning, metal3v1alpha1.StateDeleting:
+			metal3v1alpha1.StateDeprovisioning:
 			if actionRes := hsm.ensureCapacity(info, hsm.NextState); actionRes != nil {
 				return actionRes
 			}
@@ -161,7 +161,7 @@ func (hsm *hostStateMachine) checkDelayedHost(info *reconcileInfo) actionResult 
 	// host not yet tracked by the provisioner
 	switch info.host.Status.Provisioning.State {
 	case metal3v1alpha1.StateInspecting, metal3v1alpha1.StateProvisioning,
-		metal3v1alpha1.StateDeprovisioning, metal3v1alpha1.StateDeleting:
+		metal3v1alpha1.StateDeprovisioning:
 		if actionRes := hsm.ensureCapacity(info, info.host.Status.Provisioning.State); actionRes != nil {
 			return actionRes
 		}

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -187,14 +187,6 @@ func TestDeprovisioningCapacity(t *testing.T) {
 			ExpectedDeprovisioningState: metal3v1alpha1.StateAvailable,
 			ExpectedDelayed:             false,
 		},
-		{
-			Scenario:                  "transition-to-deleting",
-			Host:                      host(metal3v1alpha1.StateDeprovisioning).setDeletion().build(),
-			HasDeprovisioningCapacity: true,
-
-			ExpectedDeprovisioningState: metal3v1alpha1.StateDeleting,
-			ExpectedDelayed:             false,
-		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Ironic doesn't do any work to speak of in the host's 'deleting' state. It appears this was added (in c3c2c8841ca3ebe0341d4c6336346c397bdd99a2) due to confusion between ironic's 'deleting' (i.e. the 'deprovisioning' state in Metal³) and Metal³'s 'deleting' state.

A result of this was that hosts in the 'unmanaged' state could not be deleted, because by definition they do not have BMC credentials, but the check for Ironic capacity required them. Since unmanaged hosts do not go through 'deprovisioning', removing this unnecessary check from the 'deleting' state should be enough to allow them to be deleted again.