### PR TITLE
:seedling: run dependabot less often

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: ":seedling:"
     labels:


### PR DESCRIPTION
Running dependabot weekly for GH actions is excessive. Each bump needs to be pruned in release notes etc. Change `weekly` to `monthly` for GH actions. Security updates will ignore these schedules anyways.
