### PR TITLE
🌱 Remove explicit version when importing v1alpha1

### DIFF
--- a/controllers/metal3.io/bmceventsubscription_controller.go
+++ b/controllers/metal3.io/bmceventsubscription_controller.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/secretutils"
 	"github.com/metal3-io/baremetal-operator/pkg/utils"
@@ -64,7 +64,7 @@ func (r *BMCEventSubscriptionReconciler) Reconcile(ctx context.Context, request 
 	}()
 
 	// Fetch the BMCEventSubscription
-	subscription := &metal3v1alpha1.BMCEventSubscription{}
+	subscription := &metal3api.BMCEventSubscription{}
 	err = r.Get(ctx, request.NamespacedName, subscription)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -78,7 +78,7 @@ func (r *BMCEventSubscriptionReconciler) Reconcile(ctx context.Context, request 
 		return ctrl.Result{}, errors.Wrap(err, "could not load subscription")
 	}
 
-	host := &metal3v1alpha1.BareMetalHost{}
+	host := &metal3api.BareMetalHost{}
 	namespacedHostName := types.NamespacedName{
 		Name:      subscription.Spec.HostName,
 		Namespace: request.Namespace,
@@ -130,7 +130,7 @@ func (r *BMCEventSubscriptionReconciler) Reconcile(ctx context.Context, request 
 
 }
 
-func (r *BMCEventSubscriptionReconciler) handleError(ctx context.Context, subscription *metal3v1alpha1.BMCEventSubscription, e error, message string, requeue bool) (ctrl.Result, error) {
+func (r *BMCEventSubscriptionReconciler) handleError(ctx context.Context, subscription *metal3api.BMCEventSubscription, e error, message string, requeue bool) (ctrl.Result, error) {
 	subscription.Status.Error = message
 	err := r.Status().Update(ctx, subscription)
 	if err != nil {
@@ -145,7 +145,7 @@ func (r *BMCEventSubscriptionReconciler) handleError(ctx context.Context, subscr
 
 }
 
-func (r *BMCEventSubscriptionReconciler) addFinalizer(ctx context.Context, subscription *metal3v1alpha1.BMCEventSubscription) error {
+func (r *BMCEventSubscriptionReconciler) addFinalizer(ctx context.Context, subscription *metal3api.BMCEventSubscription) error {
 	reqLogger := r.Log.WithName("bmceventsubscription")
 
 	// Add a finalizer to newly created objects.
@@ -153,10 +153,10 @@ func (r *BMCEventSubscriptionReconciler) addFinalizer(ctx context.Context, subsc
 		reqLogger.Info(
 			"adding finalizer",
 			"existingFinalizers", subscription.Finalizers,
-			"newValue", metal3v1alpha1.BMCEventSubscriptionFinalizer,
+			"newValue", metal3api.BMCEventSubscriptionFinalizer,
 		)
 		subscription.Finalizers = append(subscription.Finalizers,
-			metal3v1alpha1.BMCEventSubscriptionFinalizer)
+			metal3api.BMCEventSubscriptionFinalizer)
 		err := r.Update(ctx, subscription)
 		if err != nil {
 			return errors.Wrap(err, "failed to add finalizer")
@@ -167,7 +167,7 @@ func (r *BMCEventSubscriptionReconciler) addFinalizer(ctx context.Context, subsc
 	return nil
 }
 
-func (r *BMCEventSubscriptionReconciler) createSubscription(ctx context.Context, prov provisioner.Provisioner, subscription *metal3v1alpha1.BMCEventSubscription) error {
+func (r *BMCEventSubscriptionReconciler) createSubscription(ctx context.Context, prov provisioner.Provisioner, subscription *metal3api.BMCEventSubscription) error {
 	reqLogger := r.Log.WithName("bmceventsubscription")
 
 	if subscription.Status.SubscriptionID != "" {
@@ -194,7 +194,7 @@ func (r *BMCEventSubscriptionReconciler) createSubscription(ctx context.Context,
 	return r.Status().Update(ctx, subscription)
 }
 
-func (r *BMCEventSubscriptionReconciler) deleteSubscription(ctx context.Context, prov provisioner.Provisioner, subscription *metal3v1alpha1.BMCEventSubscription) error {
+func (r *BMCEventSubscriptionReconciler) deleteSubscription(ctx context.Context, prov provisioner.Provisioner, subscription *metal3api.BMCEventSubscription) error {
 	reqLogger := r.Log.WithName("bmceventsubscription")
 	reqLogger.Info("deleting subscription")
 
@@ -205,7 +205,7 @@ func (r *BMCEventSubscriptionReconciler) deleteSubscription(ctx context.Context,
 
 		// Remove finalizer to allow deletion
 		subscription.Finalizers = utils.FilterStringFromList(
-			subscription.Finalizers, metal3v1alpha1.BMCEventSubscriptionFinalizer)
+			subscription.Finalizers, metal3api.BMCEventSubscriptionFinalizer)
 		reqLogger.Info("cleanup is complete, removed finalizer",
 			"remaining", subscription.Finalizers)
 		if err := r.Update(context.Background(), subscription); err != nil {
@@ -216,7 +216,7 @@ func (r *BMCEventSubscriptionReconciler) deleteSubscription(ctx context.Context,
 	return nil
 }
 
-func (r *BMCEventSubscriptionReconciler) getProvisioner(request ctrl.Request, host *metal3v1alpha1.BareMetalHost) (prov provisioner.Provisioner, ready bool, err error) {
+func (r *BMCEventSubscriptionReconciler) getProvisioner(request ctrl.Request, host *metal3api.BareMetalHost) (prov provisioner.Provisioner, ready bool, err error) {
 	reqLogger := r.Log.WithValues("bmceventsubscription", request.NamespacedName)
 
 	prov, err = r.ProvisionerFactory.NewProvisioner(provisioner.BuildHostDataNoBMC(*host), nil)
@@ -241,7 +241,7 @@ func (r *BMCEventSubscriptionReconciler) secretManager(log logr.Logger) secretut
 	return secretutils.NewSecretManager(log, r.Client, r.APIReader)
 }
 
-func (r *BMCEventSubscriptionReconciler) getHTTPHeaders(subscription metal3v1alpha1.BMCEventSubscription) ([]map[string]string, error) {
+func (r *BMCEventSubscriptionReconciler) getHTTPHeaders(subscription metal3api.BMCEventSubscription) ([]map[string]string, error) {
 	headers := []map[string]string{}
 
 	if subscription.Spec.HTTPHeadersRef == nil {
@@ -270,8 +270,8 @@ func (r *BMCEventSubscriptionReconciler) getHTTPHeaders(subscription metal3v1alp
 }
 
 func (r *BMCEventSubscriptionReconciler) updateEventHandler(e event.UpdateEvent) bool {
-	_, oldOK := e.ObjectOld.(*metal3v1alpha1.BMCEventSubscription)
-	_, newOK := e.ObjectNew.(*metal3v1alpha1.BMCEventSubscription)
+	_, oldOK := e.ObjectOld.(*metal3api.BMCEventSubscription)
+	_, newOK := e.ObjectNew.(*metal3api.BMCEventSubscription)
 	if !(oldOK && newOK) {
 		return true
 	}
@@ -292,14 +292,14 @@ func (r *BMCEventSubscriptionReconciler) updateEventHandler(e event.UpdateEvent)
 // SetupWithManager registers the reconciler to be run by the manager
 func (r *BMCEventSubscriptionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&metal3v1alpha1.BMCEventSubscription{}).
+		For(&metal3api.BMCEventSubscription{}).
 		WithEventFilter(predicate.Funcs{
 			UpdateFunc: r.updateEventHandler,
 		}).
-		Watches(&source.Kind{Type: &metal3v1alpha1.BareMetalHost{}}, &handler.EnqueueRequestForObject{}, builder.Predicates{}).
+		Watches(&source.Kind{Type: &metal3api.BareMetalHost{}}, &handler.EnqueueRequestForObject{}, builder.Predicates{}).
 		Complete(r)
 }
 
-func subscriptionHasFinalizer(subscription *metal3v1alpha1.BMCEventSubscription) bool {
-	return utils.StringInList(subscription.Finalizers, metal3v1alpha1.BMCEventSubscriptionFinalizer)
+func subscriptionHasFinalizer(subscription *metal3api.BMCEventSubscription) bool {
+	return utils.StringInList(subscription.Finalizers, metal3api.BMCEventSubscriptionFinalizer)
 }

--- a/controllers/metal3.io/controller_test.go
+++ b/controllers/metal3.io/controller_test.go
@@ -5,11 +5,11 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	logz "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 )
 
 func init() {
 	logf.SetLogger(logz.New(logz.UseDevMode(true)))
 	// Register our package types with the global scheme
-	metal3v1alpha1.AddToScheme(scheme.Scheme)
+	metal3api.AddToScheme(scheme.Scheme)
 }

--- a/controllers/metal3.io/demo_test.go
+++ b/controllers/metal3.io/demo_test.go
@@ -10,7 +10,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/demo"
 )
 
@@ -36,7 +36,7 @@ func TestDemoRegistrationError(t *testing.T) {
 	r := newDemoReconciler(host)
 
 	tryReconcile(t, r, host,
-		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
+		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
 			t.Logf("Status: %q State: %q ErrorMessage: %q",
 				host.OperationalStatus(),
 				host.Status.Provisioning.State,
@@ -54,13 +54,13 @@ func TestDemoRegistering(t *testing.T) {
 	r := newDemoReconciler(host)
 
 	tryReconcile(t, r, host,
-		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
+		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
 			t.Logf("Status: %q State: %q ErrorMessage: %q",
 				host.OperationalStatus(),
 				host.Status.Provisioning.State,
 				host.Status.ErrorMessage,
 			)
-			return host.Status.Provisioning.State == metal3v1alpha1.StateRegistering
+			return host.Status.Provisioning.State == metal3api.StateRegistering
 		},
 	)
 }
@@ -72,20 +72,20 @@ func TestDemoInspecting(t *testing.T) {
 	r := newDemoReconciler(host)
 
 	tryReconcile(t, r, host,
-		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
+		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
 			t.Logf("Status: %q State: %q ErrorMessage: %q",
 				host.OperationalStatus(),
 				host.Status.Provisioning.State,
 				host.Status.ErrorMessage,
 			)
-			return host.Status.Provisioning.State == metal3v1alpha1.StateInspecting
+			return host.Status.Provisioning.State == metal3api.StateInspecting
 		},
 	)
 }
 
 func TestDemoPreparing(t *testing.T) {
 	host := newDefaultNamedHost(demo.PreparingHost, t)
-	host.Spec.Image = &metal3v1alpha1.Image{
+	host.Spec.Image = &metal3api.Image{
 		URL:      "a-url",
 		Checksum: "a-checksum",
 	}
@@ -93,20 +93,20 @@ func TestDemoPreparing(t *testing.T) {
 	r := newDemoReconciler(host)
 
 	tryReconcile(t, r, host,
-		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
+		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
 			t.Logf("Status: %q State: %q ErrorMessage: %q",
 				host.OperationalStatus(),
 				host.Status.Provisioning.State,
 				host.Status.ErrorMessage,
 			)
-			return host.Status.Provisioning.State == metal3v1alpha1.StatePreparing
+			return host.Status.Provisioning.State == metal3api.StatePreparing
 		},
 	)
 }
 
 func TestDemoPreparingError(t *testing.T) {
 	host := newDefaultNamedHost(demo.PreparingErrorHost, t)
-	host.Spec.Image = &metal3v1alpha1.Image{
+	host.Spec.Image = &metal3api.Image{
 		URL:      "a-url",
 		Checksum: "a-checksum",
 	}
@@ -114,13 +114,13 @@ func TestDemoPreparingError(t *testing.T) {
 	r := newDemoReconciler(host)
 
 	tryReconcile(t, r, host,
-		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
+		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
 			t.Logf("Status: %q State: %q ErrorMessage: %q",
 				host.OperationalStatus(),
 				host.Status.Provisioning.State,
 				host.Status.ErrorMessage,
 			)
-			return host.Status.Provisioning.State == metal3v1alpha1.StatePreparing
+			return host.Status.Provisioning.State == metal3api.StatePreparing
 		},
 	)
 }
@@ -132,13 +132,13 @@ func TestDemoAvailable(t *testing.T) {
 	r := newDemoReconciler(host)
 
 	tryReconcile(t, r, host,
-		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
+		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
 			t.Logf("Status: %q State: %q ErrorMessage: %q",
 				host.OperationalStatus(),
 				host.Status.Provisioning.State,
 				host.Status.ErrorMessage,
 			)
-			return host.Status.Provisioning.State == metal3v1alpha1.StateAvailable
+			return host.Status.Provisioning.State == metal3api.StateAvailable
 		},
 	)
 }
@@ -147,7 +147,7 @@ func TestDemoAvailable(t *testing.T) {
 // that it is being provisioned
 func TestDemoProvisioning(t *testing.T) {
 	host := newDefaultNamedHost(demo.ProvisioningHost, t)
-	host.Spec.Image = &metal3v1alpha1.Image{
+	host.Spec.Image = &metal3api.Image{
 		URL:      "a-url",
 		Checksum: "a-checksum",
 	}
@@ -155,13 +155,13 @@ func TestDemoProvisioning(t *testing.T) {
 	r := newDemoReconciler(host)
 
 	tryReconcile(t, r, host,
-		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
+		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
 			t.Logf("Status: %q State: %q ErrorMessage: %q",
 				host.OperationalStatus(),
 				host.Status.Provisioning.State,
 				host.Status.ErrorMessage,
 			)
-			return host.Status.Provisioning.State == metal3v1alpha1.StateProvisioning
+			return host.Status.Provisioning.State == metal3api.StateProvisioning
 		},
 	)
 }
@@ -170,7 +170,7 @@ func TestDemoProvisioning(t *testing.T) {
 // that it has been provisioned
 func TestDemoProvisioned(t *testing.T) {
 	host := newDefaultNamedHost(demo.ProvisionedHost, t)
-	host.Spec.Image = &metal3v1alpha1.Image{
+	host.Spec.Image = &metal3api.Image{
 		URL:      "a-url",
 		Checksum: "a-checksum",
 	}
@@ -178,13 +178,13 @@ func TestDemoProvisioned(t *testing.T) {
 	r := newDemoReconciler(host)
 
 	tryReconcile(t, r, host,
-		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
+		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
 			t.Logf("Status: %q State: %q ErrorMessage: %q",
 				host.OperationalStatus(),
 				host.Status.Provisioning.State,
 				host.Status.ErrorMessage,
 			)
-			return host.Status.Provisioning.State == metal3v1alpha1.StateProvisioned
+			return host.Status.Provisioning.State == metal3api.StateProvisioned
 		},
 	)
 }
@@ -193,7 +193,7 @@ func TestDemoProvisioned(t *testing.T) {
 // reports that it had and error while being provisioned
 func TestDemoValidationError(t *testing.T) {
 	host := newDefaultNamedHost(demo.ValidationErrorHost, t)
-	host.Spec.Image = &metal3v1alpha1.Image{
+	host.Spec.Image = &metal3api.Image{
 		URL:      "a-url",
 		Checksum: "a-checksum",
 	}
@@ -201,7 +201,7 @@ func TestDemoValidationError(t *testing.T) {
 	r := newDemoReconciler(host)
 
 	tryReconcile(t, r, host,
-		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
+		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
 			t.Logf("Status: %q State: %q ErrorMessage: %q",
 				host.OperationalStatus(),
 				host.Status.Provisioning.State,

--- a/controllers/metal3.io/host_config_data.go
+++ b/controllers/metal3.io/host_config_data.go
@@ -5,14 +5,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/secretutils"
 )
 
 // hostConfigData is an implementation of host configuration data interface.
 // Object is able to retrive data from secrets referenced in a host spec
 type hostConfigData struct {
-	host          *metal3v1alpha1.BareMetalHost
+	host          *metal3api.BareMetalHost
 	log           logr.Logger
 	secretManager secretutils.SecretManager
 }

--- a/controllers/metal3.io/host_config_data_test.go
+++ b/controllers/metal3.io/host_config_data_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/secretutils"
 
 	corev1 "k8s.io/api/core/v1"
@@ -24,14 +24,14 @@ func TestLabelSecrets(t *testing.T) {
 	testCases := []struct {
 		name     string
 		getter   func(hcd *hostConfigData) (string, error)
-		hostSpec *metal3v1alpha1.BareMetalHostSpec
+		hostSpec *metal3api.BareMetalHostSpec
 	}{
 		{
 			name: "user-data",
 			getter: func(hcd *hostConfigData) (string, error) {
 				return hcd.UserData()
 			},
-			hostSpec: &metal3v1alpha1.BareMetalHostSpec{
+			hostSpec: &metal3api.BareMetalHostSpec{
 				UserData: &corev1.SecretReference{
 					Name:      "user-data",
 					Namespace: namespace,
@@ -43,7 +43,7 @@ func TestLabelSecrets(t *testing.T) {
 			getter: func(hcd *hostConfigData) (string, error) {
 				return hcd.MetaData()
 			},
-			hostSpec: &metal3v1alpha1.BareMetalHostSpec{
+			hostSpec: &metal3api.BareMetalHostSpec{
 				MetaData: &corev1.SecretReference{
 					Name:      "meta-data",
 					Namespace: namespace,
@@ -55,7 +55,7 @@ func TestLabelSecrets(t *testing.T) {
 			getter: func(hcd *hostConfigData) (string, error) {
 				return hcd.NetworkData()
 			},
-			hostSpec: &metal3v1alpha1.BareMetalHostSpec{
+			hostSpec: &metal3api.BareMetalHostSpec{
 				NetworkData: &corev1.SecretReference{
 					Name:      "network-data",
 					Namespace: namespace,
@@ -93,7 +93,7 @@ func TestProvisionWithHostConfig(t *testing.T) {
 
 	testCases := []struct {
 		Scenario                 string
-		Host                     *metal3v1alpha1.BareMetalHost
+		Host                     *metal3api.BareMetalHost
 		UserDataSecret           *corev1.Secret
 		PreprovNetworkDataSecret *corev1.Secret
 		NetworkDataSecret        *corev1.Secret
@@ -107,8 +107,8 @@ func TestProvisionWithHostConfig(t *testing.T) {
 		{
 			Scenario: "host with user data only",
 			Host: newHost("host-user-data",
-				&metal3v1alpha1.BareMetalHostSpec{
-					BMC: metal3v1alpha1.BMCDetails{
+				&metal3api.BareMetalHostSpec{
+					BMC: metal3api.BMCDetails{
 						Address:         "ipmi://192.168.122.1:6233",
 						CredentialsName: defaultSecretName,
 					},
@@ -126,8 +126,8 @@ func TestProvisionWithHostConfig(t *testing.T) {
 		{
 			Scenario: "host with user data only, no namespace",
 			Host: newHost("host-user-data",
-				&metal3v1alpha1.BareMetalHostSpec{
-					BMC: metal3v1alpha1.BMCDetails{
+				&metal3api.BareMetalHostSpec{
+					BMC: metal3api.BMCDetails{
 						Address:         "ipmi://192.168.122.1:6233",
 						CredentialsName: defaultSecretName,
 					},
@@ -144,8 +144,8 @@ func TestProvisionWithHostConfig(t *testing.T) {
 		{
 			Scenario: "host with preprov network data only",
 			Host: newHost("host-user-data",
-				&metal3v1alpha1.BareMetalHostSpec{
-					BMC: metal3v1alpha1.BMCDetails{
+				&metal3api.BareMetalHostSpec{
+					BMC: metal3api.BMCDetails{
 						Address:         "ipmi://192.168.122.1:6233",
 						CredentialsName: defaultSecretName,
 					},
@@ -160,8 +160,8 @@ func TestProvisionWithHostConfig(t *testing.T) {
 		{
 			Scenario: "host with preprov and regular network data",
 			Host: newHost("host-user-data",
-				&metal3v1alpha1.BareMetalHostSpec{
-					BMC: metal3v1alpha1.BMCDetails{
+				&metal3api.BareMetalHostSpec{
+					BMC: metal3api.BMCDetails{
 						Address:         "ipmi://192.168.122.1:6233",
 						CredentialsName: defaultSecretName,
 					},
@@ -180,8 +180,8 @@ func TestProvisionWithHostConfig(t *testing.T) {
 		{
 			Scenario: "host with network data only",
 			Host: newHost("host-user-data",
-				&metal3v1alpha1.BareMetalHostSpec{
-					BMC: metal3v1alpha1.BMCDetails{
+				&metal3api.BareMetalHostSpec{
+					BMC: metal3api.BMCDetails{
 						Address:         "ipmi://192.168.122.1:6233",
 						CredentialsName: defaultSecretName,
 					},
@@ -199,8 +199,8 @@ func TestProvisionWithHostConfig(t *testing.T) {
 		{
 			Scenario: "host with network data only, no namespace",
 			Host: newHost("host-user-data",
-				&metal3v1alpha1.BareMetalHostSpec{
-					BMC: metal3v1alpha1.BMCDetails{
+				&metal3api.BareMetalHostSpec{
+					BMC: metal3api.BMCDetails{
 						Address:         "ipmi://192.168.122.1:6233",
 						CredentialsName: defaultSecretName,
 					},
@@ -217,8 +217,8 @@ func TestProvisionWithHostConfig(t *testing.T) {
 		{
 			Scenario: "host with metadata only",
 			Host: newHost("host-meta-data",
-				&metal3v1alpha1.BareMetalHostSpec{
-					BMC: metal3v1alpha1.BMCDetails{
+				&metal3api.BareMetalHostSpec{
+					BMC: metal3api.BMCDetails{
 						Address:         "ipmi://192.168.122.1:6233",
 						CredentialsName: defaultSecretName,
 					},
@@ -234,8 +234,8 @@ func TestProvisionWithHostConfig(t *testing.T) {
 		{
 			Scenario: "host with metadata only, no namespace",
 			Host: newHost("host-meta-data",
-				&metal3v1alpha1.BareMetalHostSpec{
-					BMC: metal3v1alpha1.BMCDetails{
+				&metal3api.BareMetalHostSpec{
+					BMC: metal3api.BMCDetails{
 						Address:         "ipmi://192.168.122.1:6233",
 						CredentialsName: defaultSecretName,
 					},
@@ -250,8 +250,8 @@ func TestProvisionWithHostConfig(t *testing.T) {
 		{
 			Scenario: "fall back to value",
 			Host: newHost("host-user-data",
-				&metal3v1alpha1.BareMetalHostSpec{
-					BMC: metal3v1alpha1.BMCDetails{
+				&metal3api.BareMetalHostSpec{
+					BMC: metal3api.BMCDetails{
 						Address:         "ipmi://192.168.122.1:6233",
 						CredentialsName: defaultSecretName,
 					},
@@ -269,8 +269,8 @@ func TestProvisionWithHostConfig(t *testing.T) {
 		{
 			Scenario: "host with non-existent network data",
 			Host: newHost("host-user-data",
-				&metal3v1alpha1.BareMetalHostSpec{
-					BMC: metal3v1alpha1.BMCDetails{
+				&metal3api.BareMetalHostSpec{
+					BMC: metal3api.BMCDetails{
 						Address:         "ipmi://192.168.122.1:6233",
 						CredentialsName: defaultSecretName,
 					},
@@ -287,8 +287,8 @@ func TestProvisionWithHostConfig(t *testing.T) {
 		{
 			Scenario: "host with wrong key in network data secret",
 			Host: newHost("host-user-data",
-				&metal3v1alpha1.BareMetalHostSpec{
-					BMC: metal3v1alpha1.BMCDetails{
+				&metal3api.BareMetalHostSpec{
+					BMC: metal3api.BMCDetails{
 						Address:         "ipmi://192.168.122.1:6233",
 						CredentialsName: defaultSecretName,
 					},
@@ -306,8 +306,8 @@ func TestProvisionWithHostConfig(t *testing.T) {
 		{
 			Scenario: "host without keys in user data secret",
 			Host: newHost("host-user-data",
-				&metal3v1alpha1.BareMetalHostSpec{
-					BMC: metal3v1alpha1.BMCDetails{
+				&metal3api.BareMetalHostSpec{
+					BMC: metal3api.BMCDetails{
 						Address:         "ipmi://192.168.122.1:6233",
 						CredentialsName: defaultSecretName,
 					},
@@ -326,7 +326,7 @@ func TestProvisionWithHostConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Scenario, func(t *testing.T) {
-			tc.Host.Spec.Image = &metal3v1alpha1.Image{
+			tc.Host.Spec.Image = &metal3api.Image{
 				URL:      "https://example.com/image-name",
 				Checksum: "12345",
 			}

--- a/controllers/metal3.io/host_state_machine.go
+++ b/controllers/metal3.io/host_state_machine.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 
 	"github.com/go-logr/logr"
@@ -15,14 +15,14 @@ import (
 // hostStateMachine is a finite state machine that manages transitions between
 // the states of a BareMetalHost.
 type hostStateMachine struct {
-	Host        *metal3v1alpha1.BareMetalHost
-	NextState   metal3v1alpha1.ProvisioningState
+	Host        *metal3api.BareMetalHost
+	NextState   metal3api.ProvisioningState
 	Reconciler  *BareMetalHostReconciler
 	Provisioner provisioner.Provisioner
 	haveCreds   bool
 }
 
-func newHostStateMachine(host *metal3v1alpha1.BareMetalHost,
+func newHostStateMachine(host *metal3api.BareMetalHost,
 	reconciler *BareMetalHostReconciler,
 	provisioner provisioner.Provisioner,
 	haveCreds bool) *hostStateMachine {
@@ -39,35 +39,35 @@ func newHostStateMachine(host *metal3v1alpha1.BareMetalHost,
 
 type stateHandler func(*reconcileInfo) actionResult
 
-func (hsm *hostStateMachine) handlers() map[metal3v1alpha1.ProvisioningState]stateHandler {
-	return map[metal3v1alpha1.ProvisioningState]stateHandler{
-		metal3v1alpha1.StateNone:                  hsm.handleNone,
-		metal3v1alpha1.StateUnmanaged:             hsm.handleUnmanaged,
-		metal3v1alpha1.StateRegistering:           hsm.handleRegistering,
-		metal3v1alpha1.StateInspecting:            hsm.handleInspecting,
-		metal3v1alpha1.StateExternallyProvisioned: hsm.handleExternallyProvisioned,
-		metal3v1alpha1.StateMatchProfile:          hsm.handleMatchProfile, // Backward compatibility, remove eventually
-		metal3v1alpha1.StatePreparing:             hsm.handlePreparing,
-		metal3v1alpha1.StateAvailable:             hsm.handleAvailable,
-		metal3v1alpha1.StateReady:                 hsm.handleAvailable,
-		metal3v1alpha1.StateProvisioning:          hsm.handleProvisioning,
-		metal3v1alpha1.StateProvisioned:           hsm.handleProvisioned,
-		metal3v1alpha1.StateDeprovisioning:        hsm.handleDeprovisioning,
-		metal3v1alpha1.StateDeleting:              hsm.handleDeleting,
+func (hsm *hostStateMachine) handlers() map[metal3api.ProvisioningState]stateHandler {
+	return map[metal3api.ProvisioningState]stateHandler{
+		metal3api.StateNone:                  hsm.handleNone,
+		metal3api.StateUnmanaged:             hsm.handleUnmanaged,
+		metal3api.StateRegistering:           hsm.handleRegistering,
+		metal3api.StateInspecting:            hsm.handleInspecting,
+		metal3api.StateExternallyProvisioned: hsm.handleExternallyProvisioned,
+		metal3api.StateMatchProfile:          hsm.handleMatchProfile, // Backward compatibility, remove eventually
+		metal3api.StatePreparing:             hsm.handlePreparing,
+		metal3api.StateAvailable:             hsm.handleAvailable,
+		metal3api.StateReady:                 hsm.handleAvailable,
+		metal3api.StateProvisioning:          hsm.handleProvisioning,
+		metal3api.StateProvisioned:           hsm.handleProvisioned,
+		metal3api.StateDeprovisioning:        hsm.handleDeprovisioning,
+		metal3api.StateDeleting:              hsm.handleDeleting,
 	}
 }
 
-func recordStateBegin(host *metal3v1alpha1.BareMetalHost, state metal3v1alpha1.ProvisioningState, time metav1.Time) {
+func recordStateBegin(host *metal3api.BareMetalHost, state metal3api.ProvisioningState, time metav1.Time) {
 	if nextMetric := host.OperationMetricForState(state); nextMetric != nil {
 		if nextMetric.Start.IsZero() || !nextMetric.End.IsZero() {
-			*nextMetric = metal3v1alpha1.OperationMetric{
+			*nextMetric = metal3api.OperationMetric{
 				Start: time,
 			}
 		}
 	}
 }
 
-func recordStateEnd(info *reconcileInfo, host *metal3v1alpha1.BareMetalHost, state metal3v1alpha1.ProvisioningState, time metav1.Time) (changed bool) {
+func recordStateEnd(info *reconcileInfo, host *metal3api.BareMetalHost, state metal3api.ProvisioningState, time metav1.Time) (changed bool) {
 	if prevMetric := host.OperationMetricForState(state); prevMetric != nil {
 		if !prevMetric.Start.IsZero() && prevMetric.End.IsZero() {
 			prevMetric.End = time
@@ -81,7 +81,7 @@ func recordStateEnd(info *reconcileInfo, host *metal3v1alpha1.BareMetalHost, sta
 	return
 }
 
-func (hsm *hostStateMachine) ensureCapacity(info *reconcileInfo, state metal3v1alpha1.ProvisioningState) actionResult {
+func (hsm *hostStateMachine) ensureCapacity(info *reconcileInfo, state metal3api.ProvisioningState) actionResult {
 	hasCapacity, err := hsm.Provisioner.HasCapacity()
 	if err != nil {
 		return actionError{errors.Wrap(err, "failed to determine current provisioner capacity")}
@@ -94,7 +94,7 @@ func (hsm *hostStateMachine) ensureCapacity(info *reconcileInfo, state metal3v1a
 	return nil
 }
 
-func (hsm *hostStateMachine) updateHostStateFrom(initialState metal3v1alpha1.ProvisioningState,
+func (hsm *hostStateMachine) updateHostStateFrom(initialState metal3api.ProvisioningState,
 	info *reconcileInfo) actionResult {
 	if hsm.NextState != initialState {
 
@@ -103,8 +103,8 @@ func (hsm *hostStateMachine) updateHostStateFrom(initialState metal3v1alpha1.Pro
 		// The check is limited to only the (de)provisioning states to
 		// avoid putting an excessive pressure on the provisioner
 		switch hsm.NextState {
-		case metal3v1alpha1.StateInspecting, metal3v1alpha1.StateProvisioning,
-			metal3v1alpha1.StateDeprovisioning:
+		case metal3api.StateInspecting, metal3api.StateProvisioning,
+			metal3api.StateDeprovisioning:
 			if actionRes := hsm.ensureCapacity(info, hsm.NextState); actionRes != nil {
 				return actionRes
 			}
@@ -126,9 +126,9 @@ func (hsm *hostStateMachine) updateHostStateFrom(initialState metal3v1alpha1.Pro
 		// the API. That means we can safely update any status fields
 		// along with the state.
 		switch hsm.NextState {
-		case metal3v1alpha1.StateRegistering,
-			metal3v1alpha1.StateInspecting,
-			metal3v1alpha1.StateProvisioning:
+		case metal3api.StateRegistering,
+			metal3api.StateInspecting,
+			metal3api.StateProvisioning:
 			// TODO: When the user-selectable profile field is
 			// removed, move saveHostProvisioningSettings() from the
 			// controller to this point. We can't move it yet because
@@ -147,7 +147,7 @@ func (hsm *hostStateMachine) updateHostStateFrom(initialState metal3v1alpha1.Pro
 func (hsm *hostStateMachine) checkDelayedHost(info *reconcileInfo) actionResult {
 
 	// Check if there's a free slot for hosts that have been previously delayed
-	if info.host.Status.OperationalStatus == metal3v1alpha1.OperationalStatusDelayed {
+	if info.host.Status.OperationalStatus == metal3api.OperationalStatusDelayed {
 		if actionRes := hsm.ensureCapacity(info, info.host.Status.Provisioning.State); actionRes != nil {
 			return actionRes
 		}
@@ -160,8 +160,8 @@ func (hsm *hostStateMachine) checkDelayedHost(info *reconcileInfo) actionResult 
 	// Make sure the check is re-applied when provisioning an
 	// host not yet tracked by the provisioner
 	switch info.host.Status.Provisioning.State {
-	case metal3v1alpha1.StateInspecting, metal3v1alpha1.StateProvisioning,
-		metal3v1alpha1.StateDeprovisioning:
+	case metal3api.StateInspecting, metal3api.StateProvisioning,
+		metal3api.StateDeprovisioning:
 		if actionRes := hsm.ensureCapacity(info, info.host.Status.Provisioning.State); actionRes != nil {
 			return actionRes
 		}
@@ -205,7 +205,7 @@ func (hsm *hostStateMachine) ReconcileState(info *reconcileInfo) (actionRes acti
 	return actionError{fmt.Errorf("No handler found for state \"%s\"", initialState)}
 }
 
-func updateBootModeStatus(host *metal3v1alpha1.BareMetalHost) bool {
+func updateBootModeStatus(host *metal3api.BareMetalHost) bool {
 	// Make sure we have saved the current boot mode value.
 	bootMode := host.BootMode()
 	if bootMode == host.Status.Provisioning.BootMode {
@@ -223,22 +223,22 @@ func (hsm *hostStateMachine) checkInitiateDelete(log logr.Logger) bool {
 
 	switch hsm.NextState {
 	default:
-		hsm.NextState = metal3v1alpha1.StateDeleting
-	case metal3v1alpha1.StateProvisioning, metal3v1alpha1.StateProvisioned:
-		if hsm.Host.OperationalStatus() == metal3v1alpha1.OperationalStatusDetached {
+		hsm.NextState = metal3api.StateDeleting
+	case metal3api.StateProvisioning, metal3api.StateProvisioned:
+		if hsm.Host.OperationalStatus() == metal3api.OperationalStatusDetached {
 			if delayDeleteForDetachedHost(hsm.Host) {
 				log.Info("Delaying detached host deletion")
 				deleteDelayedForDetached.Inc()
 				return false
 			}
-			hsm.NextState = metal3v1alpha1.StateDeleting
+			hsm.NextState = metal3api.StateDeleting
 		} else {
-			hsm.NextState = metal3v1alpha1.StateDeprovisioning
+			hsm.NextState = metal3api.StateDeprovisioning
 		}
-	case metal3v1alpha1.StateDeprovisioning:
+	case metal3api.StateDeprovisioning:
 		// Allow state machine to run to continue deprovisioning.
 		return false
-	case metal3v1alpha1.StateDeleting:
+	case metal3api.StateDeleting:
 		// Already in deleting state. Allow state machine to run.
 		return false
 	}
@@ -246,24 +246,24 @@ func (hsm *hostStateMachine) checkInitiateDelete(log logr.Logger) bool {
 }
 
 // hasDetachedAnnotation checks for existence of baremetalhost.metal3.io/detached
-func hasDetachedAnnotation(host *metal3v1alpha1.BareMetalHost) bool {
+func hasDetachedAnnotation(host *metal3api.BareMetalHost) bool {
 	annotations := host.GetAnnotations()
 	if annotations != nil {
-		if _, ok := annotations[metal3v1alpha1.DetachedAnnotation]; ok {
+		if _, ok := annotations[metal3api.DetachedAnnotation]; ok {
 			return true
 		}
 	}
 	return false
 }
 
-func delayDeleteForDetachedHost(host *metal3v1alpha1.BareMetalHost) bool {
+func delayDeleteForDetachedHost(host *metal3api.BareMetalHost) bool {
 	annotations := host.GetAnnotations()
-	args := metal3v1alpha1.DetachedAnnotationArguments{}
-	val, present := annotations[metal3v1alpha1.DetachedAnnotation]
+	args := metal3api.DetachedAnnotationArguments{}
+	val, present := annotations[metal3api.DetachedAnnotation]
 
 	// if the host is detached, but missing the annotation, also delay delete
 	// to allow for the host to be re-attached
-	if !present && host.OperationalStatus() == metal3v1alpha1.OperationalStatusDetached {
+	if !present && host.OperationalStatus() == metal3api.OperationalStatusDetached {
 		return true
 	}
 
@@ -274,7 +274,7 @@ func delayDeleteForDetachedHost(host *metal3v1alpha1.BareMetalHost) bool {
 		}
 	}
 
-	return args.DeleteAction == metal3v1alpha1.DetachedDeleteActionDelay
+	return args.DeleteAction == metal3api.DetachedDeleteActionDelay
 }
 
 func (hsm *hostStateMachine) checkDetachedHost(info *reconcileInfo) (result actionResult) {
@@ -284,20 +284,20 @@ func (hsm *hostStateMachine) checkDetachedHost(info *reconcileInfo) (result acti
 	if hasDetachedAnnotation(hsm.Host) {
 		// Only allow detaching hosts in Provisioned/ExternallyProvisioned/Ready/Available states
 		switch info.host.Status.Provisioning.State {
-		case metal3v1alpha1.StateProvisioned, metal3v1alpha1.StateExternallyProvisioned, metal3v1alpha1.StateReady, metal3v1alpha1.StateAvailable:
+		case metal3api.StateProvisioned, metal3api.StateExternallyProvisioned, metal3api.StateReady, metal3api.StateAvailable:
 			return hsm.Reconciler.detachHost(hsm.Provisioner, info)
 		}
 	}
-	if info.host.Status.ErrorType == metal3v1alpha1.DetachError {
+	if info.host.Status.ErrorType == metal3api.DetachError {
 		clearError(info.host)
 		hsm.Host.Status.ErrorCount = 0
 		info.log.Info("removed detach error")
 		return actionUpdate{}
 	}
-	if info.host.OperationalStatus() == metal3v1alpha1.OperationalStatusDetached {
-		newStatus := metal3v1alpha1.OperationalStatusOK
+	if info.host.OperationalStatus() == metal3api.OperationalStatusDetached {
+		newStatus := metal3api.OperationalStatusOK
 		if info.host.Status.ErrorType != "" {
-			newStatus = metal3v1alpha1.OperationalStatusError
+			newStatus = metal3api.OperationalStatusError
 		}
 		info.host.SetOperationalStatus(newStatus)
 		info.log.Info("removed detached status")
@@ -315,30 +315,30 @@ func (hsm *hostStateMachine) ensureRegistered(info *reconcileInfo) (result actio
 	}
 
 	switch hsm.NextState {
-	case metal3v1alpha1.StateNone, metal3v1alpha1.StateUnmanaged:
+	case metal3api.StateNone, metal3api.StateUnmanaged:
 		// We haven't yet reached the Registration state, so don't attempt
 		// to register the Host.
 		return
-	case metal3v1alpha1.StateMatchProfile:
+	case metal3api.StateMatchProfile:
 		// Backward compatibility, remove eventually
 		return
-	case metal3v1alpha1.StateDeleting:
+	case metal3api.StateDeleting:
 		// In the deleting state the whole idea is to de-register the host
 		return
-	case metal3v1alpha1.StateRegistering:
+	case metal3api.StateRegistering:
 	default:
-		if hsm.Host.Status.ErrorType == metal3v1alpha1.RegistrationError ||
+		if hsm.Host.Status.ErrorType == metal3api.RegistrationError ||
 			!hsm.Host.Status.GoodCredentials.Match(*info.bmcCredsSecret) {
 			info.log.Info("Retrying registration")
-			recordStateBegin(hsm.Host, metal3v1alpha1.StateRegistering, metav1.Now())
+			recordStateBegin(hsm.Host, metal3api.StateRegistering, metav1.Now())
 		}
 	}
 
 	result = hsm.Reconciler.registerHost(hsm.Provisioner, info)
 	_, complete := result.(actionComplete)
 	if (result == nil || complete) &&
-		hsm.NextState != metal3v1alpha1.StateRegistering {
-		if recordStateEnd(info, hsm.Host, metal3v1alpha1.StateRegistering, metav1.Now()) {
+		hsm.NextState != metal3api.StateRegistering {
+		if recordStateEnd(info, hsm.Host, metal3api.StateRegistering, metav1.Now()) {
 			result = actionUpdate{}
 		}
 	}
@@ -351,11 +351,11 @@ func (hsm *hostStateMachine) ensureRegistered(info *reconcileInfo) (result actio
 func (hsm *hostStateMachine) handleNone(info *reconcileInfo) actionResult {
 	// No state is set, so immediately move to either Registering or Unmanaged
 	if hsm.Host.HasBMCDetails() {
-		hsm.NextState = metal3v1alpha1.StateRegistering
+		hsm.NextState = metal3api.StateRegistering
 	} else {
 		info.publishEvent("Discovered", "Discovered host with no BMC details")
-		hsm.Host.SetOperationalStatus(metal3v1alpha1.OperationalStatusDiscovered)
-		hsm.NextState = metal3v1alpha1.StateUnmanaged
+		hsm.Host.SetOperationalStatus(metal3api.OperationalStatusDiscovered)
+		hsm.NextState = metal3api.StateUnmanaged
 		hostUnmanaged.Inc()
 	}
 	return actionComplete{}
@@ -364,7 +364,7 @@ func (hsm *hostStateMachine) handleNone(info *reconcileInfo) actionResult {
 func (hsm *hostStateMachine) handleUnmanaged(info *reconcileInfo) actionResult {
 	actResult := hsm.Reconciler.actionUnmanaged(hsm.Provisioner, info)
 	if _, complete := actResult.(actionComplete); complete {
-		hsm.NextState = metal3v1alpha1.StateRegistering
+		hsm.NextState = metal3api.StateRegistering
 	}
 	return actResult
 }
@@ -375,11 +375,11 @@ func (hsm *hostStateMachine) handleRegistering(info *reconcileInfo) actionResult
 	// next state. We will not return to the Registering state, even
 	// if the credentials change and the Host must be re-registered.
 	if hsm.Host.Spec.ExternallyProvisioned {
-		hsm.NextState = metal3v1alpha1.StateExternallyProvisioned
+		hsm.NextState = metal3api.StateExternallyProvisioned
 	} else if inspectionDisabled(hsm.Host) {
-		hsm.NextState = metal3v1alpha1.StatePreparing
+		hsm.NextState = metal3api.StatePreparing
 	} else {
-		hsm.NextState = metal3v1alpha1.StateInspecting
+		hsm.NextState = metal3api.StateInspecting
 	}
 	hsm.Host.Status.ErrorCount = 0
 	return actionComplete{}
@@ -388,7 +388,7 @@ func (hsm *hostStateMachine) handleRegistering(info *reconcileInfo) actionResult
 func (hsm *hostStateMachine) handleInspecting(info *reconcileInfo) actionResult {
 	actResult := hsm.Reconciler.actionInspecting(hsm.Provisioner, info)
 	if _, complete := actResult.(actionComplete); complete {
-		hsm.NextState = metal3v1alpha1.StatePreparing
+		hsm.NextState = metal3api.StatePreparing
 		hsm.Host.Status.ErrorCount = 0
 	}
 	return actResult
@@ -396,7 +396,7 @@ func (hsm *hostStateMachine) handleInspecting(info *reconcileInfo) actionResult 
 
 func (hsm *hostStateMachine) handleMatchProfile(info *reconcileInfo) actionResult {
 	// Backward compatibility, remove eventually
-	hsm.NextState = metal3v1alpha1.StatePreparing
+	hsm.NextState = metal3api.StatePreparing
 	hsm.Host.Status.ErrorCount = 0
 	return actionComplete{}
 }
@@ -409,9 +409,9 @@ func (hsm *hostStateMachine) handleExternallyProvisioned(info *reconcileInfo) ac
 
 	// TODO(dtantsur): move this logic inside NeedsHardwareInspection?
 	if hsm.Host.NeedsHardwareInspection() && !inspectionDisabled(hsm.Host) {
-		hsm.NextState = metal3v1alpha1.StateInspecting
+		hsm.NextState = metal3api.StateInspecting
 	} else {
-		hsm.NextState = metal3v1alpha1.StatePreparing
+		hsm.NextState = metal3api.StatePreparing
 	}
 	return actionComplete{}
 }
@@ -420,27 +420,27 @@ func (hsm *hostStateMachine) handlePreparing(info *reconcileInfo) actionResult {
 	actResult := hsm.Reconciler.actionPreparing(hsm.Provisioner, info)
 	if _, complete := actResult.(actionComplete); complete {
 		hsm.Host.Status.ErrorCount = 0
-		hsm.NextState = metal3v1alpha1.StateAvailable
+		hsm.NextState = metal3api.StateAvailable
 	}
 	return actResult
 }
 
 func (hsm *hostStateMachine) handleAvailable(info *reconcileInfo) actionResult {
 	if hsm.Host.Spec.ExternallyProvisioned {
-		hsm.NextState = metal3v1alpha1.StateExternallyProvisioned
+		hsm.NextState = metal3api.StateExternallyProvisioned
 		clearHostProvisioningSettings(info.host)
 		return actionComplete{}
 	}
 
 	if hasInspectAnnotation(hsm.Host) {
-		hsm.NextState = metal3v1alpha1.StateInspecting
+		hsm.NextState = metal3api.StateInspecting
 		return actionComplete{}
 	}
 
 	if dirty, _, err := getHostProvisioningSettings(info.host, info); err != nil {
 		return actionError{err}
 	} else if dirty {
-		hsm.NextState = metal3v1alpha1.StatePreparing
+		hsm.NextState = metal3api.StatePreparing
 		return actionComplete{}
 	}
 
@@ -448,14 +448,14 @@ func (hsm *hostStateMachine) handleAvailable(info *reconcileInfo) actionResult {
 	if dirty, _, err := hsm.Reconciler.getHostFirmwareSettings(info); err != nil {
 		return actionError{err}
 	} else if dirty {
-		hsm.NextState = metal3v1alpha1.StatePreparing
+		hsm.NextState = metal3api.StatePreparing
 		return actionComplete{}
 	}
 
 	// ErrorCount is cleared when appropriate inside actionManageAvailable
 	actResult := hsm.Reconciler.actionManageAvailable(hsm.Provisioner, info)
 	if _, complete := actResult.(actionComplete); complete {
-		hsm.NextState = metal3v1alpha1.StateProvisioning
+		hsm.NextState = metal3api.StateProvisioning
 	}
 	return actResult
 }
@@ -500,13 +500,13 @@ func (hsm *hostStateMachine) imageProvisioningCancelled() bool {
 
 func (hsm *hostStateMachine) handleProvisioning(info *reconcileInfo) actionResult {
 	if hsm.Host.Status.ErrorType != "" || hsm.provisioningCancelled() {
-		hsm.NextState = metal3v1alpha1.StateDeprovisioning
+		hsm.NextState = metal3api.StateDeprovisioning
 		return actionComplete{}
 	}
 
 	actResult := hsm.Reconciler.actionProvisioning(hsm.Provisioner, info)
 	if _, complete := actResult.(actionComplete); complete {
-		hsm.NextState = metal3v1alpha1.StateProvisioned
+		hsm.NextState = metal3api.StateProvisioned
 		hsm.Host.Status.ErrorCount = 0
 	}
 	return actResult
@@ -514,7 +514,7 @@ func (hsm *hostStateMachine) handleProvisioning(info *reconcileInfo) actionResul
 
 func (hsm *hostStateMachine) handleProvisioned(info *reconcileInfo) actionResult {
 	if hsm.provisioningCancelled() {
-		hsm.NextState = metal3v1alpha1.StateDeprovisioning
+		hsm.NextState = metal3api.StateDeprovisioning
 		return actionComplete{}
 	}
 
@@ -527,19 +527,19 @@ func (hsm *hostStateMachine) handleDeprovisioning(info *reconcileInfo) actionRes
 
 	if hsm.Host.DeletionTimestamp.IsZero() {
 		if _, complete := actResult.(actionComplete); complete {
-			hsm.NextState = metal3v1alpha1.StateAvailable
+			hsm.NextState = metal3api.StateAvailable
 			hsm.Host.Status.ErrorCount = 0
 		}
 	} else {
 		skipToDelete := func() actionResult {
-			hsm.NextState = metal3v1alpha1.StateDeleting
+			hsm.NextState = metal3api.StateDeleting
 			info.postSaveCallbacks = append(info.postSaveCallbacks, deleteWithoutDeprov.Inc)
 			return actionComplete{}
 		}
 
 		switch r := actResult.(type) {
 		case actionComplete:
-			hsm.NextState = metal3v1alpha1.StateDeleting
+			hsm.NextState = metal3api.StateDeleting
 			hsm.Host.Status.ErrorCount = 0
 		case actionFailed:
 			// If the provisioner gives up deprovisioning and

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 
 	promutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -20,7 +20,7 @@ import (
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 )
 
-func testStateMachine(host *metal3v1alpha1.BareMetalHost) *hostStateMachine {
+func testStateMachine(host *metal3api.BareMetalHost) *hostStateMachine {
 	r := newTestReconciler()
 	p, _ := r.ProvisionerFactory.NewProvisioner(provisioner.BuildHostData(*host, bmc.Credentials{}),
 		func(reason, message string) {})
@@ -28,7 +28,7 @@ func testStateMachine(host *metal3v1alpha1.BareMetalHost) *hostStateMachine {
 }
 
 // Create a reconciler with a fake client to satisfy states that use the client
-func testNewReconciler(host *metal3v1alpha1.BareMetalHost) *BareMetalHostReconciler {
+func testNewReconciler(host *metal3api.BareMetalHost) *BareMetalHostReconciler {
 
 	c := fakeclient.NewFakeClient(host)
 	reconciler := &BareMetalHostReconciler{
@@ -45,99 +45,99 @@ func TestProvisioningCapacity(t *testing.T) {
 		Scenario string
 
 		HasProvisioningCapacity bool
-		Host                    *metal3v1alpha1.BareMetalHost
+		Host                    *metal3api.BareMetalHost
 
-		ExpectedProvisioningState metal3v1alpha1.ProvisioningState
+		ExpectedProvisioningState metal3api.ProvisioningState
 		ExpectedDelayed           bool
 	}{
 		{
 			Scenario:                "transition-to-inspecting-delayed",
-			Host:                    host(metal3v1alpha1.StateRegistering).build(),
+			Host:                    host(metal3api.StateRegistering).build(),
 			HasProvisioningCapacity: false,
 
-			ExpectedProvisioningState: metal3v1alpha1.StateRegistering,
+			ExpectedProvisioningState: metal3api.StateRegistering,
 			ExpectedDelayed:           true,
 		},
 		{
 			Scenario:                "transition-to-provisioning-delayed",
-			Host:                    host(metal3v1alpha1.StateAvailable).SaveHostProvisioningSettings().build(),
+			Host:                    host(metal3api.StateAvailable).SaveHostProvisioningSettings().build(),
 			HasProvisioningCapacity: false,
 
-			ExpectedProvisioningState: metal3v1alpha1.StateAvailable,
+			ExpectedProvisioningState: metal3api.StateAvailable,
 			ExpectedDelayed:           true,
 		},
 		{
 			Scenario:                "transition-to-provisioning-delayed-deprecated-ready",
-			Host:                    host(metal3v1alpha1.StateReady).SaveHostProvisioningSettings().build(),
+			Host:                    host(metal3api.StateReady).SaveHostProvisioningSettings().build(),
 			HasProvisioningCapacity: false,
 
-			ExpectedProvisioningState: metal3v1alpha1.StateReady,
+			ExpectedProvisioningState: metal3api.StateReady,
 			ExpectedDelayed:           true,
 		},
 		{
 			Scenario:                "transition-to-inspecting-ok",
-			Host:                    host(metal3v1alpha1.StateRegistering).build(),
+			Host:                    host(metal3api.StateRegistering).build(),
 			HasProvisioningCapacity: true,
 
-			ExpectedProvisioningState: metal3v1alpha1.StateInspecting,
+			ExpectedProvisioningState: metal3api.StateInspecting,
 			ExpectedDelayed:           false,
 		},
 		{
 			Scenario:                "transition-to-provisioning-ok",
-			Host:                    host(metal3v1alpha1.StateAvailable).SaveHostProvisioningSettings().build(),
+			Host:                    host(metal3api.StateAvailable).SaveHostProvisioningSettings().build(),
 			HasProvisioningCapacity: true,
 
-			ExpectedProvisioningState: metal3v1alpha1.StateProvisioning,
+			ExpectedProvisioningState: metal3api.StateProvisioning,
 			ExpectedDelayed:           false,
 		},
 
 		{
 			Scenario:                "already-delayed-delayed",
-			Host:                    host(metal3v1alpha1.StateAvailable).SetOperationalStatus(metal3v1alpha1.OperationalStatusDelayed).build(),
+			Host:                    host(metal3api.StateAvailable).SetOperationalStatus(metal3api.OperationalStatusDelayed).build(),
 			HasProvisioningCapacity: false,
 
-			ExpectedProvisioningState: metal3v1alpha1.StateAvailable,
+			ExpectedProvisioningState: metal3api.StateAvailable,
 			ExpectedDelayed:           true,
 		},
 		{
 			Scenario:                "already-delayed-ok",
-			Host:                    host(metal3v1alpha1.StateAvailable).SetOperationalStatus(metal3v1alpha1.OperationalStatusDelayed).build(),
+			Host:                    host(metal3api.StateAvailable).SetOperationalStatus(metal3api.OperationalStatusDelayed).build(),
 			HasProvisioningCapacity: true,
 
-			ExpectedProvisioningState: metal3v1alpha1.StateAvailable,
+			ExpectedProvisioningState: metal3api.StateAvailable,
 			ExpectedDelayed:           false,
 		},
 
 		{
 			Scenario:                "untracked-inspecting-delayed",
-			Host:                    host(metal3v1alpha1.StateInspecting).build(),
+			Host:                    host(metal3api.StateInspecting).build(),
 			HasProvisioningCapacity: false,
 
-			ExpectedProvisioningState: metal3v1alpha1.StateInspecting,
+			ExpectedProvisioningState: metal3api.StateInspecting,
 			ExpectedDelayed:           true,
 		},
 		{
 			Scenario:                "untracked-inspecting-ok",
-			Host:                    host(metal3v1alpha1.StateInspecting).build(),
+			Host:                    host(metal3api.StateInspecting).build(),
 			HasProvisioningCapacity: true,
 
-			ExpectedProvisioningState: metal3v1alpha1.StatePreparing,
+			ExpectedProvisioningState: metal3api.StatePreparing,
 			ExpectedDelayed:           false,
 		},
 		{
 			Scenario:                "untracked-inspecting-delayed",
-			Host:                    host(metal3v1alpha1.StateProvisioning).build(),
+			Host:                    host(metal3api.StateProvisioning).build(),
 			HasProvisioningCapacity: false,
 
-			ExpectedProvisioningState: metal3v1alpha1.StateProvisioning,
+			ExpectedProvisioningState: metal3api.StateProvisioning,
 			ExpectedDelayed:           true,
 		},
 		{
 			Scenario:                "untracked-provisioning-ok",
-			Host:                    host(metal3v1alpha1.StateProvisioning).build(),
+			Host:                    host(metal3api.StateProvisioning).build(),
 			HasProvisioningCapacity: true,
 
-			ExpectedProvisioningState: metal3v1alpha1.StateProvisioned,
+			ExpectedProvisioningState: metal3api.StateProvisioned,
 			ExpectedDelayed:           false,
 		},
 	}
@@ -154,7 +154,7 @@ func TestProvisioningCapacity(t *testing.T) {
 			result := hsm.ReconcileState(info)
 
 			assert.Equal(t, tc.ExpectedProvisioningState, tc.Host.Status.Provisioning.State)
-			assert.Equal(t, tc.ExpectedDelayed, metal3v1alpha1.OperationalStatusDelayed == tc.Host.Status.OperationalStatus, "Expected OperationalStatusDelayed")
+			assert.Equal(t, tc.ExpectedDelayed, metal3api.OperationalStatusDelayed == tc.Host.Status.OperationalStatus, "Expected OperationalStatusDelayed")
 			assert.Equal(t, tc.ExpectedDelayed, assert.ObjectsAreEqual(actionDelayed{}, result), "Expected actionDelayed")
 
 			if tc.ExpectedDelayed {
@@ -174,17 +174,17 @@ func TestDeprovisioningCapacity(t *testing.T) {
 		Scenario string
 
 		HasDeprovisioningCapacity bool
-		Host                      *metal3v1alpha1.BareMetalHost
+		Host                      *metal3api.BareMetalHost
 
-		ExpectedDeprovisioningState metal3v1alpha1.ProvisioningState
+		ExpectedDeprovisioningState metal3api.ProvisioningState
 		ExpectedDelayed             bool
 	}{
 		{
 			Scenario:                  "transition-to-deprovisionig-ready",
-			Host:                      host(metal3v1alpha1.StateDeprovisioning).build(),
+			Host:                      host(metal3api.StateDeprovisioning).build(),
 			HasDeprovisioningCapacity: true,
 
-			ExpectedDeprovisioningState: metal3v1alpha1.StateAvailable,
+			ExpectedDeprovisioningState: metal3api.StateAvailable,
 			ExpectedDelayed:             false,
 		},
 	}
@@ -201,7 +201,7 @@ func TestDeprovisioningCapacity(t *testing.T) {
 			result := hsm.ReconcileState(info)
 
 			assert.Equal(t, tc.ExpectedDeprovisioningState, tc.Host.Status.Provisioning.State)
-			assert.Equal(t, tc.ExpectedDelayed, metal3v1alpha1.OperationalStatusDelayed == tc.Host.Status.OperationalStatus, "Expected OperationalStatusDelayed")
+			assert.Equal(t, tc.ExpectedDelayed, metal3api.OperationalStatusDelayed == tc.Host.Status.OperationalStatus, "Expected OperationalStatusDelayed")
 			assert.Equal(t, tc.ExpectedDelayed, assert.ObjectsAreEqual(actionDelayed{}, result), "Expected actionDelayed")
 
 			if tc.ExpectedDelayed {
@@ -219,199 +219,199 @@ func TestDeprovisioningCapacity(t *testing.T) {
 func TestDetach(t *testing.T) {
 	testCases := []struct {
 		Scenario                  string
-		Host                      *metal3v1alpha1.BareMetalHost
+		Host                      *metal3api.BareMetalHost
 		HasDetachedAnnotation     bool
 		ExpectedDetach            bool
 		ExpectedDirty             bool
-		ExpectedOperationalStatus metal3v1alpha1.OperationalStatus
-		ExpectedState             metal3v1alpha1.ProvisioningState
+		ExpectedOperationalStatus metal3api.OperationalStatus
+		ExpectedState             metal3api.ProvisioningState
 	}{
 		{
 			Scenario:                  "ProvisionedHost",
-			Host:                      host(metal3v1alpha1.StateProvisioned).build(),
+			Host:                      host(metal3api.StateProvisioned).build(),
 			ExpectedDetach:            false,
 			ExpectedDirty:             false,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusOK,
-			ExpectedState:             metal3v1alpha1.StateProvisioned,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+			ExpectedState:             metal3api.StateProvisioned,
 		},
 		{
 			Scenario:                  "DetachProvisionedHost",
-			Host:                      host(metal3v1alpha1.StateProvisioned).build(),
+			Host:                      host(metal3api.StateProvisioned).build(),
 			HasDetachedAnnotation:     true,
 			ExpectedDetach:            true,
 			ExpectedDirty:             true,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusDetached,
-			ExpectedState:             metal3v1alpha1.StateProvisioned,
+			ExpectedOperationalStatus: metal3api.OperationalStatusDetached,
+			ExpectedState:             metal3api.StateProvisioned,
 		},
 		{
 			Scenario:                  "DeleteDetachedProvisionedHost",
-			Host:                      host(metal3v1alpha1.StateProvisioned).SetOperationalStatus(metal3v1alpha1.OperationalStatusDetached).setDeletion().build(),
+			Host:                      host(metal3api.StateProvisioned).SetOperationalStatus(metal3api.OperationalStatusDetached).setDeletion().build(),
 			HasDetachedAnnotation:     true,
 			ExpectedDetach:            false,
 			ExpectedDirty:             true,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusDetached,
+			ExpectedOperationalStatus: metal3api.OperationalStatusDetached,
 			// Should move to Deleting without any Deprovisioning
-			ExpectedState: metal3v1alpha1.StateDeleting,
+			ExpectedState: metal3api.StateDeleting,
 		},
 		{
 			Scenario:                  "ExternallyProvisionedHost",
-			Host:                      host(metal3v1alpha1.StateExternallyProvisioned).SetExternallyProvisioned().build(),
+			Host:                      host(metal3api.StateExternallyProvisioned).SetExternallyProvisioned().build(),
 			HasDetachedAnnotation:     false,
 			ExpectedDetach:            false,
 			ExpectedDirty:             false,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusOK,
-			ExpectedState:             metal3v1alpha1.StateExternallyProvisioned,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+			ExpectedState:             metal3api.StateExternallyProvisioned,
 		},
 		{
 			Scenario:                  "DetachExternallyProvisionedHost",
-			Host:                      host(metal3v1alpha1.StateExternallyProvisioned).SetExternallyProvisioned().build(),
+			Host:                      host(metal3api.StateExternallyProvisioned).SetExternallyProvisioned().build(),
 			HasDetachedAnnotation:     true,
 			ExpectedDetach:            true,
 			ExpectedDirty:             true,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusDetached,
-			ExpectedState:             metal3v1alpha1.StateExternallyProvisioned,
+			ExpectedOperationalStatus: metal3api.OperationalStatusDetached,
+			ExpectedState:             metal3api.StateExternallyProvisioned,
 		},
 		{
 			Scenario:                  "NoneHost",
-			Host:                      host(metal3v1alpha1.StateNone).build(),
+			Host:                      host(metal3api.StateNone).build(),
 			HasDetachedAnnotation:     true,
 			ExpectedDetach:            false,
 			ExpectedDirty:             true,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusDiscovered,
-			ExpectedState:             metal3v1alpha1.StateUnmanaged,
+			ExpectedOperationalStatus: metal3api.OperationalStatusDiscovered,
+			ExpectedState:             metal3api.StateUnmanaged,
 		},
 		{
 			Scenario:                  "UnmanagedHost",
-			Host:                      host(metal3v1alpha1.StateUnmanaged).build(),
+			Host:                      host(metal3api.StateUnmanaged).build(),
 			HasDetachedAnnotation:     true,
 			ExpectedDetach:            false,
 			ExpectedDirty:             false,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusOK,
-			ExpectedState:             metal3v1alpha1.StateUnmanaged,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+			ExpectedState:             metal3api.StateUnmanaged,
 		},
 		{
 			Scenario:                  "RegisteringHost",
-			Host:                      host(metal3v1alpha1.StateRegistering).build(),
+			Host:                      host(metal3api.StateRegistering).build(),
 			HasDetachedAnnotation:     true,
 			ExpectedDetach:            false,
 			ExpectedDirty:             true,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusOK,
-			ExpectedState:             metal3v1alpha1.StateInspecting,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+			ExpectedState:             metal3api.StateInspecting,
 		},
 		{
 			Scenario:                  "InspectingHost",
-			Host:                      host(metal3v1alpha1.StateInspecting).build(),
+			Host:                      host(metal3api.StateInspecting).build(),
 			HasDetachedAnnotation:     true,
 			ExpectedDetach:            false,
 			ExpectedDirty:             true,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusOK,
-			ExpectedState:             metal3v1alpha1.StatePreparing,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+			ExpectedState:             metal3api.StatePreparing,
 		},
 		{
 			Scenario:                  "DetachAvailableHost",
-			Host:                      host(metal3v1alpha1.StateAvailable).SetImageURL("").SetStatusPoweredOn(false).build(),
+			Host:                      host(metal3api.StateAvailable).SetImageURL("").SetStatusPoweredOn(false).build(),
 			HasDetachedAnnotation:     true,
 			ExpectedDetach:            true,
 			ExpectedDirty:             true,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusDetached,
-			ExpectedState:             metal3v1alpha1.StateAvailable,
+			ExpectedOperationalStatus: metal3api.OperationalStatusDetached,
+			ExpectedState:             metal3api.StateAvailable,
 		},
 		{
 			Scenario:                  "AttachAvailableHost",
-			Host:                      host(metal3v1alpha1.StateAvailable).SetImageURL("").SetStatusPoweredOn(false).build(),
+			Host:                      host(metal3api.StateAvailable).SetImageURL("").SetStatusPoweredOn(false).build(),
 			HasDetachedAnnotation:     false,
 			ExpectedDetach:            false,
 			ExpectedDirty:             true,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusOK,
-			ExpectedState:             metal3v1alpha1.StateAvailable,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+			ExpectedState:             metal3api.StateAvailable,
 		},
 		{
 			Scenario:                  "AvailableHost",
-			Host:                      host(metal3v1alpha1.StateAvailable).build(),
+			Host:                      host(metal3api.StateAvailable).build(),
 			HasDetachedAnnotation:     false,
 			ExpectedDetach:            false,
 			ExpectedDirty:             true,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusOK,
-			ExpectedState:             metal3v1alpha1.StateProvisioning,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+			ExpectedState:             metal3api.StateProvisioning,
 		},
 		{
 			Scenario:                  "DeprecatedReadyHost",
-			Host:                      host(metal3v1alpha1.StateReady).build(),
+			Host:                      host(metal3api.StateReady).build(),
 			HasDetachedAnnotation:     false,
 			ExpectedDetach:            false,
 			ExpectedDirty:             true,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusOK,
-			ExpectedState:             metal3v1alpha1.StateProvisioning,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+			ExpectedState:             metal3api.StateProvisioning,
 		},
 		{
 			Scenario:                  "PreparingHost",
-			Host:                      host(metal3v1alpha1.StatePreparing).build(),
+			Host:                      host(metal3api.StatePreparing).build(),
 			HasDetachedAnnotation:     true,
 			ExpectedDetach:            false,
 			ExpectedDirty:             true,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusOK,
-			ExpectedState:             metal3v1alpha1.StateAvailable,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+			ExpectedState:             metal3api.StateAvailable,
 		},
 		{
 			Scenario:                  "DetachAvailableHost",
-			Host:                      host(metal3v1alpha1.StateAvailable).SetImageURL("").SetStatusPoweredOn(false).build(),
+			Host:                      host(metal3api.StateAvailable).SetImageURL("").SetStatusPoweredOn(false).build(),
 			HasDetachedAnnotation:     true,
 			ExpectedDetach:            true,
 			ExpectedDirty:             true,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusDetached,
-			ExpectedState:             metal3v1alpha1.StateAvailable,
+			ExpectedOperationalStatus: metal3api.OperationalStatusDetached,
+			ExpectedState:             metal3api.StateAvailable,
 		},
 		{
 			Scenario:                  "AttachAvailableHost",
-			Host:                      host(metal3v1alpha1.StateAvailable).SetImageURL("").SetStatusPoweredOn(false).build(),
+			Host:                      host(metal3api.StateAvailable).SetImageURL("").SetStatusPoweredOn(false).build(),
 			HasDetachedAnnotation:     false,
 			ExpectedDetach:            false,
 			ExpectedDirty:             true,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusOK,
-			ExpectedState:             metal3v1alpha1.StateAvailable,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+			ExpectedState:             metal3api.StateAvailable,
 		},
 		{
 			Scenario:                  "AvailableHost",
-			Host:                      host(metal3v1alpha1.StateAvailable).build(),
+			Host:                      host(metal3api.StateAvailable).build(),
 			HasDetachedAnnotation:     false,
 			ExpectedDetach:            false,
 			ExpectedDirty:             true,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusOK,
-			ExpectedState:             metal3v1alpha1.StateProvisioning,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+			ExpectedState:             metal3api.StateProvisioning,
 		},
 		{
 			Scenario:                  "ProvisioningHost",
-			Host:                      host(metal3v1alpha1.StateProvisioning).build(),
+			Host:                      host(metal3api.StateProvisioning).build(),
 			HasDetachedAnnotation:     true,
 			ExpectedDetach:            false,
 			ExpectedDirty:             true,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusOK,
-			ExpectedState:             metal3v1alpha1.StateProvisioned,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+			ExpectedState:             metal3api.StateProvisioned,
 		},
 		{
 			Scenario:                  "DeprovisioningHost",
-			Host:                      host(metal3v1alpha1.StateDeprovisioning).build(),
+			Host:                      host(metal3api.StateDeprovisioning).build(),
 			HasDetachedAnnotation:     true,
 			ExpectedDetach:            false,
 			ExpectedDirty:             true,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusOK,
-			ExpectedState:             metal3v1alpha1.StateAvailable,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+			ExpectedState:             metal3api.StateAvailable,
 		},
 		{
 			Scenario:                  "DeletingHost",
-			Host:                      host(metal3v1alpha1.StateDeleting).setDeletion().build(),
+			Host:                      host(metal3api.StateDeleting).setDeletion().build(),
 			HasDetachedAnnotation:     true,
 			ExpectedDetach:            false,
 			ExpectedDirty:             false,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusOK,
-			ExpectedState:             metal3v1alpha1.StateDeleting,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+			ExpectedState:             metal3api.StateDeleting,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			if tc.HasDetachedAnnotation {
 				tc.Host.Annotations = map[string]string{
-					metal3v1alpha1.DetachedAnnotation: "true",
+					metal3api.DetachedAnnotation: "true",
 				}
 			}
 			prov := newMockProvisioner()
@@ -431,31 +431,31 @@ func TestDetach(t *testing.T) {
 func TestDetachError(t *testing.T) {
 	testCases := []struct {
 		Scenario                  string
-		Host                      *metal3v1alpha1.BareMetalHost
-		ExpectedOperationalStatus metal3v1alpha1.OperationalStatus
-		ExpectedState             metal3v1alpha1.ProvisioningState
+		Host                      *metal3api.BareMetalHost
+		ExpectedOperationalStatus metal3api.OperationalStatus
+		ExpectedState             metal3api.ProvisioningState
 		ClearError                bool
 		RemoveAnnotation          bool
 	}{
 		{
 			Scenario:                  "ProvisionerTemporaryError",
-			Host:                      host(metal3v1alpha1.StateProvisioned).build(),
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusDetached,
-			ExpectedState:             metal3v1alpha1.StateProvisioned,
+			Host:                      host(metal3api.StateProvisioned).build(),
+			ExpectedOperationalStatus: metal3api.OperationalStatusDetached,
+			ExpectedState:             metal3api.StateProvisioned,
 			ClearError:                true,
 		},
 		{
 			Scenario:                  "AnnotationRemovedAfterDetachError",
-			Host:                      host(metal3v1alpha1.StateProvisioned).build(),
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusOK,
-			ExpectedState:             metal3v1alpha1.StateProvisioned,
+			Host:                      host(metal3api.StateProvisioned).build(),
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+			ExpectedState:             metal3api.StateProvisioned,
 			RemoveAnnotation:          true,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			tc.Host.Annotations = map[string]string{
-				metal3v1alpha1.DetachedAnnotation: "true",
+				metal3api.DetachedAnnotation: "true",
 			}
 			prov := newMockProvisioner()
 			reconciler := testNewReconciler(tc.Host)
@@ -466,7 +466,7 @@ func TestDetachError(t *testing.T) {
 			result := hsm.ReconcileState(info)
 			assert.True(t, result.Dirty())
 			assert.Equal(t, 1, tc.Host.Status.ErrorCount)
-			assert.Equal(t, metal3v1alpha1.OperationalStatusError, info.host.OperationalStatus())
+			assert.Equal(t, metal3api.OperationalStatusError, info.host.OperationalStatus())
 			assert.Equal(t, v1alpha1.DetachError, info.host.Status.ErrorType)
 			assert.Equal(t, tc.ExpectedState, info.host.Status.Provisioning.State)
 
@@ -489,18 +489,18 @@ func TestDetachError(t *testing.T) {
 func TestProvisioningCancelled(t *testing.T) {
 	testCases := []struct {
 		Scenario string
-		Host     metal3v1alpha1.BareMetalHost
+		Host     metal3api.BareMetalHost
 		Expected bool
 	}{
 		{
 			Scenario: "with image url, unprovisioned",
-			Host: metal3v1alpha1.BareMetalHost{
+			Host: metal3api.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
 				},
-				Spec: metal3v1alpha1.BareMetalHostSpec{
-					Image: &metal3v1alpha1.Image{
+				Spec: metal3api.BareMetalHostSpec{
+					Image: &metal3api.Image{
 						URL: "not-empty",
 					},
 					Online: true,
@@ -511,13 +511,13 @@ func TestProvisioningCancelled(t *testing.T) {
 
 		{
 			Scenario: "with custom deploy, unprovisioned",
-			Host: metal3v1alpha1.BareMetalHost{
+			Host: metal3api.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
 				},
-				Spec: metal3v1alpha1.BareMetalHostSpec{
-					CustomDeploy: &metal3v1alpha1.CustomDeploy{
+				Spec: metal3api.BareMetalHostSpec{
+					CustomDeploy: &metal3api.CustomDeploy{
 						Method: "install_everything",
 					},
 					Online: true,
@@ -528,13 +528,13 @@ func TestProvisioningCancelled(t *testing.T) {
 
 		{
 			Scenario: "with image, unprovisioned",
-			Host: metal3v1alpha1.BareMetalHost{
+			Host: metal3api.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
 				},
-				Spec: metal3v1alpha1.BareMetalHostSpec{
-					Image:  &metal3v1alpha1.Image{},
+				Spec: metal3api.BareMetalHostSpec{
+					Image:  &metal3api.Image{},
 					Online: true,
 				},
 			},
@@ -543,12 +543,12 @@ func TestProvisioningCancelled(t *testing.T) {
 
 		{
 			Scenario: "without, unprovisioned",
-			Host: metal3v1alpha1.BareMetalHost{
+			Host: metal3api.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
 				},
-				Spec: metal3v1alpha1.BareMetalHostSpec{
+				Spec: metal3api.BareMetalHostSpec{
 					Online: true,
 				},
 			},
@@ -557,13 +557,13 @@ func TestProvisioningCancelled(t *testing.T) {
 
 		{
 			Scenario: "with image url, offline",
-			Host: metal3v1alpha1.BareMetalHost{
+			Host: metal3api.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
 				},
-				Spec: metal3v1alpha1.BareMetalHostSpec{
-					Image: &metal3v1alpha1.Image{
+				Spec: metal3api.BareMetalHostSpec{
+					Image: &metal3api.Image{
 						URL: "not-empty",
 					},
 					Online: false,
@@ -574,13 +574,13 @@ func TestProvisioningCancelled(t *testing.T) {
 
 		{
 			Scenario: "with custom deploy, offline",
-			Host: metal3v1alpha1.BareMetalHost{
+			Host: metal3api.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
 				},
-				Spec: metal3v1alpha1.BareMetalHostSpec{
-					CustomDeploy: &metal3v1alpha1.CustomDeploy{
+				Spec: metal3api.BareMetalHostSpec{
+					CustomDeploy: &metal3api.CustomDeploy{
 						Method: "install_everything",
 					},
 					Online: false,
@@ -591,20 +591,20 @@ func TestProvisioningCancelled(t *testing.T) {
 
 		{
 			Scenario: "provisioned with image",
-			Host: metal3v1alpha1.BareMetalHost{
+			Host: metal3api.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
 				},
-				Spec: metal3v1alpha1.BareMetalHostSpec{
-					Image: &metal3v1alpha1.Image{
+				Spec: metal3api.BareMetalHostSpec{
+					Image: &metal3api.Image{
 						URL: "same",
 					},
 					Online: true,
 				},
-				Status: metal3v1alpha1.BareMetalHostStatus{
-					Provisioning: metal3v1alpha1.ProvisionStatus{
-						Image: metal3v1alpha1.Image{
+				Status: metal3api.BareMetalHostStatus{
+					Provisioning: metal3api.ProvisionStatus{
+						Image: metal3api.Image{
 							URL: "same",
 						},
 					},
@@ -615,23 +615,23 @@ func TestProvisioningCancelled(t *testing.T) {
 
 		{
 			Scenario: "provisioned with error",
-			Host: metal3v1alpha1.BareMetalHost{
+			Host: metal3api.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
 				},
-				Spec: metal3v1alpha1.BareMetalHostSpec{
-					Image: &metal3v1alpha1.Image{
+				Spec: metal3api.BareMetalHostSpec{
+					Image: &metal3api.Image{
 						URL: "same",
 					},
 					Online: true,
 				},
-				Status: metal3v1alpha1.BareMetalHostStatus{
-					ErrorType:    metal3v1alpha1.ProvisionedRegistrationError,
+				Status: metal3api.BareMetalHostStatus{
+					ErrorType:    metal3api.ProvisionedRegistrationError,
 					ErrorMessage: "Adoption failed",
 					ErrorCount:   1,
-					Provisioning: metal3v1alpha1.ProvisionStatus{
-						Image: metal3v1alpha1.Image{
+					Provisioning: metal3api.ProvisionStatus{
+						Image: metal3api.Image{
 							URL: "same",
 						},
 					},
@@ -643,20 +643,20 @@ func TestProvisioningCancelled(t *testing.T) {
 		{
 
 			Scenario: "provisioned with custom deploy",
-			Host: metal3v1alpha1.BareMetalHost{
+			Host: metal3api.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
 				},
-				Spec: metal3v1alpha1.BareMetalHostSpec{
-					CustomDeploy: &metal3v1alpha1.CustomDeploy{
+				Spec: metal3api.BareMetalHostSpec{
+					CustomDeploy: &metal3api.CustomDeploy{
 						Method: "install_everything",
 					},
 					Online: true,
 				},
-				Status: metal3v1alpha1.BareMetalHostStatus{
-					Provisioning: metal3v1alpha1.ProvisionStatus{
-						CustomDeploy: &metal3v1alpha1.CustomDeploy{
+				Status: metal3api.BareMetalHostStatus{
+					Provisioning: metal3api.ProvisionStatus{
+						CustomDeploy: &metal3api.CustomDeploy{
 							Method: "install_everything",
 						},
 					},
@@ -667,17 +667,17 @@ func TestProvisioningCancelled(t *testing.T) {
 
 		{
 			Scenario: "removed image",
-			Host: metal3v1alpha1.BareMetalHost{
+			Host: metal3api.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
 				},
-				Spec: metal3v1alpha1.BareMetalHostSpec{
+				Spec: metal3api.BareMetalHostSpec{
 					Online: true,
 				},
-				Status: metal3v1alpha1.BareMetalHostStatus{
-					Provisioning: metal3v1alpha1.ProvisionStatus{
-						Image: metal3v1alpha1.Image{
+				Status: metal3api.BareMetalHostStatus{
+					Provisioning: metal3api.ProvisionStatus{
+						Image: metal3api.Image{
 							URL: "same",
 						},
 					},
@@ -688,17 +688,17 @@ func TestProvisioningCancelled(t *testing.T) {
 
 		{
 			Scenario: "removed custom deploy",
-			Host: metal3v1alpha1.BareMetalHost{
+			Host: metal3api.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
 				},
-				Spec: metal3v1alpha1.BareMetalHostSpec{
+				Spec: metal3api.BareMetalHostSpec{
 					Online: true,
 				},
-				Status: metal3v1alpha1.BareMetalHostStatus{
-					Provisioning: metal3v1alpha1.ProvisionStatus{
-						CustomDeploy: &metal3v1alpha1.CustomDeploy{
+				Status: metal3api.BareMetalHostStatus{
+					Provisioning: metal3api.ProvisionStatus{
+						CustomDeploy: &metal3api.CustomDeploy{
 							Method: "install_everything",
 						},
 					},
@@ -709,20 +709,20 @@ func TestProvisioningCancelled(t *testing.T) {
 
 		{
 			Scenario: "changed image",
-			Host: metal3v1alpha1.BareMetalHost{
+			Host: metal3api.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
 				},
-				Spec: metal3v1alpha1.BareMetalHostSpec{
-					Image: &metal3v1alpha1.Image{
+				Spec: metal3api.BareMetalHostSpec{
+					Image: &metal3api.Image{
 						URL: "not-empty",
 					},
 					Online: true,
 				},
-				Status: metal3v1alpha1.BareMetalHostStatus{
-					Provisioning: metal3v1alpha1.ProvisionStatus{
-						Image: metal3v1alpha1.Image{
+				Status: metal3api.BareMetalHostStatus{
+					Provisioning: metal3api.ProvisionStatus{
+						Image: metal3api.Image{
 							URL: "also-not-empty",
 						},
 					},
@@ -733,20 +733,20 @@ func TestProvisioningCancelled(t *testing.T) {
 
 		{
 			Scenario: "changed custom deploy",
-			Host: metal3v1alpha1.BareMetalHost{
+			Host: metal3api.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
 				},
-				Spec: metal3v1alpha1.BareMetalHostSpec{
-					CustomDeploy: &metal3v1alpha1.CustomDeploy{
+				Spec: metal3api.BareMetalHostSpec{
+					CustomDeploy: &metal3api.CustomDeploy{
 						Method: "install_not_everything",
 					},
 					Online: true,
 				},
-				Status: metal3v1alpha1.BareMetalHostStatus{
-					Provisioning: metal3v1alpha1.ProvisionStatus{
-						CustomDeploy: &metal3v1alpha1.CustomDeploy{
+				Status: metal3api.BareMetalHostStatus{
+					Provisioning: metal3api.ProvisionStatus{
+						CustomDeploy: &metal3api.CustomDeploy{
 							Method: "install_everything",
 						},
 					},
@@ -757,26 +757,26 @@ func TestProvisioningCancelled(t *testing.T) {
 
 		{
 			Scenario: "changed image with custom deploy",
-			Host: metal3v1alpha1.BareMetalHost{
+			Host: metal3api.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
 				},
-				Spec: metal3v1alpha1.BareMetalHostSpec{
-					Image: &metal3v1alpha1.Image{
+				Spec: metal3api.BareMetalHostSpec{
+					Image: &metal3api.Image{
 						URL: "not-empty",
 					},
-					CustomDeploy: &metal3v1alpha1.CustomDeploy{
+					CustomDeploy: &metal3api.CustomDeploy{
 						Method: "install_everything",
 					},
 					Online: true,
 				},
-				Status: metal3v1alpha1.BareMetalHostStatus{
-					Provisioning: metal3v1alpha1.ProvisionStatus{
-						Image: metal3v1alpha1.Image{
+				Status: metal3api.BareMetalHostStatus{
+					Provisioning: metal3api.ProvisionStatus{
+						Image: metal3api.Image{
 							URL: "also-not-empty",
 						},
-						CustomDeploy: &metal3v1alpha1.CustomDeploy{
+						CustomDeploy: &metal3api.CustomDeploy{
 							Method: "install_everything",
 						},
 					},
@@ -787,26 +787,26 @@ func TestProvisioningCancelled(t *testing.T) {
 
 		{
 			Scenario: "changed custom deploy with image",
-			Host: metal3v1alpha1.BareMetalHost{
+			Host: metal3api.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
 				},
-				Spec: metal3v1alpha1.BareMetalHostSpec{
-					Image: &metal3v1alpha1.Image{
+				Spec: metal3api.BareMetalHostSpec{
+					Image: &metal3api.Image{
 						URL: "not-empty",
 					},
-					CustomDeploy: &metal3v1alpha1.CustomDeploy{
+					CustomDeploy: &metal3api.CustomDeploy{
 						Method: "install_not_everything",
 					},
 					Online: true,
 				},
-				Status: metal3v1alpha1.BareMetalHostStatus{
-					Provisioning: metal3v1alpha1.ProvisionStatus{
-						Image: metal3v1alpha1.Image{
+				Status: metal3api.BareMetalHostStatus{
+					Provisioning: metal3api.ProvisionStatus{
+						Image: metal3api.Image{
 							URL: "not-empty",
 						},
-						CustomDeploy: &metal3v1alpha1.CustomDeploy{
+						CustomDeploy: &metal3api.CustomDeploy{
 							Method: "install_everything",
 						},
 					},
@@ -817,23 +817,23 @@ func TestProvisioningCancelled(t *testing.T) {
 
 		{
 			Scenario: "removed custom deploy with image",
-			Host: metal3v1alpha1.BareMetalHost{
+			Host: metal3api.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
 				},
-				Spec: metal3v1alpha1.BareMetalHostSpec{
-					Image: &metal3v1alpha1.Image{
+				Spec: metal3api.BareMetalHostSpec{
+					Image: &metal3api.Image{
 						URL: "not-empty",
 					},
 					Online: true,
 				},
-				Status: metal3v1alpha1.BareMetalHostStatus{
-					Provisioning: metal3v1alpha1.ProvisionStatus{
-						Image: metal3v1alpha1.Image{
+				Status: metal3api.BareMetalHostStatus{
+					Provisioning: metal3api.ProvisionStatus{
+						Image: metal3api.Image{
 							URL: "not-empty",
 						},
-						CustomDeploy: &metal3v1alpha1.CustomDeploy{
+						CustomDeploy: &metal3api.CustomDeploy{
 							Method: "install_everything",
 						},
 					},
@@ -861,77 +861,77 @@ func TestErrorCountIncreasedOnActionFailure(t *testing.T) {
 	poweroffError := "some details"
 	tests := []struct {
 		Scenario           string
-		Host               *metal3v1alpha1.BareMetalHost
+		Host               *metal3api.BareMetalHost
 		ProvisionerErrorOn string
 		originalError      string
 		ExpectedError      string
 	}{
 		{
 			Scenario:           "registration",
-			Host:               host(metal3v1alpha1.StateRegistering).build(),
+			Host:               host(metal3api.StateRegistering).build(),
 			ProvisionerErrorOn: "ValidateManagementAccess",
 			originalError:      defaultError,
 			ExpectedError:      defaultError,
 		},
 		{
 			Scenario:           "inspecting",
-			Host:               host(metal3v1alpha1.StateInspecting).build(),
+			Host:               host(metal3api.StateInspecting).build(),
 			ProvisionerErrorOn: "InspectHardware",
 			originalError:      defaultError,
 			ExpectedError:      defaultError,
 		},
 		{
 			Scenario:           "provisioning",
-			Host:               host(metal3v1alpha1.StateProvisioning).SetImageURL("imageSpecUrl").build(),
+			Host:               host(metal3api.StateProvisioning).SetImageURL("imageSpecUrl").build(),
 			ProvisionerErrorOn: "Provision",
 			originalError:      defaultError,
 			ExpectedError:      defaultError,
 		},
 		{
 			Scenario:           "deprovisioning",
-			Host:               host(metal3v1alpha1.StateDeprovisioning).build(),
+			Host:               host(metal3api.StateDeprovisioning).build(),
 			ProvisionerErrorOn: "Deprovision",
 			originalError:      defaultError,
 			ExpectedError:      defaultError,
 		},
 		{
 			Scenario:           "available-power-on",
-			Host:               host(metal3v1alpha1.StateAvailable).SetImageURL("").SetStatusPoweredOn(false).build(),
+			Host:               host(metal3api.StateAvailable).SetImageURL("").SetStatusPoweredOn(false).build(),
 			ProvisionerErrorOn: "PowerOn",
 			originalError:      defaultError,
 			ExpectedError:      defaultError,
 		},
 		{
 			Scenario:           "available-power-off",
-			Host:               host(metal3v1alpha1.StateAvailable).SetImageURL("").SetOnline(false).build(),
+			Host:               host(metal3api.StateAvailable).SetImageURL("").SetOnline(false).build(),
 			ProvisionerErrorOn: "PowerOff",
 			originalError:      poweroffError,
 			ExpectedError:      clarifySoftPoweroffFailure + poweroffError,
 		},
 		{
 			Scenario:           "deprecated-ready-power-on",
-			Host:               host(metal3v1alpha1.StateReady).SetImageURL("").SetStatusPoweredOn(false).build(),
+			Host:               host(metal3api.StateReady).SetImageURL("").SetStatusPoweredOn(false).build(),
 			ProvisionerErrorOn: "PowerOn",
 			originalError:      defaultError,
 			ExpectedError:      defaultError,
 		},
 		{
 			Scenario:           "deprecated-ready-power-off",
-			Host:               host(metal3v1alpha1.StateReady).SetImageURL("").SetOnline(false).build(),
+			Host:               host(metal3api.StateReady).SetImageURL("").SetOnline(false).build(),
 			ProvisionerErrorOn: "PowerOff",
 			originalError:      poweroffError,
 			ExpectedError:      clarifySoftPoweroffFailure + poweroffError,
 		},
 		{
 			Scenario:           "externally-provisioned-adopt-failed",
-			Host:               host(metal3v1alpha1.StateExternallyProvisioned).SetExternallyProvisioned().build(),
+			Host:               host(metal3api.StateExternallyProvisioned).SetExternallyProvisioned().build(),
 			ProvisionerErrorOn: "Adopt",
 			originalError:      defaultError,
 			ExpectedError:      defaultError,
 		},
 		{
 			Scenario:           "provisioned-adopt-failed",
-			Host:               host(metal3v1alpha1.StateProvisioned).build(),
+			Host:               host(metal3api.StateProvisioned).build(),
 			ProvisionerErrorOn: "Adopt",
 			originalError:      defaultError,
 			ExpectedError:      defaultError,
@@ -958,49 +958,49 @@ func TestErrorCountClearedOnStateTransition(t *testing.T) {
 
 	tests := []struct {
 		Scenario                     string
-		Host                         *metal3v1alpha1.BareMetalHost
-		TargetState                  metal3v1alpha1.ProvisioningState
+		Host                         *metal3api.BareMetalHost
+		TargetState                  metal3api.ProvisioningState
 		PreserveErrorCountOnComplete bool
 	}{
 		{
 			Scenario:    "registering-to-inspecting",
-			Host:        host(metal3v1alpha1.StateRegistering).build(),
-			TargetState: metal3v1alpha1.StateInspecting,
+			Host:        host(metal3api.StateRegistering).build(),
+			TargetState: metal3api.StateInspecting,
 		},
 		{
 			Scenario:    "registering-to-preparing",
-			Host:        host(metal3v1alpha1.StateRegistering).DisableInspection().build(),
-			TargetState: metal3v1alpha1.StatePreparing,
+			Host:        host(metal3api.StateRegistering).DisableInspection().build(),
+			TargetState: metal3api.StatePreparing,
 		},
 		{
 			Scenario:    "inspecting-to-preparing",
-			Host:        host(metal3v1alpha1.StateInspecting).build(),
-			TargetState: metal3v1alpha1.StatePreparing,
+			Host:        host(metal3api.StateInspecting).build(),
+			TargetState: metal3api.StatePreparing,
 		},
 		{
 			Scenario:    "matchprofile-to-preparing",
-			Host:        host(metal3v1alpha1.StateMatchProfile).build(),
-			TargetState: metal3v1alpha1.StatePreparing,
+			Host:        host(metal3api.StateMatchProfile).build(),
+			TargetState: metal3api.StatePreparing,
 		},
 		{
 			Scenario:    "preparing-to-ready",
-			Host:        host(metal3v1alpha1.StatePreparing).build(),
-			TargetState: metal3v1alpha1.StateAvailable,
+			Host:        host(metal3api.StatePreparing).build(),
+			TargetState: metal3api.StateAvailable,
 		},
 		{
 			Scenario:    "provisioning-to-provisioned",
-			Host:        host(metal3v1alpha1.StateProvisioning).build(),
-			TargetState: metal3v1alpha1.StateProvisioned,
+			Host:        host(metal3api.StateProvisioning).build(),
+			TargetState: metal3api.StateProvisioned,
 		},
 		{
 			Scenario:    "deprovisioning-to-ready",
-			Host:        host(metal3v1alpha1.StateDeprovisioning).build(),
-			TargetState: metal3v1alpha1.StateAvailable,
+			Host:        host(metal3api.StateDeprovisioning).build(),
+			TargetState: metal3api.StateAvailable,
 		},
 		{
 			Scenario:    "deprovisioning-to-deleting",
-			Host:        host(metal3v1alpha1.StateDeprovisioning).setDeletion().build(),
-			TargetState: metal3v1alpha1.StateDeleting,
+			Host:        host(metal3api.StateDeprovisioning).setDeletion().build(),
+			TargetState: metal3api.StateDeleting,
 		},
 	}
 	for _, tt := range tests {
@@ -1023,20 +1023,20 @@ func TestErrorClean(t *testing.T) {
 
 	tests := []struct {
 		Scenario    string
-		Host        *metal3v1alpha1.BareMetalHost
+		Host        *metal3api.BareMetalHost
 		SecretName  string
 		ExpectError bool
 	}{
 		{
 			Scenario: "clean-after-registration-error",
-			Host: host(metal3v1alpha1.StateInspecting).
-				SetStatusError(metal3v1alpha1.OperationalStatusError, metal3v1alpha1.RegistrationError, "some error", 1).
+			Host: host(metal3api.StateInspecting).
+				SetStatusError(metal3api.OperationalStatusError, metal3api.RegistrationError, "some error", 1).
 				build(),
 		},
 		{
 			Scenario: "clean-after-creds-change",
-			Host: host(metal3v1alpha1.StateAvailable).
-				SetStatusError(metal3v1alpha1.OperationalStatusError, metal3v1alpha1.InspectionError, "some error", 1).
+			Host: host(metal3api.StateAvailable).
+				SetStatusError(metal3api.OperationalStatusError, metal3api.InspectionError, "some error", 1).
 				build(),
 			SecretName: "NewCreds",
 		},
@@ -1070,56 +1070,56 @@ func TestErrorClean(t *testing.T) {
 func TestDeleteWaitsForDetach(t *testing.T) {
 	tests := []struct {
 		Scenario                  string
-		Host                      *metal3v1alpha1.BareMetalHost
-		ExpectedState             metal3v1alpha1.ProvisioningState
-		ExpectedOperationalStatus metal3v1alpha1.OperationalStatus
+		Host                      *metal3api.BareMetalHost
+		ExpectedState             metal3api.ProvisioningState
+		ExpectedOperationalStatus metal3api.OperationalStatus
 	}{
 		{
 			Scenario: "detached-delay",
-			Host: host(metal3v1alpha1.StateProvisioned).
-				SetOperationalStatus(metal3v1alpha1.OperationalStatusDetached).
+			Host: host(metal3api.StateProvisioned).
+				SetOperationalStatus(metal3api.OperationalStatusDetached).
 				setDeletion().
 				setDetached("{\"deleteAction\": \"delay\"}").
 				build(),
-			ExpectedState:             metal3v1alpha1.StateProvisioned,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusDetached,
+			ExpectedState:             metal3api.StateProvisioned,
+			ExpectedOperationalStatus: metal3api.OperationalStatusDetached,
 		},
 		{
 			Scenario: "detached-delete",
-			Host: host(metal3v1alpha1.StateProvisioned).
-				SetOperationalStatus(metal3v1alpha1.OperationalStatusDetached).
+			Host: host(metal3api.StateProvisioned).
+				SetOperationalStatus(metal3api.OperationalStatusDetached).
 				setDeletion().
 				setDetached("{\"deleteAction\": \"delete\"}").
 				build(),
-			ExpectedState:             metal3v1alpha1.StateDeleting,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusDetached,
+			ExpectedState:             metal3api.StateDeleting,
+			ExpectedOperationalStatus: metal3api.OperationalStatusDetached,
 		},
 		{
 			Scenario: "detached-not-json",
-			Host: host(metal3v1alpha1.StateProvisioned).
-				SetOperationalStatus(metal3v1alpha1.OperationalStatusDetached).
+			Host: host(metal3api.StateProvisioned).
+				SetOperationalStatus(metal3api.OperationalStatusDetached).
 				setDeletion().
 				setDetached("true").
 				build(),
-			ExpectedState:             metal3v1alpha1.StateDeleting,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusDetached,
+			ExpectedState:             metal3api.StateDeleting,
+			ExpectedOperationalStatus: metal3api.OperationalStatusDetached,
 		},
 		{
 			Scenario: "detached-no-annotation",
-			Host: host(metal3v1alpha1.StateProvisioned).
-				SetOperationalStatus(metal3v1alpha1.OperationalStatusDetached).
+			Host: host(metal3api.StateProvisioned).
+				SetOperationalStatus(metal3api.OperationalStatusDetached).
 				setDeletion().
 				build(),
-			ExpectedState:             metal3v1alpha1.StateProvisioned,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusOK,
+			ExpectedState:             metal3api.StateProvisioned,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
 		},
 		{
 			Scenario: "attached",
-			Host: host(metal3v1alpha1.StateProvisioned).
+			Host: host(metal3api.StateProvisioned).
 				setDeletion().
 				build(),
-			ExpectedState:             metal3v1alpha1.StateDeprovisioning,
-			ExpectedOperationalStatus: metal3v1alpha1.OperationalStatusOK,
+			ExpectedState:             metal3api.StateDeprovisioning,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
 		},
 	}
 	for _, tt := range tests {
@@ -1139,12 +1139,12 @@ func TestDeleteWaitsForDetach(t *testing.T) {
 }
 
 type hostBuilder struct {
-	metal3v1alpha1.BareMetalHost
+	metal3api.BareMetalHost
 }
 
-func host(state metal3v1alpha1.ProvisioningState) *hostBuilder {
+func host(state metal3api.ProvisioningState) *hostBuilder {
 
-	creds := metal3v1alpha1.CredentialsStatus{
+	creds := metal3api.CredentialsStatus{
 		Reference: &corev1.SecretReference{
 			Name:      "secretRefName",
 			Namespace: "secretNs",
@@ -1153,7 +1153,7 @@ func host(state metal3v1alpha1.ProvisioningState) *hostBuilder {
 	}
 
 	return &hostBuilder{
-		metal3v1alpha1.BareMetalHost{
+		metal3api.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
 				Namespace: "bar",
@@ -1165,29 +1165,29 @@ func host(state metal3v1alpha1.ProvisioningState) *hostBuilder {
 				},
 				RootDeviceHints: &v1alpha1.RootDeviceHints{},
 			},
-			Status: metal3v1alpha1.BareMetalHostStatus{
+			Status: metal3api.BareMetalHostStatus{
 				HardwareProfile: profile.DefaultProfileName,
-				Provisioning: metal3v1alpha1.ProvisionStatus{
+				Provisioning: metal3api.ProvisionStatus{
 					State:           state,
 					BootMode:        v1alpha1.DefaultBootMode,
-					RootDeviceHints: &metal3v1alpha1.RootDeviceHints{},
+					RootDeviceHints: &metal3api.RootDeviceHints{},
 					Image: v1alpha1.Image{
 						URL: "", //needs provisioning
 					},
-					RAID: &metal3v1alpha1.RAIDConfig{
-						SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{},
+					RAID: &metal3api.RAIDConfig{
+						SoftwareRAIDVolumes: []metal3api.SoftwareRAIDVolume{},
 					},
 				},
 				GoodCredentials:   creds,
 				TriedCredentials:  creds,
-				OperationalStatus: metal3v1alpha1.OperationalStatusOK,
+				OperationalStatus: metal3api.OperationalStatusOK,
 				PoweredOn:         true,
 			},
 		},
 	}
 }
 
-func (hb *hostBuilder) build() *metal3v1alpha1.BareMetalHost {
+func (hb *hostBuilder) build() *metal3api.BareMetalHost {
 	return &hb.BareMetalHost
 }
 
@@ -1208,13 +1208,13 @@ func (hb *hostBuilder) SetExternallyProvisioned() *hostBuilder {
 }
 
 func (hb *hostBuilder) SetImageURL(url string) *hostBuilder {
-	hb.Spec.Image = &metal3v1alpha1.Image{
+	hb.Spec.Image = &metal3api.Image{
 		URL: url,
 	}
 	return hb
 }
 
-func (hb *hostBuilder) SetStatusError(opStatus metal3v1alpha1.OperationalStatus, errType metal3v1alpha1.ErrorType, errMsg string, errCount int) *hostBuilder {
+func (hb *hostBuilder) SetStatusError(opStatus metal3api.OperationalStatus, errType metal3api.ErrorType, errMsg string, errCount int) *hostBuilder {
 	hb.Status.OperationalStatus = opStatus
 	hb.Status.ErrorType = errType
 	hb.Status.ErrorMessage = errMsg
@@ -1238,7 +1238,7 @@ func (hb *hostBuilder) SetOnline(status bool) *hostBuilder {
 	return hb
 }
 
-func (hb *hostBuilder) SetOperationalStatus(status metal3v1alpha1.OperationalStatus) *hostBuilder {
+func (hb *hostBuilder) SetOperationalStatus(status metal3api.OperationalStatus) *hostBuilder {
 	hb.Status.OperationalStatus = status
 	return hb
 }
@@ -1261,11 +1261,11 @@ func (hb *hostBuilder) setDetached(val string) *hostBuilder {
 	if hb.Annotations == nil {
 		hb.Annotations = make(map[string]string, 1)
 	}
-	hb.Annotations[metal3v1alpha1.DetachedAnnotation] = val
+	hb.Annotations[metal3api.DetachedAnnotation] = val
 	return hb
 }
 
-func makeDefaultReconcileInfo(host *metal3v1alpha1.BareMetalHost) *reconcileInfo {
+func makeDefaultReconcileInfo(host *metal3api.BareMetalHost) *reconcileInfo {
 	return &reconcileInfo{
 		log:     logf.Log.WithName("controllers").WithName("BareMetalHost").WithName("host_state_machine"),
 		host:    host,
@@ -1329,12 +1329,12 @@ func (m *mockProvisioner) ValidateManagementAccess(data provisioner.ManagementAc
 	return m.getNextResultByMethod("ValidateManagementAccess"), "", err
 }
 
-func (m *mockProvisioner) PreprovisioningImageFormats() ([]metal3v1alpha1.ImageFormat, error) {
+func (m *mockProvisioner) PreprovisioningImageFormats() ([]metal3api.ImageFormat, error) {
 	return nil, nil
 }
 
-func (m *mockProvisioner) InspectHardware(data provisioner.InspectData, restartOnFailure, refresh, forceReboot bool) (result provisioner.Result, started bool, details *metal3v1alpha1.HardwareDetails, err error) {
-	details = &metal3v1alpha1.HardwareDetails{}
+func (m *mockProvisioner) InspectHardware(data provisioner.InspectData, restartOnFailure, refresh, forceReboot bool) (result provisioner.Result, started bool, details *metal3api.HardwareDetails, err error) {
+	details = &metal3api.HardwareDetails{}
 	return m.getNextResultByMethod("InspectHardware"), true, details, err
 }
 
@@ -1371,7 +1371,7 @@ func (m *mockProvisioner) PowerOn(force bool) (result provisioner.Result, err er
 	return m.getNextResultByMethod("PowerOn"), err
 }
 
-func (m *mockProvisioner) PowerOff(rebootMode metal3v1alpha1.RebootMode, force bool) (result provisioner.Result, err error) {
+func (m *mockProvisioner) PowerOff(rebootMode metal3api.RebootMode, force bool) (result provisioner.Result, err error) {
 	return m.getNextResultByMethod("PowerOff"), err
 }
 
@@ -1379,83 +1379,83 @@ func (m *mockProvisioner) IsReady() (result bool, err error) {
 	return
 }
 
-func (m *mockProvisioner) GetFirmwareSettings(includeSchema bool) (settings metal3v1alpha1.SettingsMap, schema map[string]metal3v1alpha1.SettingSchema, err error) {
+func (m *mockProvisioner) GetFirmwareSettings(includeSchema bool) (settings metal3api.SettingsMap, schema map[string]metal3api.SettingSchema, err error) {
 	return
 }
 
-func (m *mockProvisioner) AddBMCEventSubscriptionForNode(subscription *metal3v1alpha1.BMCEventSubscription, httpHeaders provisioner.HTTPHeaders) (result provisioner.Result, err error) {
+func (m *mockProvisioner) AddBMCEventSubscriptionForNode(subscription *metal3api.BMCEventSubscription, httpHeaders provisioner.HTTPHeaders) (result provisioner.Result, err error) {
 	return result, nil
 }
 
-func (m *mockProvisioner) RemoveBMCEventSubscriptionForNode(subscription metal3v1alpha1.BMCEventSubscription) (result provisioner.Result, err error) {
+func (m *mockProvisioner) RemoveBMCEventSubscriptionForNode(subscription metal3api.BMCEventSubscription) (result provisioner.Result, err error) {
 	return result, nil
 }
 
 func TestUpdateBootModeStatus(t *testing.T) {
 	testCases := []struct {
 		Scenario       string
-		SpecValue      metal3v1alpha1.BootMode
-		StatusValue    metal3v1alpha1.BootMode
-		ExpectedValue  metal3v1alpha1.BootMode
+		SpecValue      metal3api.BootMode
+		StatusValue    metal3api.BootMode
+		ExpectedValue  metal3api.BootMode
 		ExpectedChange bool
 	}{
 		{
 			Scenario:       "default",
 			SpecValue:      "",
 			StatusValue:    "",
-			ExpectedValue:  metal3v1alpha1.DefaultBootMode,
+			ExpectedValue:  metal3api.DefaultBootMode,
 			ExpectedChange: true,
 		},
 
 		{
 			Scenario:       "set UEFI",
-			SpecValue:      metal3v1alpha1.UEFI,
+			SpecValue:      metal3api.UEFI,
 			StatusValue:    "",
-			ExpectedValue:  metal3v1alpha1.UEFI,
+			ExpectedValue:  metal3api.UEFI,
 			ExpectedChange: true,
 		},
 
 		{
 			Scenario:       "already UEFI",
-			SpecValue:      metal3v1alpha1.UEFI,
-			StatusValue:    metal3v1alpha1.UEFI,
-			ExpectedValue:  metal3v1alpha1.UEFI,
+			SpecValue:      metal3api.UEFI,
+			StatusValue:    metal3api.UEFI,
+			ExpectedValue:  metal3api.UEFI,
 			ExpectedChange: false,
 		},
 
 		{
 			Scenario:       "set Legacy",
-			SpecValue:      metal3v1alpha1.Legacy,
+			SpecValue:      metal3api.Legacy,
 			StatusValue:    "",
-			ExpectedValue:  metal3v1alpha1.Legacy,
+			ExpectedValue:  metal3api.Legacy,
 			ExpectedChange: true,
 		},
 
 		{
 			Scenario:       "already Legacy",
-			SpecValue:      metal3v1alpha1.Legacy,
-			StatusValue:    metal3v1alpha1.Legacy,
-			ExpectedValue:  metal3v1alpha1.Legacy,
+			SpecValue:      metal3api.Legacy,
+			StatusValue:    metal3api.Legacy,
+			ExpectedValue:  metal3api.Legacy,
 			ExpectedChange: false,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Scenario, func(t *testing.T) {
-			host := metal3v1alpha1.BareMetalHost{
+			host := metal3api.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
 				},
-				Spec: metal3v1alpha1.BareMetalHostSpec{
-					Image: &metal3v1alpha1.Image{
+				Spec: metal3api.BareMetalHostSpec{
+					Image: &metal3api.Image{
 						URL: "not-empty",
 					},
 					Online:   true,
 					BootMode: tc.SpecValue,
 				},
-				Status: metal3v1alpha1.BareMetalHostStatus{
-					Provisioning: metal3v1alpha1.ProvisionStatus{
-						Image: metal3v1alpha1.Image{
+				Status: metal3api.BareMetalHostStatus{
+					Provisioning: metal3api.ProvisionStatus{
+						Image: metal3api.Image{
 							URL: "also-not-empty",
 						},
 						BootMode: tc.StatusValue,

--- a/controllers/metal3.io/hostfirmwaresettings_test.go
+++ b/controllers/metal3.io/hostfirmwaresettings_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,7 +34,7 @@ var (
 )
 
 // Test support for HostFirmwareSettings in the HostFirmwareSettingsReconciler
-func getTestHFSReconciler(host *metal3v1alpha1.HostFirmwareSettings) *HostFirmwareSettingsReconciler {
+func getTestHFSReconciler(host *metal3api.HostFirmwareSettings) *HostFirmwareSettingsReconciler {
 
 	c := fakeclient.NewFakeClient(host)
 	reconciler := &HostFirmwareSettingsReconciler{
@@ -45,7 +45,7 @@ func getTestHFSReconciler(host *metal3v1alpha1.HostFirmwareSettings) *HostFirmwa
 	return reconciler
 }
 
-func getMockProvisioner(settings metal3v1alpha1.SettingsMap, schema map[string]metal3v1alpha1.SettingSchema) *hsfMockProvisioner {
+func getMockProvisioner(settings metal3api.SettingsMap, schema map[string]metal3api.SettingSchema) *hsfMockProvisioner {
 	return &hsfMockProvisioner{
 		Settings: settings,
 		Schema:   schema,
@@ -54,8 +54,8 @@ func getMockProvisioner(settings metal3v1alpha1.SettingsMap, schema map[string]m
 }
 
 type hsfMockProvisioner struct {
-	Settings metal3v1alpha1.SettingsMap
-	Schema   map[string]metal3v1alpha1.SettingSchema
+	Settings metal3api.SettingsMap
+	Schema   map[string]metal3api.SettingSchema
 	Error    error
 }
 
@@ -67,7 +67,7 @@ func (m *hsfMockProvisioner) ValidateManagementAccess(data provisioner.Managemen
 	return
 }
 
-func (m *hsfMockProvisioner) InspectHardware(data provisioner.InspectData, force, refresh bool) (result provisioner.Result, started bool, details *metal3v1alpha1.HardwareDetails, err error) {
+func (m *hsfMockProvisioner) InspectHardware(data provisioner.InspectData, force, refresh bool) (result provisioner.Result, started bool, details *metal3api.HardwareDetails, err error) {
 	return
 }
 
@@ -103,7 +103,7 @@ func (m *hsfMockProvisioner) PowerOn(force bool) (result provisioner.Result, err
 	return
 }
 
-func (m *hsfMockProvisioner) PowerOff(rebootMode metal3v1alpha1.RebootMode, force bool) (result provisioner.Result, err error) {
+func (m *hsfMockProvisioner) PowerOff(rebootMode metal3api.RebootMode, force bool) (result provisioner.Result, err error) {
 	return
 }
 
@@ -111,22 +111,22 @@ func (m *hsfMockProvisioner) IsReady() (result bool, err error) {
 	return
 }
 
-func (m *hsfMockProvisioner) GetFirmwareSettings(includeSchema bool) (settings metal3v1alpha1.SettingsMap, schema map[string]metal3v1alpha1.SettingSchema, err error) {
+func (m *hsfMockProvisioner) GetFirmwareSettings(includeSchema bool) (settings metal3api.SettingsMap, schema map[string]metal3api.SettingSchema, err error) {
 
 	return m.Settings, m.Schema, m.Error
 }
 
-func (m *hsfMockProvisioner) AddBMCEventSubscriptionForNode(subscription *metal3v1alpha1.BMCEventSubscription, httpHeaders provisioner.HTTPHeaders) (result provisioner.Result, err error) {
+func (m *hsfMockProvisioner) AddBMCEventSubscriptionForNode(subscription *metal3api.BMCEventSubscription, httpHeaders provisioner.HTTPHeaders) (result provisioner.Result, err error) {
 	return result, nil
 }
 
-func (m *hsfMockProvisioner) RemoveBMCEventSubscriptionForNode(subscription metal3v1alpha1.BMCEventSubscription) (result provisioner.Result, err error) {
+func (m *hsfMockProvisioner) RemoveBMCEventSubscriptionForNode(subscription metal3api.BMCEventSubscription) (result provisioner.Result, err error) {
 	return result, nil
 }
 
-func getSchema() *metal3v1alpha1.FirmwareSchema {
+func getSchema() *metal3api.FirmwareSchema {
 
-	schema := &metal3v1alpha1.FirmwareSchema{
+	schema := &metal3api.FirmwareSchema{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "FirmwareSchema",
 			APIVersion: "metal3.io/v1alpha1"},
@@ -147,9 +147,9 @@ func getSchema() *metal3v1alpha1.FirmwareSchema {
 }
 
 // Mock settings to return from provisioner
-func getCurrentSettings() metal3v1alpha1.SettingsMap {
+func getCurrentSettings() metal3api.SettingsMap {
 
-	return metal3v1alpha1.SettingsMap{
+	return metal3api.SettingsMap{
 		"L2Cache":               "10x512 KB",
 		"NetworkBootRetryCount": "20",
 		"ProcVirtualization":    "Disabled",
@@ -159,9 +159,9 @@ func getCurrentSettings() metal3v1alpha1.SettingsMap {
 }
 
 // Mock schema to return from provisioner
-func getCurrentSchemaSettings() map[string]metal3v1alpha1.SettingSchema {
+func getCurrentSchemaSettings() map[string]metal3api.SettingSchema {
 
-	return map[string]metal3v1alpha1.SettingSchema{
+	return map[string]metal3api.SettingSchema{
 		"AssetTag": {
 			AttributeType: "String",
 			MinLength:     &minLength,
@@ -201,9 +201,9 @@ func getCurrentSchemaSettings() map[string]metal3v1alpha1.SettingSchema {
 }
 
 // Create the baremetalhost reconciler and use that to create bmh in same namespace
-func createBaremetalHost() *metal3v1alpha1.BareMetalHost {
+func createBaremetalHost() *metal3api.BareMetalHost {
 
-	bmh := &metal3v1alpha1.BareMetalHost{}
+	bmh := &metal3api.BareMetalHost{}
 	bmh.ObjectMeta = metav1.ObjectMeta{Name: hostName, Namespace: hostNamespace}
 	c := fakeclient.NewFakeClient(bmh)
 
@@ -218,7 +218,7 @@ func createBaremetalHost() *metal3v1alpha1.BareMetalHost {
 	return bmh
 }
 
-func getExpectedSchema() *metal3v1alpha1.FirmwareSchema {
+func getExpectedSchema() *metal3api.FirmwareSchema {
 	firmwareSchema := getSchema()
 	firmwareSchema.ObjectMeta.ResourceVersion = "1"
 	firmwareSchema.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
@@ -233,7 +233,7 @@ func getExpectedSchema() *metal3v1alpha1.FirmwareSchema {
 	return firmwareSchema
 }
 
-func getExpectedSchemaTwoOwners() *metal3v1alpha1.FirmwareSchema {
+func getExpectedSchemaTwoOwners() *metal3api.FirmwareSchema {
 	firmwareSchema := getSchema()
 	firmwareSchema.ObjectMeta.ResourceVersion = "2"
 	firmwareSchema.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
@@ -254,12 +254,12 @@ func getExpectedSchemaTwoOwners() *metal3v1alpha1.FirmwareSchema {
 }
 
 // Create an HFS with input spec settings
-func getHFS(spec metal3v1alpha1.HostFirmwareSettingsSpec) *metal3v1alpha1.HostFirmwareSettings {
+func getHFS(spec metal3api.HostFirmwareSettingsSpec) *metal3api.HostFirmwareSettings {
 
-	hfs := &metal3v1alpha1.HostFirmwareSettings{}
+	hfs := &metal3api.HostFirmwareSettings{}
 
-	hfs.Status = metal3v1alpha1.HostFirmwareSettingsStatus{
-		Settings: metal3v1alpha1.SettingsMap{
+	hfs.Status = metal3api.HostFirmwareSettingsStatus{
+		Settings: metal3api.SettingsMap{
 			"CustomPostMessage":     "All tests passed",
 			"L2Cache":               "10x256 KB",
 			"NetworkBootRetryCount": "10",
@@ -286,17 +286,17 @@ func TestStoreHostFirmwareSettings(t *testing.T) {
 	testCases := []struct {
 		Scenario string
 		// the resource that the reconciler is managing
-		CurrentHFSResource *metal3v1alpha1.HostFirmwareSettings
+		CurrentHFSResource *metal3api.HostFirmwareSettings
 		// whether to create a schema resource before calling reconciler
 		CreateSchemaResource bool
 		// the expected created or updated resource
-		ExpectedSettings *metal3v1alpha1.HostFirmwareSettings
+		ExpectedSettings *metal3api.HostFirmwareSettings
 		// whether the spec values pass the validity test
 		SpecIsValid bool
 	}{
 		{
 			Scenario: "initial hfs resource with no schema",
-			CurrentHFSResource: &metal3v1alpha1.HostFirmwareSettings{
+			CurrentHFSResource: &metal3api.HostFirmwareSettings{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "HostFirmwareSettings",
 					APIVersion: "metal3.io/v1alpha1"},
@@ -304,22 +304,22 @@ func TestStoreHostFirmwareSettings(t *testing.T) {
 					Name:            hostName,
 					Namespace:       hostNamespace,
 					ResourceVersion: "1"},
-				Spec: metal3v1alpha1.HostFirmwareSettingsSpec{
-					Settings: metal3v1alpha1.DesiredSettingsMap{},
+				Spec: metal3api.HostFirmwareSettingsSpec{
+					Settings: metal3api.DesiredSettingsMap{},
 				},
-				Status: metal3v1alpha1.HostFirmwareSettingsStatus{},
+				Status: metal3api.HostFirmwareSettingsStatus{},
 			},
 			CreateSchemaResource: false,
-			ExpectedSettings: &metal3v1alpha1.HostFirmwareSettings{
-				Spec: metal3v1alpha1.HostFirmwareSettingsSpec{
-					Settings: metal3v1alpha1.DesiredSettingsMap{},
+			ExpectedSettings: &metal3api.HostFirmwareSettings{
+				Spec: metal3api.HostFirmwareSettingsSpec{
+					Settings: metal3api.DesiredSettingsMap{},
 				},
-				Status: metal3v1alpha1.HostFirmwareSettingsStatus{
-					FirmwareSchema: &metal3v1alpha1.SchemaReference{
+				Status: metal3api.HostFirmwareSettingsStatus{
+					FirmwareSchema: &metal3api.SchemaReference{
 						Name:      schemaName,
 						Namespace: hostNamespace,
 					},
-					Settings: metal3v1alpha1.SettingsMap{
+					Settings: metal3api.SettingsMap{
 						"AssetTag":              "X45672917",
 						"L2Cache":               "10x512 KB",
 						"NetworkBootRetryCount": "20",
@@ -336,7 +336,7 @@ func TestStoreHostFirmwareSettings(t *testing.T) {
 		},
 		{
 			Scenario: "initial hfs resource with existing schema",
-			CurrentHFSResource: &metal3v1alpha1.HostFirmwareSettings{
+			CurrentHFSResource: &metal3api.HostFirmwareSettings{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "HostFirmwareSettings",
 					APIVersion: "metal3.io/v1alpha1"},
@@ -344,22 +344,22 @@ func TestStoreHostFirmwareSettings(t *testing.T) {
 					Name:            hostName,
 					Namespace:       hostNamespace,
 					ResourceVersion: "1"},
-				Spec: metal3v1alpha1.HostFirmwareSettingsSpec{
-					Settings: metal3v1alpha1.DesiredSettingsMap{},
+				Spec: metal3api.HostFirmwareSettingsSpec{
+					Settings: metal3api.DesiredSettingsMap{},
 				},
-				Status: metal3v1alpha1.HostFirmwareSettingsStatus{},
+				Status: metal3api.HostFirmwareSettingsStatus{},
 			},
 			CreateSchemaResource: true,
-			ExpectedSettings: &metal3v1alpha1.HostFirmwareSettings{
-				Spec: metal3v1alpha1.HostFirmwareSettingsSpec{
-					Settings: metal3v1alpha1.DesiredSettingsMap{},
+			ExpectedSettings: &metal3api.HostFirmwareSettings{
+				Spec: metal3api.HostFirmwareSettingsSpec{
+					Settings: metal3api.DesiredSettingsMap{},
 				},
-				Status: metal3v1alpha1.HostFirmwareSettingsStatus{
-					FirmwareSchema: &metal3v1alpha1.SchemaReference{
+				Status: metal3api.HostFirmwareSettingsStatus{
+					FirmwareSchema: &metal3api.SchemaReference{
 						Name:      schemaName,
 						Namespace: hostNamespace,
 					},
-					Settings: metal3v1alpha1.SettingsMap{
+					Settings: metal3api.SettingsMap{
 						"AssetTag":              "X45672917",
 						"L2Cache":               "10x512 KB",
 						"NetworkBootRetryCount": "20",
@@ -376,7 +376,7 @@ func TestStoreHostFirmwareSettings(t *testing.T) {
 		},
 		{
 			Scenario: "updated settings",
-			CurrentHFSResource: &metal3v1alpha1.HostFirmwareSettings{
+			CurrentHFSResource: &metal3api.HostFirmwareSettings{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "HostFirmwareSettings",
 					APIVersion: "metal3.io/v1alpha1"},
@@ -384,19 +384,19 @@ func TestStoreHostFirmwareSettings(t *testing.T) {
 					Name:            hostName,
 					Namespace:       hostNamespace,
 					ResourceVersion: "1"},
-				Spec: metal3v1alpha1.HostFirmwareSettingsSpec{
-					Settings: metal3v1alpha1.DesiredSettingsMap{
+				Spec: metal3api.HostFirmwareSettingsSpec{
+					Settings: metal3api.DesiredSettingsMap{
 						"NetworkBootRetryCount": intstr.FromString("10"),
 						"ProcVirtualization":    intstr.FromString("Enabled"),
 						"AssetTag":              intstr.FromString("Z98765432"),
 					},
 				},
-				Status: metal3v1alpha1.HostFirmwareSettingsStatus{
-					FirmwareSchema: &metal3v1alpha1.SchemaReference{
+				Status: metal3api.HostFirmwareSettingsStatus{
+					FirmwareSchema: &metal3api.SchemaReference{
 						Name:      schemaName,
 						Namespace: hostNamespace,
 					},
-					Settings: metal3v1alpha1.SettingsMap{
+					Settings: metal3api.SettingsMap{
 						"AssetTag":              "Z98765432",
 						"L2Cache":               "10x256 KB",
 						"NetworkBootRetryCount": "10",
@@ -405,20 +405,20 @@ func TestStoreHostFirmwareSettings(t *testing.T) {
 				},
 			},
 			CreateSchemaResource: true,
-			ExpectedSettings: &metal3v1alpha1.HostFirmwareSettings{
-				Spec: metal3v1alpha1.HostFirmwareSettingsSpec{
-					Settings: metal3v1alpha1.DesiredSettingsMap{
+			ExpectedSettings: &metal3api.HostFirmwareSettings{
+				Spec: metal3api.HostFirmwareSettingsSpec{
+					Settings: metal3api.DesiredSettingsMap{
 						"NetworkBootRetryCount": intstr.FromString("10"),
 						"ProcVirtualization":    intstr.FromString("Enabled"),
 						"AssetTag":              intstr.FromString("Z98765432"),
 					},
 				},
-				Status: metal3v1alpha1.HostFirmwareSettingsStatus{
-					FirmwareSchema: &metal3v1alpha1.SchemaReference{
+				Status: metal3api.HostFirmwareSettingsStatus{
+					FirmwareSchema: &metal3api.SchemaReference{
 						Name:      schemaName,
 						Namespace: hostNamespace,
 					},
-					Settings: metal3v1alpha1.SettingsMap{
+					Settings: metal3api.SettingsMap{
 						"AssetTag":              "X45672917",
 						"L2Cache":               "10x512 KB",
 						"NetworkBootRetryCount": "20",
@@ -435,7 +435,7 @@ func TestStoreHostFirmwareSettings(t *testing.T) {
 		},
 		{
 			Scenario: "spec updated with invalid setting",
-			CurrentHFSResource: &metal3v1alpha1.HostFirmwareSettings{
+			CurrentHFSResource: &metal3api.HostFirmwareSettings{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "HostFirmwareSettings",
 					APIVersion: "metal3.io/v1alpha1"},
@@ -443,18 +443,18 @@ func TestStoreHostFirmwareSettings(t *testing.T) {
 					Name:            hostName,
 					Namespace:       hostNamespace,
 					ResourceVersion: "1"},
-				Spec: metal3v1alpha1.HostFirmwareSettingsSpec{
-					Settings: metal3v1alpha1.DesiredSettingsMap{
+				Spec: metal3api.HostFirmwareSettingsSpec{
+					Settings: metal3api.DesiredSettingsMap{
 						"NetworkBootRetryCount": intstr.FromInt(1000),
 						"ProcVirtualization":    intstr.FromString("Enabled"),
 					},
 				},
-				Status: metal3v1alpha1.HostFirmwareSettingsStatus{
-					FirmwareSchema: &metal3v1alpha1.SchemaReference{
+				Status: metal3api.HostFirmwareSettingsStatus{
+					FirmwareSchema: &metal3api.SchemaReference{
 						Name:      schemaName,
 						Namespace: hostNamespace,
 					},
-					Settings: metal3v1alpha1.SettingsMap{
+					Settings: metal3api.SettingsMap{
 						"L2Cache":               "10x256 KB",
 						"NetworkBootRetryCount": "10",
 						"ProcVirtualization":    "Enabled",
@@ -462,19 +462,19 @@ func TestStoreHostFirmwareSettings(t *testing.T) {
 				},
 			},
 			CreateSchemaResource: true,
-			ExpectedSettings: &metal3v1alpha1.HostFirmwareSettings{
-				Spec: metal3v1alpha1.HostFirmwareSettingsSpec{
-					Settings: metal3v1alpha1.DesiredSettingsMap{
+			ExpectedSettings: &metal3api.HostFirmwareSettings{
+				Spec: metal3api.HostFirmwareSettingsSpec{
+					Settings: metal3api.DesiredSettingsMap{
 						"NetworkBootRetryCount": intstr.FromInt(1000),
 						"ProcVirtualization":    intstr.FromString("Enabled"),
 					},
 				},
-				Status: metal3v1alpha1.HostFirmwareSettingsStatus{
-					FirmwareSchema: &metal3v1alpha1.SchemaReference{
+				Status: metal3api.HostFirmwareSettingsStatus{
+					FirmwareSchema: &metal3api.SchemaReference{
 						Name:      schemaName,
 						Namespace: hostNamespace,
 					},
-					Settings: metal3v1alpha1.SettingsMap{
+					Settings: metal3api.SettingsMap{
 						"AssetTag":              "X45672917",
 						"L2Cache":               "10x512 KB",
 						"NetworkBootRetryCount": "20",
@@ -491,7 +491,7 @@ func TestStoreHostFirmwareSettings(t *testing.T) {
 		},
 		{
 			Scenario: "spec has same settings as current",
-			CurrentHFSResource: &metal3v1alpha1.HostFirmwareSettings{
+			CurrentHFSResource: &metal3api.HostFirmwareSettings{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "HostFirmwareSettings",
 					APIVersion: "metal3.io/v1alpha1"},
@@ -499,18 +499,18 @@ func TestStoreHostFirmwareSettings(t *testing.T) {
 					Name:            hostName,
 					Namespace:       hostNamespace,
 					ResourceVersion: "1"},
-				Spec: metal3v1alpha1.HostFirmwareSettingsSpec{
-					Settings: metal3v1alpha1.DesiredSettingsMap{
+				Spec: metal3api.HostFirmwareSettingsSpec{
+					Settings: metal3api.DesiredSettingsMap{
 						"NetworkBootRetryCount": intstr.FromInt(20),
 						"ProcVirtualization":    intstr.FromString("Disabled"),
 					},
 				},
-				Status: metal3v1alpha1.HostFirmwareSettingsStatus{
-					FirmwareSchema: &metal3v1alpha1.SchemaReference{
+				Status: metal3api.HostFirmwareSettingsStatus{
+					FirmwareSchema: &metal3api.SchemaReference{
 						Name:      schemaName,
 						Namespace: hostNamespace,
 					},
-					Settings: metal3v1alpha1.SettingsMap{
+					Settings: metal3api.SettingsMap{
 						"L2Cache":               "10x256 KB",
 						"NetworkBootRetryCount": "10",
 						"ProcVirtualization":    "Enabled",
@@ -518,19 +518,19 @@ func TestStoreHostFirmwareSettings(t *testing.T) {
 				},
 			},
 			CreateSchemaResource: true,
-			ExpectedSettings: &metal3v1alpha1.HostFirmwareSettings{
-				Spec: metal3v1alpha1.HostFirmwareSettingsSpec{
-					Settings: metal3v1alpha1.DesiredSettingsMap{
+			ExpectedSettings: &metal3api.HostFirmwareSettings{
+				Spec: metal3api.HostFirmwareSettingsSpec{
+					Settings: metal3api.DesiredSettingsMap{
 						"NetworkBootRetryCount": intstr.FromInt(20),
 						"ProcVirtualization":    intstr.FromString("Disabled"),
 					},
 				},
-				Status: metal3v1alpha1.HostFirmwareSettingsStatus{
-					FirmwareSchema: &metal3v1alpha1.SchemaReference{
+				Status: metal3api.HostFirmwareSettingsStatus{
+					FirmwareSchema: &metal3api.SchemaReference{
 						Name:      schemaName,
 						Namespace: hostNamespace,
 					},
-					Settings: metal3v1alpha1.SettingsMap{
+					Settings: metal3api.SettingsMap{
 						"AssetTag":              "X45672917",
 						"L2Cache":               "10x512 KB",
 						"NetworkBootRetryCount": "20",
@@ -589,7 +589,7 @@ func TestStoreHostFirmwareSettings(t *testing.T) {
 			// Check that resources get created or updated
 			key := client.ObjectKey{
 				Namespace: hfs.ObjectMeta.Namespace, Name: hfs.ObjectMeta.Name}
-			actualSettings := &metal3v1alpha1.HostFirmwareSettings{}
+			actualSettings := &metal3api.HostFirmwareSettings{}
 			err = r.Client.Get(ctx, key, actualSettings)
 			assert.Equal(t, nil, err)
 
@@ -605,10 +605,10 @@ func TestStoreHostFirmwareSettings(t *testing.T) {
 
 			key = client.ObjectKey{
 				Namespace: hfs.ObjectMeta.Namespace, Name: schemaName}
-			actualSchema := &metal3v1alpha1.FirmwareSchema{}
+			actualSchema := &metal3api.FirmwareSchema{}
 			err = r.Client.Get(ctx, key, actualSchema)
 			assert.Equal(t, nil, err)
-			var expectedSchema *metal3v1alpha1.FirmwareSchema
+			var expectedSchema *metal3api.FirmwareSchema
 			if tc.CreateSchemaResource {
 				expectedSchema = getExpectedSchemaTwoOwners()
 			} else {
@@ -624,13 +624,13 @@ func TestValidateHostFirmwareSettings(t *testing.T) {
 
 	testCases := []struct {
 		Scenario      string
-		SpecSettings  metal3v1alpha1.HostFirmwareSettingsSpec
+		SpecSettings  metal3api.HostFirmwareSettingsSpec
 		ExpectedError string
 	}{
 		{
 			Scenario: "valid spec changes with schema",
-			SpecSettings: metal3v1alpha1.HostFirmwareSettingsSpec{
-				Settings: metal3v1alpha1.DesiredSettingsMap{
+			SpecSettings: metal3api.HostFirmwareSettingsSpec{
+				Settings: metal3api.DesiredSettingsMap{
 					"CustomPostMessage":     intstr.FromString("All tests passed"),
 					"ProcVirtualization":    intstr.FromString("Disabled"),
 					"NetworkBootRetryCount": intstr.FromInt(20),
@@ -640,8 +640,8 @@ func TestValidateHostFirmwareSettings(t *testing.T) {
 		},
 		{
 			Scenario: "invalid string",
-			SpecSettings: metal3v1alpha1.HostFirmwareSettingsSpec{
-				Settings: metal3v1alpha1.DesiredSettingsMap{
+			SpecSettings: metal3api.HostFirmwareSettingsSpec{
+				Settings: metal3api.DesiredSettingsMap{
 					"CustomPostMessage":     intstr.FromString("A really long POST message"),
 					"ProcVirtualization":    intstr.FromString("Disabled"),
 					"NetworkBootRetryCount": intstr.FromInt(20),
@@ -651,8 +651,8 @@ func TestValidateHostFirmwareSettings(t *testing.T) {
 		},
 		{
 			Scenario: "invalid int",
-			SpecSettings: metal3v1alpha1.HostFirmwareSettingsSpec{
-				Settings: metal3v1alpha1.DesiredSettingsMap{
+			SpecSettings: metal3api.HostFirmwareSettingsSpec{
+				Settings: metal3api.DesiredSettingsMap{
 					"CustomPostMessage":     intstr.FromString("All tests passed"),
 					"ProcVirtualization":    intstr.FromString("Disabled"),
 					"NetworkBootRetryCount": intstr.FromInt(2000),
@@ -662,8 +662,8 @@ func TestValidateHostFirmwareSettings(t *testing.T) {
 		},
 		{
 			Scenario: "invalid enum",
-			SpecSettings: metal3v1alpha1.HostFirmwareSettingsSpec{
-				Settings: metal3v1alpha1.DesiredSettingsMap{
+			SpecSettings: metal3api.HostFirmwareSettingsSpec{
+				Settings: metal3api.DesiredSettingsMap{
 					"CustomPostMessage":     intstr.FromString("All tests passed"),
 					"ProcVirtualization":    intstr.FromString("Not enabled"),
 					"NetworkBootRetryCount": intstr.FromString("20"),
@@ -673,8 +673,8 @@ func TestValidateHostFirmwareSettings(t *testing.T) {
 		},
 		{
 			Scenario: "invalid name",
-			SpecSettings: metal3v1alpha1.HostFirmwareSettingsSpec{
-				Settings: metal3v1alpha1.DesiredSettingsMap{
+			SpecSettings: metal3api.HostFirmwareSettingsSpec{
+				Settings: metal3api.DesiredSettingsMap{
 					"SomeNewSetting": intstr.FromString("foo"),
 				},
 			},
@@ -682,8 +682,8 @@ func TestValidateHostFirmwareSettings(t *testing.T) {
 		},
 		{
 			Scenario: "invalid password in spec",
-			SpecSettings: metal3v1alpha1.HostFirmwareSettingsSpec{
-				Settings: metal3v1alpha1.DesiredSettingsMap{
+			SpecSettings: metal3api.HostFirmwareSettingsSpec{
+				Settings: metal3api.DesiredSettingsMap{
 					"CustomPostMessage":     intstr.FromString("All tests passed"),
 					"ProcVirtualization":    intstr.FromString("Disabled"),
 					"NetworkBootRetryCount": intstr.FromString("20"),
@@ -694,8 +694,8 @@ func TestValidateHostFirmwareSettings(t *testing.T) {
 		},
 		{
 			Scenario: "string instead of int",
-			SpecSettings: metal3v1alpha1.HostFirmwareSettingsSpec{
-				Settings: metal3v1alpha1.DesiredSettingsMap{
+			SpecSettings: metal3api.HostFirmwareSettingsSpec{
+				Settings: metal3api.DesiredSettingsMap{
 					"CustomPostMessage":     intstr.FromString("All tests passed"),
 					"ProcVirtualization":    intstr.FromString("Disabled"),
 					"NetworkBootRetryCount": intstr.FromString("foo"),

--- a/controllers/metal3.io/metrics.go
+++ b/controllers/metal3.io/metrics.go
@@ -6,7 +6,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 )
 
 const (
@@ -76,22 +76,22 @@ var delayedDeprovisioningHostCounters = prometheus.NewCounterVec(prometheus.Coun
 
 var slowOperationBuckets = []float64{30, 90, 180, 360, 720, 1440}
 
-var stateTime = map[metal3v1alpha1.ProvisioningState]*prometheus.HistogramVec{
-	metal3v1alpha1.StateRegistering: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+var stateTime = map[metal3api.ProvisioningState]*prometheus.HistogramVec{
+	metal3api.StateRegistering: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "metal3_operation_register_duration_seconds",
 		Help: "Length of time per registration per host",
 	}, []string{labelHostNamespace, labelHostName}),
-	metal3v1alpha1.StateInspecting: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	metal3api.StateInspecting: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "metal3_operation_inspect_duration_seconds",
 		Help:    "Length of time per hardware inspection per host",
 		Buckets: slowOperationBuckets,
 	}, []string{labelHostNamespace, labelHostName}),
-	metal3v1alpha1.StateProvisioning: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	metal3api.StateProvisioning: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "metal3_operation_provision_duration_seconds",
 		Help:    "Length of time per hardware provision operation per host",
 		Buckets: slowOperationBuckets,
 	}, []string{labelHostNamespace, labelHostName}),
-	metal3v1alpha1.StateDeprovisioning: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	metal3api.StateDeprovisioning: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "metal3_operation_deprovision_duration_seconds",
 		Help:    "Length of time per hardware deprovision operation per host",
 		Buckets: slowOperationBuckets,
@@ -165,7 +165,7 @@ func hostMetricLabels(request ctrl.Request) prometheus.Labels {
 	}
 }
 
-func stateChangeMetricLabels(prevState, newState metal3v1alpha1.ProvisioningState) prometheus.Labels {
+func stateChangeMetricLabels(prevState, newState metal3api.ProvisioningState) prometheus.Labels {
 	return prometheus.Labels{
 		labelPrevState: string(prevState),
 		labelNewState:  string(newState),

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	logz "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 )
@@ -114,7 +114,7 @@ func (p *demoProvisioner) ValidateManagementAccess(data provisioner.ManagementAc
 	return
 }
 
-func (p *demoProvisioner) PreprovisioningImageFormats() ([]metal3v1alpha1.ImageFormat, error) {
+func (p *demoProvisioner) PreprovisioningImageFormats() ([]metal3api.ImageFormat, error) {
 	return nil, nil
 }
 
@@ -122,7 +122,7 @@ func (p *demoProvisioner) PreprovisioningImageFormats() ([]metal3v1alpha1.ImageF
 // details of devices discovered on the hardware. It may be called
 // multiple times, and should return true for its dirty flag until the
 // inspection is completed.
-func (p *demoProvisioner) InspectHardware(data provisioner.InspectData, restartOnFailure, refresh, forceReboot bool) (result provisioner.Result, started bool, details *metal3v1alpha1.HardwareDetails, err error) {
+func (p *demoProvisioner) InspectHardware(data provisioner.InspectData, restartOnFailure, refresh, forceReboot bool) (result provisioner.Result, started bool, details *metal3api.HardwareDetails, err error) {
 	started = true
 	hostName := p.objectMeta.Name
 
@@ -136,9 +136,9 @@ func (p *demoProvisioner) InspectHardware(data provisioner.InspectData, restartO
 
 	p.log.Info("continuing inspection by setting details")
 	details =
-		&metal3v1alpha1.HardwareDetails{
+		&metal3api.HardwareDetails{
 			RAMMebibytes: 128 * 1024,
-			NIC: []metal3v1alpha1.NIC{
+			NIC: []metal3api.NIC{
 				{
 					Name:      "nic-1",
 					Model:     "virt-io",
@@ -156,24 +156,24 @@ func (p *demoProvisioner) InspectHardware(data provisioner.InspectData, restartO
 					PXE:       false,
 				},
 			},
-			Storage: []metal3v1alpha1.Storage{
+			Storage: []metal3api.Storage{
 				{
 					Name:       "disk-1 (boot)",
 					Rotational: false,
-					SizeBytes:  metal3v1alpha1.TebiByte * 93,
+					SizeBytes:  metal3api.TebiByte * 93,
 					Model:      "Dell CFJ61",
 				},
 				{
 					Name:       "disk-2",
 					Rotational: false,
-					SizeBytes:  metal3v1alpha1.TebiByte * 93,
+					SizeBytes:  metal3api.TebiByte * 93,
 					Model:      "Dell CFJ61",
 				},
 			},
-			CPU: metal3v1alpha1.CPU{
+			CPU: metal3api.CPU{
 				Arch:           "x86_64",
 				Model:          "Core 2 Duo",
-				ClockMegahertz: 3.0 * metal3v1alpha1.GigaHertz,
+				ClockMegahertz: 3.0 * metal3api.GigaHertz,
 				Flags:          []string{"lm", "hypervisor", "vmx"},
 				Count:          1,
 			},
@@ -330,7 +330,7 @@ func (p *demoProvisioner) PowerOn(force bool) (result provisioner.Result, err er
 
 // PowerOff ensures the server is powered off independently of any image
 // provisioning operation.
-func (p *demoProvisioner) PowerOff(rebootMode metal3v1alpha1.RebootMode, force bool) (result provisioner.Result, err error) {
+func (p *demoProvisioner) PowerOff(rebootMode metal3api.RebootMode, force bool) (result provisioner.Result, err error) {
 
 	hostName := p.objectMeta.Name
 	switch hostName {
@@ -354,16 +354,16 @@ func (p *demoProvisioner) IsReady() (result bool, err error) {
 	return true, nil
 }
 
-func (p *demoProvisioner) GetFirmwareSettings(includeSchema bool) (settings metal3v1alpha1.SettingsMap, schema map[string]metal3v1alpha1.SettingSchema, err error) {
+func (p *demoProvisioner) GetFirmwareSettings(includeSchema bool) (settings metal3api.SettingsMap, schema map[string]metal3api.SettingSchema, err error) {
 
 	p.log.Info("getting BIOS settings")
 	return
 }
 
-func (p *demoProvisioner) AddBMCEventSubscriptionForNode(subscription *metal3v1alpha1.BMCEventSubscription, httpHeaders provisioner.HTTPHeaders) (result provisioner.Result, err error) {
+func (p *demoProvisioner) AddBMCEventSubscriptionForNode(subscription *metal3api.BMCEventSubscription, httpHeaders provisioner.HTTPHeaders) (result provisioner.Result, err error) {
 	return result, nil
 }
 
-func (p *demoProvisioner) RemoveBMCEventSubscriptionForNode(subscription metal3v1alpha1.BMCEventSubscription) (result provisioner.Result, err error) {
+func (p *demoProvisioner) RemoveBMCEventSubscriptionForNode(subscription metal3api.BMCEventSubscription) (result provisioner.Result, err error) {
 	return result, nil
 }

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -6,7 +6,7 @@ import (
 	"github.com/go-logr/logr"
 	logz "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 )
@@ -66,13 +66,13 @@ type Fixture struct {
 	// state to manage the two-step adopt process
 	adopted bool
 	// state to manage provisioning
-	image metal3v1alpha1.Image
+	image metal3api.Image
 	// state to manage power
 	poweredOn bool
 
 	validateError string
 
-	customDeploy *metal3v1alpha1.CustomDeploy
+	customDeploy *metal3api.CustomDeploy
 }
 
 // NewProvisioner returns a new Fixture Provisioner
@@ -117,7 +117,7 @@ func (p *fixtureProvisioner) ValidateManagementAccess(data provisioner.Managemen
 	return
 }
 
-func (p *fixtureProvisioner) PreprovisioningImageFormats() ([]metal3v1alpha1.ImageFormat, error) {
+func (p *fixtureProvisioner) PreprovisioningImageFormats() ([]metal3api.ImageFormat, error) {
 	return nil, nil
 }
 
@@ -125,7 +125,7 @@ func (p *fixtureProvisioner) PreprovisioningImageFormats() ([]metal3v1alpha1.Ima
 // details of devices discovered on the hardware. It may be called
 // multiple times, and should return true for its dirty flag until the
 // inspection is completed.
-func (p *fixtureProvisioner) InspectHardware(data provisioner.InspectData, restartOnFailure, refresh, forceReboot bool) (result provisioner.Result, started bool, details *metal3v1alpha1.HardwareDetails, err error) {
+func (p *fixtureProvisioner) InspectHardware(data provisioner.InspectData, restartOnFailure, refresh, forceReboot bool) (result provisioner.Result, started bool, details *metal3api.HardwareDetails, err error) {
 	// The inspection is ongoing. We'll need to check the fixture
 	// status for the server here until it is ready for us to get the
 	// inspection details. Simulate that for now by creating the
@@ -133,9 +133,9 @@ func (p *fixtureProvisioner) InspectHardware(data provisioner.InspectData, resta
 	p.log.Info("continuing inspection by setting details")
 	started = true
 	details =
-		&metal3v1alpha1.HardwareDetails{
+		&metal3api.HardwareDetails{
 			RAMMebibytes: 128 * 1024,
-			NIC: []metal3v1alpha1.NIC{
+			NIC: []metal3api.NIC{
 				{
 					Name:      "nic-1",
 					Model:     "virt-io",
@@ -153,24 +153,24 @@ func (p *fixtureProvisioner) InspectHardware(data provisioner.InspectData, resta
 					PXE:       false,
 				},
 			},
-			Storage: []metal3v1alpha1.Storage{
+			Storage: []metal3api.Storage{
 				{
 					Name:       "disk-1 (boot)",
 					Rotational: false,
-					SizeBytes:  metal3v1alpha1.TebiByte * 93,
+					SizeBytes:  metal3api.TebiByte * 93,
 					Model:      "Dell CFJ61",
 				},
 				{
 					Name:       "disk-2",
 					Rotational: false,
-					SizeBytes:  metal3v1alpha1.TebiByte * 93,
+					SizeBytes:  metal3api.TebiByte * 93,
 					Model:      "Dell CFJ61",
 				},
 			},
-			CPU: metal3v1alpha1.CPU{
+			CPU: metal3api.CPU{
 				Arch:           "x86_64",
 				Model:          "FancyPants CPU",
-				ClockMegahertz: 3.0 * metal3v1alpha1.GigaHertz,
+				ClockMegahertz: 3.0 * metal3api.GigaHertz,
 				Flags:          []string{"fpu", "hypervisor", "sse", "vmx"},
 				Count:          1,
 			},
@@ -251,7 +251,7 @@ func (p *fixtureProvisioner) Deprovision(restartOnFailure bool) (result provisio
 	if p.state.image.URL != "" {
 		p.publisher("DeprovisionStarted", "Image deprovisioning started")
 		p.log.Info("clearing hardware details")
-		p.state.image = metal3v1alpha1.Image{}
+		p.state.image = metal3api.Image{}
 		result.Dirty = true
 		return result, nil
 	}
@@ -311,7 +311,7 @@ func (p *fixtureProvisioner) PowerOn(force bool) (result provisioner.Result, err
 
 // PowerOff ensures the server is powered off independently of any image
 // provisioning operation.
-func (p *fixtureProvisioner) PowerOff(rebootMode metal3v1alpha1.RebootMode, force bool) (result provisioner.Result, err error) {
+func (p *fixtureProvisioner) PowerOff(rebootMode metal3api.RebootMode, force bool) (result provisioner.Result, err error) {
 	p.log.Info("ensuring host is powered off")
 
 	if p.state.poweredOn {
@@ -336,15 +336,15 @@ func (p *fixtureProvisioner) IsReady() (result bool, err error) {
 	return p.state.BecomeReadyCounter == 0, nil
 }
 
-func (p *fixtureProvisioner) GetFirmwareSettings(includeSchema bool) (settings metal3v1alpha1.SettingsMap, schema map[string]metal3v1alpha1.SettingSchema, err error) {
+func (p *fixtureProvisioner) GetFirmwareSettings(includeSchema bool) (settings metal3api.SettingsMap, schema map[string]metal3api.SettingSchema, err error) {
 	p.log.Info("getting BIOS settings")
 	return
 }
 
-func (p *fixtureProvisioner) AddBMCEventSubscriptionForNode(subscription *metal3v1alpha1.BMCEventSubscription, httpHeaders provisioner.HTTPHeaders) (result provisioner.Result, err error) {
+func (p *fixtureProvisioner) AddBMCEventSubscriptionForNode(subscription *metal3api.BMCEventSubscription, httpHeaders provisioner.HTTPHeaders) (result provisioner.Result, err error) {
 	return result, nil
 }
 
-func (p *fixtureProvisioner) RemoveBMCEventSubscriptionForNode(subscription metal3v1alpha1.BMCEventSubscription) (result provisioner.Result, err error) {
+func (p *fixtureProvisioner) RemoveBMCEventSubscriptionForNode(subscription metal3api.BMCEventSubscription) (result provisioner.Result, err error) {
 	return result, nil
 }

--- a/pkg/provisioner/ironic/bios_test.go
+++ b/pkg/provisioner/ironic/bios_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/testserver"
@@ -23,32 +23,32 @@ func TestGetFirmwareSettings(t *testing.T) {
 
 	cases := []struct {
 		name                string
-		expectedSettingsMap metal3v1alpha1.SettingsMap
-		expectedSchemaMap   map[string]metal3v1alpha1.SettingSchema
+		expectedSettingsMap metal3api.SettingsMap
+		expectedSchemaMap   map[string]metal3api.SettingSchema
 		includeSchema       bool
 		ironic              *testserver.IronicMock
 		expectedError       string
 	}{
 		{
 			name: "no-schema",
-			expectedSettingsMap: metal3v1alpha1.SettingsMap{
+			expectedSettingsMap: metal3api.SettingsMap{
 				"L2Cache":            "10x256 KB",
 				"NumCores":           "10",
 				"ProcVirtualization": "Enabled",
 			},
-			expectedSchemaMap: map[string]metal3v1alpha1.SettingSchema{},
+			expectedSchemaMap: map[string]metal3api.SettingSchema{},
 			ironic:            testserver.NewIronic(t).BIOSSettings(nodeUUID),
 			includeSchema:     false,
 			expectedError:     "",
 		},
 		{
 			name: "include-schema",
-			expectedSettingsMap: metal3v1alpha1.SettingsMap{
+			expectedSettingsMap: metal3api.SettingsMap{
 				"L2Cache":            "10x256 KB",
 				"NumCores":           "10",
 				"ProcVirtualization": "Enabled",
 			},
-			expectedSchemaMap: map[string]metal3v1alpha1.SettingSchema{
+			expectedSchemaMap: map[string]metal3api.SettingSchema{
 				"L2Cache": {
 					AttributeType:   "String",
 					AllowableValues: []string{},
@@ -86,8 +86,8 @@ func TestGetFirmwareSettings(t *testing.T) {
 		},
 		{
 			name:                "error404",
-			expectedSettingsMap: metal3v1alpha1.SettingsMap(nil),
-			expectedSchemaMap:   map[string]metal3v1alpha1.SettingSchema(nil),
+			expectedSettingsMap: metal3api.SettingsMap(nil),
+			expectedSchemaMap:   map[string]metal3api.SettingSchema(nil),
 			ironic:              testserver.NewIronic(t).NoBIOS(nodeUUID),
 			includeSchema:       false,
 			expectedError:       "could not get node for BIOS settings: Host not registered",

--- a/pkg/provisioner/ironic/capabilities_test.go
+++ b/pkg/provisioner/ironic/capabilities_test.go
@@ -6,20 +6,20 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
 	"github.com/stretchr/testify/assert"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 )
 
 func TestBuildCapabilitiesValue(t *testing.T) {
 	cases := []struct {
 		Scenario      string
 		Node          nodes.Node
-		Mode          metal3v1alpha1.BootMode
+		Mode          metal3api.BootMode
 		ExpectedValue string
 	}{
 		{
 			Scenario:      "unset",
 			Node:          nodes.Node{},
-			Mode:          metal3v1alpha1.UEFI,
+			Mode:          metal3api.UEFI,
 			ExpectedValue: "boot_mode:uefi",
 		},
 		{
@@ -29,7 +29,7 @@ func TestBuildCapabilitiesValue(t *testing.T) {
 					"capabilities": "",
 				},
 			},
-			Mode:          metal3v1alpha1.UEFI,
+			Mode:          metal3api.UEFI,
 			ExpectedValue: "boot_mode:uefi",
 		},
 		{
@@ -39,7 +39,7 @@ func TestBuildCapabilitiesValue(t *testing.T) {
 					"capabilities": "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true",
 				},
 			},
-			Mode:          metal3v1alpha1.UEFI,
+			Mode:          metal3api.UEFI,
 			ExpectedValue: "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true,boot_mode:uefi",
 		},
 		{
@@ -49,7 +49,7 @@ func TestBuildCapabilitiesValue(t *testing.T) {
 					"capabilities": "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true",
 				},
 			},
-			Mode:          metal3v1alpha1.UEFISecureBoot,
+			Mode:          metal3api.UEFISecureBoot,
 			ExpectedValue: "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true,boot_mode:uefi,secure_boot:true",
 		},
 		{
@@ -59,7 +59,7 @@ func TestBuildCapabilitiesValue(t *testing.T) {
 					"capabilities": "boot_mode:uefi,cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true",
 				},
 			},
-			Mode:          metal3v1alpha1.UEFI,
+			Mode:          metal3api.UEFI,
 			ExpectedValue: "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true,boot_mode:uefi",
 		},
 		{
@@ -69,7 +69,7 @@ func TestBuildCapabilitiesValue(t *testing.T) {
 					"capabilities": "boot_mode:bios,cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true",
 				},
 			},
-			Mode:          metal3v1alpha1.Legacy,
+			Mode:          metal3api.Legacy,
 			ExpectedValue: "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true,boot_mode:bios",
 		},
 		{
@@ -79,7 +79,7 @@ func TestBuildCapabilitiesValue(t *testing.T) {
 					"capabilities": "boot_mode:bios,cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true",
 				},
 			},
-			Mode:          metal3v1alpha1.UEFI,
+			Mode:          metal3api.UEFI,
 			ExpectedValue: "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true,boot_mode:uefi",
 		},
 		{
@@ -89,7 +89,7 @@ func TestBuildCapabilitiesValue(t *testing.T) {
 					"capabilities": "boot_mode:uefi,cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true",
 				},
 			},
-			Mode:          metal3v1alpha1.Legacy,
+			Mode:          metal3api.Legacy,
 			ExpectedValue: "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true,boot_mode:bios",
 		},
 		{
@@ -99,7 +99,7 @@ func TestBuildCapabilitiesValue(t *testing.T) {
 					"capabilities": "boot_mode:uefi,cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true",
 				},
 			},
-			Mode:          metal3v1alpha1.UEFISecureBoot,
+			Mode:          metal3api.UEFISecureBoot,
 			ExpectedValue: "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true,boot_mode:uefi,secure_boot:true",
 		},
 		{
@@ -109,7 +109,7 @@ func TestBuildCapabilitiesValue(t *testing.T) {
 					"capabilities": "boot_mode:uefi,cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true,secure_boot:true",
 				},
 			},
-			Mode:          metal3v1alpha1.UEFI,
+			Mode:          metal3api.UEFI,
 			ExpectedValue: "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true,boot_mode:uefi",
 		},
 	}

--- a/pkg/provisioner/ironic/devicehints/devicehints.go
+++ b/pkg/provisioner/ironic/devicehints/devicehints.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"strings"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 )
 
 // MakeHintMap converts a RootDeviceHints instance into a string map
 // suitable to pass to ironic.
-func MakeHintMap(source *metal3v1alpha1.RootDeviceHints) map[string]string {
+func MakeHintMap(source *metal3api.RootDeviceHints) map[string]string {
 	hints := map[string]string{}
 
 	if source == nil {

--- a/pkg/provisioner/ironic/devicehints/devicehints_test.go
+++ b/pkg/provisioner/ironic/devicehints/devicehints_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 )
 
 func TestMakeHintMap(t *testing.T) {
@@ -14,12 +14,12 @@ func TestMakeHintMap(t *testing.T) {
 
 	for _, tc := range []struct {
 		Scenario string
-		Hints    metal3v1alpha1.RootDeviceHints
+		Hints    metal3api.RootDeviceHints
 		Expected map[string]string
 	}{
 		{
 			Scenario: "device-name",
-			Hints: metal3v1alpha1.RootDeviceHints{
+			Hints: metal3api.RootDeviceHints{
 				DeviceName: "userd_devicename",
 			},
 			Expected: map[string]string{
@@ -28,7 +28,7 @@ func TestMakeHintMap(t *testing.T) {
 		},
 		{
 			Scenario: "hctl",
-			Hints: metal3v1alpha1.RootDeviceHints{
+			Hints: metal3api.RootDeviceHints{
 				HCTL: "1:2:3:4",
 			},
 			Expected: map[string]string{
@@ -37,7 +37,7 @@ func TestMakeHintMap(t *testing.T) {
 		},
 		{
 			Scenario: "model",
-			Hints: metal3v1alpha1.RootDeviceHints{
+			Hints: metal3api.RootDeviceHints{
 				Model: "userd_model",
 			},
 			Expected: map[string]string{
@@ -46,7 +46,7 @@ func TestMakeHintMap(t *testing.T) {
 		},
 		{
 			Scenario: "vendor",
-			Hints: metal3v1alpha1.RootDeviceHints{
+			Hints: metal3api.RootDeviceHints{
 				Vendor: "userd_vendor",
 			},
 			Expected: map[string]string{
@@ -55,7 +55,7 @@ func TestMakeHintMap(t *testing.T) {
 		},
 		{
 			Scenario: "serial-number",
-			Hints: metal3v1alpha1.RootDeviceHints{
+			Hints: metal3api.RootDeviceHints{
 				SerialNumber: "userd_serial",
 			},
 			Expected: map[string]string{
@@ -64,7 +64,7 @@ func TestMakeHintMap(t *testing.T) {
 		},
 		{
 			Scenario: "min-size",
-			Hints: metal3v1alpha1.RootDeviceHints{
+			Hints: metal3api.RootDeviceHints{
 				MinSizeGigabytes: 40,
 			},
 			Expected: map[string]string{
@@ -73,7 +73,7 @@ func TestMakeHintMap(t *testing.T) {
 		},
 		{
 			Scenario: "wwn",
-			Hints: metal3v1alpha1.RootDeviceHints{
+			Hints: metal3api.RootDeviceHints{
 				WWN: "userd_wwn",
 			},
 			Expected: map[string]string{
@@ -82,7 +82,7 @@ func TestMakeHintMap(t *testing.T) {
 		},
 		{
 			Scenario: "wwn-with-extension",
-			Hints: metal3v1alpha1.RootDeviceHints{
+			Hints: metal3api.RootDeviceHints{
 				WWNWithExtension: "userd_with_extension",
 			},
 			Expected: map[string]string{
@@ -91,7 +91,7 @@ func TestMakeHintMap(t *testing.T) {
 		},
 		{
 			Scenario: "wwn-extension",
-			Hints: metal3v1alpha1.RootDeviceHints{
+			Hints: metal3api.RootDeviceHints{
 				WWNVendorExtension: "userd_vendor_extension",
 			},
 			Expected: map[string]string{
@@ -100,7 +100,7 @@ func TestMakeHintMap(t *testing.T) {
 		},
 		{
 			Scenario: "rotational-true",
-			Hints: metal3v1alpha1.RootDeviceHints{
+			Hints: metal3api.RootDeviceHints{
 				Rotational: &addressableTrue,
 			},
 			Expected: map[string]string{
@@ -109,7 +109,7 @@ func TestMakeHintMap(t *testing.T) {
 		},
 		{
 			Scenario: "rotational-false",
-			Hints: metal3v1alpha1.RootDeviceHints{
+			Hints: metal3api.RootDeviceHints{
 				Rotational: &addressableFalse,
 			},
 			Expected: map[string]string{
@@ -118,7 +118,7 @@ func TestMakeHintMap(t *testing.T) {
 		},
 		{
 			Scenario: "everything-bagel",
-			Hints: metal3v1alpha1.RootDeviceHints{
+			Hints: metal3api.RootDeviceHints{
 				DeviceName:         "userd_devicename",
 				HCTL:               "1:2:3:4",
 				Model:              "userd_model",
@@ -145,7 +145,7 @@ func TestMakeHintMap(t *testing.T) {
 		},
 		{
 			Scenario: "empty",
-			Hints:    metal3v1alpha1.RootDeviceHints{},
+			Hints:    metal3api.RootDeviceHints{},
 			Expected: map[string]string{},
 		},
 	} {

--- a/pkg/provisioner/ironic/hardwaredetails/hardwaredetails_test.go
+++ b/pkg/provisioner/ironic/hardwaredetails/hardwaredetails_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/v1/introspection"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 )
 
 func TestGetVLANs(t *testing.T) {
@@ -31,10 +31,10 @@ func TestGetVLANs(t *testing.T) {
 	if len(vlans) != 2 {
 		t.Errorf("Expected 2 VLANs, got %d", len(vlans))
 	}
-	if (vlans[0] != metal3v1alpha1.VLAN{ID: 1, Name: "vlan1"}) {
+	if (vlans[0] != metal3api.VLAN{ID: 1, Name: "vlan1"}) {
 		t.Errorf("Unexpected VLAN %d %s", vlans[0].ID, vlans[0].Name)
 	}
-	if (vlans[1] != metal3v1alpha1.VLAN{ID: 4094, Name: "vlan4094"}) {
+	if (vlans[1] != metal3api.VLAN{ID: 4094, Name: "vlan4094"}) {
 		t.Errorf("Unexpected VLAN %d %s", vlans[1].ID, vlans[1].Name)
 	}
 }
@@ -72,19 +72,19 @@ func TestGetVLANsMalformed(t *testing.T) {
 	if len(vlans) != 5 {
 		t.Errorf("Expected 5 VLANs, got %d", len(vlans))
 	}
-	if (vlans[0] != metal3v1alpha1.VLAN{Name: "vlan1"}) {
+	if (vlans[0] != metal3api.VLAN{Name: "vlan1"}) {
 		t.Errorf("Unexpected VLAN %d %s", vlans[0].ID, vlans[0].Name)
 	}
-	if (vlans[1] != metal3v1alpha1.VLAN{ID: 1}) {
+	if (vlans[1] != metal3api.VLAN{ID: 1}) {
 		t.Errorf("Unexpected VLAN %d %s", vlans[0].ID, vlans[0].Name)
 	}
-	if (vlans[2] != metal3v1alpha1.VLAN{Name: "vlan2"}) {
+	if (vlans[2] != metal3api.VLAN{Name: "vlan2"}) {
 		t.Errorf("Unexpected VLAN %d %s", vlans[0].ID, vlans[0].Name)
 	}
-	if (vlans[3] != metal3v1alpha1.VLAN{ID: 3}) {
+	if (vlans[3] != metal3api.VLAN{ID: 3}) {
 		t.Errorf("Unexpected VLAN %d %s", vlans[0].ID, vlans[0].Name)
 	}
-	if (vlans[4] != metal3v1alpha1.VLAN{}) {
+	if (vlans[4] != metal3api.VLAN{}) {
 		t.Errorf("Unexpected VLAN %d %s", vlans[0].ID, vlans[0].Name)
 	}
 
@@ -191,19 +191,19 @@ func TestGetNICDetails(t *testing.T) {
 	if len(nics) != 5 {
 		t.Errorf("Expected 5 NICs, got %d", len(nics))
 	}
-	if (!reflect.DeepEqual(nics[0], metal3v1alpha1.NIC{
+	if (!reflect.DeepEqual(nics[0], metal3api.NIC{
 		Name: "eth0",
 		MAC:  "00:11:22:33:44:55",
 		IP:   "192.0.2.1",
 		PXE:  true,
-		VLANs: []metal3v1alpha1.VLAN{
+		VLANs: []metal3api.VLAN{
 			{ID: 1},
 		},
 		VLANID: 1,
 	})) {
 		t.Errorf("Unexpected NIC data")
 	}
-	if (!reflect.DeepEqual(nics[1], metal3v1alpha1.NIC{
+	if (!reflect.DeepEqual(nics[1], metal3api.NIC{
 		Name:      "eth1",
 		MAC:       "66:77:88:99:aa:bb",
 		IP:        "2001:db8::1",
@@ -211,21 +211,21 @@ func TestGetNICDetails(t *testing.T) {
 	})) {
 		t.Errorf("Unexpected NIC data")
 	}
-	if (!reflect.DeepEqual(nics[2], metal3v1alpha1.NIC{
+	if (!reflect.DeepEqual(nics[2], metal3api.NIC{
 		Name: "eth46",
 		MAC:  "00:11:22:33:44:66",
 		IP:   "192.0.2.2",
 	})) {
 		t.Errorf("Unexpected NIC data")
 	}
-	if (!reflect.DeepEqual(nics[3], metal3v1alpha1.NIC{
+	if (!reflect.DeepEqual(nics[3], metal3api.NIC{
 		Name: "eth46",
 		MAC:  "00:11:22:33:44:66",
 		IP:   "2001:db8::2",
 	})) {
 		t.Errorf("Unexpected NIC data")
 	}
-	if (!reflect.DeepEqual(nics[4], metal3v1alpha1.NIC{
+	if (!reflect.DeepEqual(nics[4], metal3api.NIC{
 		Name: "ethNoIp",
 		MAC:  "00:11:22:33:44:77",
 	})) {
@@ -299,7 +299,7 @@ func TestGetFirmwareDetails(t *testing.T) {
 	// Finally, ensure we can handle completely empty firmware data
 	firmware = getFirmwareDetails(introspection.ExtraHardwareDataSection{})
 
-	if (firmware != metal3v1alpha1.Firmware{}) {
+	if (firmware != metal3api.Firmware{}) {
 		t.Errorf("Expected firmware data to be empty but got: %s", firmware)
 	}
 

--- a/pkg/provisioner/ironic/inspecthardware_test.go
+++ b/pkg/provisioner/ironic/inspecthardware_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/v1/introspection"
 	"github.com/stretchr/testify/assert"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
@@ -270,7 +270,7 @@ func TestInspectHardware(t *testing.T) {
 			}
 
 			result, started, details, err := prov.InspectHardware(
-				provisioner.InspectData{BootMode: metal3v1alpha1.DefaultBootMode},
+				provisioner.InspectData{BootMode: metal3api.DefaultBootMode},
 				tc.restartOnFailure, false, tc.forceReboot)
 
 			assert.Equal(t, tc.expectedStarted, started)

--- a/pkg/provisioner/ironic/ironic_test.go
+++ b/pkg/provisioner/ironic/ironic_test.go
@@ -8,7 +8,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	logz "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
@@ -37,7 +37,7 @@ func newTestProvisionerFactory() ironicProvisionerFactory {
 
 // A private function to construct an ironicProvisioner (rather than a
 // Provisioner interface) in a consistent way for tests.
-func newProvisionerWithSettings(host metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher, ironicURL string, ironicAuthSettings clients.AuthConfig, inspectorURL string, inspectorAuthSettings clients.AuthConfig) (*ironicProvisioner, error) {
+func newProvisionerWithSettings(host metal3api.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher, ironicURL string, ironicAuthSettings clients.AuthConfig, inspectorURL string, inspectorAuthSettings clients.AuthConfig) (*ironicProvisioner, error) {
 	hostData := provisioner.BuildHostData(host, bmcCreds)
 
 	tlsConf := clients.TLSConfig{}
@@ -57,25 +57,25 @@ func newProvisionerWithSettings(host metal3v1alpha1.BareMetalHost, bmcCreds bmc.
 	return factory.ironicProvisioner(hostData, publisher)
 }
 
-func makeHost() metal3v1alpha1.BareMetalHost {
+func makeHost() metal3api.BareMetalHost {
 	rotational := true
 
-	return metal3v1alpha1.BareMetalHost{
+	return metal3api.BareMetalHost{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myhost",
 			Namespace: "myns",
 			UID:       "27720611-e5d1-45d3-ba3a-222dcfaa4ca2",
 		},
-		Spec: metal3v1alpha1.BareMetalHostSpec{
-			BMC: metal3v1alpha1.BMCDetails{
+		Spec: metal3api.BareMetalHostSpec{
+			BMC: metal3api.BMCDetails{
 				Address: "test://test.bmc/",
 			},
-			Image: &metal3v1alpha1.Image{
+			Image: &metal3api.Image{
 				URL: "not-empty",
 			},
 			Online:          true,
 			HardwareProfile: "libvirt",
-			RootDeviceHints: &metal3v1alpha1.RootDeviceHints{
+			RootDeviceHints: &metal3api.RootDeviceHints{
 				DeviceName:         "userd_devicename",
 				HCTL:               "1:2:3:4",
 				Model:              "userd_model",
@@ -88,12 +88,12 @@ func makeHost() metal3v1alpha1.BareMetalHost {
 				Rotational:         &rotational,
 			},
 		},
-		Status: metal3v1alpha1.BareMetalHostStatus{
-			Provisioning: metal3v1alpha1.ProvisionStatus{
+		Status: metal3api.BareMetalHostStatus{
+			Provisioning: metal3api.ProvisionStatus{
 				ID: "provisioning-id",
 				// Place the hints in the status field to pretend the
 				// controller has already reconciled partially.
-				RootDeviceHints: &metal3v1alpha1.RootDeviceHints{
+				RootDeviceHints: &metal3api.RootDeviceHints{
 					DeviceName:         "userd_devicename",
 					HCTL:               "1:2:3:4",
 					Model:              "userd_model",
@@ -105,23 +105,23 @@ func makeHost() metal3v1alpha1.BareMetalHost {
 					WWNVendorExtension: "userd_vendor_extension",
 					Rotational:         &rotational,
 				},
-				BootMode: metal3v1alpha1.UEFI,
+				BootMode: metal3api.UEFI,
 			},
 			HardwareProfile: "libvirt",
 		},
 	}
 }
 
-func makeHostLiveIso() (host metal3v1alpha1.BareMetalHost) {
+func makeHostLiveIso() (host metal3api.BareMetalHost) {
 	host = makeHost()
 	format := "live-iso"
 	host.Spec.Image.DiskFormat = &format
 	return host
 }
 
-func makeHostCustomDeploy(only bool) (host metal3v1alpha1.BareMetalHost) {
+func makeHostCustomDeploy(only bool) (host metal3api.BareMetalHost) {
 	host = makeHost()
-	host.Spec.CustomDeploy = &metal3v1alpha1.CustomDeploy{
+	host.Spec.CustomDeploy = &metal3api.CustomDeploy{
 		Method: "install_everything",
 	}
 	if only {
@@ -136,7 +136,7 @@ func nullEventPublisher(reason, message string) {}
 func TestNewNoBMCDetails(t *testing.T) {
 	// Create a host without BMC details
 	host := makeHost()
-	host.Spec.BMC = metal3v1alpha1.BMCDetails{}
+	host.Spec.BMC = metal3api.BMCDetails{}
 
 	factory := newTestProvisionerFactory()
 	prov, err := factory.NewProvisioner(provisioner.BuildHostData(host, bmc.Credentials{}), nullEventPublisher)

--- a/pkg/provisioner/ironic/power_test.go
+++ b/pkg/provisioner/ironic/power_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/v1/introspection"
 	"github.com/stretchr/testify/assert"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/testserver"
@@ -158,7 +158,7 @@ func TestPowerOff(t *testing.T) {
 		expectedRequestAfter int
 		expectedErrorResult  bool
 		expectedReason       string
-		rebootMode           metal3v1alpha1.RebootMode
+		rebootMode           metal3api.RebootMode
 	}{
 		{
 			name: "node-already-power-off",
@@ -184,7 +184,7 @@ func TestPowerOff(t *testing.T) {
 				TargetProvisionState: "",
 				UUID:                 nodeUUID,
 			}),
-			rebootMode:     metal3v1alpha1.RebootModeSoft,
+			rebootMode:     metal3api.RebootModeSoft,
 			expectedDirty:  true,
 			expectedReason: softPowerOffReason,
 		},
@@ -196,7 +196,7 @@ func TestPowerOff(t *testing.T) {
 				UUID:                 nodeUUID,
 			}),
 			expectedDirty:  true,
-			rebootMode:     metal3v1alpha1.RebootModeHard,
+			rebootMode:     metal3api.RebootModeHard,
 			expectedReason: hardPowerOffReason,
 		},
 		{
@@ -226,7 +226,7 @@ func TestPowerOff(t *testing.T) {
 				TargetProvisionState: "",
 				UUID:                 nodeUUID,
 			}),
-			rebootMode:     metal3v1alpha1.RebootModeSoft,
+			rebootMode:     metal3api.RebootModeSoft,
 			force:          true,
 			expectedDirty:  true,
 			expectedReason: hardPowerOffReason,
@@ -239,7 +239,7 @@ func TestPowerOff(t *testing.T) {
 				UUID:                 nodeUUID,
 				LastError:            "hard power off failed",
 			}),
-			rebootMode:          metal3v1alpha1.RebootModeHard,
+			rebootMode:          metal3api.RebootModeHard,
 			expectedDirty:       false,
 			expectedErrorResult: true,
 		},
@@ -251,7 +251,7 @@ func TestPowerOff(t *testing.T) {
 				UUID:                 nodeUUID,
 				LastError:            "hard power off failed",
 			}),
-			rebootMode:     metal3v1alpha1.RebootModeHard,
+			rebootMode:     metal3api.RebootModeHard,
 			force:          true,
 			expectedDirty:  true,
 			expectedReason: hardPowerOffReason,
@@ -335,7 +335,7 @@ func TestSoftPowerOffFallback(t *testing.T) {
 		t.Fatalf("could not create provisioner: %s", err)
 	}
 
-	_, err = prov.PowerOff(metal3v1alpha1.RebootModeSoft, false)
+	_, err = prov.PowerOff(metal3api.RebootModeSoft, false)
 	assert.Error(t, err)
 	assert.False(t, errors.As(err, &softPowerOffUnsupportedError{}))
 

--- a/pkg/provisioner/ironic/prepare_test.go
+++ b/pkg/provisioner/ironic/prepare_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/v1/introspection"
 	"github.com/stretchr/testify/assert"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
@@ -184,8 +184,8 @@ func TestPrepare(t *testing.T) {
 			prepData := provisioner.PrepareData{}
 			if tc.existRaidConfig {
 				host.Spec.BMC.Address = "raid-test://test.bmc/"
-				prepData.TargetRAIDConfig = &metal3v1alpha1.RAIDConfig{
-					HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{
+				prepData.TargetRAIDConfig = &metal3api.RAIDConfig{
+					HardwareRAIDVolumes: []metal3api.HardwareRAIDVolume{
 						{
 							Name:  "root",
 							Level: "1",

--- a/pkg/provisioner/ironic/raid.go
+++ b/pkg/provisioner/ironic/raid.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
 	"github.com/pkg/errors"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/devicehints"
 )
@@ -63,7 +63,7 @@ func setTargetRAIDCfg(p *ironicProvisioner, raidInterface string, ironicNode *no
 }
 
 // BuildTargetRAIDCfg build RAID logical disks, this method doesn't set the root volume
-func BuildTargetRAIDCfg(raid *metal3v1alpha1.RAIDConfig) (logicalDisks []nodes.LogicalDisk, err error) {
+func BuildTargetRAIDCfg(raid *metal3api.RAIDConfig) (logicalDisks []nodes.LogicalDisk, err error) {
 	// Deal possible panic
 	defer func() {
 		r := recover()
@@ -87,7 +87,7 @@ func BuildTargetRAIDCfg(raid *metal3v1alpha1.RAIDConfig) (logicalDisks []nodes.L
 }
 
 // A private method to build hardware RAID disks
-func buildTargetHardwareRAIDCfg(volumes []metal3v1alpha1.HardwareRAIDVolume) (logicalDisks []nodes.LogicalDisk, err error) {
+func buildTargetHardwareRAIDCfg(volumes []metal3api.HardwareRAIDVolume) (logicalDisks []nodes.LogicalDisk, err error) {
 	var (
 		logicalDisk    nodes.LogicalDisk
 		nameCheckFlags = make(map[string]int)
@@ -152,7 +152,7 @@ func buildTargetHardwareRAIDCfg(volumes []metal3v1alpha1.HardwareRAIDVolume) (lo
 }
 
 // A private method to build software RAID disks
-func buildTargetSoftwareRAIDCfg(volumes []metal3v1alpha1.SoftwareRAIDVolume) (logicalDisks []nodes.LogicalDisk, err error) {
+func buildTargetSoftwareRAIDCfg(volumes []metal3api.SoftwareRAIDVolume) (logicalDisks []nodes.LogicalDisk, err error) {
 	var (
 		logicalDisk nodes.LogicalDisk
 	)
@@ -184,7 +184,7 @@ func buildTargetSoftwareRAIDCfg(volumes []metal3v1alpha1.SoftwareRAIDVolume) (lo
 }
 
 // BuildRAIDCleanSteps build the clean steps for RAID configuration from BaremetalHost spec
-func BuildRAIDCleanSteps(raidInterface string, target *metal3v1alpha1.RAIDConfig, actual *metal3v1alpha1.RAIDConfig) (cleanSteps []nodes.CleanStep, err error) {
+func BuildRAIDCleanSteps(raidInterface string, target *metal3api.RAIDConfig, actual *metal3api.RAIDConfig) (cleanSteps []nodes.CleanStep, err error) {
 	_, err = CheckRAIDInterface(raidInterface, target, actual)
 	if err != nil {
 		return nil, err
@@ -277,7 +277,7 @@ func BuildRAIDCleanSteps(raidInterface string, target *metal3v1alpha1.RAIDConfig
 }
 
 // CheckRAIDInterface checks the current RAID interface against the requested configuration
-func CheckRAIDInterface(raidInterface string, target, actual *metal3v1alpha1.RAIDConfig) (string, error) {
+func CheckRAIDInterface(raidInterface string, target, actual *metal3api.RAIDConfig) (string, error) {
 	if target == nil {
 		return raidInterface, nil
 	}

--- a/pkg/provisioner/ironic/raid_test.go
+++ b/pkg/provisioner/ironic/raid_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
 	"github.com/stretchr/testify/assert"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 )
 
 func TestBuildTargetRAIDCfg(t *testing.T) {
@@ -23,14 +23,14 @@ func TestBuildTargetRAIDCfg(t *testing.T) {
 
 	cases := []struct {
 		name          string
-		raid          *metal3v1alpha1.RAIDConfig
+		raid          *metal3api.RAIDConfig
 		expected      []nodes.LogicalDisk
 		expectedError string
 	}{
 		{
 			name: "hardware raid, physicalDisks without controller",
-			raid: &metal3v1alpha1.RAIDConfig{
-				HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{
+			raid: &metal3api.RAIDConfig{
+				HardwareRAIDVolumes: []metal3api.HardwareRAIDVolume{
 					{
 						Name:          "volume1",
 						Level:         "1",
@@ -43,8 +43,8 @@ func TestBuildTargetRAIDCfg(t *testing.T) {
 		}, // end of test case
 		{
 			name: "hardware raid, len(physicalDisks) != numberOfPhysicalDisks",
-			raid: &metal3v1alpha1.RAIDConfig{
-				HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{
+			raid: &metal3api.RAIDConfig{
+				HardwareRAIDVolumes: []metal3api.HardwareRAIDVolume{
 					{
 						Name:                  "volume1",
 						Level:                 "1",
@@ -59,8 +59,8 @@ func TestBuildTargetRAIDCfg(t *testing.T) {
 		},
 		{
 			name: "hardware raid",
-			raid: &metal3v1alpha1.RAIDConfig{
-				HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{
+			raid: &metal3api.RAIDConfig{
+				HardwareRAIDVolumes: []metal3api.HardwareRAIDVolume{
 					{
 						Name:       "root",
 						Level:      "1",
@@ -72,7 +72,7 @@ func TestBuildTargetRAIDCfg(t *testing.T) {
 						Rotational: &TRUE,
 					},
 				},
-				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{
+				SoftwareRAIDVolumes: []metal3api.SoftwareRAIDVolume{
 					{
 						Level: "1",
 					},
@@ -98,8 +98,8 @@ func TestBuildTargetRAIDCfg(t *testing.T) {
 		},
 		{
 			name: "hardware raid, same volume's name",
-			raid: &metal3v1alpha1.RAIDConfig{
-				HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{
+			raid: &metal3api.RAIDConfig{
+				HardwareRAIDVolumes: []metal3api.HardwareRAIDVolume{
 					{
 						Name:  "v1",
 						Level: "1",
@@ -114,8 +114,8 @@ func TestBuildTargetRAIDCfg(t *testing.T) {
 		},
 		{
 			name: "hardware raid, volume's name is empty",
-			raid: &metal3v1alpha1.RAIDConfig{
-				HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{
+			raid: &metal3api.RAIDConfig{
+				HardwareRAIDVolumes: []metal3api.HardwareRAIDVolume{
 					{
 						Name:  "",
 						Level: "1",
@@ -141,11 +141,11 @@ func TestBuildTargetRAIDCfg(t *testing.T) {
 		},
 		{
 			name: "software raid",
-			raid: &metal3v1alpha1.RAIDConfig{
-				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{
+			raid: &metal3api.RAIDConfig{
+				SoftwareRAIDVolumes: []metal3api.SoftwareRAIDVolume{
 					{
 						Level: "1",
-						PhysicalDisks: []metal3v1alpha1.RootDeviceHints{
+						PhysicalDisks: []metal3api.RootDeviceHints{
 							{
 								MinSizeGigabytes: 100,
 							},
@@ -180,8 +180,8 @@ func TestBuildTargetRAIDCfg(t *testing.T) {
 		},
 		{
 			name: "software raid, the level in first volume isn't RAID1",
-			raid: &metal3v1alpha1.RAIDConfig{
-				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{
+			raid: &metal3api.RAIDConfig{
+				SoftwareRAIDVolumes: []metal3api.SoftwareRAIDVolume{
 					{
 						Level: "0",
 					},
@@ -199,7 +199,7 @@ func TestBuildTargetRAIDCfg(t *testing.T) {
 		},
 		{
 			name: "volumes is nil",
-			raid: &metal3v1alpha1.RAIDConfig{
+			raid: &metal3api.RAIDConfig{
 				HardwareRAIDVolumes: nil,
 				SoftwareRAIDVolumes: nil,
 			},
@@ -207,9 +207,9 @@ func TestBuildTargetRAIDCfg(t *testing.T) {
 		},
 		{
 			name: "volumes is empty",
-			raid: &metal3v1alpha1.RAIDConfig{
-				HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{},
-				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{},
+			raid: &metal3api.RAIDConfig{
+				HardwareRAIDVolumes: []metal3api.HardwareRAIDVolume{},
+				SoftwareRAIDVolumes: []metal3api.SoftwareRAIDVolume{},
 			},
 			expected: nil,
 		},
@@ -235,8 +235,8 @@ func TestBuildRAIDCleanSteps(t *testing.T) {
 	cases := []struct {
 		name          string
 		raidInterface string
-		target        *metal3v1alpha1.RAIDConfig
-		actual        *metal3v1alpha1.RAIDConfig
+		target        *metal3api.RAIDConfig
+		actual        *metal3api.RAIDConfig
 		expected      []nodes.CleanStep
 		expectedError bool
 	}{
@@ -248,13 +248,13 @@ func TestBuildRAIDCleanSteps(t *testing.T) {
 		{
 			name:          "keep hardware RAID",
 			raidInterface: "irmc",
-			target:        &metal3v1alpha1.RAIDConfig{},
+			target:        &metal3api.RAIDConfig{},
 		},
 		{
 			name:          "configure hardware RAID",
 			raidInterface: "irmc",
-			target: &metal3v1alpha1.RAIDConfig{
-				HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{
+			target: &metal3api.RAIDConfig{
+				HardwareRAIDVolumes: []metal3api.HardwareRAIDVolume{
 					{
 						Name:  "root",
 						Level: "1",
@@ -275,16 +275,16 @@ func TestBuildRAIDCleanSteps(t *testing.T) {
 		{
 			name:          "have same hardware RAID",
 			raidInterface: "irmc",
-			target: &metal3v1alpha1.RAIDConfig{
-				HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{
+			target: &metal3api.RAIDConfig{
+				HardwareRAIDVolumes: []metal3api.HardwareRAIDVolume{
 					{
 						Name:  "root",
 						Level: "1",
 					},
 				},
 			},
-			actual: &metal3v1alpha1.RAIDConfig{
-				HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{
+			actual: &metal3api.RAIDConfig{
+				HardwareRAIDVolumes: []metal3api.HardwareRAIDVolume{
 					{
 						Name:  "root",
 						Level: "1",
@@ -295,11 +295,11 @@ func TestBuildRAIDCleanSteps(t *testing.T) {
 		{
 			name:          "clear hardware RAID",
 			raidInterface: "irmc",
-			target: &metal3v1alpha1.RAIDConfig{
-				HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{},
+			target: &metal3api.RAIDConfig{
+				HardwareRAIDVolumes: []metal3api.HardwareRAIDVolume{},
 			},
-			actual: &metal3v1alpha1.RAIDConfig{
-				HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{
+			actual: &metal3api.RAIDConfig{
+				HardwareRAIDVolumes: []metal3api.HardwareRAIDVolume{
 					{
 						Name:  "root",
 						Level: "1",
@@ -316,8 +316,8 @@ func TestBuildRAIDCleanSteps(t *testing.T) {
 		{
 			name:          "configure software RAID",
 			raidInterface: "agent",
-			target: &metal3v1alpha1.RAIDConfig{
-				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{
+			target: &metal3api.RAIDConfig{
+				SoftwareRAIDVolumes: []metal3api.SoftwareRAIDVolume{
 					{
 						Level: "1",
 					},
@@ -341,15 +341,15 @@ func TestBuildRAIDCleanSteps(t *testing.T) {
 		{
 			name:          "have same software RAID",
 			raidInterface: "agent",
-			target: &metal3v1alpha1.RAIDConfig{
-				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{
+			target: &metal3api.RAIDConfig{
+				SoftwareRAIDVolumes: []metal3api.SoftwareRAIDVolume{
 					{
 						Level: "1",
 					},
 				},
 			},
-			actual: &metal3v1alpha1.RAIDConfig{
-				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{
+			actual: &metal3api.RAIDConfig{
+				SoftwareRAIDVolumes: []metal3api.SoftwareRAIDVolume{
 					{
 						Level: "1",
 					},
@@ -359,26 +359,26 @@ func TestBuildRAIDCleanSteps(t *testing.T) {
 		{
 			name:          "keep missing software RAID",
 			raidInterface: "agent",
-			target: &metal3v1alpha1.RAIDConfig{
-				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{},
+			target: &metal3api.RAIDConfig{
+				SoftwareRAIDVolumes: []metal3api.SoftwareRAIDVolume{},
 			},
 		},
 		{
 			name:          "keep empty software RAID",
 			raidInterface: "agent",
-			target: &metal3v1alpha1.RAIDConfig{
-				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{},
+			target: &metal3api.RAIDConfig{
+				SoftwareRAIDVolumes: []metal3api.SoftwareRAIDVolume{},
 			},
-			actual: &metal3v1alpha1.RAIDConfig{},
+			actual: &metal3api.RAIDConfig{},
 		},
 		{
 			name:          "clear software RAID",
 			raidInterface: "agent",
-			target: &metal3v1alpha1.RAIDConfig{
-				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{},
+			target: &metal3api.RAIDConfig{
+				SoftwareRAIDVolumes: []metal3api.SoftwareRAIDVolume{},
 			},
-			actual: &metal3v1alpha1.RAIDConfig{
-				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{
+			actual: &metal3api.RAIDConfig{
+				SoftwareRAIDVolumes: []metal3api.SoftwareRAIDVolume{
 					{
 						Level: "1",
 					},
@@ -413,22 +413,22 @@ func TestBuildRAIDCleanSteps(t *testing.T) {
 func TestCheckRAIDConfigure(t *testing.T) {
 	cases := []struct {
 		raidInterface        string
-		RAID                 *metal3v1alpha1.RAIDConfig
+		RAID                 *metal3api.RAIDConfig
 		expectedError        bool
 		expectedNewInterface string
-		currentRAID          *metal3v1alpha1.RAIDConfig
+		currentRAID          *metal3api.RAIDConfig
 	}{
 		{
 			raidInterface: "no-raid",
 		},
 		{
 			raidInterface: "no-raid",
-			RAID:          &metal3v1alpha1.RAIDConfig{},
+			RAID:          &metal3api.RAIDConfig{},
 		},
 		{
 			raidInterface: "no-raid",
-			RAID: &metal3v1alpha1.RAIDConfig{
-				HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{
+			RAID: &metal3api.RAIDConfig{
+				HardwareRAIDVolumes: []metal3api.HardwareRAIDVolume{
 					{
 						Name:  "root",
 						Level: "1",
@@ -439,8 +439,8 @@ func TestCheckRAIDConfigure(t *testing.T) {
 		},
 		{
 			raidInterface: "no-raid",
-			RAID: &metal3v1alpha1.RAIDConfig{
-				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{
+			RAID: &metal3api.RAIDConfig{
+				SoftwareRAIDVolumes: []metal3api.SoftwareRAIDVolume{
 					{
 						Level: "1",
 					},
@@ -453,12 +453,12 @@ func TestCheckRAIDConfigure(t *testing.T) {
 		},
 		{
 			raidInterface: "agent",
-			RAID:          &metal3v1alpha1.RAIDConfig{},
+			RAID:          &metal3api.RAIDConfig{},
 		},
 		{
 			raidInterface: "agent",
-			RAID: &metal3v1alpha1.RAIDConfig{
-				HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{
+			RAID: &metal3api.RAIDConfig{
+				HardwareRAIDVolumes: []metal3api.HardwareRAIDVolume{
 					{
 						Name:  "root",
 						Level: "1",
@@ -469,8 +469,8 @@ func TestCheckRAIDConfigure(t *testing.T) {
 		},
 		{
 			raidInterface: "agent",
-			RAID: &metal3v1alpha1.RAIDConfig{
-				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{
+			RAID: &metal3api.RAIDConfig{
+				SoftwareRAIDVolumes: []metal3api.SoftwareRAIDVolume{
 					{
 						Level: "1",
 					},
@@ -482,12 +482,12 @@ func TestCheckRAIDConfigure(t *testing.T) {
 		},
 		{
 			raidInterface: "hardware",
-			RAID:          &metal3v1alpha1.RAIDConfig{},
+			RAID:          &metal3api.RAIDConfig{},
 		},
 		{
 			raidInterface: "hardware",
-			RAID: &metal3v1alpha1.RAIDConfig{
-				HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{
+			RAID: &metal3api.RAIDConfig{
+				HardwareRAIDVolumes: []metal3api.HardwareRAIDVolume{
 					{
 						Name:  "root",
 						Level: "1",
@@ -497,8 +497,8 @@ func TestCheckRAIDConfigure(t *testing.T) {
 		},
 		{
 			raidInterface: "hardware",
-			RAID: &metal3v1alpha1.RAIDConfig{
-				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{
+			RAID: &metal3api.RAIDConfig{
+				SoftwareRAIDVolumes: []metal3api.SoftwareRAIDVolume{
 					{
 						Level: "1",
 					},
@@ -508,11 +508,11 @@ func TestCheckRAIDConfigure(t *testing.T) {
 		},
 		{
 			raidInterface: "hardware",
-			RAID: &metal3v1alpha1.RAIDConfig{
-				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{},
+			RAID: &metal3api.RAIDConfig{
+				SoftwareRAIDVolumes: []metal3api.SoftwareRAIDVolume{},
 			},
-			currentRAID: &metal3v1alpha1.RAIDConfig{
-				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{
+			currentRAID: &metal3api.RAIDConfig{
+				SoftwareRAIDVolumes: []metal3api.SoftwareRAIDVolume{
 					{
 						Level: "1",
 					},

--- a/pkg/provisioner/ironic/updateopts_test.go
+++ b/pkg/provisioner/ironic/updateopts_test.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/utils/pointer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/profile"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
@@ -467,7 +467,7 @@ func TestGetUpdateOptsForNodeWithRootHints(t *testing.T) {
 
 	provData := provisioner.ProvisionData{
 		Image:           *host.Spec.Image,
-		BootMode:        metal3v1alpha1.DefaultBootMode,
+		BootMode:        metal3api.DefaultBootMode,
 		RootDeviceHints: host.Status.Provisioning.RootDeviceHints,
 	}
 	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates
@@ -522,28 +522,28 @@ func TestGetUpdateOptsForNodeWithRootHints(t *testing.T) {
 }
 
 func TestGetUpdateOptsForNodeVirtual(t *testing.T) {
-	host := metal3v1alpha1.BareMetalHost{
+	host := metal3api.BareMetalHost{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myhost",
 			Namespace: "myns",
 			UID:       "27720611-e5d1-45d3-ba3a-222dcfaa4ca2",
 		},
-		Spec: metal3v1alpha1.BareMetalHostSpec{
-			BMC: metal3v1alpha1.BMCDetails{
+		Spec: metal3api.BareMetalHostSpec{
+			BMC: metal3api.BMCDetails{
 				Address: "test://test.bmc/",
 			},
-			Image: &metal3v1alpha1.Image{
+			Image: &metal3api.Image{
 				URL:          "not-empty",
 				Checksum:     "checksum",
-				ChecksumType: metal3v1alpha1.MD5,
+				ChecksumType: metal3api.MD5,
 				DiskFormat:   pointer.StringPtr("raw"),
 			},
 			Online:          true,
 			HardwareProfile: "unknown",
 		},
-		Status: metal3v1alpha1.BareMetalHostStatus{
+		Status: metal3api.BareMetalHostStatus{
 			HardwareProfile: "libvirt",
-			Provisioning: metal3v1alpha1.ProvisionStatus{
+			Provisioning: metal3api.ProvisionStatus{
 				ID: "provisioning-id",
 			},
 		},
@@ -563,7 +563,7 @@ func TestGetUpdateOptsForNodeVirtual(t *testing.T) {
 	hwProf, _ := profile.GetProfile("libvirt")
 	provData := provisioner.ProvisionData{
 		Image:           *host.Spec.Image,
-		BootMode:        metal3v1alpha1.DefaultBootMode,
+		BootMode:        metal3api.DefaultBootMode,
 		HardwareProfile: hwProf,
 	}
 	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates
@@ -630,27 +630,27 @@ func TestGetUpdateOptsForNodeVirtual(t *testing.T) {
 }
 
 func TestGetUpdateOptsForNodeDell(t *testing.T) {
-	host := metal3v1alpha1.BareMetalHost{
+	host := metal3api.BareMetalHost{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myhost",
 			Namespace: "myns",
 			UID:       "27720611-e5d1-45d3-ba3a-222dcfaa4ca2",
 		},
-		Spec: metal3v1alpha1.BareMetalHostSpec{
-			BMC: metal3v1alpha1.BMCDetails{
+		Spec: metal3api.BareMetalHostSpec{
+			BMC: metal3api.BMCDetails{
 				Address: "test://test.bmc/",
 			},
-			Image: &metal3v1alpha1.Image{
+			Image: &metal3api.Image{
 				URL:          "not-empty",
 				Checksum:     "checksum",
-				ChecksumType: metal3v1alpha1.MD5,
+				ChecksumType: metal3api.MD5,
 				//DiskFormat not given to verify it is not added in instance_info
 			},
 			Online: true,
 		},
-		Status: metal3v1alpha1.BareMetalHostStatus{
+		Status: metal3api.BareMetalHostStatus{
 			HardwareProfile: "dell",
-			Provisioning: metal3v1alpha1.ProvisionStatus{
+			Provisioning: metal3api.ProvisionStatus{
 				ID: "provisioning-id",
 			},
 		},
@@ -670,7 +670,7 @@ func TestGetUpdateOptsForNodeDell(t *testing.T) {
 	hwProf, _ := profile.GetProfile("dell")
 	provData := provisioner.ProvisionData{
 		Image:           *host.Spec.Image,
-		BootMode:        metal3v1alpha1.DefaultBootMode,
+		BootMode:        metal3api.DefaultBootMode,
 		HardwareProfile: hwProf,
 	}
 	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates
@@ -743,7 +743,7 @@ func TestGetUpdateOptsForNodeLiveIso(t *testing.T) {
 
 	provData := provisioner.ProvisionData{
 		Image:    *host.Spec.Image,
-		BootMode: metal3v1alpha1.DefaultBootMode,
+		BootMode: metal3api.DefaultBootMode,
 	}
 	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates
 
@@ -812,7 +812,7 @@ func TestGetUpdateOptsForNodeImageToLiveIso(t *testing.T) {
 
 	provData := provisioner.ProvisionData{
 		Image:    *host.Spec.Image,
-		BootMode: metal3v1alpha1.DefaultBootMode,
+		BootMode: metal3api.DefaultBootMode,
 	}
 	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates
 
@@ -876,7 +876,7 @@ func TestGetUpdateOptsForNodeLiveIsoToImage(t *testing.T) {
 	host := makeHost()
 	host.Spec.Image.URL = "newimage"
 	host.Spec.Image.Checksum = "thechecksum"
-	host.Spec.Image.ChecksumType = metal3v1alpha1.MD5
+	host.Spec.Image.ChecksumType = metal3api.MD5
 	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, eventPublisher,
 		"https://ironic.test", auth, "https://ironic.test", auth,
 	)
@@ -892,7 +892,7 @@ func TestGetUpdateOptsForNodeLiveIsoToImage(t *testing.T) {
 
 	provData := provisioner.ProvisionData{
 		Image:    *host.Spec.Image,
-		BootMode: metal3v1alpha1.DefaultBootMode,
+		BootMode: metal3api.DefaultBootMode,
 	}
 	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates
 
@@ -964,8 +964,8 @@ func TestGetUpdateOptsForNodeCustomDeploy(t *testing.T) {
 	ironicNode := &nodes.Node{}
 
 	provData := provisioner.ProvisionData{
-		Image:        metal3v1alpha1.Image{},
-		BootMode:     metal3v1alpha1.DefaultBootMode,
+		Image:        metal3api.Image{},
+		BootMode:     metal3api.DefaultBootMode,
 		CustomDeploy: host.Spec.CustomDeploy,
 	}
 	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates
@@ -1024,7 +1024,7 @@ func TestGetUpdateOptsForNodeCustomDeployWithImage(t *testing.T) {
 
 	provData := provisioner.ProvisionData{
 		Image:        *host.Spec.Image,
-		BootMode:     metal3v1alpha1.DefaultBootMode,
+		BootMode:     metal3api.DefaultBootMode,
 		CustomDeploy: host.Spec.CustomDeploy,
 	}
 	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates
@@ -1092,8 +1092,8 @@ func TestGetUpdateOptsForNodeImageToCustomDeploy(t *testing.T) {
 	}
 
 	provData := provisioner.ProvisionData{
-		Image:        metal3v1alpha1.Image{},
-		BootMode:     metal3v1alpha1.DefaultBootMode,
+		Image:        metal3api.Image{},
+		BootMode:     metal3api.DefaultBootMode,
 		CustomDeploy: host.Spec.CustomDeploy,
 	}
 	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates
@@ -1147,28 +1147,28 @@ func TestGetUpdateOptsForNodeImageToCustomDeploy(t *testing.T) {
 }
 
 func TestGetUpdateOptsForNodeSecureBoot(t *testing.T) {
-	host := metal3v1alpha1.BareMetalHost{
+	host := metal3api.BareMetalHost{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myhost",
 			Namespace: "myns",
 			UID:       "27720611-e5d1-45d3-ba3a-222dcfaa4ca2",
 		},
-		Spec: metal3v1alpha1.BareMetalHostSpec{
-			BMC: metal3v1alpha1.BMCDetails{
+		Spec: metal3api.BareMetalHostSpec{
+			BMC: metal3api.BMCDetails{
 				Address: "test://test.bmc/",
 			},
-			Image: &metal3v1alpha1.Image{
+			Image: &metal3api.Image{
 				URL:          "not-empty",
 				Checksum:     "checksum",
-				ChecksumType: metal3v1alpha1.MD5,
+				ChecksumType: metal3api.MD5,
 				DiskFormat:   pointer.StringPtr("raw"),
 			},
 			Online:          true,
 			HardwareProfile: "unknown",
 		},
-		Status: metal3v1alpha1.BareMetalHostStatus{
+		Status: metal3api.BareMetalHostStatus{
 			HardwareProfile: "libvirt",
-			Provisioning: metal3v1alpha1.ProvisionStatus{
+			Provisioning: metal3api.ProvisionStatus{
 				ID: "provisioning-id",
 			},
 		},
@@ -1188,7 +1188,7 @@ func TestGetUpdateOptsForNodeSecureBoot(t *testing.T) {
 	hwProf, _ := profile.GetProfile("libvirt")
 	provData := provisioner.ProvisionData{
 		Image:           *host.Spec.Image,
-		BootMode:        metal3v1alpha1.UEFISecureBoot,
+		BootMode:        metal3api.UEFISecureBoot,
 		HardwareProfile: hwProf,
 	}
 	patches := prov.getUpdateOptsForNode(ironicNode, provData).Updates

--- a/pkg/provisioner/ironic/validatemanagementaccess_test.go
+++ b/pkg/provisioner/ironic/validatemanagementaccess_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/ports"
 	"github.com/stretchr/testify/assert"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/imageprovider"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
@@ -345,7 +345,7 @@ func TestValidateManagementAccessExistingSteadyStateNoUpdate(t *testing.T) {
 	liveFormat := "live-iso"
 	imageTypes := []struct {
 		DeployInterface string
-		Image           *metal3v1alpha1.Image
+		Image           *metal3api.Image
 		InstanceInfo    map[string]interface{}
 		DriverInfo      map[string]interface{}
 	}{
@@ -364,7 +364,7 @@ func TestValidateManagementAccessExistingSteadyStateNoUpdate(t *testing.T) {
 			},
 		},
 		{
-			Image: &metal3v1alpha1.Image{
+			Image: &metal3api.Image{
 				URL:      "theimage",
 				Checksum: "thechecksum",
 			},
@@ -387,7 +387,7 @@ func TestValidateManagementAccessExistingSteadyStateNoUpdate(t *testing.T) {
 		},
 		{
 			DeployInterface: "ramdisk",
-			Image: &metal3v1alpha1.Image{
+			Image: &metal3api.Image{
 				URL:        "theimage",
 				DiskFormat: &liveFormat,
 			},
@@ -764,7 +764,7 @@ func TestValidateManagementAccessUnsupportedSecureBoot(t *testing.T) {
 		t.Fatalf("could not create provisioner: %s", err)
 	}
 
-	result, _, err := prov.ValidateManagementAccess(provisioner.ManagementAccessData{BootMode: metal3v1alpha1.UEFISecureBoot}, false, false)
+	result, _, err := prov.ValidateManagementAccess(provisioner.ManagementAccessData{BootMode: metal3api.UEFISecureBoot}, false, false)
 	if err != nil {
 		t.Fatalf("error from ValidateManagementAccess: %s", err)
 	}
@@ -777,7 +777,7 @@ func TestValidateManagementAccessNoBMCDetails(t *testing.T) {
 	defer ironic.Stop()
 
 	host := makeHost()
-	host.Spec.BMC = metal3v1alpha1.BMCDetails{}
+	host.Spec.BMC = metal3api.BMCDetails{}
 
 	auth := clients.AuthConfig{Type: clients.NoAuth}
 	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher,
@@ -800,7 +800,7 @@ func TestValidateManagementAccessMalformedBMCAddress(t *testing.T) {
 	defer ironic.Stop()
 
 	host := makeHost()
-	host.Spec.BMC = metal3v1alpha1.BMCDetails{
+	host.Spec.BMC = metal3api.BMCDetails{
 		Address: "<ipmi://192.168.122.1:6233>",
 	}
 
@@ -827,7 +827,7 @@ func TestPreprovisioningImageFormats(t *testing.T) {
 		Name              string
 		Address           string
 		PreprovImgEnabled bool
-		Expected          []metal3v1alpha1.ImageFormat
+		Expected          []metal3api.ImageFormat
 	}{
 		{
 			Name:     "disabled ipmi",
@@ -843,13 +843,13 @@ func TestPreprovisioningImageFormats(t *testing.T) {
 			Name:              "enabled ipmi",
 			Address:           "ipmi://example.test",
 			PreprovImgEnabled: true,
-			Expected:          []metal3v1alpha1.ImageFormat{"initrd"},
+			Expected:          []metal3api.ImageFormat{"initrd"},
 		},
 		{
 			Name:              "enabled virtualmedia",
 			Address:           "redfish-virtualmedia://example.test",
 			PreprovImgEnabled: true,
-			Expected:          []metal3v1alpha1.ImageFormat{"iso", "initrd"},
+			Expected:          []metal3api.ImageFormat{"iso", "initrd"},
 		},
 	}
 
@@ -963,7 +963,7 @@ func TestSetDeployImage(t *testing.T) {
 				GeneratedImage: imageprovider.GeneratedImage{
 					ImageURL: buildIso,
 				},
-				Format: metal3v1alpha1.ImageFormatISO,
+				Format: metal3api.ImageFormatISO,
 			},
 			ExpectBuild: true,
 			ExpectISO:   true,
@@ -982,7 +982,7 @@ func TestSetDeployImage(t *testing.T) {
 				GeneratedImage: imageprovider.GeneratedImage{
 					ImageURL: buildRamdisk,
 				},
-				Format: metal3v1alpha1.ImageFormatInitRD,
+				Format: metal3api.ImageFormatInitRD,
 			},
 			ExpectBuild: true,
 			ExpectISO:   false,
@@ -1003,7 +1003,7 @@ func TestSetDeployImage(t *testing.T) {
 					KernelURL:         buildKernel,
 					ExtraKernelParams: kernelParams,
 				},
-				Format: metal3v1alpha1.ImageFormatInitRD,
+				Format: metal3api.ImageFormatInitRD,
 			},
 			ExpectBuild:        true,
 			ExpectISO:          false,
@@ -1024,7 +1024,7 @@ func TestSetDeployImage(t *testing.T) {
 				GeneratedImage: imageprovider.GeneratedImage{
 					ImageURL: buildIso,
 				},
-				Format: metal3v1alpha1.ImageFormatISO,
+				Format: metal3api.ImageFormatISO,
 			},
 			ExpectBuild: false,
 			ExpectISO:   false,
@@ -1041,7 +1041,7 @@ func TestSetDeployImage(t *testing.T) {
 				GeneratedImage: imageprovider.GeneratedImage{
 					ImageURL: buildRamdisk,
 				},
-				Format: metal3v1alpha1.ImageFormatInitRD,
+				Format: metal3api.ImageFormatInitRD,
 			},
 			ExpectISO: false,
 			ExpectPXE: false,
@@ -1056,7 +1056,7 @@ func TestSetDeployImage(t *testing.T) {
 				GeneratedImage: imageprovider.GeneratedImage{
 					ImageURL: buildRamdisk,
 				},
-				Format: metal3v1alpha1.ImageFormatISO,
+				Format: metal3api.ImageFormatISO,
 			},
 			ExpectISO: false,
 			ExpectPXE: false,
@@ -1072,7 +1072,7 @@ func TestSetDeployImage(t *testing.T) {
 				GeneratedImage: imageprovider.GeneratedImage{
 					ImageURL: buildRamdisk,
 				},
-				Format: metal3v1alpha1.ImageFormatISO,
+				Format: metal3api.ImageFormatISO,
 			},
 			ExpectISO: false,
 			ExpectPXE: false,

--- a/pkg/secretutils/secret_manager.go
+++ b/pkg/secretutils/secret_manager.go
@@ -13,12 +13,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/utils"
 )
 
 const (
-	SecretsFinalizer = metal3v1alpha1.BareMetalHostFinalizer + "/secret"
+	SecretsFinalizer = metal3api.BareMetalHostFinalizer + "/secret"
 )
 
 // SecretManager is a type for fetching Secrets whether or not they are in the


### PR DESCRIPTION
We're going to have more API versions, hardcoding v1alpha1 will
no longer be reasonable. Use metal3api as a shorter name.