### PR TITLE
🌱 Add github workflow for e2e fixture tests

### DIFF
--- a/.github/workflows/e2e-fixture-test.yml
+++ b/.github/workflows/e2e-fixture-test.yml
@@ -1,0 +1,35 @@
+name: E2E Fixture Test
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.gitignore'
+      - 'hack/*.sh'
+      - 'LICENSE'
+      - 'SECURITY_CONTACTS'
+      - 'DCO'
+      - 'OWNERS'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Build BMO e2e Docker Image
+      env:
+        IMG: quay.io/metal3-io/baremetal-operator:e2e
+      run: make docker
+
+    - name: Set Up Environment and Run BMO e2e Tests
+      env:
+        E2E_CONF_FILE: ${GITHUB_WORKSPACE}/test/e2e/config/fixture.yaml
+        USE_EXISTING_CLUSTER: "false"
+      run: make test-e2e

--- a/test/e2e/basic_ops_test.go
+++ b/test/e2e/basic_ops_test.go
@@ -82,13 +82,6 @@ var _ = Describe("basic", func() {
 		err = clusterProxy.GetClient().Create(ctx, &bmh)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("waiting for the BMH to be in registering state")
-		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
-			Client: clusterProxy.GetClient(),
-			Bmh:    bmh,
-			State:  metal3api.StateRegistering,
-		}, e2eConfig.GetIntervals(specName, "wait-registering")...)
-
 		By("waiting for the BMH to become available")
 		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
 			Client: clusterProxy.GetClient(),

--- a/test/e2e/basic_provisioning_test.go
+++ b/test/e2e/basic_provisioning_test.go
@@ -78,13 +78,6 @@ var _ = Describe("Provisioning", func() {
 		err = clusterProxy.GetClient().Create(ctx, &bmh)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Waiting for the BMH to be in registering state")
-		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
-			Client: clusterProxy.GetClient(),
-			Bmh:    bmh,
-			State:  metal3api.StateRegistering,
-		}, e2eConfig.GetIntervals(specName, "wait-registering")...)
-
 		By("Waiting for the BMH to become available")
 		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
 			Client: clusterProxy.GetClient(),

--- a/test/e2e/config/ironic.yaml
+++ b/test/e2e/config/ironic.yaml
@@ -33,7 +33,7 @@ intervals:
   default/wait-registering: ["1m", "5s"]
   inspection/wait-registration-error: ["1m", "5s"]
   external-inspection/wait-available: ["20s", "1s"]
-  default/wait-inspecting: ["2m", "10s"]
+  default/wait-inspecting: ["2m", "2s"]
   default/wait-available: ["10m", "1s"]
   default/wait-deployment: ["5m", "1s"]
   default/wait-namespace-deleted: ["10m", "1s"]

--- a/test/e2e/external_inspection_test.go
+++ b/test/e2e/external_inspection_test.go
@@ -232,13 +232,6 @@ var _ = Describe("External Inspection", func() {
 		err = clusterProxy.GetClient().Create(ctx, &bmh)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("waiting for the BMH to be in registering state")
-		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
-			Client: clusterProxy.GetClient(),
-			Bmh:    bmh,
-			State:  metal3api.StateRegistering,
-		}, e2eConfig.GetIntervals(specName, "wait-registering")...)
-
 		By("waiting for the BMH to become available")
 		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
 			Client: clusterProxy.GetClient(),

--- a/test/e2e/inspection_test.go
+++ b/test/e2e/inspection_test.go
@@ -123,13 +123,6 @@ var _ = Describe("Inspection", func() {
 		err = clusterProxy.GetClient().Create(ctx, &bmh)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("waiting for the BMH to be in registering state")
-		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
-			Client: clusterProxy.GetClient(),
-			Bmh:    bmh,
-			State:  metal3api.StateRegistering,
-		}, e2eConfig.GetIntervals(specName, "wait-registering")...)
-
 		By("waiting for the BMH to be in inspecting state")
 		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
 			Client: clusterProxy.GetClient(),

--- a/test/e2e/re_inspection_test.go
+++ b/test/e2e/re_inspection_test.go
@@ -86,13 +86,6 @@ var _ = Describe("Re-Inspection", func() {
 		err = clusterProxy.GetClient().Create(ctx, &bmh)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("waiting for the BMH to be in registering state")
-		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
-			Client: clusterProxy.GetClient(),
-			Bmh:    bmh,
-			State:  metal3api.StateRegistering,
-		}, e2eConfig.GetIntervals(specName, "wait-registering")...)
-
 		By("waiting for the BMH to become available")
 		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
 			Client: clusterProxy.GetClient(),


### PR DESCRIPTION
**What this PR does / why we need it**:
Implement lightweight fixture-based tests to ensure CI platform flexibility.

Fixes #1406
