### PR TITLE
:seedling: Reduce GH fixture test GINKGO_NODES to 1

### DIFF
--- a/.github/workflows/e2e-fixture-test.yml
+++ b/.github/workflows/e2e-fixture-test.yml
@@ -35,4 +35,5 @@ jobs:
       env:
         E2E_CONF_FILE: ${{ github.workspace }}/test/e2e/config/fixture.yaml
         USE_EXISTING_CLUSTER: "false"
+        GINKGO_NODES: 1
       run: make test-e2e


### PR DESCRIPTION
We're facing many failures in GH-action-based E2E fixture tests. This is likely due to the github VM is too small and cannot handle two gingko threads.
