### PR TITLE
:bug: Remove duplicate declaration of annotation constants outside metal3api

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -48,18 +48,18 @@ const (
 	// from the status annotation.
 	StatusAnnotation = "baremetalhost.metal3.io/status"
 
-	// RebootAnnotation is the annotation which tells the host which mode to use
+	// RebootAnnotationPrefix is the annotation which tells the host which mode to use
 	// when rebooting - hard/soft
 	RebootAnnotationPrefix = "reboot.metal3.io"
 
-	// InspectAnnotation is used to specify if automatic introspection carried out
+	// InspectAnnotationPrefix is used to specify if automatic introspection carried out
 	// during registration of BMH is enabled or disabled
-	InspectAnnotation = "inspect.metal3.io"
+	InspectAnnotationPrefix = "inspect.metal3.io"
 
 	// HardwareDetailsAnnotation provides the hardware details for the host
 	// in case its not already part of the host status and when introspection
 	// is disabed
-	HardwareDetailsAnnotation = "inspect.metal3.io/hardwaredetails"
+	HardwareDetailsAnnotation = InspectAnnotationPrefix + "/hardwaredetails"
 )
 
 // RootDeviceHints holds the hints for specifying the storage location

--- a/apis/metal3.io/v1alpha1/baremetalhost_validation.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_validation.go
@@ -192,10 +192,10 @@ func validateAnnotations(host *BareMetalHost) []error {
 			err = validateStatusAnnotation(value)
 		case strings.HasPrefix(annotation, RebootAnnotationPrefix+"/") || annotation == RebootAnnotationPrefix:
 			err = validateRebootAnnotation(value)
-		case annotation == InspectAnnotation:
+		case annotation == InspectAnnotationPrefix:
 			err = validateInspectAnnotation(value)
 		case annotation == HardwareDetailsAnnotation:
-			inspect := host.Annotations[InspectAnnotation]
+			inspect := host.Annotations[InspectAnnotationPrefix]
 			err = validateHwdDetailsAnnotation(value, inspect)
 		default:
 			err = nil

--- a/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -640,7 +640,7 @@ func TestValidateCreate(t *testing.T) {
 					Name:      "test",
 					Namespace: "test-namespace",
 					Annotations: map[string]string{
-						InspectAnnotation:         "disabled",
+						InspectAnnotationPrefix:   "disabled",
 						HardwareDetailsAnnotation: `{"INVALIDField":{"manufacturer":"QEMU","productName":"Standard PC (Q35 + ICH9, 2009)","serialNumber":""},"firmware":{"bios":{"date":"","vendor":"","version":""}},"ramMebibytes":4096,"nics":[{"name":"eth0","model":"0x1af4 0x0001","mac":"00:b7:8b:bb:3d:f6","ip":"172.22.0.64","speedGbps":0,"vlanId":0,"pxe":true}],"storage":[{"name":"/dev/sda","rotational":true,"sizeBytes":53687091200,"vendor":"QEMU","model":"QEMU HARDDISK","serialNumber":"drive-scsi0-0-0-0","hctl":"6:0:0:0"}],"cpu":{"arch":"x86_64","model":"Intel Xeon E3-12xx v2 (IvyBridge)","clockMegahertz":2494.224,"flags":["foo"],"count":4},"hostname":"hwdAnnotation-0"}`,
 					},
 				},
@@ -655,7 +655,7 @@ func TestValidateCreate(t *testing.T) {
 					Name:      "test",
 					Namespace: "test-namespace",
 					Annotations: map[string]string{
-						InspectAnnotation:         "disabled",
+						InspectAnnotationPrefix:   "disabled",
 						HardwareDetailsAnnotation: `{"INVALIDField":{"manufacturer":"QEMU","productName":"Standard PC (Q35 + ICH9, 2009)","serialNumber":""},"firmware":{"bios":{"date":"","vendor":"","version":""}},"ramMebibytes":4096,"nics":[{"name":"eth0","model":"0x1af4 0x0001","mac":"00:b7:8b:bb:3d:f6","ip":"172.22.0.64","speedGbps":0,"vlanId":0,"pxe":true}],"storage":[{"name":"/dev/sda","rotational":true,"sizeBytes":53687091200,"vendor":"QEMU","model":"QEMU HARDDISK","serialNumber":"drive-scsi0-0-0-0","hctl":"6:0:0:0"}],"cpu":{"arch":"x86_64","model":"Intel Xeon E3-12xx v2 (IvyBridge)","clockMegahertz":2494.224,"flags":["foo"],"count":4},"hostname":"hwdAnnotation-0"`,
 					},
 				},
@@ -671,7 +671,7 @@ func TestValidateCreate(t *testing.T) {
 					Name:      "test",
 					Namespace: "test-namespace",
 					Annotations: map[string]string{
-						InspectAnnotation: "enabled",
+						InspectAnnotationPrefix: "enabled",
 					},
 				},
 			},

--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -247,14 +247,14 @@ func waitForProvisioningState(t *testing.T, r *BareMetalHostReconciler, host *me
 func TestHardwareDetails_EmptyStatus(t *testing.T) {
 	host := newDefaultHost(t)
 	host.Annotations = map[string]string{
-		hardwareDetailsAnnotation: hwdAnnotation,
+		metal3api.HardwareDetailsAnnotation: hwdAnnotation,
 	}
 
 	r := newTestReconciler(host)
 
 	tryReconcile(t, r, host,
 		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
-			_, found := host.Annotations[hardwareDetailsAnnotation]
+			_, found := host.Annotations[metal3api.HardwareDetailsAnnotation]
 			if host.Status.HardwareDetails != nil && host.Status.HardwareDetails.Hostname == "hwdAnnotation-0" && !found {
 				return true
 			}
@@ -268,7 +268,7 @@ func TestHardwareDetails_EmptyStatus(t *testing.T) {
 func TestHardwareDetails_StatusPresent(t *testing.T) {
 	host := newDefaultHost(t)
 	host.Annotations = map[string]string{
-		hardwareDetailsAnnotation: hwdAnnotation,
+		metal3api.HardwareDetailsAnnotation: hwdAnnotation,
 	}
 	time := metav1.Now()
 	host.Status.LastUpdated = &time
@@ -280,7 +280,7 @@ func TestHardwareDetails_StatusPresent(t *testing.T) {
 
 	tryReconcile(t, r, host,
 		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
-			_, found := host.Annotations[hardwareDetailsAnnotation]
+			_, found := host.Annotations[metal3api.HardwareDetailsAnnotation]
 			if host.Status.HardwareDetails != nil && host.Status.HardwareDetails.Hostname == "existinghost" && !found {
 				return true
 			}
@@ -295,8 +295,8 @@ func TestHardwareDetails_StatusPresent(t *testing.T) {
 func TestHardwareDetails_StatusPresentInspectDisabled(t *testing.T) {
 	host := newDefaultHost(t)
 	host.Annotations = map[string]string{
-		inspectAnnotationPrefix:   "disabled",
-		hardwareDetailsAnnotation: hwdAnnotation,
+		metal3api.InspectAnnotationPrefix:   "disabled",
+		metal3api.HardwareDetailsAnnotation: hwdAnnotation,
 	}
 	time := metav1.Now()
 	host.Status.LastUpdated = &time
@@ -308,7 +308,7 @@ func TestHardwareDetails_StatusPresentInspectDisabled(t *testing.T) {
 
 	tryReconcile(t, r, host,
 		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
-			_, found := host.Annotations[hardwareDetailsAnnotation]
+			_, found := host.Annotations[metal3api.HardwareDetailsAnnotation]
 			if host.Status.HardwareDetails != nil && host.Status.HardwareDetails.Hostname == "hwdAnnotation-0" && !found {
 				return true
 			}
@@ -323,8 +323,8 @@ func TestHardwareDetails_Invalid(t *testing.T) {
 	host := newDefaultHost(t)
 	badAnnotation := fmt.Sprintf("{\"hardware\": %s}", hwdAnnotation)
 	host.Annotations = map[string]string{
-		inspectAnnotationPrefix:   "disabled",
-		hardwareDetailsAnnotation: badAnnotation,
+		metal3api.InspectAnnotationPrefix:   "disabled",
+		metal3api.HardwareDetailsAnnotation: badAnnotation,
 	}
 	time := metav1.Now()
 	host.Status.LastUpdated = &time
@@ -487,7 +487,7 @@ func TestPause(t *testing.T) {
 func TestInspectDisabled(t *testing.T) {
 	host := newDefaultHost(t)
 	host.Annotations = map[string]string{
-		inspectAnnotationPrefix: "disabled",
+		metal3api.InspectAnnotationPrefix: "disabled",
 	}
 	r := newTestReconciler(host)
 	waitForProvisioningState(t, r, host, metal3api.StatePreparing)
@@ -589,7 +589,7 @@ func TestInspectionDisabledAnnotation(t *testing.T) {
 
 	assert.False(t, inspectionDisabled(host))
 
-	host.Annotations[inspectAnnotationPrefix] = "disabled"
+	host.Annotations[metal3api.InspectAnnotationPrefix] = "disabled"
 	assert.True(t, inspectionDisabled(host))
 }
 
@@ -615,29 +615,29 @@ func TestHasRebootAnnotation(t *testing.T) {
 		{
 			Scenario: "Simple with empty value",
 			Annotations: map[string]string{
-				rebootAnnotationPrefix: "",
+				metal3api.RebootAnnotationPrefix: "",
 			},
 			expectedReboot: true,
 		},
 		{
 			Scenario: "Suffixed with empty value",
 			Annotations: map[string]string{
-				rebootAnnotationPrefix + "/foo": "",
+				metal3api.RebootAnnotationPrefix + "/foo": "",
 			},
 			expectedReboot: true,
 		},
 		{
 			Scenario: "Two suffixed with empty value",
 			Annotations: map[string]string{
-				rebootAnnotationPrefix + "/foo": "",
-				rebootAnnotationPrefix + "/bar": "",
+				metal3api.RebootAnnotationPrefix + "/foo": "",
+				metal3api.RebootAnnotationPrefix + "/bar": "",
 			},
 			expectedReboot: true,
 		},
 		{
 			Scenario: "Suffixed with soft reboot",
 			Annotations: map[string]string{
-				rebootAnnotationPrefix + "/foo": "{\"mode\": \"soft\"}",
+				metal3api.RebootAnnotationPrefix + "/foo": "{\"mode\": \"soft\"}",
 			},
 			expectedReboot: true,
 			expectedMode:   metal3api.RebootModeSoft,
@@ -645,7 +645,7 @@ func TestHasRebootAnnotation(t *testing.T) {
 		{
 			Scenario: "Suffixed with hard reboot",
 			Annotations: map[string]string{
-				rebootAnnotationPrefix + "/foo": "{\"mode\": \"hard\"}",
+				metal3api.RebootAnnotationPrefix + "/foo": "{\"mode\": \"hard\"}",
 			},
 			expectedReboot: true,
 			expectedMode:   metal3api.RebootModeHard,
@@ -653,15 +653,15 @@ func TestHasRebootAnnotation(t *testing.T) {
 		{
 			Scenario: "Suffixed with bad JSON",
 			Annotations: map[string]string{
-				rebootAnnotationPrefix + "/foo": "{\"bad\"= \"json\"]",
+				metal3api.RebootAnnotationPrefix + "/foo": "{\"bad\"= \"json\"]",
 			},
 			expectedReboot: true,
 		},
 		{
 			Scenario: "Two suffixed with different values",
 			Annotations: map[string]string{
-				rebootAnnotationPrefix + "/foo": "{\"mode\": \"hard\"}",
-				rebootAnnotationPrefix + "/bar": "{\"mode\": \"soft\"}",
+				metal3api.RebootAnnotationPrefix + "/foo": "{\"mode\": \"hard\"}",
+				metal3api.RebootAnnotationPrefix + "/bar": "{\"mode\": \"soft\"}",
 			},
 			expectedReboot: true,
 			expectedMode:   metal3api.RebootModeHard,
@@ -669,7 +669,7 @@ func TestHasRebootAnnotation(t *testing.T) {
 		{
 			Scenario: "Suffixed with force",
 			Annotations: map[string]string{
-				rebootAnnotationPrefix + "/foo": "{\"force\": true}",
+				metal3api.RebootAnnotationPrefix + "/foo": "{\"force\": true}",
 			},
 			expectForce:    true,
 			expectedReboot: true,
@@ -677,7 +677,7 @@ func TestHasRebootAnnotation(t *testing.T) {
 		{
 			Scenario: "Expect force",
 			Annotations: map[string]string{
-				rebootAnnotationPrefix + "/foo": "{\"mode\": \"hard\"}",
+				metal3api.RebootAnnotationPrefix + "/foo": "{\"mode\": \"hard\"}",
 			},
 			expectForce:    true,
 			expectedReboot: false,
@@ -706,7 +706,7 @@ func TestHasRebootAnnotation(t *testing.T) {
 func TestRebootWithSuffixlessAnnotation(t *testing.T) {
 	host := newDefaultHost(t)
 	host.Annotations = make(map[string]string)
-	host.Annotations[rebootAnnotationPrefix] = ""
+	host.Annotations[metal3api.RebootAnnotationPrefix] = ""
 	host.Status.PoweredOn = true
 	host.Status.Provisioning.State = metal3api.StateProvisioned
 	host.Spec.Online = true
@@ -728,7 +728,7 @@ func TestRebootWithSuffixlessAnnotation(t *testing.T) {
 
 	tryReconcile(t, r, host,
 		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
-			if _, exists := host.Annotations[rebootAnnotationPrefix]; exists {
+			if _, exists := host.Annotations[metal3api.RebootAnnotationPrefix]; exists {
 				return false
 			}
 
@@ -764,7 +764,7 @@ func TestRebootWithSuffixlessAnnotation(t *testing.T) {
 func TestRebootWithSuffixedAnnotation(t *testing.T) {
 	host := newDefaultHost(t)
 	host.Annotations = make(map[string]string)
-	annotation := rebootAnnotationPrefix + "/foo"
+	annotation := metal3api.RebootAnnotationPrefix + "/foo"
 	host.Annotations[annotation] = ""
 	host.Status.PoweredOn = true
 	host.Status.Provisioning.State = metal3api.StateProvisioned

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -1245,7 +1245,7 @@ func (hb *hostBuilder) DisableInspection() *hostBuilder {
 	if hb.Annotations == nil {
 		hb.Annotations = make(map[string]string, 1)
 	}
-	hb.Annotations[inspectAnnotationPrefix] = "disabled"
+	hb.Annotations[metal3api.InspectAnnotationPrefix] = "disabled"
 	return hb
 }
 


### PR DESCRIPTION
Remove duplicate declaration of annotation constants in Controller

<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
