### PR TITLE
🌱 Allow BMC address to be updated

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_validation.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_validation.go
@@ -75,8 +75,11 @@ func (host *BareMetalHost) validateChanges(old *BareMetalHost) []error {
 		errs = append(errs, err...)
 	}
 
-	if old.Spec.BMC.Address != "" && host.Spec.BMC.Address != old.Spec.BMC.Address {
-		errs = append(errs, errors.New("BMC address can not be changed once it is set"))
+	if old.Spec.BMC.Address != "" &&
+		host.Spec.BMC.Address != old.Spec.BMC.Address &&
+		host.Status.OperationalStatus != OperationalStatusDetached &&
+		host.Status.Provisioning.State != StateRegistering {
+		errs = append(errs, errors.New("BMC address can not be changed if the BMH is not in the Registering state, or if the BMH is not detached"))
 	}
 
 	if old.Spec.BootMACAddress != "" && host.Spec.BootMACAddress != old.Spec.BootMACAddress {

--- a/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -720,7 +720,44 @@ func TestValidateUpdate(t *testing.T) {
 				Spec: BareMetalHostSpec{
 					BMC: BMCDetails{
 						Address: "test-address"}}},
-			wantedErr: "BMC address can not be changed once it is set",
+			wantedErr: "BMC address can not be changed if the BMH is not in the Registering state, or if the BMH is not detached",
+		},
+		{
+			name: "updateAddressBMHRegistering",
+			newBMH: &BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: BareMetalHostSpec{
+					BMC: BMCDetails{
+						Address: "test-address-changed"}},
+				Status: BareMetalHostStatus{
+					Provisioning: ProvisionStatus{
+						State: StateRegistering}}},
+			oldBMH: &BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: BareMetalHostSpec{
+					BMC: BMCDetails{
+						Address: "test-address"}}},
+			wantedErr: "",
+		},
+		{
+			name: "updateAddressBMHDetached",
+			newBMH: &BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: BareMetalHostSpec{
+					BMC: BMCDetails{
+						Address: "test-address-changed"}},
+				Status: BareMetalHostStatus{
+					OperationalStatus: OperationalStatusDetached}},
+			oldBMH: &BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: BareMetalHostSpec{
+					BMC: BMCDetails{
+						Address: "test-address"}}},
+			wantedErr: "",
 		},
 		{
 			name: "updateBootMAC",

--- a/pkg/provisioner/ironic/validatemanagementaccess_test.go
+++ b/pkg/provisioner/ironic/validatemanagementaccess_test.go
@@ -892,6 +892,121 @@ func TestValidateManagementAccessMalformedBMCAddress(t *testing.T) {
 	assert.Equal(t, "failed to parse BMC address information: failed to parse BMC address information: parse \"<ipmi://192.168.122.1:6233>\": first path segment in URL cannot contain colon", result.ErrorMessage)
 }
 
+func TestValidateManagementAccessUpdateBMCAddressIP(t *testing.T) {
+	host := makeHost()
+	host.Spec.BMC.Address = "ipmi://192.168.122.10:623"
+	host.Status.Provisioning.ID = "uuid"
+
+	ironic := testserver.NewIronic(t).
+		Node(nodes.Node{
+			Name: host.Namespace + nameSeparator + host.Name,
+			UUID: "uuid",
+			DriverInfo: map[string]interface{}{
+				"ipmi_address":    "192.168.122.1",
+				"ipmi_port":       623,
+				"ipmi_username":   "",
+				"ipmi_password":   "",
+				"ipmi_priv_level": "ADMINISTRATOR",
+			},
+			ProvisionState: string(nodes.Verifying),
+		}).NodeUpdate(
+		nodes.Node{
+			Name: host.Namespace + nameSeparator + host.Name,
+			UUID: "uuid",
+			DriverInfo: map[string]interface{}{
+				"ipmi_address":    "192.168.122.10",
+				"ipmi_port":       623,
+				"ipmi_username":   "",
+				"ipmi_password":   "",
+				"ipmi_priv_level": "ADMINISTRATOR",
+			},
+			ProvisionState: string(nodes.Verifying),
+		})
+
+	ironic.Start()
+	defer ironic.Stop()
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nil, ironic.Endpoint(), auth)
+
+	if err != nil {
+		t.Fatalf("could not create provisioner: %s", err)
+	}
+
+	result, provID, err := prov.ValidateManagementAccess(provisioner.ManagementAccessData{}, false, false)
+	if err != nil {
+		t.Fatalf("error from ValidateManagementAccess: %s", err)
+	}
+	assert.Equal(t, "", result.ErrorMessage)
+	assert.Equal(t, "uuid", provID)
+
+	updates := ironic.GetLastNodeUpdateRequestFor("uuid")
+	assert.Equal(t, "/driver_info", updates[0].Path)
+	newValues := updates[0].Value.(map[string]interface{})
+	assert.Equal(t, "192.168.122.10", newValues["ipmi_address"])
+}
+
+func TestValidateManagementAccessUpdateBMCAddressProtocol(t *testing.T) {
+	host := makeHost()
+	host.Spec.BMC.Address = "redfish://192.168.122.1:623"
+	host.Spec.BootMACAddress = "11:11:11:11:11:11"
+	host.Status.Provisioning.ID = "uuid"
+
+	nodePort := ports.Port{
+		NodeUUID: "uuid",
+		Address:  "11:11:11:11:11:11",
+	}
+
+	ironic := testserver.NewIronic(t).
+		Node(nodes.Node{
+			Name: host.Namespace + nameSeparator + host.Name,
+			UUID: "uuid",
+			DriverInfo: map[string]interface{}{
+				"ipmi_address":    "192.168.122.1",
+				"ipmi_port":       623,
+				"ipmi_username":   "",
+				"ipmi_password":   "",
+				"ipmi_priv_level": "ADMINISTRATOR",
+				"ipmi_verify_ca":  false,
+			},
+			ProvisionState: string(nodes.Verifying),
+		}).NodeUpdate(
+		nodes.Node{
+			Name: host.Namespace + nameSeparator + host.Name,
+			UUID: "uuid",
+			DriverInfo: map[string]interface{}{
+				"redfish_address":   "https://192.168.122.1:443",
+				"redfish_username":  "",
+				"redfish_password":  "",
+				"redfish_system_id": "/redfish/v1/Systems/1/",
+				"redfish_verify_ca": false,
+			},
+			ProvisionState: string(nodes.Verifying),
+		}).Port(nodePort)
+
+	ironic.Start()
+	defer ironic.Stop()
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nil, ironic.Endpoint(), auth)
+
+	if err != nil {
+		t.Fatalf("could not create provisioner: %s", err)
+	}
+
+	result, provID, err := prov.ValidateManagementAccess(provisioner.ManagementAccessData{}, false, false)
+	if err != nil {
+		t.Fatalf("error from ValidateManagementAccess: %s", err)
+	}
+	assert.Equal(t, "", result.ErrorMessage)
+	assert.Equal(t, "uuid", provID)
+
+	updates := ironic.GetLastNodeUpdateRequestFor("uuid")
+	assert.Equal(t, "/driver_info", updates[0].Path)
+	newValues := updates[0].Value.(map[string]interface{})
+	assert.Equal(t, "https://192.168.122.1:623", newValues["redfish_address"])
+}
+
 func TestPreprovisioningImageFormats(t *testing.T) {
 	ironicEndpoint := "http://ironic.test"
 	auth := clients.AuthConfig{Type: clients.NoAuth}


### PR DESCRIPTION
Allow BMC address to be updated if the BMH is in the Registering state or is detached.

This allows the BMC address to be updated if there are changes in the BMC network, or if a mistake was made when setting it the first time.