### PR TITLE
:bug: Don't munge timestamp in structured logs, again

### DIFF
--- a/main.go
+++ b/main.go
@@ -175,6 +175,8 @@ func main() {
 	if devLogging {
 		logOpts.Development = true
 		logOpts.TimeEncoder = zapcore.ISO8601TimeEncoder
+	} else {
+		logOpts.TimeEncoder = zapcore.EpochTimeEncoder
 	}
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&logOpts)))
 


### PR DESCRIPTION
Structured logging tools expect a POSIX timestamp. 0a887a16fb26dd26a2b372953ec8d860a3a251b5 reverted to changing the timestamp formatting only in development log mode, after 9ecf1718dfe3f785e151b6d2b5a01ba04e0a00a9 had explicitly and unconditionally set the format to ISO-8601.

However, almost immediately after this, 5bf044038b17aec6c2265d325046f475bc4bb52f bumped the controller-runtime version from 0.13.1 to 0.14.5. In 0.14, the default zap options in controller-runtime [changed to RFC3339](https://github.com/kubernetes-sigs/controller-runtime/commit/60e524b7f4a6264662adfd1a2bd3e40b75393270) - which is the same as ISO-8601 but even worse because subsecond precision (which can be very important to debugging) is lost as well.

This change explicitly restores the original default.