### PR TITLE
🌱 bump markdownlint to 0.13.0

### DIFF
--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# TODO:
+# Fix these two failures in future commit, and remove the ignore rules
+#
+# Further documentation is available for these failures:
+# - MD029: https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md029---ordered-list-item-prefix
+# - MD013: https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md013---line-length
+
 set -eux
 
 IS_CONTAINER=${IS_CONTAINER:-false}
@@ -11,7 +18,7 @@ if [ "${IS_CONTAINER}" != "false" ]; then
        \( -path ./vendor -o -path ./.github \) \
       -prune -o -name '*.md' -exec \
       mdl --style all --warnings \
-      --rules "MD001,MD002,MD003,MD004,MD005,MD006,MD007,MD009,MD010,MD011,MD012,MD014,MD018,MD019,MD020,MD021,MD022,MD023,MD024,MD025,MD026,MD027,MD028,MD030,MD031,MD032,MD033,MD034,MD035,MD036,MD037,MD038,MD039,MD040,MD041" \
+      --rules "~MD013,~MD029" \
       {} \+
 else
   "${CONTAINER_RUNTIME}" run --rm \
@@ -19,45 +26,6 @@ else
     --volume "${PWD}:/workdir:ro,z" \
     --entrypoint sh \
     --workdir /workdir \
-    docker.io/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2 \
-    /workdir/hack/markdownlint.sh "${@}"
-fi;
-
-# $ mdl --style all -l
-# MD001 - Header levels should only increment by one level at a time
-# MD002 - First header should be a top level header
-# MD003 - Header style
-# MD004 - Unordered list style
-# MD005 - Inconsistent indentation for list items at the same level
-# MD006 - Consider starting bulleted lists at the beginning of the line
-# MD007 - Unordered list indentation
-# MD009 - Trailing spaces
-# MD010 - Hard tabs
-# MD011 - Reversed link syntax
-# MD012 - Multiple consecutive blank lines
-# MD014 - Dollar signs used before commands without showing output
-# MD018 - No space after hash on atx style header
-# MD019 - Multiple spaces after hash on atx style header
-# MD020 - No space inside hashes on closed atx style header
-# MD021 - Multiple spaces inside hashes on closed atx style header
-# MD022 - Headers should be surrounded by blank lines
-# MD023 - Headers must start at the beginning of the line
-# MD024 - Multiple headers with the same content
-# MD025 - Multiple top level headers in the same document
-# MD026 - Trailing punctuation in header
-# MD027 - Multiple spaces after blockquote symbol
-# MD028 - Blank line inside blockquote
-# MD029 - Ordered list item prefix - DISABLED
-# MD030 - Spaces after list markers
-# MD031 - Fenced code blocks should be surrounded by blank lines
-# MD032 - Lists should be surrounded by blank lines
-# MD033 - Inline HTML
-# MD034 - Bare URL used
-# MD035 - Horizontal rule style
-# MD036 - Emphasis used instead of a header
-# MD037 - Spaces inside emphasis markers
-# MD038 - Spaces inside code span elements
-# MD039 - Spaces inside link text
-# MD040 - Fenced code blocks should have a language specified
-# MD041 - First line in file should be a top level header
-# MD046 - Code block style - DISABLED
+    docker.io/pipelinecomponents/markdownlint:0.13.0@sha256:9c0cdfb64fd3f1d3bdc5181629b39c2e43b6a52fc9fdc146611e1860845bbae0 \
+    /workdir/hack/markdownlint.sh "$@"
+fi


### PR DESCRIPTION
Manual cherry-pick of #1467.

This is needed to keep project-infra config clean.