### PR TITLE
Set minimum TLS version for webhook

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"os"
@@ -157,8 +158,14 @@ func main() {
 		Scheme:             scheme,
 		MetricsBindAddress: metricsBindAddr,
 		WebhookServer: webhook.NewServer(webhook.Options{
-			Port:          webhookPort,
-			TLSMinVersion: "1.2",
+			Port: webhookPort,
+			TLSOpts: []func(*tls.Config){
+				func(c *tls.Config) {
+					if c.MinVersion < tls.VersionTLS12 {
+						c.MinVersion = tls.VersionTLS12
+					}
+				},
+			},
 		}),
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        leaderElectionID,

--- a/main.go
+++ b/main.go
@@ -157,7 +157,8 @@ func main() {
 		Scheme:             scheme,
 		MetricsBindAddress: metricsBindAddr,
 		WebhookServer: webhook.NewServer(webhook.Options{
-			Port: webhookPort,
+			Port:          webhookPort,
+			TLSMinVersion: "1.2",
 		}),
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        leaderElectionID,


### PR DESCRIPTION
The default in controller-runtime is for the minimum TLS webhook version to be TLS 1.0, which is pretty long in the tooth. We should set this explicitly.