### PR TITLE
🌱 add release-* as branch trigger to e2e fixture workflow

### DIFF
--- a/.github/workflows/e2e-fixture-test.yml
+++ b/.github/workflows/e2e-fixture-test.yml
@@ -2,7 +2,9 @@ name: E2E Fixture Test
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+    - 'main'
+    - 'release-*'
     paths-ignore:
     - '**/*.md'
     - 'docs/**'


### PR DESCRIPTION
Adding release-* as branch trigger to e2e fixture workflow, so when the next release branch is cut, we get e2e fixture triggering correctly.

This doesn't enable e2e fixture for branches that do not have this workflow file themselves, so right now we only support e2e fixtures in main and release-0.5.
