### PR TITLE
🌱 Delete "ok-to-test" label from dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: ":seedling:"
-    labels:
-      - "ok-to-test"
     # Go
   - package-ecosystem: "gomod"
     directory: "/"
@@ -24,8 +22,6 @@ updates:
       - dependency-name: "k8s.io/*"
     commit-message:
       prefix: ":seedling:"
-    labels:
-      - "ok-to-test"
   - package-ecosystem: "gomod"
     directory: "/apis"
     schedule:
@@ -38,16 +34,12 @@ updates:
       - dependency-name: "k8s.io/*"
     commit-message:
       prefix: ":seedling:"
-    labels:
-      - "ok-to-test"
   - package-ecosystem: "gomod"
     directory: "/pkg/hardwareutils"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: ":seedling:"
-    labels:
-      - "ok-to-test"
   - package-ecosystem: "gomod"
     directory: "/hack/tools"
     schedule:
@@ -58,5 +50,3 @@ updates:
       - dependency-name: "sigs.k8s.io/controller-tools"
     commit-message:
       prefix: ":seedling:"
-    labels:
-      - "ok-to-test"


### PR DESCRIPTION
Dependabot recently is creating quite a few unnecessary PRs which need to be closed manually, having ok-to-test creates a lot of unneeded tests. Removing the label would allow adding labels selectively by reviewers and save some test bandwidth