### PR TITLE
🌱 add support for beta/rc releases in release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   build:
-    name: release
+    name: tag release
     runs-on: ubuntu-latest
 
     permissions:
@@ -36,4 +36,4 @@ jobs:
       with:
         draft: true
         files: out/*
-        body_path: releasenotes/releasenotes.md
+        body_path: releasenotes/${{ env.RELEASE_TAG }}.md

--- a/Makefile
+++ b/Makefile
@@ -328,15 +328,15 @@ mod: ## Clean up go module settings
 ## Release
 ## --------------------------------------
 RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
-PREVIOUS_TAG ?= $(shell git tag -l | grep -B 1 "^$(RELEASE_TAG)" | head -n 1)
 RELEASE_NOTES_DIR := releasenotes
+PREVIOUS_TAG ?= $(shell git tag -l | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" | sort -V | grep -B1 $(RELEASE_TAG) | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$$" | head -n 1 2>/dev/null)
 
 $(RELEASE_NOTES_DIR):
 	mkdir -p $(RELEASE_NOTES_DIR)/
 
 .PHONY: release-notes
 release-notes: $(RELEASE_NOTES_DIR)
-	go run ./hack/tools/release_notes.go --from=$(PREVIOUS_TAG) > $(RELEASE_NOTES_DIR)/releasenotes.md
+	go run ./hack/tools/release/notes.go --from=$(PREVIOUS_TAG) > $(RELEASE_NOTES_DIR)/$(RELEASE_TAG).md
 
 go-version: ## Print the go version we use to compile our binaries and images
 	@echo $(GO_VERSION)


### PR DESCRIPTION
Support beta and RC releases in release note generator. Rename notes.go the same way, and add nice unfolding summary section to hide details in beta/rc notes.

Fix previous release tag pattern detection in Makefile.

Example output visible in CAPM3 PR: https://github.com/metal3-io/cluster-api-provider-metal3/pull/1567