### PR TITLE
🌱 Mount ironic HTPASSWD as volume instead of environment variable

### DIFF
--- a/ironic-deployment/components/basic-auth/auth.yaml
+++ b/ironic-deployment/components/basic-auth/auth.yaml
@@ -8,8 +8,14 @@ spec:
       containers:
       - name: ironic
         envFrom:
-        # This is the htpassword matching the ironic password
-        - secretRef:
-            name: ironic-htpasswd
         - configMapRef:
             name: ironic-bmo-configmap
+        volumeMounts:
+        - name: ironic-htpasswd
+          mountPath: "/auth/ironic"
+          readOnly: true
+      volumes:
+      # This is the htpassword matching the ironic password
+      - name: ironic-htpasswd
+        secret:
+          secretName: ironic-htpasswd

--- a/ironic-deployment/overlays/basic-auth_tls/basic-auth_tls.yaml
+++ b/ironic-deployment/overlays/basic-auth_tls/basic-auth_tls.yaml
@@ -8,7 +8,13 @@ spec:
       containers:
       - name: ironic-httpd
         envFrom:
-        - secretRef:
-            name: ironic-htpasswd
         - configMapRef:
             name: ironic-bmo-configmap
+        volumeMounts:
+        - name: ironic-htpasswd
+          mountPath: "/auth/ironic"
+          readOnly: true
+      volumes:
+      - name: ironic-htpasswd
+        secret:
+          secretName: ironic-htpasswd

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -148,8 +148,8 @@ if [[ "${DEPLOY_BASIC_AUTH}" == "true" ]]; then
     fi
 
     if [[ "${DEPLOY_IRONIC}" == "true" ]]; then
-        echo "IRONIC_HTPASSWD=$(htpasswd -n -b -B "${IRONIC_USERNAME}" "${IRONIC_PASSWORD}")" > \
-        "${TEMP_IRONIC_OVERLAY}/ironic-htpasswd"
+        echo "${IRONIC_USERNAME}" > "${TEMP_IRONIC_OVERLAY}/ironic-username"
+        echo "${IRONIC_PASSWORD}" > "${TEMP_IRONIC_OVERLAY}/ironic-password"
     fi
 fi
 
@@ -164,7 +164,9 @@ if [[ "${DEPLOY_IRONIC}" == "true" ]]; then
     --namespace=baremetal-operator-system --nameprefix=baremetal-operator-
 
     if [ "${DEPLOY_BASIC_AUTH}" == "true" ]; then
-        ${KUSTOMIZE} edit add secret ironic-htpasswd --from-env-file=ironic-htpasswd
+        # These files are created below
+        ${KUSTOMIZE} edit add secret ironic-htpasswd \
+            --from-file=username=ironic-username --from-file=password=ironic-password
 
         if [[ "${DEPLOY_TLS}" == "true" ]]; then
             # Basic-auth + TLS is special since TLS also means reverse proxy, which affects basic-auth.
@@ -270,7 +272,8 @@ if [[ "${DEPLOY_BASIC_AUTH}" == "true" ]]; then
     fi
 
     if [[ "${DEPLOY_IRONIC}" == "true" ]]; then
-        rm "${TEMP_IRONIC_OVERLAY}/ironic-htpasswd"
+        rm "${TEMP_IRONIC_OVERLAY}/ironic-username"
+        rm "${TEMP_IRONIC_OVERLAY}/ironic-password"
 
         rm -f "${TEMP_IRONIC_OVERLAY}/ironic-auth-config"
         rm -f "${TEMP_IRONIC_OVERLAY}/ironic-inspector-auth-config"

--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -169,11 +169,18 @@ if [[ -r "${IPXE_KEY_FILE}" ]]; then
 fi
 
 BASIC_AUTH_MOUNTS=""
-IRONIC_HTPASSWD=""
+IRONIC_HTPASSWD_USERNAME_FILE="${IRONIC_DATA_DIR}/auth/ironic-username"
+IRONIC_HTPASSWD_PASSWORD_FILE="${IRONIC_DATA_DIR}/auth/ironic-password"
+set +x
 if [ -n "$IRONIC_USERNAME" ]; then
-     IRONIC_HTPASSWD="$(htpasswd -n -b -B "${IRONIC_USERNAME}" "${IRONIC_PASSWORD}")"
-     IRONIC_HTPASSWD="--env HTTP_BASIC_HTPASSWD=${IRONIC_HTPASSWD} --env IRONIC_HTPASSWD=${IRONIC_HTPASSWD}"
+     echo "$IRONIC_USERNAME" > "${IRONIC_HTPASSWD_USERNAME_FILE}"
+     IRONIC_HTPASSWD_USERNAME="-v ${IRONIC_HTPASSWD_USERNAME_FILE}:/auth/ironic/username"
 fi
+if [ -n "$IRONIC_PASSWORD" ]; then
+     echo "${IRONIC_PASSWORD}" > "${IRONIC_HTPASSWD_PASSWORD_FILE}"
+     IRONIC_HTPASSWD_PASSWORD="-v ${IRONIC_HTPASSWD_PASSWORD_FILE}:/auth/ironic/password"
+fi
+set -x
 
 sudo mkdir -p "$IRONIC_DATA_DIR/html/images"
 # Locally supplied IPA images are imported here when the environment variables are set accordingly.
@@ -192,6 +199,7 @@ fi
 
 "$SCRIPTDIR/tools/remove_local_ironic.sh"
 
+set +x
 if [ "$IRONIC_USE_MARIADB" = "true" ]; then
     # set password for mariadb
     mariadb_password=$(echo "$(date;hostname)"|sha256sum |cut -c-20)
@@ -199,6 +207,7 @@ if [ "$IRONIC_USE_MARIADB" = "true" ]; then
 else
     IRONIC_MARIADB_PASSWORD=
 fi
+set -x
 
 POD=""
 
@@ -235,9 +244,10 @@ sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name dnsmasq \
 # https://github.com/metal3-io/ironic-image/blob/main/scripts/runhttpd
 # shellcheck disable=SC2086
 sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name httpd \
-     ${POD} ${CERTS_MOUNTS} ${BASIC_AUTH_MOUNTS} ${IRONIC_HTPASSWD} \
+     ${POD} ${CERTS_MOUNTS} ${BASIC_AUTH_MOUNTS} \
      --env-file "${IRONIC_DATA_DIR}/ironic-vars.env" \
-     -v "$IRONIC_DATA_DIR:/shared" --entrypoint /bin/runhttpd "${IRONIC_IMAGE}"
+     -v "${IRONIC_DATA_DIR}:/shared" ${IRONIC_HTPASSWD_USERNAME} \
+     ${IRONIC_HTPASSWD_PASSWORD} --entrypoint /bin/runhttpd "${IRONIC_IMAGE}"
 
 if [ "$IRONIC_USE_MARIADB" = "true" ]; then
     # https://github.com/metal3-io/mariadb-image/blob/main/runmariadb
@@ -252,10 +262,11 @@ fi
 # https://github.com/metal3-io/ironic-image/blob/main/scripts/runironic
 # shellcheck disable=SC2086
 sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name ironic \
-     ${POD} ${CERTS_MOUNTS} ${BASIC_AUTH_MOUNTS} ${IRONIC_HTPASSWD} \
+     ${POD} ${CERTS_MOUNTS} ${BASIC_AUTH_MOUNTS} \
      --env-file "${IRONIC_DATA_DIR}/ironic-vars.env" \
      ${IRONIC_MARIADB_PASSWORD} --entrypoint /bin/runironic \
-     -v "$IRONIC_DATA_DIR:/shared" "${IRONIC_IMAGE}"
+     -v "$IRONIC_DATA_DIR:/shared" ${IRONIC_HTPASSWD_USERNAME} \
+     ${IRONIC_HTPASSWD_PASSWORD} "${IRONIC_IMAGE}"
 
 # Start ironic-endpoint-keepalived
 # shellcheck disable=SC2086


### PR DESCRIPTION
Security baselines such as CIS do not recommend using secrets as environment variables, but using files instead. Therefore, the IRONIC_HTPASSWD and INSPECTOR_HTPASSWD will now be mounted as volumes instead of environment variables.