### PR TITLE
🐛 Fix VM selection in clean-e2e.sh

### DIFF
--- a/hack/clean-e2e.sh
+++ b/hack/clean-e2e.sh
@@ -8,17 +8,7 @@ docker rm -f vbmc
 docker rm -f image-server-e2e
 docker rm -f sushy-tools
 
-virsh_vms=$(virsh list --name --all)
-
-for vm in ${virsh_vms}; do
-  if [[ "${vm}" =~ "bmo-e2e-" ]]; then
-    virsh -c qemu:///system destroy --domain "${vm}"
-    virsh -c qemu:///system undefine --domain "${vm}" --nvram --remove-all-storage
-  fi
-done
-
-virsh -c qemu:///system net-destroy baremetal-e2e
-virsh -c qemu:///system net-undefine baremetal-e2e
+"${REPO_ROOT}/tools/bmh_test/clean_local_bmh_test_setup.sh" "^bmo-e2e-"
 
 rm -rf "${REPO_ROOT}/test/e2e/_artifacts"
 rm -rf "${REPO_ROOT}"/artifacts-*

--- a/tools/bmh_test/clean_local_bmh_test_setup.sh
+++ b/tools/bmh_test/clean_local_bmh_test_setup.sh
@@ -1,24 +1,24 @@
 #!/usr/bin/env bash
 
-set -eux
+set -ux
 
+BMH_NAME_REGEX="${1:-^bmh-test-}"
 # Get a list of all virtual machines
-VM_LIST=$(virsh -c qemu:///system list --all --name | grep '^bmh-test-') || true
+VM_LIST=$(virsh -c qemu:///system list --all --name | grep "${BMH_NAME_REGEX}")
 
 if [[ -n "${VM_LIST}" ]]; then
     # Loop through the list and delete each virtual machine
     for vm_name in ${VM_LIST}; do
         virsh -c qemu:///system destroy --domain "${vm_name}"
         virsh -c qemu:///system undefine --domain "${vm_name}" --remove-all-storage
-        kubectl delete baremetalhost "${vm_name}" || true
+        kubectl delete baremetalhost "${vm_name}"
     done
 else
     echo "No virtual machines found. Skipping..."
 fi
 
 # Clear vbmc
-docker stop vbmc
-docker rm vbmc 
+docker rm -f vbmc 
 
 # Clear network
 virsh -c qemu:///system net-destroy baremetal-e2e


### PR DESCRIPTION
Fixes #1531

This PR takes the `tools/bmh_test/clean_local_bmh_test_setup.sh` into use:
- Removed `-e` as many operations could fail, but the script should keep going
