### PR TITLE
:bug: Trigger reconcile on Secret change

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -1763,9 +1764,11 @@ func (r *BareMetalHostReconciler) SetupWithManager(mgr ctrl.Manager, preprovImgE
 				UpdateFunc: r.updateEventHandler,
 			}).
 		WithOptions(opts).
-		Owns(&corev1.Secret{})
+		Owns(&corev1.Secret{}, builder.MatchEveryOwner)
 
 	if preprovImgEnable {
+		// We use SetControllerReference() to set the owner reference, so no
+		// need to pass MatchEveryOwner
 		controller.Owns(&metal3api.PreprovisioningImage{})
 	}
 

--- a/controllers/metal3.io/preprovisioningimage_controller.go
+++ b/controllers/metal3.io/preprovisioningimage_controller.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	metal3 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
@@ -353,6 +354,6 @@ func (r *PreprovisioningImageReconciler) CanStart() bool {
 func (r *PreprovisioningImageReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&metal3.PreprovisioningImage{}).
-		Owns(&corev1.Secret{}).
+		Owns(&corev1.Secret{}, builder.MatchEveryOwner).
 		Complete(r)
 }


### PR DESCRIPTION
The default meaning of the Owns() method in the controller-runtime controller is to only trigger reconciles on owner references where we have the 'controller' flag set.

We have never set the 'controller' flag on the networkData Secret used in both the BareMetalHost and PreprovisioningImage controllers.

Since #1164 we no longer set the 'controller' flag on our owner references for Secrets either, in order to allow the same BMC Secret to be shared amongst multiple hosts.

In each of these case we were either never or no longer triggering a reconcile when the Secret changed. Add the MatchEveryOwner option to ensure that we still trigger a reconcile even when the 'controller' flag is not set in the owner reference.

Fixes #1321
