### PR TITLE
:sparkles: Pass preprovisioningNetworkData to Ironic

### DIFF
--- a/controllers/metal3.io/host_config_data.go
+++ b/controllers/metal3.io/host_config_data.go
@@ -94,6 +94,26 @@ func (hcd *hostConfigData) NetworkData() (string, error) {
 	return networkDataRaw, err
 }
 
+// PreprovisioningNetworkData get preprovisioning network configuration
+func (hcd *hostConfigData) PreprovisioningNetworkData() (string, error) {
+	if hcd.host.Spec.PreprovisioningNetworkDataName == "" {
+		return "", nil
+	}
+	networkDataRaw, err := hcd.getSecretData(
+		hcd.host.Spec.PreprovisioningNetworkDataName,
+		hcd.host.Namespace,
+		"networkData",
+	)
+	if err != nil {
+		_, isNoDataErr := err.(NoDataInSecretError)
+		if isNoDataErr {
+			hcd.log.Info("PreprovisioningNetworkData networkData key is not set, returning empty data")
+			return "", nil
+		}
+	}
+	return networkDataRaw, err
+}
+
 // MetaData get host metatdata
 func (hcd *hostConfigData) MetaData() (string, error) {
 	if hcd.host.Spec.MetaData == nil {

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -74,12 +74,13 @@ type PreprovisioningImage struct {
 }
 
 type ManagementAccessData struct {
-	BootMode              metal3api.BootMode
-	AutomatedCleaningMode metal3api.AutomatedCleaningMode
-	State                 metal3api.ProvisioningState
-	CurrentImage          *metal3api.Image
-	PreprovisioningImage  *PreprovisioningImage
-	HasCustomDeploy       bool
+	BootMode                   metal3api.BootMode
+	AutomatedCleaningMode      metal3api.AutomatedCleaningMode
+	State                      metal3api.ProvisioningState
+	CurrentImage               *metal3api.Image
+	PreprovisioningImage       *PreprovisioningImage
+	PreprovisioningNetworkData string
+	HasCustomDeploy            bool
 }
 
 type AdoptData struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

Ironic supports [DHCP-less provisioning](https://docs.openstack.org/ironic/latest/admin/dhcp-less.html), which I expected to work via Metal<sup>3</sup>, particularly since we already provide the [IPAM controller](https://github.com/metal3-io/ip-address-manager) which can be used to statically assign control plane IPs.

[Recent discussions](https://kubernetes.slack.com/archives/CHD49TLE7/p1695719774588889) however highlighted that this flow is not currently possible via Metal<sup>3</sup>, unless you implement a custom `PreprovisioningImage` controller, or have other downstream customisations.

In the case where `--build-preprov-image` is passed to BMO, we enable creation of the `PreprovisioningImage` CR and an internal default controller (which does not embed the `preprovisioningNetworkData`, but downstream custom controllers are doing so, so we don't want to break existing users opting into this flow)

In the case where `--build-preprov-image` is *not* passed, Ironic can be configured to inject `network_data` into the Ramdisk, and IMO this seems like reasonable default behaviour when no image controller is enabled. 

In this mode if the user provides `preprovsioningNetworkDataName` we'll set the Node `network_data` on initial registration of the Ironic node.  

This means when IPA boots for inspection, the virtual media device can be mounted and the `openstack/latest/network_data.json` file retrieved to configure the network (e.g by `glean` in the upstream Ironic flow, but users can build a Ramdisk image with any tool/script that consumes this file)

Note that I don't think the current upstream IPA image currently includes simple-init/glean so this will still require a custom Ramdisk image, but it does mean we can support DHCP-less without mandating a custom `PreprovisioningImage` controller.


