### PR TITLE
⚠️ adopt manifests for kustomize v5

### DIFF
--- a/config/basic-auth/default/kustomization.yaml
+++ b/config/basic-auth/default/kustomization.yaml
@@ -15,5 +15,5 @@ secretGenerator:
     - username=ironic-inspector-username
     - password=ironic-inspector-password
 
-patchesStrategicMerge:
-- credentials_patch.yaml
+patches:
+- path: credentials_patch.yaml

--- a/config/basic-auth/tls/kustomization.yaml
+++ b/config/basic-auth/tls/kustomization.yaml
@@ -14,5 +14,5 @@ secretGenerator:
     - username=ironic-inspector-username
     - password=ironic-inspector-password
 
-patchesStrategicMerge:
-- credentials_patch.yaml
+patches:
+- path: credentials_patch.yaml

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
 - bases/metal3.io_hardwaredata.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_baremetalhosts.yaml
@@ -23,7 +23,7 @@ patchesStrategicMerge:
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_baremetalhosts.yaml
+- path: patches/cainjection_in_baremetalhosts.yaml
 #- patches/cainjection_in_hostfirmwaresettings.yaml
 #- patches/cainjection_in_firmwareschemas.yaml
 #- patches/cainjection_in_preprovisioningimages.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ namePrefix: baremetal-operator-
 #commonLabels:
 #  someName: someValue
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager
@@ -24,11 +24,11 @@ bases:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+- path: manager_auth_proxy_patch.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
@@ -36,47 +36,89 @@ patchesStrategicMerge:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-- manager_webhook_patch.yaml
+- path: manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-- webhookcainjection_patch.yaml
+- path: webhookcainjection_patch.yaml
 
-# the following config is for teaching kustomize how to do var substitution
-vars:
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-  objref:
+replacements:
+- source:
     kind: Certificate
     group: cert-manager.io
     version: v1
     name: serving-cert # this name should match the one in certificate.yaml
-  fieldref:
     fieldpath: metadata.namespace
-- name: CERTIFICATE_NAME
-  objref:
+  targets:
+  - select:
+      kind: ValidatingWebhookConfiguration
+    fieldPaths:
+      - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+  - select:
+      kind: CustomResourceDefinition
+      name: baremetalhosts.metal3.io
+    fieldPaths:
+      - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+- source:
     kind: Certificate
     group: cert-manager.io
     version: v1
     name: serving-cert # this name should match the one in certificate.yaml
-- name: SERVICE_NAMESPACE # namespace of the service
-  objref:
+    fieldpath: metadata.name
+  targets:
+  - select:
+      kind: ValidatingWebhookConfiguration
+    fieldPaths:
+      - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 1
+  - select:
+      kind: CustomResourceDefinition
+      name: baremetalhosts.metal3.io
+    fieldPaths:
+      - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 1
+- source:
     kind: Service
     version: v1
     name: webhook-service
-  fieldref:
     fieldpath: metadata.namespace
-- name: SERVICE_NAME
-  objref:
+  targets:
+  - select:
+      kind: Certificate
+    fieldPaths:
+    - spec.dnsNames.*
+    options:
+      delimiter: '.'
+      index: 1
+- source:
     kind: Service
     version: v1
     name: webhook-service
+    fieldpath: metadata.name
+  targets:
+  - select:
+      kind: Certificate
+    fieldPaths:
+    - spec.dnsNames.*
+    options:
+      delimiter: '.'
+      index: 0
 
-# Add ironic configmap-generator 
+# Add ironic configmap-generator
 generatorOptions:
  disableNameSuffixHash: true
- 
+
 configMapGenerator:
 - behavior: create
   envs:

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
+resources:
 - namespace
 - default

--- a/config/tls/kustomization.yaml
+++ b/config/tls/kustomization.yaml
@@ -5,5 +5,5 @@ resources:
 - ../default
 - ../namespace
 
-patchesStrategicMerge:
-- tls_ca_patch.yaml
+patches:
+- path: tls_ca_patch.yaml

--- a/ironic-deployment/components/basic-auth/kustomization.yaml
+++ b/ironic-deployment/components/basic-auth/kustomization.yaml
@@ -17,5 +17,5 @@ secretGenerator:
   files:
   - auth-config=ironic-inspector-auth-config
 
-patchesStrategicMerge:
-- auth.yaml
+patches:
+- path: auth.yaml

--- a/ironic-deployment/components/keepalived/kustomization.yaml
+++ b/ironic-deployment/components/keepalived/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
-patchesStrategicMerge:
-- keepalived_patch.yaml
+patches:
+- path: keepalived_patch.yaml
 
 configMapGenerator:
 - envs:

--- a/ironic-deployment/components/mariadb/kustomization.yaml
+++ b/ironic-deployment/components/mariadb/kustomization.yaml
@@ -4,8 +4,8 @@ kind: Component
 resources:
 - certificate.yaml
 
-patchesStrategicMerge:
-- mariadb_patch.yaml
+patches:
+- path: mariadb_patch.yaml
 
 secretGenerator:
 - literals:

--- a/ironic-deployment/components/tls/kustomization.yaml
+++ b/ironic-deployment/components/tls/kustomization.yaml
@@ -4,8 +4,8 @@ kind: Component
 resources:
 - certificate.yaml
 
-patchesStrategicMerge:
-- tls.yaml
+patches:
+- path: tls.yaml
 
 configurations:
 - kustomizeconfig.yaml

--- a/ironic-deployment/overlays/basic-auth_tls/kustomization.yaml
+++ b/ironic-deployment/overlays/basic-auth_tls/kustomization.yaml
@@ -12,5 +12,5 @@ components:
 # When using TLS, the ironic-httpd container is acting as a reverse-proxy.
 # This means that we need to add the basic-auth related environment
 # variables on ironic-httpd with this patch.
-patchesStrategicMerge:
-- basic-auth_tls.yaml
+patches:
+- path: basic-auth_tls.yaml


### PR DESCRIPTION

**What this PR does / why we need it**:

building kustomize layers with kustomize v5 outputs warnings of deprecation

```
$ kustomize build default/ > render/capm3.yaml 
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```
