### PR TITLE
🌱 Reduce the preprovisioning image retry delay

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -54,7 +54,7 @@ import (
 const (
 	hostErrorRetryDelay           = time.Second * 10
 	unmanagedRetryDelay           = time.Minute * 10
-	preprovImageRetryDelay        = time.Minute * 5
+	preprovImageRetryDelay        = time.Second * 30
 	provisionerNotReadyRetryDelay = time.Second * 30
 	subResourceNotReadyRetryDelay = time.Second * 60
 	rebootAnnotationPrefix        = "reboot.metal3.io"


### PR DESCRIPTION
Five minutes is a lot. Neither the built-in image provider nor the one
we have in OpenShift takes so much to build images.