### PR TITLE
🌱 Refactor handling the provisioner's ready status

### DIFF
--- a/pkg/provisioner/ironic/adopt_test.go
+++ b/pkg/provisioner/ironic/adopt_test.go
@@ -27,7 +27,7 @@ func TestAdopt(t *testing.T) {
 	}{
 		{
 			name: "node-in-enroll",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				ProvisionState: string(nodes.Enroll),
 				UUID:           nodeUUID,
 			}),
@@ -47,7 +47,7 @@ func TestAdopt(t *testing.T) {
 		},
 		{
 			name: "node-in-adopting",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				ProvisionState: string(nodes.Adopting),
 				UUID:           nodeUUID,
 			}),
@@ -57,7 +57,7 @@ func TestAdopt(t *testing.T) {
 		},
 		{
 			name: "node-in-verifying",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				ProvisionState: string(nodes.Verifying),
 				UUID:           nodeUUID,
 			}),
@@ -67,7 +67,7 @@ func TestAdopt(t *testing.T) {
 		},
 		{
 			name: "node-in-AdoptFail",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				ProvisionState: string(nodes.AdoptFail),
 				UUID:           nodeUUID,
 			}),
@@ -88,7 +88,7 @@ func TestAdopt(t *testing.T) {
 		},
 		{
 			name: "node-in-Active",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				ProvisionState: string(nodes.Active),
 				UUID:           nodeUUID,
 			}),
@@ -97,7 +97,7 @@ func TestAdopt(t *testing.T) {
 		},
 		{
 			name: "node-in-Maintenance",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				ProvisionState: string(nodes.Active),
 				UUID:           nodeUUID,
 				Maintenance:    true,
@@ -109,7 +109,7 @@ func TestAdopt(t *testing.T) {
 		},
 		{
 			name: "node-in-Fault",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				ProvisionState: string(nodes.Active),
 				UUID:           nodeUUID,
 				Maintenance:    true,

--- a/pkg/provisioner/ironic/configdrive_test.go
+++ b/pkg/provisioner/ironic/configdrive_test.go
@@ -122,7 +122,7 @@ func TestEmpty(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			ironic := testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic := testserver.NewIronic(t).Node(nodes.Node{
 				ProvisionState: string(nodes.Active),
 				UUID:           nodeUUID,
 			})

--- a/pkg/provisioner/ironic/delete_test.go
+++ b/pkg/provisioner/ironic/delete_test.go
@@ -90,13 +90,13 @@ func deleteTest(t *testing.T, detach bool) {
 			name: "host-not-found",
 
 			hostName: "worker-0",
-			ironic:   testserver.NewIronic(t).Ready().NodeError(nodeUUID, http.StatusGatewayTimeout),
+			ironic:   testserver.NewIronic(t).NodeError(nodeUUID, http.StatusGatewayTimeout),
 
 			expectedError: "failed to find node by ID 33ce8659-7400-4c68-9535-d10766f07a58: Gateway Timeout.*",
 		},
 		{
 			name:   "not-ironic-node",
-			ironic: testserver.NewIronic(t).Ready().NoNode(nodeUUID).NoNode("myns" + nameSeparator + "myhost").NoNode("myhost"),
+			ironic: testserver.NewIronic(t).NoNode(nodeUUID).NoNode("myns" + nameSeparator + "myhost").NoNode("myhost"),
 		},
 		{
 			name: "available-node",

--- a/pkg/provisioner/ironic/inspecthardware_test.go
+++ b/pkg/provisioner/ironic/inspecthardware_test.go
@@ -89,7 +89,7 @@ func TestInspectHardware(t *testing.T) {
 		},
 		{
 			name: "introspection-status-retry-on-wait",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				UUID:           nodeUUID,
 				ProvisionState: "inspect wait",
 			}),
@@ -99,7 +99,7 @@ func TestInspectHardware(t *testing.T) {
 		},
 		{
 			name: "introspection-status-retry-on-inspecting",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				UUID:           nodeUUID,
 				ProvisionState: "inspecting",
 			}),
@@ -109,7 +109,7 @@ func TestInspectHardware(t *testing.T) {
 		},
 		{
 			name: "introspection-failed",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				UUID:           nodeUUID,
 				ProvisionState: "inspect failed",
 				LastError:      "Timeout",
@@ -119,7 +119,7 @@ func TestInspectHardware(t *testing.T) {
 		},
 		{
 			name: "introspection-aborted",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				UUID:           nodeUUID,
 				ProvisionState: "inspect failed",
 				LastError:      "Inspection was aborted by request.",
@@ -135,7 +135,7 @@ func TestInspectHardware(t *testing.T) {
 		},
 		{
 			name: "inspection-in-progress - forceReboot",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				UUID:           nodeUUID,
 				ProvisionState: string(nodes.InspectWait),
 			}).WithNodeStatesProvisionUpdate(nodeUUID),
@@ -147,7 +147,7 @@ func TestInspectHardware(t *testing.T) {
 		},
 		{
 			name: "inspection-failed",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				UUID:           nodeUUID,
 				ProvisionState: string(nodes.InspectFail),
 			}),
@@ -156,7 +156,7 @@ func TestInspectHardware(t *testing.T) {
 		},
 		{
 			name: "inspection-failed force",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				UUID:           nodeUUID,
 				ProvisionState: string(nodes.InspectFail),
 			}).NodeUpdate(nodes.Node{
@@ -172,7 +172,7 @@ func TestInspectHardware(t *testing.T) {
 		},
 		{
 			name: "inspection-forceReboot",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				UUID:           nodeUUID,
 				ProvisionState: string(nodes.InspectWait),
 			}).WithNodeStatesProvisionUpdate(nodeUUID),
@@ -184,7 +184,7 @@ func TestInspectHardware(t *testing.T) {
 		},
 		{
 			name: "inspection-complete",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				UUID:           nodeUUID,
 				ProvisionState: string(nodes.Manageable),
 			}).WithInventory(nodeUUID, nodes.InventoryData{

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1979,14 +1979,6 @@ func ironicNodeName(objMeta metav1.ObjectMeta) string {
 	return objMeta.Namespace + nameSeparator + objMeta.Name
 }
 
-// IsReady checks if the provisioning backend is available
-func (p *ironicProvisioner) IsReady() (result bool, err error) {
-	p.debugLog.Info("verifying ironic provisioner dependencies")
-
-	checker := newIronicDependenciesChecker(p.client, p.log)
-	return checker.IsReady()
-}
-
 func (p *ironicProvisioner) HasCapacity() (result bool, err error) {
 	bmcAccess, err := p.bmcAccess()
 	if err != nil {

--- a/pkg/provisioner/ironic/power_test.go
+++ b/pkg/provisioner/ironic/power_test.go
@@ -30,14 +30,14 @@ func TestPowerOn(t *testing.T) {
 	}{
 		{
 			name: "node-already-power-on",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				PowerState: powerOn,
 				UUID:       nodeUUID,
 			}),
 		},
 		{
 			name: "waiting-for-target-power-on",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				PowerState:       powerOff,
 				TargetPowerState: powerOn,
 				UUID:             nodeUUID,
@@ -57,7 +57,7 @@ func TestPowerOn(t *testing.T) {
 		},
 		{
 			name: "power-on wait for Provisioning state",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				PowerState:           powerOff,
 				TargetPowerState:     powerOff,
 				TargetProvisionState: string(nodes.TargetDeleted),
@@ -68,7 +68,7 @@ func TestPowerOn(t *testing.T) {
 		},
 		{
 			name: "power-on wait for locked host",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				PowerState:           powerOff,
 				TargetPowerState:     powerOff,
 				TargetProvisionState: "",
@@ -79,7 +79,7 @@ func TestPowerOn(t *testing.T) {
 		},
 		{
 			name: "power-on with LastError",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				PowerState:       powerOff,
 				TargetPowerState: powerOff,
 				UUID:             nodeUUID,
@@ -92,7 +92,7 @@ func TestPowerOn(t *testing.T) {
 		{
 			name:  "power-on with LastError",
 			force: true,
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				PowerState:       powerOff,
 				TargetPowerState: powerOff,
 				UUID:             nodeUUID,
@@ -153,14 +153,14 @@ func TestPowerOff(t *testing.T) {
 	}{
 		{
 			name: "node-already-power-off",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				PowerState: powerOff,
 				UUID:       nodeUUID,
 			}),
 		},
 		{
 			name: "waiting-for-target-power-off",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				PowerState:       powerOn,
 				TargetPowerState: powerOff,
 				UUID:             nodeUUID,
@@ -192,7 +192,7 @@ func TestPowerOff(t *testing.T) {
 		},
 		{
 			name: "power-off wait for Provisioning state",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				PowerState:           powerOn,
 				TargetProvisionState: string(nodes.TargetDeleted),
 				UUID:                 nodeUUID,
@@ -202,7 +202,7 @@ func TestPowerOff(t *testing.T) {
 		},
 		{
 			name: "power-off wait for locked host",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				PowerState:           powerOn,
 				TargetProvisionState: "",
 				UUID:                 nodeUUID,
@@ -297,7 +297,7 @@ func TestSoftPowerOffFallback(t *testing.T) {
 		PowerState: powerOn,
 		UUID:       nodeUUID,
 	}
-	ironic := testserver.NewIronic(t).Ready().Node(node).WithNodeStatesPowerUpdate(nodeUUID, http.StatusBadRequest)
+	ironic := testserver.NewIronic(t).Node(node).WithNodeStatesPowerUpdate(nodeUUID, http.StatusBadRequest)
 	ironic.Start()
 	defer ironic.Stop()
 

--- a/pkg/provisioner/ironic/provision_test.go
+++ b/pkg/provisioner/ironic/provision_test.go
@@ -97,7 +97,7 @@ func TestProvision(t *testing.T) {
 		},
 		{
 			name: "active state",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				ProvisionState: string(nodes.Active),
 				UUID:           nodeUUID,
 			}),
@@ -106,7 +106,7 @@ func TestProvision(t *testing.T) {
 		},
 		{
 			name: "other state: Cleaning",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				ProvisionState: string(nodes.Cleaning),
 				UUID:           nodeUUID,
 			}),
@@ -115,7 +115,7 @@ func TestProvision(t *testing.T) {
 		},
 		{
 			name: "other state: Deploy Wait",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				ProvisionState: string(nodes.DeployWait),
 				UUID:           nodeUUID,
 			}),
@@ -243,7 +243,7 @@ func TestDeprovision(t *testing.T) {
 		},
 		{
 			name: "deleting state",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				ProvisionState: string(nodes.Deleting),
 				UUID:           nodeUUID,
 			}),
@@ -252,7 +252,7 @@ func TestDeprovision(t *testing.T) {
 		},
 		{
 			name: "cleaning state",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				ProvisionState: string(nodes.Cleaning),
 				UUID:           nodeUUID,
 			}),
@@ -261,7 +261,7 @@ func TestDeprovision(t *testing.T) {
 		},
 		{
 			name: "cleanWait state",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				ProvisionState: string(nodes.CleanWait),
 				UUID:           nodeUUID,
 			}),

--- a/pkg/provisioner/ironic/ready_test.go
+++ b/pkg/provisioner/ironic/ready_test.go
@@ -23,14 +23,14 @@ func TestProvisionerIsReady(t *testing.T) {
 	}{
 		{
 			name:                "IsReady",
-			ironic:              testserver.NewIronic(t).Ready().WithDrivers(),
-			expectedIronicCalls: "/v1;/v1/drivers;",
+			ironic:              testserver.NewIronic(t).WithDrivers(),
+			expectedIronicCalls: "/v1/;/v1/drivers;",
 			expectedIsReady:     true,
 		},
 		{
 			name:                "NoDriversLoaded",
-			ironic:              testserver.NewIronic(t).Ready(),
-			expectedIronicCalls: "/v1;/v1/drivers;",
+			ironic:              testserver.NewIronic(t),
+			expectedIronicCalls: "/v1/;/v1/drivers;",
 		},
 		{
 			name:            "IronicDown",
@@ -40,13 +40,13 @@ func TestProvisionerIsReady(t *testing.T) {
 			name:                "IronicNotOk",
 			ironic:              testserver.NewIronic(t).NotReady(http.StatusInternalServerError),
 			expectedIsReady:     false,
-			expectedIronicCalls: "/v1;",
+			expectedIronicCalls: "/v1/;",
 		},
 		{
 			name:                "IronicNotOkAndNotExpected",
 			ironic:              testserver.NewIronic(t).NotReady(http.StatusBadGateway),
 			expectedIsReady:     false,
-			expectedIronicCalls: "/v1;",
+			expectedIronicCalls: "/v1/;",
 		},
 	}
 

--- a/pkg/provisioner/ironic/updatehardwarestate_test.go
+++ b/pkg/provisioner/ironic/updatehardwarestate_test.go
@@ -29,14 +29,14 @@ func TestUpdateHardwareState(t *testing.T) {
 	}{
 		{
 			name: "unknown-power-state",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				UUID: nodeUUID,
 			}),
 			expectUnreadablePower: true,
 		},
 		{
 			name: "updated-power-on-state",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				UUID:       nodeUUID,
 				PowerState: "power on",
 			}),
@@ -44,7 +44,7 @@ func TestUpdateHardwareState(t *testing.T) {
 		},
 		{
 			name: "not-updated-power-on-state",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				UUID:       nodeUUID,
 				PowerState: "power on",
 			}),
@@ -52,7 +52,7 @@ func TestUpdateHardwareState(t *testing.T) {
 		},
 		{
 			name: "updated-power-off-state",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				UUID:       nodeUUID,
 				PowerState: "power off",
 			}),
@@ -60,7 +60,7 @@ func TestUpdateHardwareState(t *testing.T) {
 		},
 		{
 			name: "not-updated-power-off-state",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				UUID:       nodeUUID,
 				PowerState: "power off",
 			}),
@@ -68,7 +68,7 @@ func TestUpdateHardwareState(t *testing.T) {
 		},
 		{
 			name: "no-power",
-			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
 				UUID:       nodeUUID,
 				PowerState: "None",
 			}),
@@ -79,7 +79,7 @@ func TestUpdateHardwareState(t *testing.T) {
 			name: "node-not-found",
 
 			hostName: "worker-0",
-			ironic:   testserver.NewIronic(t).Ready().NodeError(nodeUUID, http.StatusGatewayTimeout),
+			ironic:   testserver.NewIronic(t).NodeError(nodeUUID, http.StatusGatewayTimeout),
 
 			expectedError: "failed to find node by ID 33ce8659-7400-4c68-9535-d10766f07a58: Gateway Timeout.*",
 
@@ -89,7 +89,7 @@ func TestUpdateHardwareState(t *testing.T) {
 			name: "node-not-found-by-name",
 
 			hostName: "worker-0",
-			ironic:   testserver.NewIronic(t).Ready().NoNode(nodeUUID).NodeError("myns"+nameSeparator+"myhost", http.StatusGatewayTimeout),
+			ironic:   testserver.NewIronic(t).NoNode(nodeUUID).NodeError("myns"+nameSeparator+"myhost", http.StatusGatewayTimeout),
 
 			expectedError: "Host not registered",
 
@@ -97,7 +97,7 @@ func TestUpdateHardwareState(t *testing.T) {
 		},
 		{
 			name:   "not-ironic-node",
-			ironic: testserver.NewIronic(t).Ready().NoNode(nodeUUID).NoNode("myns" + nameSeparator + "myhost").NoNode("myhost"),
+			ironic: testserver.NewIronic(t).NoNode(nodeUUID).NoNode("myns" + nameSeparator + "myhost").NoNode("myhost"),
 
 			expectedError: "Host not registered",
 

--- a/pkg/provisioner/ironic/validatemanagementaccess_test.go
+++ b/pkg/provisioner/ironic/validatemanagementaccess_test.go
@@ -25,7 +25,7 @@ func TestValidateManagementAccessNoMAC(t *testing.T) {
 	host.Spec.BootMACAddress = ""
 	host.Status.Provisioning.ID = "" // so we don't lookup by uuid
 
-	ironic := testserver.NewIronic(t).Ready().NoNode(host.Namespace + nameSeparator + host.Name).NoNode(host.Name)
+	ironic := testserver.NewIronic(t).NoNode(host.Namespace + nameSeparator + host.Name).NoNode(host.Name)
 	ironic.Start()
 	defer ironic.Stop()
 
@@ -49,7 +49,7 @@ func TestValidateManagementAccessMACOptional(t *testing.T) {
 	host.Spec.BootMACAddress = ""
 
 	// Set up ironic server to return the node
-	ironic := testserver.NewIronic(t).Ready().
+	ironic := testserver.NewIronic(t).
 		Node(nodes.Node{
 			Name: host.Namespace + nameSeparator + host.Name,
 			UUID: host.Status.Provisioning.ID,
@@ -86,7 +86,7 @@ func TestValidateManagementAccessCreateNodeNoImage(t *testing.T) {
 		createdNode = &node
 	}
 
-	ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).NoNode(host.Namespace + nameSeparator + host.Name).NoNode(host.Name)
+	ironic := testserver.NewIronic(t).CreateNodes(createCallback).NoNode(host.Namespace + nameSeparator + host.Name).NoNode(host.Name)
 	ironic.AddDefaultResponse("/v1/nodes/node-0", "PATCH", http.StatusOK, "{}")
 	ironic.Start()
 	defer ironic.Stop()
@@ -120,7 +120,7 @@ func TestValidateManagementAccessCreateWithImage(t *testing.T) {
 		createdNode = &node
 	}
 
-	ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).NoNode(host.Namespace + nameSeparator + host.Name).NoNode(host.Name)
+	ironic := testserver.NewIronic(t).CreateNodes(createCallback).NoNode(host.Namespace + nameSeparator + host.Name).NoNode(host.Name)
 	ironic.AddDefaultResponse("/v1/nodes/node-0", "PATCH", http.StatusOK, "{}")
 	ironic.Start()
 	defer ironic.Stop()
@@ -156,7 +156,7 @@ func TestValidateManagementAccessCreateWithLiveIso(t *testing.T) {
 		createdNode = &node
 	}
 
-	ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).NoNode(host.Namespace + nameSeparator + host.Name).NoNode(host.Name)
+	ironic := testserver.NewIronic(t).CreateNodes(createCallback).NoNode(host.Namespace + nameSeparator + host.Name).NoNode(host.Name)
 	ironic.AddDefaultResponse("/v1/nodes/node-0", "PATCH", http.StatusOK, "{}")
 	ironic.Start()
 	defer ironic.Stop()
@@ -190,7 +190,7 @@ func TestValidateManagementAccessExistingNode(t *testing.T) {
 		t.Fatal("create callback should not be invoked for existing node")
 	}
 
-	ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).Node(nodes.Node{
+	ironic := testserver.NewIronic(t).CreateNodes(createCallback).Node(nodes.Node{
 		Name: host.Namespace + nameSeparator + host.Name,
 		UUID: "uuid",
 	}).NodeUpdate(
@@ -289,7 +289,7 @@ func TestValidateManagementAccessExistingNodeContinue(t *testing.T) {
 				t.Fatal("create callback should not be invoked for existing node")
 			}
 
-			ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).Node(nodes.Node{
+			ironic := testserver.NewIronic(t).CreateNodes(createCallback).Node(nodes.Node{
 				Name:           host.Namespace + nameSeparator + host.Name,
 				UUID:           "uuid", // to match status in host
 				ProvisionState: string(status),
@@ -451,7 +451,7 @@ func TestValidateManagementAccessExistingSteadyStateNoUpdate(t *testing.T) {
 			if provisionState == "" {
 				provisionState = string(nodes.Manageable)
 			}
-			ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).Node(nodes.Node{
+			ironic := testserver.NewIronic(t).CreateNodes(createCallback).Node(nodes.Node{
 				Name:            host.Namespace + nameSeparator + host.Name,
 				UUID:            "uuid", // to match status in host
 				ProvisionState:  provisionState,
@@ -517,7 +517,7 @@ func TestValidateManagementAccessExistingNodeWaiting(t *testing.T) {
 					"test_port":      "42",
 				},
 			}
-			ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).Node(node).NodeUpdate(nodes.Node{
+			ironic := testserver.NewIronic(t).CreateNodes(createCallback).Node(node).NodeUpdate(nodes.Node{
 				UUID: "uuid",
 			}).WithNodeStatesProvisionUpdate(node.UUID)
 			ironic.Start()
@@ -615,7 +615,7 @@ func TestValidateManagementAccessLinkExistingIronicNodeByMAC(t *testing.T) {
 		t.Fatal("create callback should not be invoked for existing node")
 	}
 
-	ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).Node(existingNode).Port(existingNodePort)
+	ironic := testserver.NewIronic(t).CreateNodes(createCallback).Node(existingNode).Port(existingNodePort)
 	ironic.AddDefaultResponse("/v1/nodes/myns"+nameSeparator+"myhost", "GET", http.StatusNotFound, "")
 	ironic.AddDefaultResponse("/v1/nodes/myhost", "GET", http.StatusNotFound, "")
 	ironic.AddDefaultResponse("/v1/nodes/"+existingNode.UUID, "PATCH", http.StatusOK, "{\"uuid\": \"33ce8659-7400-4c68-9535-d10766f07a58\"}")
@@ -657,7 +657,7 @@ func TestValidateManagementAccessExistingPortWithWrongUUID(t *testing.T) {
 		t.Fatal("create callback should not be invoked for existing node")
 	}
 
-	ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).Node(existingNode).Port(existingNodePort)
+	ironic := testserver.NewIronic(t).CreateNodes(createCallback).Node(existingNode).Port(existingNodePort)
 	ironic.AddDefaultResponse("/v1/nodes/myns"+nameSeparator+"myhost", "GET", http.StatusNotFound, "")
 	ironic.AddDefaultResponse("/v1/nodes/myhost", "GET", http.StatusNotFound, "")
 	ironic.AddDefaultResponse("/v1/nodes/random-wrong-id", "GET", http.StatusNotFound, "")
@@ -701,7 +701,7 @@ func TestValidateManagementAccessExistingPortButHasName(t *testing.T) {
 		t.Fatal("create callback should not be invoked for existing node")
 	}
 
-	ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).Node(existingNode).Port(existingNodePort)
+	ironic := testserver.NewIronic(t).CreateNodes(createCallback).Node(existingNode).Port(existingNodePort)
 	ironic.AddDefaultResponse("/v1/nodes/myns"+nameSeparator+"myhost", "GET", http.StatusNotFound, "")
 	ironic.AddDefaultResponse("/v1/nodes/myhost", "GET", http.StatusNotFound, "")
 	ironic.Start()
@@ -738,7 +738,7 @@ func TestValidateManagementAccessAddTwoHostsWithSameMAC(t *testing.T) {
 		t.Fatal("create callback should not be invoked for existing node")
 	}
 
-	ironic := testserver.NewIronic(t).Ready().CreateNodes(createCallback).Node(existingNode).NodeUpdate(nodes.Node{
+	ironic := testserver.NewIronic(t).CreateNodes(createCallback).Node(existingNode).NodeUpdate(nodes.Node{
 		UUID: "33ce8659-7400-4c68-9535-d10766f07a58",
 	}).Port(existingNodePort)
 	ironic.Start()
@@ -770,7 +770,7 @@ func TestValidateManagementAccessUnsupportedSecureBoot(t *testing.T) {
 	host := makeHost()
 	host.Status.Provisioning.ID = "" // so we don't lookup by uuid
 
-	ironic := testserver.NewIronic(t).Ready().NoNode("myns" + nameSeparator + host.Name).NoNode(host.Name)
+	ironic := testserver.NewIronic(t).NoNode("myns" + nameSeparator + host.Name).NoNode(host.Name)
 	ironic.Start()
 	defer ironic.Stop()
 
@@ -788,7 +788,7 @@ func TestValidateManagementAccessUnsupportedSecureBoot(t *testing.T) {
 }
 
 func TestValidateManagementAccessNoBMCDetails(t *testing.T) {
-	ironic := testserver.NewIronic(t).Ready()
+	ironic := testserver.NewIronic(t)
 	ironic.Start()
 	defer ironic.Stop()
 
@@ -809,7 +809,7 @@ func TestValidateManagementAccessNoBMCDetails(t *testing.T) {
 }
 
 func TestValidateManagementAccessMalformedBMCAddress(t *testing.T) {
-	ironic := testserver.NewIronic(t).Ready()
+	ironic := testserver.NewIronic(t)
 	ironic.Start()
 	defer ironic.Stop()
 
@@ -1160,7 +1160,7 @@ func TestSetExternalURL(t *testing.T) {
 	host := makeHost()
 	host.Spec.BMC.Address = "redfish-virtualmedia://[fe80::fc33:62ff:fe83:8a76]:6233"
 
-	ironic := testserver.NewIronic(t).Ready().
+	ironic := testserver.NewIronic(t).
 		Node(nodes.Node{
 			Name: host.Namespace + nameSeparator + host.Name,
 			UUID: host.Status.Provisioning.ID,
@@ -1190,7 +1190,7 @@ func TestSetExternalURLIPv4(t *testing.T) {
 	host := makeHost()
 	host.Spec.BMC.Address = "redfish-virtualmedia://1.1.1.1:1111"
 
-	ironic := testserver.NewIronic(t).Ready().
+	ironic := testserver.NewIronic(t).
 		Node(nodes.Node{
 			Name: host.Namespace + nameSeparator + host.Name,
 			UUID: host.Status.Provisioning.ID,
@@ -1220,7 +1220,7 @@ func TestSetExternalURLRemoving(t *testing.T) {
 	host := makeHost()
 	host.Spec.BMC.Address = "redfish-virtualmedia://1.1.1.1:1111"
 
-	ironic := testserver.NewIronic(t).Ready().
+	ironic := testserver.NewIronic(t).
 		Node(nodes.Node{
 			Name: host.Namespace + nameSeparator + host.Name,
 			UUID: host.Status.Provisioning.ID,


### PR DESCRIPTION
In preparation for the future microversion negotiation handling:
1) Remove the unnecessary ironicDependenciesChecker abstraction.
   It probably made more sense when Inspector was used explicitly.
2) Change tests to make Ready the default state (and NotReady
   an explicit override for the few tests that need it).