### PR TITLE
🌱 Add disableNameSuffixHash to 'temp' overlay in 'deploy.sh' script for bmo

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -189,6 +189,12 @@ if [[ "${DEPLOY_IRONIC}" == "true" ]]; then
     pushd "${TEMP_IRONIC_OVERLAY}"
     ${KUSTOMIZE} create --resources=../../../config/namespace \
     --namespace=baremetal-operator-system --nameprefix=baremetal-operator-
+    # Disable the name suffix hash for generated resources.
+    # facilitating better compatibility with development tools like Tilt
+    cat <<EOF >>kustomization.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+EOF
 
     if [ "${DEPLOY_BASIC_AUTH}" == "true" ]; then
         ${KUSTOMIZE} edit add secret ironic-htpasswd --from-env-file=ironic-htpasswd
@@ -229,6 +235,12 @@ if [[ "${DEPLOY_BMO}" == "true" ]]; then
     pushd "${TEMP_BMO_OVERLAY}"
     ${KUSTOMIZE} create --resources=../../base,../../namespace \
     --namespace=baremetal-operator-system
+    # Disable the name suffix hash for generated resources.
+    # facilitating better compatibility with development tools like Tilt
+    cat <<EOF >>kustomization.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+EOF
 
     if [ "${DEPLOY_BASIC_AUTH}" == "true" ]; then
         ${KUSTOMIZE} edit add component ../../components/basic-auth


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR disables the suffix hash for the configmap ironic in the bmo deployment, it will make Tilt know the name in dev-env by ensuring the configmap name remain constant.
