### PR TITLE
⚠️ Change iBMC to use iPXE instead of PXE

### DIFF
--- a/pkg/hardwareutils/bmc/access_test.go
+++ b/pkg/hardwareutils/bmc/access_test.go
@@ -637,7 +637,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			needsMac:   true,
 			driver:     "ibmc",
 			bios:       "",
-			boot:       "pxe",
+			boot:       "ipxe",
 			management: "ibmc",
 			power:      "ibmc",
 		},

--- a/pkg/hardwareutils/bmc/ibmc.go
+++ b/pkg/hardwareutils/bmc/ibmc.go
@@ -84,7 +84,7 @@ func (a *ibmcAccessDetails) BIOSInterface() string {
 }
 
 func (a *ibmcAccessDetails) BootInterface() string {
-	return "pxe"
+	return "ipxe"
 }
 
 func (a *ibmcAccessDetails) ManagementInterface() string {


### PR DESCRIPTION
All other drivers use either iPXE or virtual media. Our ironic-image
does not even configure plain PXE properly, so it's not usable.
In any case, all in-tree network booting drivers should use iPXE
for consistent user experience.