### PR TITLE
🌱 bump shellcheck to v0.10.0

### DIFF
--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -7,15 +7,13 @@ CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
   TOP_DIR="${1:-.}"
-  find "${TOP_DIR}" \
-       \( -path ./vendor -prune \) \
-       -o -name '*.sh' -exec shellcheck -s bash {} \+
+  find "${TOP_DIR}" \( -path ./vendor -prune \) -o -name '*.sh' -exec shellcheck -s bash {} \+
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/workdir:ro,z" \
     --entrypoint sh \
     --workdir /workdir \
-    docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7 \
-    /workdir/hack/shellcheck.sh "${@}"
-fi;
+    docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63 \
+    /workdir/hack/shellcheck.sh "$@"
+fi


### PR DESCRIPTION
Shellcheck had its first release since 2022, so bump it.

/hold
Needs project-infra change too.