### PR TITLE
🌱 Improve deploy.sh to differentiate between build and run of kustomize

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -110,7 +110,8 @@ mkdir -p "${TEMP_BMO_OVERLAY}"
 mkdir -p "${TEMP_IRONIC_OVERLAY}"
 
 KUSTOMIZE="${SCRIPTDIR}/tools/bin/kustomize"
-make -C "$(dirname "$0")/.." "${KUSTOMIZE}"
+KUSTOMIZE_BUILD="tools/bin/kustomize"
+make -C "$(dirname "$0")/.." "${KUSTOMIZE_BUILD}"
 
 #
 # Generate credentials as needed


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently deploy.sh tries to use ${SCRIPTDIR} in its KUSTOMIZE variable which breaks calling it via the Makefile to build kustomize in some cases (it certainly does on my system!). To fix, I added another variable, KUSTOMIZE_BUILD which points to exactly what the Makefile wants to see.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
