### PR TITLE
🌱 Enable the Redfish RAID interfaces

### DIFF
--- a/pkg/hardwareutils/bmc/redfish.go
+++ b/pkg/hardwareutils/bmc/redfish.go
@@ -116,7 +116,7 @@ func (a *redfishAccessDetails) PowerInterface() string {
 }
 
 func (a *redfishAccessDetails) RAIDInterface() string {
-	return "no-raid"
+	return "redfish"
 }
 
 func (a *redfishAccessDetails) VendorInterface() string {

--- a/pkg/hardwareutils/bmc/redfish_virtualmedia.go
+++ b/pkg/hardwareutils/bmc/redfish_virtualmedia.go
@@ -84,7 +84,7 @@ func (a *redfishVirtualMediaAccessDetails) PowerInterface() string {
 }
 
 func (a *redfishVirtualMediaAccessDetails) RAIDInterface() string {
-	return "no-raid"
+	return "redfish"
 }
 
 func (a *redfishVirtualMediaAccessDetails) VendorInterface() string {


### PR DESCRIPTION
Enable the redfish and redfish-virtualmedia RAID interfaces so that RAID can be configured using these interfaces.
