### PR TITLE
🌱 Add 'wait-power-state' interval to fixture test for flake fix

### DIFF
--- a/test/e2e/config/fixture.yaml
+++ b/test/e2e/config/fixture.yaml
@@ -48,3 +48,4 @@ intervals:
   default/wait-deleting: ["5s", "10ms"]
   default/wait-deleted: ["5s", "10ms"]
   default/wait-secret-deletion: ["5s", "10ms"]
+  default/wait-power-state: ["5s", "10ms"]


### PR DESCRIPTION
**What this PR does / why we need it**:
 Add the interval 'wait-power-state' to our fixture test to fix a flake. 