### PR TITLE
✨ Add flags for configuring rate limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ ironic-inspector-auth-config
 ironic-rpc-auth-config
 HTTP_BASIC_HTPASSWD
 ironic-deployment/overlays/temp
+
+# Development containers (https://containers.dev/)
+.devcontainer


### PR DESCRIPTION
**What this PR does / why we need it**:

This matches https://github.com/metal3-io/cluster-api-provider-metal3/pull/959 and https://github.com/kubernetes-sigs/cluster-api/pull/8579

There is a built-in rate limit for the controller when talking to the Kubernetes API. So far it has not been possible to configure this limit. This commit adds flags for setting both the QPS and the burst for the rate limit. The default remains the same as before (20 QPS, 30 burst).

New flags:

--kube-api-qps
--kube-api-burst

Also adds .devcontainer to .gitignore

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
