### PR TITLE
 🌱 Add dependabot workflow and configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: ":seedling:"
+    labels:
+      - "ok-to-test"
+    # Go
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # Ignore controller-runtime as its upgraded manually.
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+      # Ignore k8s and its transitives modules as they are upgraded manually
+      # together with controller-runtime.
+      - dependency-name: "k8s.io/*"
+    commit-message:
+      prefix: ":seedling:"
+    labels:
+      - "ok-to-test"
+  - package-ecosystem: "gomod"
+    directory: "/apis"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # Ignore controller-runtime as its upgraded manually.
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+      # Ignore k8s and its transitives modules as they are upgraded manually
+      # together with controller-runtime.
+      - dependency-name: "k8s.io/*"
+    commit-message:
+      prefix: ":seedling:"
+    labels:
+      - "ok-to-test"
+  - package-ecosystem: "gomod"
+    directory: "/pkg/hardwareutils"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: ":seedling:"
+    labels:
+      - "ok-to-test"
+  - package-ecosystem: "gomod"
+    directory: "/hack/tools"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # Ignore k8s and its transitives modules as they are upgraded manually
+      # together with controller-runtime.
+      - dependency-name: "sigs.k8s.io/controller-tools"
+    commit-message:
+      prefix: ":seedling:"
+    labels:
+      - "ok-to-test"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,48 @@
+name: dependabot
+
+on:
+  pull_request:
+    branches:
+      - dependabot/**
+  push:
+    branches:
+      - dependabot/**
+  workflow_dispatch:
+
+permissions:
+  contents: write # Allow to update the PR.
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+    - name: Calculate go version
+      id: vars
+      run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
+    - name: Set up Go
+      uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+      with:
+        go-version: ${{ steps.vars.outputs.go_version }}
+    - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      name: Restore go cache
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Update all modules
+      run: make mod
+    - name: Update generated code
+      run: make generate
+    - uses: EndBug/add-and-commit@1bad3abcf0d6ec49a5857d124b0bfb52dc7bb081 # v9.1.3
+      name: Commit changes
+      with:
+        author_name: dependabot[bot]
+        author_email: 49699333+dependabot[bot]@users.noreply.github.com
+        default_author: github_actor
+        message: 'Update generated code'

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ RUN_NAMESPACE = metal3
 GO_TEST_FLAGS = $(TEST_FLAGS)
 DEBUG = --debug
 COVER_PROFILE = cover.out
+GO_VERSION ?= 1.19.10
 
 # CRD Generation Options
 #
@@ -278,6 +279,9 @@ $(RELEASE_NOTES_DIR):
 .PHONY: release-notes
 release-notes: $(RELEASE_NOTES_DIR)
 	go run ./hack/tools/release_notes.go --from=$(PREVIOUS_TAG) > $(RELEASE_NOTES_DIR)/releasenotes.md
+
+go-version: ## Print the go version we use to compile our binaries and images
+	@echo $(GO_VERSION)
 
 ## --------------------------------------
 ## Clean


### PR DESCRIPTION
This PR adds dependabot configuration which enables dependabot to automatically open PRs for bumping go modules and tags while ignoring a few of the gomodule update for example controller-runtim or k8s.io/* for manual bumping. This will run as a github workflow. 
