### PR TITLE
🌱 Allow BMC address to be updated 

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_validation.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_validation.go
@@ -75,8 +75,12 @@ func (host *BareMetalHost) validateChanges(old *BareMetalHost) []error {
 		errs = append(errs, err...)
 	}
 
-	if old.Spec.BMC.Address != "" && host.Spec.BMC.Address != old.Spec.BMC.Address {
-		errs = append(errs, errors.New("BMC address can not be changed once it is set"))
+	if old.Spec.BMC.Address != "" &&
+		host.Spec.BMC.Address != old.Spec.BMC.Address &&
+		host.Status.OperationalStatus != OperationalStatusDetached &&
+		host.Status.Provisioning.State != StateRegistering {
+		errs = append(errs, errors.New("BMC address can not be changed if the BMH is not "+
+			"in the Registering state, or if the BMH is not detached."))
 	}
 
 	if old.Spec.BootMACAddress != "" && host.Spec.BootMACAddress != old.Spec.BootMACAddress {

--- a/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -720,7 +720,45 @@ func TestValidateUpdate(t *testing.T) {
 				Spec: BareMetalHostSpec{
 					BMC: BMCDetails{
 						Address: "test-address"}}},
-			wantedErr: "BMC address can not be changed once it is set",
+			wantedErr: "BMC address can not be changed if the BMH is not in the Registering state, " +
+				"or if the BMH is not detached.",
+		},
+		{
+			name: "updateAddressBMHRegistering",
+			newBMH: &BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: BareMetalHostSpec{
+					BMC: BMCDetails{
+						Address: "test-address-changed"}},
+				Status: BareMetalHostStatus{
+					Provisioning: ProvisionStatus{
+						State: ProvisioningState(StateRegistering)}}},
+			oldBMH: &BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: BareMetalHostSpec{
+					BMC: BMCDetails{
+						Address: "test-address"}}},
+			wantedErr: "",
+		},
+		{
+			name: "updateAddressBMHDetached",
+			newBMH: &BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: BareMetalHostSpec{
+					BMC: BMCDetails{
+						Address: "test-address-changed"}},
+				Status: BareMetalHostStatus{
+					OperationalStatus: OperationalStatus(OperationalStatusDetached)}},
+			oldBMH: &BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: BareMetalHostSpec{
+					BMC: BMCDetails{
+						Address: "test-address"}}},
+			wantedErr: "",
 		},
 		{
 			name: "updateBootMAC",


### PR DESCRIPTION
Allow BMC address to be updated if the BMH is in the Registering state or is detached.

This allows the BMC address to be updated if there are changes in the BMC network, or if a mistake was made when setting it the first time. 
