### PR TITLE
🌱 pin distroless to static:nonroot with sha digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Support FROM override
 ARG BUILD_IMAGE=docker.io/golang:1.19.6@sha256:7ce31d15a3a4dbf20446cccffa4020d3a2974ad2287d96123f55caf22c7adb71
-ARG BASE_IMAGE=gcr.io/distroless/base:latest
+ARG BASE_IMAGE=gcr.io/distroless/static@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f  # nonroot
 
 # Build the manager binary
 FROM $BUILD_IMAGE AS builder


### PR DESCRIPTION
Change distroless from base:latest to static:nonroot like other controller images, and pin it with sha digest.