### PR TITLE
🌱 reduce github actions permissions

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -1,41 +1,46 @@
 name: build-images-action
+
 on:
   push:
     branches:
-      - 'main'
-      - 'release-*'
+    - 'main'
+    - 'release-*'
     tags:
-      - 'v*'
+    - 'v*'
+
 permissions: {}
+
 jobs:
   build:
     name: Build container images
     runs-on: ubuntu-latest
-    if: github.repository == 'metal3-io/baremetal-operator'
+
     permissions:
       contents: read
+
+    if: github.repository == 'metal3-io/baremetal-operator'
     steps:
-      - name: build bmo image
-        uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
-        with:
-          jenkins_url: "https://jenkins.nordix.org/"
-          jenkins_user: "metal3.bot@gmail.com"
-          jenkins_token: ${{ secrets.JENKINS_TOKEN }}
-          job_name: "metal3_baremetal-operator_container_image_building"
-          job_params: |
-            {
-              "BUILD_CONTAINER_IMAGE_GIT_REFERENCE": "${{ github.ref }}"
-            }
-          job_timeout: "1000"
-      - name: build keepalived image
-        uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
-        with:
-          jenkins_url: "https://jenkins.nordix.org/"
-          jenkins_user: "metal3.bot@gmail.com"
-          jenkins_token: ${{ secrets.JENKINS_TOKEN }}
-          job_name: "metal3_keepalived_container_image_building"
-          job_params: |
-            {
-              "BUILD_CONTAINER_IMAGE_GIT_REFERENCE": "${{ github.ref }}"
-            }
-          job_timeout: "1000"
+    - name: build bmo image
+      uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
+      with:
+        jenkins_url: "https://jenkins.nordix.org/"
+        jenkins_user: "metal3.bot@gmail.com"
+        jenkins_token: ${{ secrets.JENKINS_TOKEN }}
+        job_name: "metal3_baremetal-operator_container_image_building"
+        job_params: |
+          {
+            "BUILD_CONTAINER_IMAGE_GIT_REFERENCE": "${{ github.ref }}"
+          }
+        job_timeout: "1000"
+    - name: build keepalived image
+      uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
+      with:
+        jenkins_url: "https://jenkins.nordix.org/"
+        jenkins_user: "metal3.bot@gmail.com"
+        jenkins_token: ${{ secrets.JENKINS_TOKEN }}
+        job_name: "metal3_keepalived_container_image_building"
+        job_params: |
+          {
+            "BUILD_CONTAINER_IMAGE_GIT_REFERENCE": "${{ github.ref }}"
+          }
+        job_timeout: "1000"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -3,19 +3,22 @@ name: dependabot
 on:
   pull_request:
     branches:
-      - dependabot/**
+    - dependabot/**
   push:
     branches:
-      - dependabot/**
+    - dependabot/**
   workflow_dispatch:
 
-permissions:
-  contents: write # Allow to update the PR.
+permissions: {}
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/e2e-fixture-test.yml
+++ b/.github/workflows/e2e-fixture-test.yml
@@ -2,23 +2,26 @@ name: E2E Fixture Test
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - '.gitignore'
-      - 'hack/*.sh'
-      - 'LICENSE'
-      - 'SECURITY_CONTACTS'
-      - 'DCO'
-      - 'OWNERS'
+    - '**/*.md'
+    - 'docs/**'
+    - '.gitignore'
+    - 'hack/*.sh'
+    - 'LICENSE'
+    - 'SECURITY_CONTACTS'
+    - 'DCO'
+    - 'OWNERS'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   test:
+    name: e2e test
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/kubesec.yml
+++ b/.github/workflows/kubesec.yml
@@ -1,36 +1,37 @@
 name: Kubesec
+
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   schedule:
-    - cron: '30 7 * * 4'
+  - cron: '30 7 * * 4'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   setup:
-    # This workflow is only of value to the metal3-io/baremetal-operator repository and
-    # would always fail in forks
-    if: github.repository == 'metal3-io/baremetal-operator'
+    name: setup
     runs-on: ubuntu-20.04
+
     permissions:
       actions: read
       contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Collect all yaml
-        id: list_yaml
-        run: |
-          LIST_YAML="$(find * -type f -name '*.yaml')"
-          echo "::set-output name=value::$(IFS=$','; echo $LIST_YAML | jq -cnR '[inputs | select(length>0)]'; IFS=$'\n')"
+    if: github.repository == 'metal3-io/baremetal-operator'
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Collect all yaml
+      id: list_yaml
+      run: |
+        LIST_YAML="$(find * -type f -name '*.yaml')"
+        echo "::set-output name=value::$(IFS=$','; echo $LIST_YAML | jq -cnR '[inputs | select(length>0)]'; IFS=$'\n')"
     outputs:
       matrix: ${{ steps.list_yaml.outputs.value }}
 
   lint:
-    needs: [ setup ]
+    needs: [setup]
     name: Kubesec
     runs-on: ubuntu-20.04
     permissions:
@@ -41,24 +42,24 @@ jobs:
       matrix:
         value: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Checkout code
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Run kubesec scanner
-        uses: controlplaneio/kubesec-action@43d0ddff5ffee89a6bb9f29b64cd865411137b14
-        with:
-          input: ${{ matrix.value }}
-          format: template
-          template: template/sarif.tpl
-          output: ${{ matrix.value }}.sarif
-          exit-code: "0"
+    - name: Run kubesec scanner
+      uses: controlplaneio/kubesec-action@43d0ddff5ffee89a6bb9f29b64cd865411137b14 # v0.0.2
+      with:
+        input: ${{ matrix.value }}
+        format: template
+        template: template/sarif.tpl
+        output: ${{ matrix.value }}.sarif
+        exit-code: "0"
 
-      - name: Save result into a variable
-        id: save_result
-        run: echo "::set-output name=result::$(cat ${{ matrix.value }}.sarif | jq -c '.runs')"
+    - name: Save result into a variable
+      id: save_result
+      run: echo "::set-output name=result::$(cat ${{ matrix.value }}.sarif | jq -c '.runs')"
 
-      - name: Upload Kubesec scan results to GitHub Security tab
-        if: ${{ steps.save_result.outputs.result != '[]' }}
-        uses: github/codeql-action/upload-sarif@012739e5082ff0c22ca6d6ab32e07c36df03c4a4 # v3.22.12
-        with:
-          sarif_file: ${{ matrix.value }}.sarif
+    - name: Upload Kubesec scan results to GitHub Security tab
+      if: ${{ steps.save_result.outputs.result != '[]' }}
+      uses: github/codeql-action/upload-sarif@012739e5082ff0c22ca6d6ab32e07c36df03c4a4 # v3.22.12
+      with:
+        sarif_file: ${{ matrix.value }}.sarif

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -4,18 +4,18 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
     paths:
-      - '**.md'
+    - '**.md'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   markdown-link-check:
     name: Broken Links
-    # This workflow is only of value to the metal3-io repository and
-    # would always fail in forks
-    if: github.repository == 'metal3-io/baremetal-operator'
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1

--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -4,13 +4,16 @@ on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
-permissions:
-  checks: write
+permissions: {}
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
     name: verify PR contents
+    runs-on: ubuntu-latest
+
+    permissions:
+      checks: write
+
     steps:
     - name: Verifier action
       id: verifier

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,39 +1,39 @@
+name: release
+
 on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
     - "v*"
 
-name: release
-
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build:
+    name: release
+    runs-on: ubuntu-latest
+
     permissions:
       contents: write
-    # This workflow is only of value to the metal3-io/baremetal-operator repository and
-    # would always fail in forks
+
     if: github.repository == 'metal3-io/baremetal-operator'
-    runs-on: ubuntu-latest
     steps:
-      - name: Export RELEASE_TAG var
-        run:  echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
-      - name: checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          fetch-depth: 0
-      - name: Install go
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-        with:
-          go-version: '1.20'
-      - name: Generate release notes
-        run: |
-          make release-notes
-      - name: Release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
-        with:
-          draft: true
-          files: out/*
-          body_path: releasenotes/releasenotes.md
+    - name: Export RELEASE_TAG var
+      run: echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
+    - name: checkout code
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        fetch-depth: 0
+    - name: Install go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version: '1.20'
+    - name: Generate release notes
+      run: |
+        make release-notes
+    - name: Release
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+      with:
+        draft: true
+        files: out/*
+        body_path: releasenotes/releasenotes.md


### PR DESCRIPTION
Move permissions from top-level to job-level as well.

Cleanup actions formatting to be the same for easier reading and maintenance. Add missing version tags.

These is highlighted by the CLOmonitor/OpenSSF Scorecard. This restores score for token permissions to 10/10.

/hold
until https://github.com/metal3-io/ip-address-manager/pull/408 is reviewed and merged.