### PR TITLE
🐛 Fix an indentation error in kustomization file regarding ironic configmap generator

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 - ../base
 
 generatorOptions:
- disableNameSuffixHash: true
+  disableNameSuffixHash: true
 
 configMapGenerator:
 - name: ironic


### PR DESCRIPTION
**What this PR does / why we need it**:
As title describes
