### PR TITLE
🌱 E2E: Workaround issue with minikube image load

### DIFF
--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -58,7 +58,11 @@ minikube stop
 minikube start
 
 # Load the BMO e2e image into it
-minikube image load quay.io/metal3-io/baremetal-operator:e2e
+# minikube image load quay.io/metal3-io/baremetal-operator:e2e
+# Temporary workaround for https://github.com/kubernetes/minikube/issues/18021
+docker image save -o /tmp/bmo-e2e.tar quay.io/metal3-io/baremetal-operator:e2e
+minikube image load /tmp/bmo-e2e.tar
+rm /tmp/bmo-e2e.tar
 
 # This IP is defined by the network we created above.
 IP_ADDRESS="192.168.222.1"


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a bug in the [new docker release](https://github.com/google/go-containerregistry/issues/1870) that [affects minikube image load](https://github.com/kubernetes/minikube/issues/18021). While we wait for a new minikube release, we can work around the issue by exporting the image to an archive and load it from there instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
