### PR TITLE
🌱 Add ironic and bmo cleanup for upgrade BMO E2E tests

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -129,7 +129,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	if e2eConfig.GetVariable("DEPLOY_IRONIC") != "false" {
 		// Install Ironic
 		By("Installing Ironic")
-		err := BuildAndApplyKustomize(ctx, &BuildAndApplyKustomizeInput{
+		err := BuildAndApplyKustomization(ctx, &BuildAndApplyKustomizationInput{
 			Kustomization:       e2eConfig.GetVariable("IRONIC_KUSTOMIZATION"),
 			ClusterProxy:        clusterProxy,
 			WaitForDeployment:   true,
@@ -146,7 +146,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	if e2eConfig.GetVariable("DEPLOY_BMO") != "false" {
 		// Install BMO
 		By("Installing BMO")
-		err := BuildAndApplyKustomize(ctx, &BuildAndApplyKustomizeInput{
+		err := BuildAndApplyKustomization(ctx, &BuildAndApplyKustomizationInput{
 			Kustomization:       e2eConfig.GetVariable("BMO_KUSTOMIZATION"),
 			ClusterProxy:        clusterProxy,
 			WaitForDeployment:   true,


### PR DESCRIPTION
This PR adds Ironic and BMO to the cleanup phase in upgrade tests. This is needed as a preparation for multiple upgrade tests (multiple versions of BMO upgrade + ironic upgrade), as the test has to start from a clean state (with no Ironic nor BMO).
We also move installation of Ironic and BMO to the `It{}`, as it's more related to the test itself, rather than a preparation.

Notice that this change has allowed the test to be ran multiple times using the same cluster, as followed:
```
export GINKGO_FOCUS=upgrade
hack/ci-e2e.sh # first time
export UPGRADE_DEPLOY_CERT_MANAGER=false
<extra exports normally handled by ci-e2e.sh>
make test-e2e # As many times as needed
```
We could apply this to the required e2e tests as well if running multiple times is a requirement. That's not the main focus of the PR though.