### PR TITLE
Revert "🌱 Reduce the preprovisioning image retry delay"

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -54,7 +54,7 @@ import (
 const (
 	hostErrorRetryDelay           = time.Second * 10
 	unmanagedRetryDelay           = time.Minute * 10
-	preprovImageRetryDelay        = time.Second * 30
+	preprovImageRetryDelay        = time.Minute * 5
 	provisionerNotReadyRetryDelay = time.Second * 30
 	subResourceNotReadyRetryDelay = time.Second * 60
 	rebootAnnotationPrefix        = "reboot.metal3.io"


### PR DESCRIPTION
Quoting @zaneb:

> Hold on, the controller is [watching](https://github.com/metal3-io/baremetal-operator/blob/main/controllers/metal3.io/baremetalhost_controller.go#L1747) the PreprovisioningImage so it will be notified immediately when something changes.
> This delay is for how long before we pointlessly requeue the BMH when nothing has changed. If anything it should maybe be longer than 5 minutes so that we don't pointlessly hammer the API when e.g. the preprovisioning image controller is down.
> I think we should revert this.

Reverts metal3-io/baremetal-operator#1275