### PR TITLE
🐛 Skip power off BMH if registration error OR no credentials

### DIFF
--- a/controllers/metal3.io/host_state_machine.go
+++ b/controllers/metal3.io/host_state_machine.go
@@ -585,8 +585,8 @@ func (hsm *hostStateMachine) handlePoweringOffBeforeDelete(info *reconcileInfo) 
 			return skipToDelete()
 		}
 	case actionError:
-		if r.NeedsRegistration() && !hsm.haveCreds {
-			// If the host is not registered as a node in Ironic and we
+		if r.NeedsRegistration() || !hsm.haveCreds {
+			// If the host is not registered as a node in Ironic or we
 			// lack the credentials to power it off, just continue to
 			// delete.
 			return skipToDelete()


### PR DESCRIPTION
If a BMH is not registered OR we do not have proper credentials for it, we cannot power off before deleting. Therefore we should skip to deletion in either of these cases, not just when both hold.

**What this PR does / why we need it**:

If a BMH is not registered OR we do not have proper credentials for it, we cannot power off before deleting. Therefore we should skip to deletion in either of these cases, not just when both hold.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1385
