### PR TITLE
Move hardware profile code to the api module

### DIFF
--- a/apis/metal3.io/v1alpha1/profile/profile.go
+++ b/apis/metal3.io/v1alpha1/profile/profile.go
@@ -1,4 +1,4 @@
-package hardware
+package profile
 
 import (
 	"fmt"

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -43,7 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	"github.com/metal3-io/baremetal-operator/pkg/hardware"
+	"github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/profile"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/imageprovider"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
@@ -659,7 +659,7 @@ func getHostArchitecture(host *metal3v1alpha1.BareMetalHost) string {
 		host.Status.HardwareDetails.CPU.Arch != "" {
 		return host.Status.HardwareDetails.CPU.Arch
 	}
-	if hwprof, err := hardware.GetProfile(host.Status.HardwareProfile); err == nil {
+	if hwprof, err := profile.GetProfile(host.Status.HardwareProfile); err == nil {
 		return hwprof.CPUArch
 	}
 	return ""
@@ -882,7 +882,7 @@ func updateRootDeviceHints(host *metal3v1alpha1.BareMetalHost, info *reconcileIn
 	// precedence. Otherwise use the values from the hardware profile.
 	hintSource := host.Spec.RootDeviceHints
 	if hintSource == nil {
-		hwProf, err := hardware.GetProfile(host.HardwareProfile())
+		hwProf, err := profile.GetProfile(host.HardwareProfile())
 		if err != nil {
 			return false, errors.Wrap(err, "failed to update root device hints")
 		}
@@ -1030,14 +1030,14 @@ func getHardwareProfileName(host *metal3v1alpha1.BareMetalHost) string {
 	if strings.HasPrefix(host.Spec.BMC.Address, "libvirt") {
 		return "libvirt"
 	}
-	return hardware.DefaultProfileName
+	return profile.DefaultProfileName
 }
 
 func (r *BareMetalHostReconciler) matchProfile(info *reconcileInfo) (dirty bool, err error) {
 	hardwareProfile := getHardwareProfileName(info.host)
 	info.log.Info("using hardware profile", "profile", hardwareProfile)
 
-	_, err = hardware.GetProfile(hardwareProfile)
+	_, err = profile.GetProfile(hardwareProfile)
 	if err != nil {
 		info.log.Info("invalid hardware profile", "profile", hardwareProfile)
 		return
@@ -1139,7 +1139,7 @@ func (r *BareMetalHostReconciler) actionProvisioning(prov provisioner.Provisione
 	}
 	info.log.Info("provisioning")
 
-	hwProf, err := hardware.GetProfile(info.host.HardwareProfile())
+	hwProf, err := profile.GetProfile(info.host.HardwareProfile())
 	if err != nil {
 		return actionError{errors.Wrap(err,
 			fmt.Sprintf("could not start provisioning with bad hardware profile %s",

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -15,7 +15,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	"github.com/metal3-io/baremetal-operator/pkg/hardware"
+	"github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/profile"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 )
@@ -1166,7 +1166,7 @@ func host(state metal3v1alpha1.ProvisioningState) *hostBuilder {
 				RootDeviceHints: &v1alpha1.RootDeviceHints{},
 			},
 			Status: metal3v1alpha1.BareMetalHostStatus{
-				HardwareProfile: hardware.DefaultProfileName,
+				HardwareProfile: profile.DefaultProfileName,
 				Provisioning: metal3v1alpha1.ProvisionStatus{
 					State:           state,
 					BootMode:        v1alpha1.DefaultBootMode,

--- a/pkg/provisioner/ironic/updateopts_test.go
+++ b/pkg/provisioner/ironic/updateopts_test.go
@@ -14,7 +14,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	"github.com/metal3-io/baremetal-operator/pkg/hardware"
+	"github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/profile"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
@@ -560,7 +560,7 @@ func TestGetUpdateOptsForNodeVirtual(t *testing.T) {
 	}
 	ironicNode := &nodes.Node{}
 
-	hwProf, _ := hardware.GetProfile("libvirt")
+	hwProf, _ := profile.GetProfile("libvirt")
 	provData := provisioner.ProvisionData{
 		Image:           *host.Spec.Image,
 		BootMode:        metal3v1alpha1.DefaultBootMode,
@@ -667,7 +667,7 @@ func TestGetUpdateOptsForNodeDell(t *testing.T) {
 	}
 	ironicNode := &nodes.Node{}
 
-	hwProf, _ := hardware.GetProfile("dell")
+	hwProf, _ := profile.GetProfile("dell")
 	provData := provisioner.ProvisionData{
 		Image:           *host.Spec.Image,
 		BootMode:        metal3v1alpha1.DefaultBootMode,
@@ -1185,7 +1185,7 @@ func TestGetUpdateOptsForNodeSecureBoot(t *testing.T) {
 	}
 	ironicNode := &nodes.Node{}
 
-	hwProf, _ := hardware.GetProfile("libvirt")
+	hwProf, _ := profile.GetProfile("libvirt")
 	provData := provisioner.ProvisionData{
 		Image:           *host.Spec.Image,
 		BootMode:        metal3v1alpha1.UEFISecureBoot,

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -7,7 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	"github.com/metal3-io/baremetal-operator/pkg/hardware"
+	"github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/profile"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/imageprovider"
 )
@@ -109,7 +109,7 @@ type ProvisionData struct {
 	Image           metal3v1alpha1.Image
 	HostConfig      HostConfigData
 	BootMode        metal3v1alpha1.BootMode
-	HardwareProfile hardware.Profile
+	HardwareProfile profile.Profile
 	RootDeviceHints *metal3v1alpha1.RootDeviceHints
 	CustomDeploy    *metal3v1alpha1.CustomDeploy
 }


### PR DESCRIPTION
Since this code now defines how we map one API concept (the hardware profile string) to default values for other API concepts (root device hints), it is effectively part of the API definition. It is also not expected to exist in future API versions. The webhook for translating hosts between versions will need to access this code, so it will need to be inside the API module. Finally, similar to the hardwareutils module, this is useful in other contexts and moving it out of the main module eliminates extraneous external dependencies being dragged with it.