### PR TITLE
🌱 Integrate sushy-tools and Redfish into e2e testing

### DIFF
--- a/hack/clean-e2e.sh
+++ b/hack/clean-e2e.sh
@@ -6,6 +6,7 @@ cd "${REPO_ROOT}" || exit 1
 minikube delete
 docker rm -f vbmc
 docker rm -f image-server-e2e
+docker rm -f sushy-tools
 virsh -c qemu:///system destroy --domain bmo-e2e-0
 virsh -c qemu:///system undefine --domain bmo-e2e-0 --remove-all-storage
 virsh -c qemu:///system net-destroy baremetal-e2e

--- a/test/e2e/config/ironic.yaml
+++ b/test/e2e/config/ironic.yaml
@@ -22,7 +22,7 @@ variables:
   # Test credentials. The tests will create a BMH with these.
   BMC_USER: admin
   BMC_PASSWORD: password
-  BMC_ADDRESS: ipmi://192.168.222.1:16230
+  BMC_ADDRESS: "ipmi://192.168.222.1:16230"
   BOOT_MAC_ADDRESS: "00:60:2f:31:81:01"
   IMAGE_URL: "http://192.168.222.1/cirros-0.6.2-x86_64-disk.img"
   IMAGE_CHECKSUM: "c8fc807773e5354afe61636071771906"
@@ -33,7 +33,7 @@ intervals:
   inspection/wait-registration-error: ["1m", "5s"]
   external-inspection/wait-available: ["20s", "1s"]
   default/wait-inspecting: ["2m", "10s"]
-  default/wait-available: ["10m", "10s"]
+  default/wait-available: ["10m", "1s"]
   default/wait-deployment: ["5m", "1s"]
   default/wait-namespace-deleted: ["10m", "1s"]
   ironic/wait-deployment: ["10m", "2s"]

--- a/test/e2e/sushy-tools/sushy-emulator.conf
+++ b/test/e2e/sushy-tools/sushy-emulator.conf
@@ -1,0 +1,36 @@
+# Listen on the local IP address 192.168.222.1
+SUSHY_EMULATOR_LISTEN_IP = u'192.168.222.1'
+
+# Bind to TCP port 8000
+SUSHY_EMULATOR_LISTEN_PORT = 8000
+
+# Serve this SSL certificate to the clients
+SUSHY_EMULATOR_SSL_CERT = None
+
+# If SSL certificate is being served, this is its RSA private key
+SUSHY_EMULATOR_SSL_KEY = None
+
+# The OpenStack cloud ID to use. This option enables OpenStack driver.
+SUSHY_EMULATOR_OS_CLOUD = None
+# The libvirt URI to use. This option enables libvirt driver.
+SUSHY_EMULATOR_LIBVIRT_URI = u'qemu:///system'
+
+# Instruct the libvirt driver to ignore any instructions to
+# set the boot device. Allowing the UEFI firmware to instead
+# rely on the EFI Boot Manager
+# Note: This sets the legacy boot element to dev="fd"
+# and relies on the floppy not existing, it likely wont work
+# your VM has a floppy drive.
+SUSHY_EMULATOR_IGNORE_BOOT_DEVICE = False
+
+# The map of firmware loaders dependant on the boot mode and
+# system architecture. Ideally the x86_64 loader will be capable
+# of secure boot or not based on the chosen nvram.
+SUSHY_EMULATOR_BOOT_LOADER_MAP = {
+    u'UEFI': {
+        u'x86_64': u'/usr/share/OVMF/OVMF_CODE.secboot.fd'
+    },
+    u'Legacy': {
+        u'x86_64': None
+    }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR augments the e2e testing framework by integrating sushy-tools and Redfish, enhancing test coverage across different management interfaces alongside the existing VBMC and IPMI tests.

Fixes #1374
