### PR TITLE
🌱 Enabled last batch of linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,28 +8,37 @@ run:
 linters:
   disable-all: true
   enable:
+  - asasalint
   - asciicheck
+  - bidichk
   - bodyclose
+  #- containedctx
   - dogsled
-  # - errcheck
-  # - errorlint
+  - dupword
+  - durationcheck
+  - errcheck
+  - errchkjson
   - exportloopref
   - gci
+  - ginkgolinter
   - goconst
   - gocritic
   - godot
   - gofmt
   - goimports
+  - goprintffuncname
+  - gosec
   - gosimple
   - govet
   - importas
-  - gosec
   - ineffassign
+  - loggercheck
   - misspell
-  # - nakedret
-  # - nilerr
-  # - noctx
+  - nakedret
+  - nilerr
+  - noctx
   - nolintlint
+  - nosprintfhostport
   - prealloc
   - predeclared
   - revive
@@ -39,11 +48,12 @@ linters:
   - thelper
   - typecheck
   - unconvert
+  - unparam
   - unused
+  - usestdlibvars
   - whitespace
   # Run with --fast=false for more extensive checks
   fast: true
-
 linters-settings:
   gosec:
     go: "1.21"
@@ -113,9 +123,13 @@ issues:
     - goconst
   - path: _test\.go
     linters:
-    - unused
+    - errcheck
+    - gci
+    - noctx
     - revive
     - stylecheck
+    - unparam
+    - unused
   # Specific exclude rules for deprecated fields that are still part of the codebase.
   # These should be removed as the referenced deprecated item is removed from the project.
   - linters:

--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -132,7 +132,7 @@ const (
 	OperationalStatusOK OperationalStatus = "OK"
 
 	// OperationalStatusDiscovered is the status value for when the
-	// host is only partially configured, such as when when the BMC
+	// host is only partially configured, such as when the BMC
 	// address is known but the login credentials are not.
 	OperationalStatusDiscovered OperationalStatus = "discovered"
 

--- a/cmd/make-virt-host/main.go
+++ b/cmd/make-virt-host/main.go
@@ -156,7 +156,14 @@ func main() {
 	}
 
 	domainResult := Domain{}
-	xml.Unmarshal(virshOut, &domainResult)
+	err = xml.Unmarshal(virshOut, &domainResult)
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"ERROR: Could not unmarshal details of domain %s: %s\n",
+			virshDomain, err)
+		os.Exit(1)
+	}
+
 	if *verbose {
 		fmt.Printf("%v\n", domainResult)
 	}
@@ -192,7 +199,12 @@ func main() {
 	}
 
 	var vbmcResult []VBMC
-	json.Unmarshal(vbmcOut, &vbmcResult)
+	err = json.Unmarshal(vbmcOut, &vbmcResult)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Could not unmarshal details of vbmc: %s\n", err)
+		os.Exit(1)
+	}
+
 	nameToPort := make(map[string]int)
 	for _, vbmc := range vbmcResult {
 		if *verbose {

--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -138,7 +138,7 @@ func newTestReconcilerWithFixture(fix *fixture.Fixture, initObjs ...runtime.Obje
 	c := clientBuilder.Build()
 	// Add a default secret that can be used by most hosts.
 	bmcSecret := newBMCCredsSecret(defaultSecretName, "User", "Pass")
-	c.Create(context.TODO(), bmcSecret)
+	_ = c.Create(context.TODO(), bmcSecret)
 
 	return &BareMetalHostReconciler{
 		Client:             c,
@@ -547,7 +547,8 @@ func TestDoNotAddSecretFinalizersDuringDelete(t *testing.T) {
 	// The fake client will immediately remove the host
 	// from its cache, so let's keep the latest updated
 	// host
-	r.Get(context.TODO(), request.NamespacedName, host)
+	err = r.Get(context.TODO(), request.NamespacedName, host)
+	assert.NoError(t, err)
 	_, err = r.Reconcile(context.Background(), request)
 	assert.NoError(t, err)
 
@@ -555,7 +556,8 @@ func TestDoNotAddSecretFinalizersDuringDelete(t *testing.T) {
 	// secret update (and a slow host deletion), let's push
 	// back the host in the client cache.
 	host.ResourceVersion = ""
-	r.Client.Create(context.TODO(), host)
+	err = r.Client.Create(context.TODO(), host)
+	assert.NoError(t, err)
 	previousSecret := getHostSecret(t, r, host)
 	_, err = r.Reconcile(context.Background(), request)
 	assert.NoError(t, err)
@@ -772,7 +774,8 @@ func TestRebootWithSuffixedAnnotation(t *testing.T) {
 	)
 
 	delete(host.Annotations, annotation)
-	r.Update(context.TODO(), host)
+	err := r.Update(context.TODO(), host)
+	assert.NoError(t, err)
 
 	tryReconcile(t, r, host,
 		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
@@ -2679,7 +2682,8 @@ func TestHostFirmwareSettings(t *testing.T) {
 			i.request = newRequest(host)
 
 			hfs := newHostFirmwareSettings(host, tc.Conditions)
-			r.Create(context.TODO(), hfs)
+			err := r.Create(context.TODO(), hfs)
+			assert.NoError(t, err)
 
 			dirty, _, err := r.getHostFirmwareSettings(i)
 			if err != nil {
@@ -2747,7 +2751,8 @@ func TestHFSTransitionToPreparing(t *testing.T) {
 		},
 	}
 
-	r.Update(context.TODO(), hfs)
+	err := r.Update(context.TODO(), hfs)
+	assert.NoError(t, err)
 
 	waitForProvisioningState(t, r, host, metal3api.StatePreparing)
 }
@@ -2779,7 +2784,8 @@ func TestHFSEmptyStatusSettings(t *testing.T) {
 		},
 	}
 
-	r.Update(context.TODO(), hfs)
+	err := r.Update(context.TODO(), hfs)
+	assert.NoError(t, err)
 
 	tryReconcile(t, r, host,
 		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
@@ -2795,7 +2801,8 @@ func TestHFSEmptyStatusSettings(t *testing.T) {
 		},
 	}
 
-	r.Update(context.TODO(), hfs)
+	err = r.Update(context.TODO(), hfs)
+	assert.NoError(t, err)
 	tryReconcile(t, r, host,
 		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
 			return host.Status.Provisioning.State == metal3api.StateAvailable

--- a/controllers/metal3.io/bmceventsubscription_controller.go
+++ b/controllers/metal3.io/bmceventsubscription_controller.go
@@ -123,7 +123,7 @@ func (r *BMCEventSubscriptionReconciler) Reconcile(ctx context.Context, request 
 		return ctrl.Result{}, nil
 	}
 
-	return
+	return result, nil
 }
 
 func (r *BMCEventSubscriptionReconciler) handleError(ctx context.Context, subscription *metal3api.BMCEventSubscription, e error, message string, requeue bool) (ctrl.Result, error) {

--- a/controllers/metal3.io/bmceventsubscription_controller_test.go
+++ b/controllers/metal3.io/bmceventsubscription_controller_test.go
@@ -25,8 +25,10 @@ func newBMCTestReconcilerWithFixture(fix *fixture.Fixture, initObjs ...runtime.O
 	c := clientBuilder.Build()
 	// Add a default secret that can be used by most subscriptions.
 	bmcSecret := newBMCCredsSecret(defaultSecretName, "User", "Pass")
-	c.Create(context.TODO(), bmcSecret)
-
+	err := c.Create(context.TODO(), bmcSecret)
+	if err != nil {
+		return nil
+	}
 	return &BMCEventSubscriptionReconciler{
 		Client:             c,
 		ProvisionerFactory: fix,

--- a/controllers/metal3.io/controller_test.go
+++ b/controllers/metal3.io/controller_test.go
@@ -10,5 +10,8 @@ import (
 func init() {
 	logf.SetLogger(logz.New(logz.UseDevMode(true)))
 	// Register our package types with the global scheme
-	metal3api.AddToScheme(scheme.Scheme)
+	err := metal3api.AddToScheme(scheme.Scheme)
+	if err != nil {
+		logf.Log.Error(err, "Cannot Add scheme into metal3api")
+	}
 }

--- a/controllers/metal3.io/demo_test.go
+++ b/controllers/metal3.io/demo_test.go
@@ -22,7 +22,7 @@ func newDemoReconciler(initObjs ...runtime.Object) *BareMetalHostReconciler {
 
 	// Add a default secret that can be used by most hosts.
 	bmcSecret := newSecret(defaultSecretName, map[string]string{"username": "User", "password": "Pass"})
-	c.Create(goctx.TODO(), bmcSecret)
+	_ = c.Create(goctx.TODO(), bmcSecret)
 
 	return &BareMetalHostReconciler{
 		Client:             c,

--- a/controllers/metal3.io/host_config_data_test.go
+++ b/controllers/metal3.io/host_config_data_test.go
@@ -70,13 +70,15 @@ func TestLabelSecrets(t *testing.T) {
 			}
 
 			secret := newSecret(tc.name, map[string]string{"value": "somedata"})
-			c.Create(context.TODO(), secret)
+			err := c.Create(context.TODO(), secret)
+			assert.NoError(t, err)
 
-			_, err := tc.getter(hcd)
+			_, err = tc.getter(hcd)
 			assert.NoError(t, err)
 
 			actualSecret := &corev1.Secret{}
-			c.Get(context.TODO(), types.NamespacedName{Name: tc.name, Namespace: namespace}, actualSecret)
+			err = c.Get(context.TODO(), types.NamespacedName{Name: tc.name, Namespace: namespace}, actualSecret)
+			assert.NoError(t, err)
 			assert.Equal(t, "baremetal", actualSecret.Labels["environment.metal3.io"])
 		})
 	}
@@ -332,10 +334,10 @@ func TestProvisionWithHostConfig(t *testing.T) {
 			tc.Host.Spec.Online = true
 
 			c := fakeclient.NewClientBuilder().WithObjects(tc.Host).Build()
-			c.Create(context.TODO(), testBMCSecret)
-			c.Create(context.TODO(), tc.UserDataSecret)
-			c.Create(context.TODO(), tc.NetworkDataSecret)
-			c.Create(context.TODO(), tc.PreprovNetworkDataSecret)
+			_ = c.Create(context.TODO(), testBMCSecret)
+			_ = c.Create(context.TODO(), tc.UserDataSecret)
+			_ = c.Create(context.TODO(), tc.NetworkDataSecret)
+			_ = c.Create(context.TODO(), tc.PreprovNetworkDataSecret)
 			baselog := ctrl.Log.WithName("controllers").WithName("BareMetalHost")
 			hcd := &hostConfigData{
 				host:          tc.Host,

--- a/controllers/metal3.io/host_state_machine.go
+++ b/controllers/metal3.io/host_state_machine.go
@@ -324,20 +324,20 @@ func (hsm *hostStateMachine) ensureRegistered(info *reconcileInfo) (result actio
 		// If we are in the process of deletion (which may start with
 		// deprovisioning) and we have been unable to obtain any credentials,
 		// don't attempt to re-register the Host as this will always fail.
-		return
+		return nil
 	}
 
 	switch hsm.NextState {
 	case metal3api.StateNone, metal3api.StateUnmanaged:
 		// We haven't yet reached the Registration state, so don't attempt
 		// to register the Host.
-		return
+		return result
 	case metal3api.StateMatchProfile:
 		// Backward compatibility, remove eventually
-		return
+		return result
 	case metal3api.StateDeleting:
 		// In the deleting state the whole idea is to de-register the host
-		return
+		return result
 	case metal3api.StateRegistering:
 	default:
 		if hsm.Host.Status.ErrorType == metal3api.RegistrationError ||
@@ -358,7 +358,7 @@ func (hsm *hostStateMachine) ensureRegistered(info *reconcileInfo) (result actio
 	if complete {
 		result = actionUpdate{}
 	}
-	return
+	return result
 }
 
 func (hsm *hostStateMachine) handleNone(info *reconcileInfo) actionResult {

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -1192,7 +1192,7 @@ func (hb *hostBuilder) build() *metal3api.BareMetalHost {
 
 func (hb *hostBuilder) SaveHostProvisioningSettings() *hostBuilder {
 	info := makeDefaultReconcileInfo(&hb.BareMetalHost)
-	saveHostProvisioningSettings(&hb.BareMetalHost, info)
+	_, _ = saveHostProvisioningSettings(&hb.BareMetalHost, info)
 	return hb
 }
 

--- a/controllers/metal3.io/hostfirmwarecomponents_test.go
+++ b/controllers/metal3.io/hostfirmwarecomponents_test.go
@@ -104,7 +104,10 @@ func createBaremetalHostHFC() *metal3api.BareMetalHost {
 		ProvisionerFactory: nil,
 		Log:                ctrl.Log.WithName("bmh_reconciler").WithName("BareMetalHost"),
 	}
-	reconciler.Create(context.TODO(), bmh)
+	err := reconciler.Create(context.TODO(), bmh)
+	if err != nil {
+		return nil
+	}
 
 	return bmh
 }

--- a/controllers/metal3.io/hostfirmwaresettings_test.go
+++ b/controllers/metal3.io/hostfirmwaresettings_test.go
@@ -142,7 +142,7 @@ func createBaremetalHost() *metal3api.BareMetalHost {
 		Log:                ctrl.Log.WithName("bmh_reconciler").WithName("BareMetalHost"),
 	}
 
-	reconciler.Create(context.TODO(), bmh)
+	_ = reconciler.Create(context.TODO(), bmh)
 
 	return bmh
 }
@@ -503,7 +503,8 @@ func TestStoreHostFirmwareSettings(t *testing.T) {
 				firmwareSchema := getSchema()
 				firmwareSchema.Spec.Schema = getCurrentSchemaSettings()
 
-				r.Client.Create(ctx, firmwareSchema)
+				err := r.Client.Create(ctx, firmwareSchema)
+				assert.NoError(t, err)
 			}
 
 			currentSettings, schema, err := prov.GetFirmwareSettings(true)

--- a/main_test.go
+++ b/main_test.go
@@ -40,7 +40,7 @@ func TestTLSInsecureCiperSuite(t *testing.T) {
 		klog.SetOutput(bufWriter)
 		klog.LogToStderr(false) // this is important, because klog by default logs to stderr only
 		_, err := GetTLSOptionOverrideFuncs(tlsMockOptions)
-		g.Expect(err).Should(BeNil())
+		g.Expect(err).ShouldNot(HaveOccurred())
 		g.Expect(bufWriter.String()).Should(ContainSubstring("use of insecure cipher 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256' detected."))
 	})
 }
@@ -76,7 +76,7 @@ func Test13CipherSuite(t *testing.T) {
 		klog.LogToStderr(false) // this is important, because klog by default logs to stderr only
 		_, err := GetTLSOptionOverrideFuncs(tlsMockOptions)
 		g.Expect(bufWriter.String()).Should(ContainSubstring("warning: Cipher suites should not be set for TLS version 1.3. Ignoring ciphers"))
-		g.Expect(err).Should(BeNil())
+		g.Expect(err).ShouldNot(HaveOccurred())
 	})
 }
 
@@ -93,7 +93,7 @@ func TestGetTLSVersion(t *testing.T) {
 		tlsVersion := "TLS12"
 		version, err := GetTLSVersion(tlsVersion)
 		g.Expect(version).To(Equal(VersionTLS12))
-		g.Expect(err).Should(BeNil())
+		g.Expect(err).ShouldNot(HaveOccurred())
 	})
 }
 
@@ -106,6 +106,6 @@ func TestTLSOptions(t *testing.T) {
 			TLSCipherSuites: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
 		}
 		_, err := GetTLSOptionOverrideFuncs(tlsMockOptions)
-		g.Expect(err).Should(BeNil())
+		g.Expect(err).ShouldNot(HaveOccurred())
 	})
 }

--- a/pkg/hardwareutils/bmc/ilo4.go
+++ b/pkg/hardwareutils/bmc/ilo4.go
@@ -170,5 +170,5 @@ func (a *iLOAccessDetails) BuildBIOSSettings(firmwareConfig *FirmwareConfig) (se
 		)
 	}
 
-	return
+	return settings, nil
 }

--- a/pkg/hardwareutils/bmc/ilo5.go
+++ b/pkg/hardwareutils/bmc/ilo5.go
@@ -155,5 +155,5 @@ func (a *iLO5AccessDetails) BuildBIOSSettings(firmwareConfig *FirmwareConfig) (s
 		)
 	}
 
-	return
+	return settings, nil
 }

--- a/pkg/hardwareutils/bmc/irmc.go
+++ b/pkg/hardwareutils/bmc/irmc.go
@@ -161,5 +161,5 @@ func (a *iRMCAccessDetails) BuildBIOSSettings(firmwareConfig *FirmwareConfig) (s
 		)
 	}
 
-	return
+	return settings, nil
 }

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -127,7 +127,7 @@ func (p *demoProvisioner) InspectHardware(_ provisioner.InspectData, _, _, _ boo
 		// state in Reconcile()
 		result.Dirty = true
 		result.RequeueAfter = time.Second * 5
-		return
+		return result, started, nil, nil
 	}
 
 	p.log.Info("continuing inspection by setting details")
@@ -176,7 +176,7 @@ func (p *demoProvisioner) InspectHardware(_ provisioner.InspectData, _, _, _ boo
 		}
 	p.publisher("InspectionComplete", "Hardware inspection completed")
 
-	return
+	return result, started, details, nil
 }
 
 // UpdateHardwareState fetches the latest hardware state of the server

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -184,7 +184,7 @@ func (p *fixtureProvisioner) InspectHardware(_ provisioner.InspectData, _, _, _ 
 		}
 	p.publisher("InspectionComplete", "Hardware inspection completed")
 
-	return
+	return result, started, details, nil
 }
 
 // UpdateHardwareState fetches the latest hardware state of the server

--- a/pkg/provisioner/ironic/dependencies.go
+++ b/pkg/provisioner/ironic/dependencies.go
@@ -35,7 +35,7 @@ func (p *ironicProvisioner) checkIronicConductor() (ready bool, err error) {
 	}
 
 	driverCount := 0
-	pager.EachPage(p.ctx, func(_ context.Context, page pagination.Page) (bool, error) {
+	_ = pager.EachPage(p.ctx, func(_ context.Context, page pagination.Page) (bool, error) {
 		actual, driverErr := drivers.ExtractDrivers(page)
 		if driverErr != nil {
 			return false, driverErr
@@ -43,6 +43,7 @@ func (p *ironicProvisioner) checkIronicConductor() (ready bool, err error) {
 		driverCount += len(actual)
 		return true, nil
 	})
+
 	// If we have any drivers, conductor is up.
 	ready = driverCount > 0
 

--- a/pkg/provisioner/ironic/raid.go
+++ b/pkg/provisioner/ironic/raid.go
@@ -94,7 +94,7 @@ func buildTargetHardwareRAIDCfg(volumes []metal3api.HardwareRAIDVolume) (logical
 	)
 
 	if len(volumes) == 0 {
-		return
+		return nil, nil
 	}
 
 	for index, volume := range volumes {
@@ -148,7 +148,7 @@ func buildTargetHardwareRAIDCfg(volumes []metal3api.HardwareRAIDVolume) (logical
 		logicalDisks = append(logicalDisks, logicalDisk)
 	}
 
-	return
+	return logicalDisks, nil
 }
 
 // A private method to build software RAID disks.
@@ -198,10 +198,10 @@ func BuildRAIDCleanSteps(raidInterface string, target *metal3api.RAIDConfig, act
 			actual.HardwareRAIDVolumes = nil
 		}
 		if reflect.DeepEqual(target, actual) {
-			return
+			return cleanSteps, nil
 		}
 		if len(target.SoftwareRAIDVolumes) == 0 && (actual == nil || len(actual.SoftwareRAIDVolumes) == 0) {
-			return
+			return cleanSteps, nil
 		}
 
 		cleanSteps = append(
@@ -220,7 +220,7 @@ func BuildRAIDCleanSteps(raidInterface string, target *metal3api.RAIDConfig, act
 
 		// If software raid configuration is empty, only need to clear old configuration
 		if len(target.SoftwareRAIDVolumes) == 0 {
-			return
+			return cleanSteps, nil
 		}
 
 		cleanSteps = append(
@@ -230,14 +230,14 @@ func BuildRAIDCleanSteps(raidInterface string, target *metal3api.RAIDConfig, act
 				Step:      "create_configuration",
 			},
 		)
-		return
+		return cleanSteps, nil
 	}
 
 	// Hardware RAID
 	// If hardware RAID configuration is nil,
 	// keep old hardware RAID configuration
 	if raidInterface == noRAIDInterface || target == nil || target.HardwareRAIDVolumes == nil {
-		return
+		return cleanSteps, nil
 	}
 
 	// Ignore SoftwareRAIDVolumes
@@ -246,7 +246,7 @@ func BuildRAIDCleanSteps(raidInterface string, target *metal3api.RAIDConfig, act
 		actual.SoftwareRAIDVolumes = nil
 	}
 	if reflect.DeepEqual(target, actual) {
-		return
+		return cleanSteps, nil
 	}
 
 	// Add ‘delete_configuration’ before ‘create_configuration’ to make sure
@@ -261,7 +261,7 @@ func BuildRAIDCleanSteps(raidInterface string, target *metal3api.RAIDConfig, act
 
 	// If hardware raid configuration is empty, only need to clear old configuration
 	if len(target.HardwareRAIDVolumes) == 0 {
-		return
+		return cleanSteps, nil
 	}
 
 	// ‘create_configuration’ doesn’t remove existing disks. It is recommended
@@ -273,7 +273,7 @@ func BuildRAIDCleanSteps(raidInterface string, target *metal3api.RAIDConfig, act
 			Step:      "create_configuration",
 		},
 	)
-	return
+	return cleanSteps, nil
 }
 
 // CheckRAIDInterface checks the current RAID interface against the requested configuration.

--- a/pkg/provisioner/ironic/testbmc/testbmc.go
+++ b/pkg/provisioner/ironic/testbmc/testbmc.go
@@ -152,5 +152,5 @@ func (a *testAccessDetails) BuildBIOSSettings(firmwareConfig *bmc.FirmwareConfig
 		)
 	}
 
-	return
+	return settings, nil
 }

--- a/pkg/provisioner/ironic/testserver/ironic.go
+++ b/pkg/provisioner/ironic/testserver/ironic.go
@@ -133,7 +133,7 @@ func (m *IronicMock) Node(node nodes.Node) *IronicMock {
 	return m
 }
 
-// NodeUpdateError configures configures the server with an error response for [PATCH] /v1/nodes/{id}.
+// NodeUpdateError configures the server with an error response for [PATCH] /v1/nodes/{id}.
 func (m *IronicMock) NodeUpdateError(id string, errorCode int) *IronicMock {
 	m.ResponseWithCode(m.buildURL(v1node+id, http.MethodPatch), "", errorCode)
 	return m
@@ -154,7 +154,7 @@ func (m *IronicMock) NodeUpdate(node nodes.Node) *IronicMock {
 // GetLastNodeUpdateRequestFor returns the content of the last update request for the specified node.
 func (m *IronicMock) GetLastNodeUpdateRequestFor(id string) (updates []nodes.UpdateOperation) {
 	if bodyRaw, ok := m.GetLastRequestFor(v1node+id, http.MethodPatch); ok {
-		json.Unmarshal([]byte(bodyRaw), &updates)
+		_ = json.Unmarshal([]byte(bodyRaw), &updates)
 	}
 
 	return
@@ -163,13 +163,13 @@ func (m *IronicMock) GetLastNodeUpdateRequestFor(id string) (updates []nodes.Upd
 // GetLastNodeStatesProvisionUpdateRequestFor returns the content of the last provisioning request for the specified node.
 func (m *IronicMock) GetLastNodeStatesProvisionUpdateRequestFor(id string) (update nodes.ProvisionStateOpts) {
 	if bodyRaw, ok := m.GetLastRequestFor(v1node+id+"/states/provision", http.MethodPut); ok {
-		json.Unmarshal([]byte(bodyRaw), &update)
+		_ = json.Unmarshal([]byte(bodyRaw), &update)
 	}
 
 	return
 }
 
-// NodeMaintenanceError configures configures the server with an error response for [PUT] /v1/nodes/{id}/maintenance.
+// NodeMaintenanceError configures the server with an error response for [PUT] /v1/nodes/{id}/maintenance.
 func (m *IronicMock) NodeMaintenanceError(id string, errorCode int) *IronicMock {
 	m.ResponseWithCode(m.buildURL(v1node+id+maintenance, http.MethodPut), "", errorCode)
 	return m

--- a/test/e2e/cert_manager.go
+++ b/test/e2e/cert_manager.go
@@ -22,7 +22,7 @@ func checkCertManagerAPI(clusterProxy framework.ClusterProxy) error {
 }
 
 func installCertManager(ctx context.Context, clusterProxy framework.ClusterProxy, cmVersion string) error {
-	response, err := http.Get(fmt.Sprintf("https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml", cmVersion))
+	response, err := http.Get(fmt.Sprintf("https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml", cmVersion)) //nolint: noctx
 	if err != nil {
 		return errors.Wrapf(err, "Error downloading cert-manager manifest")
 	}
@@ -44,7 +44,11 @@ func installCertManager(ctx context.Context, clusterProxy framework.ClusterProxy
 func checkCertManagerWebhook(ctx context.Context, clusterProxy framework.ClusterProxy) error {
 	scheme := clusterProxy.GetScheme()
 	const ns = "cert-manager"
-	cmapi.AddToScheme(scheme)
+	err := cmapi.AddToScheme(scheme)
+	if err != nil {
+		return err
+	}
+
 	cl, err := client.New(clusterProxy.GetRESTConfig(), client.Options{
 		Scheme: scheme,
 	})

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -328,7 +328,7 @@ func (input *BuildAndApplyKustomizationInput) validate() error {
 // BuildAndApplyKustomization takes input from BuildAndApplyKustomizationInput. It builds the provided kustomization
 // and apply it to the cluster provided by clusterProxy.
 func BuildAndApplyKustomization(ctx context.Context, input *BuildAndApplyKustomizationInput) error {
-	Expect(input.validate()).To(BeNil())
+	Expect(input.validate()).To(Succeed())
 	var err error
 	kustomization := input.Kustomization
 	clusterProxy := input.ClusterProxy
@@ -377,7 +377,7 @@ func BuildAndApplyKustomization(ctx context.Context, input *BuildAndApplyKustomi
 func DeploymentRolledOut(ctx context.Context, clusterProxy framework.ClusterProxy, name string, namespace string, desiredGeneration int64) bool {
 	clientSet := clusterProxy.GetClientSet()
 	deploy, err := clientSet.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
-	Expect(err).To(BeNil())
+	Expect(err).ToNot(HaveOccurred())
 	if deploy != nil {
 		// When the number of replicas is equal to the number of available and updated
 		// replicas, we know that only "new" pods are running. When we also

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -167,8 +167,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	kubeconfigPath := parts[0]
 	scheme := runtime.NewScheme()
 	framework.TryAddDefaultSchemes(scheme)
-	metal3api.AddToScheme(scheme)
-
+	err := metal3api.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
 	e2eConfig = LoadE2EConfig(configPath)
 	bmcs = LoadBMCConfig(bmcConfigPath)
 	bmc = (*bmcs)[GinkgoParallelProcess()-1]

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -373,11 +373,13 @@ var _ = Describe("Upgrade", Label("optional", "upgrade"), func() {
 		Expect(kubeconfigPath).To(BeAnExistingFile(), "Failed to get the kubeconfig file for the cluster")
 		scheme := runtime.NewScheme()
 		framework.TryAddDefaultSchemes(scheme)
-		metal3api.AddToScheme(scheme)
-		upgradeClusterProxy = framework.NewClusterProxy(upgradeClusterName, kubeconfigPath, scheme)
+		err := metal3api.AddToScheme(scheme)
+		Expect(err).NotTo(HaveOccurred())
+		upgradeClusterProxy = framework.NewClusterProxy("bmo-e2e-upgrade", kubeconfigPath, scheme)
 		DeferCleanup(func() {
 			upgradeClusterProxy.Dispose(ctx)
 		})
+
 		if e2eConfig.GetVariable("UPGRADE_DEPLOY_CERT_MANAGER") != "false" {
 			By("Installing cert-manager on the upgrade cluster")
 			cmVersion := e2eConfig.GetVariable("CERT_MANAGER_VERSION")


### PR DESCRIPTION
This PR adds the following last set of golangci linters

  - asasalint
  - bidichk
  - dupword
  - durationcheck
  - errcheck
  - errchkjson
  - gci
  - ginkgolinter
  - goprintffuncname
  - loggercheck
  - nakedret
  - nilerr
  - noctx
  - nosprintfhostport
  - unparam
  - usestdlibvars
  
  I was also eager to enabled `containedctx`, however it had some issues with recently introduced structs with the following error
  
```
  pkg/provisioner/ironic/ironic.go:112:2: found a struct that contains a context.Context field (containedctx)
        ctx context.Context
```

Since this needs discussion, this is currently disabled. 