### PR TITLE
🌱 Implement Detached/Status Annotation E2E Test

### DIFF
--- a/test/e2e/basic_provisioning_test.go
+++ b/test/e2e/basic_provisioning_test.go
@@ -2,20 +2,25 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 )
 
-var _ = Describe("Provisioning", func() {
+var _ = Describe("BMH Provisioning and Annotation Management", func() {
 	var (
 		specName       = "provisioning-ops"
 		namespace      *corev1.Namespace
@@ -40,7 +45,7 @@ var _ = Describe("Provisioning", func() {
 		})
 	})
 
-	It("should provision and then deprovision a BMH", func() {
+	It("provisions a BMH, applies detached and status annotations, then deprovisions", func() {
 		By("Creating a secret with BMH credentials")
 		bmcCredentials := corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -117,6 +122,133 @@ var _ = Describe("Provisioning", func() {
 			Bmh:    bmh,
 			State:  metal3api.StateProvisioned,
 		}, e2eConfig.GetIntervals(specName, "wait-provisioned")...)
+
+		By("Retrieving the latest BMH object")
+		err = clusterProxy.GetClient().Get(ctx, client.ObjectKey{
+			Name:      bmh.Name,
+			Namespace: bmh.Namespace,
+		}, &bmh)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Adding the detached annotation")
+		helper, err = patch.NewHelper(&bmh, clusterProxy.GetClient())
+		Expect(err).NotTo(HaveOccurred())
+
+		// Add the detached annotation; "true" is used explicitly to clarify intent.
+		bmh.ObjectMeta.Annotations["baremetalhost.metal3.io/detached"] = "true"
+
+		Expect(helper.Patch(ctx, &bmh)).To(Succeed())
+
+		By("Saving the status to a JSON string")
+		savedStatus := bmh.Status
+		statusJSON, err := json.Marshal(savedStatus)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Deleting the BMH")
+		// Wait for 2 seconds to allow time to confirm annotation is set
+		// TODO: fix this so we do not need the sleep
+		time.Sleep(2 * time.Second)
+
+		err = clusterProxy.GetClient().Delete(ctx, &bmh)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the BMH to be deleted")
+		Eventually(func() (string, error) {
+			var currentBmh metal3api.BareMetalHost
+			err := clusterProxy.GetClient().Get(ctx, types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}, &currentBmh)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					// If the BMH is not found, we assume it has been successfully deleted.
+					return "deleted", nil
+				}
+				// Any other error should be returned.
+				return "", err
+			}
+
+			currentStatus := currentBmh.Status.Provisioning.State
+
+			// If the state is 'deleting' or 'provisioned', we continue polling.
+			if currentStatus == "deleting" || currentStatus == "provisioned" {
+				return string(currentStatus), nil
+			}
+
+			// Any other state is unexpected, and we stop the polling.
+			return "", StopTrying(fmt.Sprintf("BMH is in an unexpected state: %s", currentStatus))
+		}, e2eConfig.GetIntervals(specName, "wait-deleted")...).Should(Equal("deleted"))
+
+		By("Waiting for the secret to be deleted")
+		Eventually(func() bool {
+			err := clusterProxy.GetClient().Get(ctx, client.ObjectKey{
+				Name:      "bmc-credentials",
+				Namespace: namespace.Name,
+			}, &corev1.Secret{})
+			return apierrors.IsNotFound(err)
+		}, e2eConfig.GetIntervals(specName, "wait-secret-deletion")...).Should(BeTrue())
+
+		By("Creating a secret with BMH credentials")
+		secretName := "bmc-credentials"
+		bmcCredentials = corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace.Name,
+			},
+			StringData: map[string]string{
+				"username": bmcUser,
+				"password": bmcPassword,
+			},
+		}
+
+		err = clusterProxy.GetClient().Create(ctx, &bmcCredentials)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Recreating the BMH with the previously saved status in the status annotation")
+		bmh = metal3api.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      specName,
+				Namespace: namespace.Name,
+				Annotations: map[string]string{
+					metal3api.StatusAnnotation: string(statusJSON),
+				},
+			},
+			Spec: metal3api.BareMetalHostSpec{
+				Online: true,
+				BMC: metal3api.BMCDetails{
+					Address:         bmcAddress,
+					CredentialsName: "bmc-credentials",
+				},
+				BootMode:       metal3api.Legacy,
+				BootMACAddress: bootMacAddress,
+				Image: &metal3api.Image{
+					URL:      e2eConfig.GetVariable("IMAGE_URL"),
+					Checksum: e2eConfig.GetVariable("IMAGE_CHECKSUM"),
+				},
+				RootDeviceHints: &metal3api.RootDeviceHints{
+					DeviceName: "/dev/vda",
+				},
+			},
+		}
+
+		err = clusterProxy.GetClient().Create(ctx, &bmh)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Checking that the BMH goes directly to 'provisioned' state")
+		Eventually(func() (string, error) {
+			var currentBmh metal3api.BareMetalHost
+			err := clusterProxy.GetClient().Get(ctx, types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}, &currentBmh)
+			if err != nil {
+				// Handle errors that may occur while fetching the BMH.
+				return "", err
+			}
+
+			currentStatus := currentBmh.Status.Provisioning.State
+
+			if currentStatus == "provisioned" || currentStatus == "" {
+				return string(currentStatus), nil
+			}
+
+			// Any other state is unexpected, and we stop the polling.
+			return "", StopTrying(fmt.Sprintf("BMH should not be in '%s' state", currentStatus))
+		}, e2eConfig.GetIntervals(specName, "wait-provisioned")...).Should(Equal("provisioned"))
 
 		By("Triggering the deprovisioning of the BMH")
 		helper, err = patch.NewHelper(&bmh, clusterProxy.GetClient())

--- a/test/e2e/config/fixture.yaml
+++ b/test/e2e/config/fixture.yaml
@@ -40,3 +40,5 @@ intervals:
   default/wait-provisioned: ["20s", "1s"]
   default/wait-deprovisioning: ["5s", "10ms"]
   default/wait-available: ["20s", "1s"]
+  default/wait-deleting: ["5s", "10ms"]
+  default/wait-secret-deletion: ["5s", "10ms"]

--- a/test/e2e/config/ironic.yaml
+++ b/test/e2e/config/ironic.yaml
@@ -23,7 +23,11 @@ variables:
   # Test credentials. The tests will create a BMH with these.
   BMC_USER: admin
   BMC_PASSWORD: password
-  BMC_ADDRESS: "ipmi://192.168.222.1:16230"
+  # During development, select the preferred BMC interface when running tests from the command line:
+  # Note: These settings are only applicable for command line executions, not when running via the ci-e2e.sh script.
+  # Uncomment the desired BMC_ADDRESS line:
+  # BMC_ADDRESS: "ipmi://192.168.222.1:16230"
+  BMC_ADDRESS: "redfish+http://192.168.222.1:8000/redfish/v1/Systems/bmo-e2e-0"
   BOOT_MAC_ADDRESS: "00:60:2f:31:81:01"
   IMAGE_URL: "http://192.168.222.1/cirros-0.6.2-x86_64-disk.img"
   IMAGE_CHECKSUM: "c8fc807773e5354afe61636071771906"
@@ -42,3 +46,5 @@ intervals:
   default/wait-provisioning: ["20s", "1s"]
   default/wait-provisioned: ["5m", "1s"]
   default/wait-deprovisioning: ["1m", "10ms"]
+  default/wait-deleted: ["20s", "10ms"]
+  default/wait-secret-deletion: ["1m", "1s"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Validate BMH status retention across delete & recreate with annotations.

Fixes #1368
