### PR TITLE
🌱 Fixing ensure-go script to allow go versions greater than MINIMUM_GO_VERSION

### DIFF
--- a/hack/e2e/ensure_go.sh
+++ b/hack/e2e/ensure_go.sh
@@ -22,7 +22,7 @@ verify_go_version()
 
     local go_version
     IFS=" " read -ra go_version <<< "$(go version)"
-    if ! [[ "${MINIMUM_GO_VERSION}" =~ .*"${go_version[2]}".* ]]; then
+    if [[ "${MINIMUM_GO_VERSION}" != $(echo -e "${MINIMUM_GO_VERSION}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]] && [[ "${go_version[2]}" != "devel" ]]; then
         cat << EOF
 Detected go version: ${go_version[2]}.
 Requires ${MINIMUM_GO_VERSION} or greater.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Right now ensure_go.sh gives an error while e2e tests locally even when the go version is greater than MINIMUM_GO_VERSION which is wrong. This PR is fixing it, we already have this script working in CAPM3, this PR is just taking code from there. Check here: https://github.com/metal3-io/baremetal-operator/blob/783eb742630067146b4b98173c32a3d96348778a/hack/e2e/ensure_go.sh#L25C12-L25C12 

