### PR TITLE
🌱 E2E: Fix basic auth config

### DIFF
--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -121,6 +121,12 @@ IRONIC_PASSWORD="$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 12 | head -n 1)"
 IRONIC_INSPECTOR_USERNAME="$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 12 | head -n 1)"
 IRONIC_INSPECTOR_PASSWORD="$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 12 | head -n 1)"
 
+# These must be exported so that envsubst can pick them up below
+export IRONIC_USERNAME
+export IRONIC_PASSWORD
+export IRONIC_INSPECTOR_USERNAME
+export IRONIC_INSPECTOR_PASSWORD
+
 for overlay in "${BMO_OVERLAYS[@]}"; do
   echo "${IRONIC_USERNAME}" > "${overlay}/ironic-username"
   echo "${IRONIC_PASSWORD}" > "${overlay}/ironic-password"


### PR DESCRIPTION
**What this PR does / why we need it**:

The variables used for setting basic auth credentials were not exported, meaning that envsubst did not pick them up. This caused the auth config to have empty values.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
