### PR TITLE
🐛 Fix ginkgo version mismatch between cli and import package in e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ CRD_OPTIONS ?= "crd:allowDangerousTypes=true,crdVersions=v1"
 KUSTOMIZE = tools/bin/kustomize
 CONTROLLER_GEN = tools/bin/controller-gen
 GINKGO = tools/bin/ginkgo
-GINKGO_VER = v2.13.0
+GINKGO_VER = v2.13.2
 
 # See pkg/version.go for details
 SOURCE_GIT_COMMIT ?= $(shell git rev-parse --short HEAD)


### PR DESCRIPTION
There's a difference between the ginkgo cli version and ginkgo version that e2e uses:
https://github.com/Nordix/baremetal-operator/blob/main/test/go.mod#L9
https://github.com/Nordix/baremetal-operator/blob/main/Makefile#L27

Error log:
```bash
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:                                                             
  Ginkgo CLI Version:                                                                                                                                                      
    2.13.0                                                                                                                                                                 
  Mismatched package versions found:                                                                                                                                       
    2.13.2 used by e2e  
```