### PR TITLE
🌱 bump gosec to 2.18.2

### DIFF
--- a/hack/gosec.sh
+++ b/hack/gosec.sh
@@ -8,13 +8,16 @@ CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 if [ "${IS_CONTAINER}" != "false" ]; then
   export XDG_CACHE_HOME="/tmp/.cache"
 
-  gosec -severity medium --confidence medium -quiet ./...
+  # It seems like gosec does not handle submodules well. Therefore we skip them and run separately.
+  gosec -severity medium --confidence medium -quiet -exclude-dir=apis -exclude-dir=hack/tools ./...
+  (cd apis && gosec -severity medium --confidence medium -quiet ./...)
+  (cd hack/tools && gosec -severity medium --confidence medium -quiet ./...)
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/metal3-io/baremetal-operator:ro,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/baremetal-operator \
-    docker.io/securego/gosec:2.14.0@sha256:73858f8b1b9b7372917677151ec6deeceeaa40c5b02753080bd647dede14e213 \
-    /go/src/github.com/metal3-io/baremetal-operator/hack/gosec.sh "${@}"
-fi;
+    docker.io/securego/gosec:2.18.2@sha256:2f9daee1739765788945b79de7f46229f33fda5ed35127393d8a1e459f3a7577 \
+    /go/src/github.com/metal3-io/baremetal-operator/hack/gosec.sh "$@"
+fi


### PR DESCRIPTION
Manual cherry-pick of #1474.

It also backports #1362 that makes gosec.sh actually do something for non-root modules.
