### PR TITLE
🐛 Do not update instance_info and deploy_interface for active nodes

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -546,7 +546,8 @@ func (p *ironicProvisioner) configureImages(data provisioner.ManagementAccessDat
 	deployImageInfo := setDeployImage(p.config, bmcAccess, data.PreprovisioningImage)
 	updater.SetDriverInfoOpts(deployImageInfo, ironicNode)
 
-	if data.CurrentImage != nil || data.HasCustomDeploy {
+	// NOTE(dtantsur): It is risky to update image information for active nodes since it may affect the ability to clean up.
+	if (data.CurrentImage != nil || data.HasCustomDeploy) && ironicNode.ProvisionState != string(nodes.Active) {
 		p.getImageUpdateOptsForNode(ironicNode, data.CurrentImage, data.BootMode, data.HasCustomDeploy, updater)
 	}
 	updater.SetTopLevelOpt("automated_clean",


### PR DESCRIPTION
Doing so may interfere with cleaning. Updates to deploy_interface will
be rejected by Ironic, causing BMO to enter infinite reconcile retries.