### PR TITLE
📖 fix previous release detection in make release-notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -313,7 +313,7 @@ mod: ## Clean up go module settings
 ## Release
 ## --------------------------------------
 RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
-PREVIOUS_TAG ?= $(shell git tag -l | grep -B 1 $(RELEASE_TAG) | head -n 1)
+PREVIOUS_TAG ?= $(shell git tag -l | grep -B 1 "^$(RELEASE_TAG)" | head -n 1)
 RELEASE_NOTES_DIR := releasenotes
 
 $(RELEASE_NOTES_DIR):


### PR DESCRIPTION
We're overlapping our version numbers with really old version numbers, ie. capm3-v0.4.1 vs v0.4.1 when using grep without line-start ^. Fix the issue, so the correct previous tag is used in release automation.
