### PR TITLE
🌱 Remove last traces of auth-config

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -107,8 +107,6 @@ ironic-deployment/
 ├── components
 │   ├── basic-auth
 │   │   ├── auth.yaml
-│   │   ├── ironic-auth-config
-│   │   ├── ironic-auth-config-tpl
 │   │   ├── ironic-htpasswd
 │   │   └── kustomization.yaml
 │   ├── keepalived

--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -140,9 +140,6 @@ for overlay in "${BMO_OVERLAYS[@]}"; do
   fi
 done
 
-envsubst < "${REPO_ROOT}/ironic-deployment/components/basic-auth/ironic-auth-config-tpl" > \
-  "${IRONIC_OVERLAY}/ironic-auth-config"
-
 echo "IRONIC_HTPASSWD=$(htpasswd -n -b -B "${IRONIC_USERNAME}" "${IRONIC_PASSWORD}")" > \
   "${IRONIC_OVERLAY}/ironic-htpasswd"
 

--- a/ironic-deployment/components/basic-auth/auth.yaml
+++ b/ironic-deployment/components/basic-auth/auth.yaml
@@ -8,12 +8,8 @@ spec:
       containers:
       - name: ironic
         envFrom:
-        # This is the htpassword matching the ironic-auth-config
+        # This is the htpassword matching the ironic password
         - secretRef:
             name: ironic-htpasswd
         - configMapRef:
             name: ironic-bmo-configmap
-      volumes:
-      - name: ironic-auth-config
-        secret:
-          secretName: ironic-auth-config

--- a/ironic-deployment/components/basic-auth/kustomization.yaml
+++ b/ironic-deployment/components/basic-auth/kustomization.yaml
@@ -1,11 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
-# NOTE: This component requires secrets with the basic auth credentials and config!
-# How you create them is up to you.
-# The required secrets are:
-# - ironic-htpasswd
-# - ironic-auth-config
+# NOTE: This component requires secrets with the basic auth credential!
+# How you create them is up to you. The required secret is ironic-htpasswd.
 #
 # The content should be as in these examples:
 #
@@ -15,15 +12,6 @@ kind: Component
 #   name: ironic-htpasswd
 # data:
 #   IRONIC_HTPASSWD: <base64-encoded-htpasswd-string>
-# ---
-# apiVersion: v1
-# kind: Secret
-# metadata:
-#   name: ironic-auth-config
-# data:
-#   auth-config: <base64-encoded-auth-config>
-#
-# Check `ironic-auth-config-tpl` for a template of what to put in the auth-config.
 
 patches:
   - path: auth.yaml

--- a/ironic-deployment/overlays/basic-auth_tls/basic-auth_tls.yaml
+++ b/ironic-deployment/overlays/basic-auth_tls/basic-auth_tls.yaml
@@ -12,11 +12,3 @@ spec:
             name: ironic-htpasswd
         - configMapRef:
             name: ironic-bmo-configmap
-        volumeMounts:
-        - mountPath: /auth/ironic
-          name: ironic-auth-config
-          readOnly: true
-      volumes:
-      - name: ironic-auth-config
-        secret:
-          secretName: ironic-auth-config

--- a/ironic-deployment/overlays/basic-auth_tls/kustomization.yaml
+++ b/ironic-deployment/overlays/basic-auth_tls/kustomization.yaml
@@ -20,6 +20,3 @@ patches:
 #   envs:
 #   - ironic-htpasswd
 #   name: ironic-htpasswd
-# - name: ironic-auth-config
-#   files:
-#   - auth-config=ironic-auth-config

--- a/ironic-deployment/overlays/e2e/kustomization.yaml
+++ b/ironic-deployment/overlays/e2e/kustomization.yaml
@@ -24,9 +24,6 @@ secretGenerator:
   behavior: create
   envs:
   - ironic-htpasswd
-- name: ironic-auth-config
-  files:
-  - auth-config=ironic-auth-config
 
 replacements:
   # Replace IRONIC_HOST_IP in certificates with the PROVISIONING_IP from the configmap

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -101,7 +101,6 @@ RESTART_CONTAINER_CERTIFICATE_UPDATED=${RESTART_CONTAINER_CERTIFICATE_UPDATED:-"
 export NAMEPREFIX=${NAMEPREFIX:-"baremetal-operator"}
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
-IRONIC_BASIC_AUTH_COMPONENT="${SCRIPTDIR}/ironic-deployment/components/basic-auth"
 
 TEMP_BMO_OVERLAY="${SCRIPTDIR}/config/overlays/temp"
 TEMP_IRONIC_OVERLAY="${SCRIPTDIR}/ironic-deployment/overlays/temp"
@@ -149,9 +148,6 @@ if [[ "${DEPLOY_BASIC_AUTH}" == "true" ]]; then
     fi
 
     if [[ "${DEPLOY_IRONIC}" == "true" ]]; then
-        envsubst < "${IRONIC_BASIC_AUTH_COMPONENT}/ironic-auth-config-tpl" > \
-        "${TEMP_IRONIC_OVERLAY}/ironic-auth-config"
-
         echo "IRONIC_HTPASSWD=$(htpasswd -n -b -B "${IRONIC_USERNAME}" "${IRONIC_PASSWORD}")" > \
         "${TEMP_IRONIC_OVERLAY}/ironic-htpasswd"
     fi
@@ -169,7 +165,6 @@ if [[ "${DEPLOY_IRONIC}" == "true" ]]; then
 
     if [ "${DEPLOY_BASIC_AUTH}" == "true" ]; then
         ${KUSTOMIZE} edit add secret ironic-htpasswd --from-env-file=ironic-htpasswd
-        ${KUSTOMIZE} edit add secret ironic-auth-config --from-file=auth-config=ironic-auth-config
 
         if [[ "${DEPLOY_TLS}" == "true" ]]; then
             # Basic-auth + TLS is special since TLS also means reverse proxy, which affects basic-auth.
@@ -275,9 +270,9 @@ if [[ "${DEPLOY_BASIC_AUTH}" == "true" ]]; then
     fi
 
     if [[ "${DEPLOY_IRONIC}" == "true" ]]; then
-        rm "${TEMP_IRONIC_OVERLAY}/ironic-auth-config"
         rm "${TEMP_IRONIC_OVERLAY}/ironic-htpasswd"
 
+        rm -f "${TEMP_IRONIC_OVERLAY}/ironic-auth-config"
         rm -f "${TEMP_IRONIC_OVERLAY}/ironic-inspector-auth-config"
         rm -f "${TEMP_IRONIC_OVERLAY}/ironic-inspector-htpasswd"
     fi

--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -171,9 +171,6 @@ fi
 BASIC_AUTH_MOUNTS=""
 IRONIC_HTPASSWD=""
 if [ -n "$IRONIC_USERNAME" ]; then
-     envsubst < "${SCRIPTDIR}/ironic-deployment/components/basic-auth/ironic-auth-config-tpl" > \
-        "${IRONIC_DATA_DIR}/auth/ironic-auth-config"
-     BASIC_AUTH_MOUNTS="-v ${IRONIC_DATA_DIR}/auth/ironic-auth-config:/auth/ironic/auth-config"
      IRONIC_HTPASSWD="$(htpasswd -n -b -B "${IRONIC_USERNAME}" "${IRONIC_PASSWORD}")"
      IRONIC_HTPASSWD="--env HTTP_BASIC_HTPASSWD=${IRONIC_HTPASSWD} --env IRONIC_HTPASSWD=${IRONIC_HTPASSWD}"
 fi


### PR DESCRIPTION
It was only used for cross-service communication. Now that the
deployment scripts no longer support inspector, it is unused.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>