### PR TITLE
📖 fix releasing.md on annotated tags

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -81,12 +81,12 @@ We also need to create one or more tags for the Go modules ecosystem:
 
 - For any subdirectory with `go.mod` in it (excluding `hack/tools`), create
   another Git tag with directory prefix, ie.
-  `git tag -s apis/v0.x.y -m apis/v0.x.y`.
+  `git tag -s apis/v0.x.y`.
   For BMO, these directories are `apis` and `pkg/hardwareutils`. This enables
   the tags to be used as a Go module version for any downstream users.
-  **NOTE**: Do not create annotated tags for Go modules. Release notes expects
-  only the main tag to be annotated, otherwise it might create incorrect
-  release notes.
+  **NOTE**: Do not create annotated tags (`-a` or `-m`) for Go modules. Release
+  notes expects only the main tag to be annotated, otherwise it might create
+  incorrect release notes.
 
 ### Release artifacts
 


### PR DESCRIPTION
-m also implies -a, so neither of them can be present.
