### PR TITLE
:seedling: Update ironic basic-auth-tls overlay

### DIFF
--- a/ironic-deployment/overlays/basic-auth_tls/kustomization.yaml
+++ b/ironic-deployment/overlays/basic-auth_tls/kustomization.yaml
@@ -9,6 +9,13 @@ components:
 - ../../components/basic-auth
 - ../../components/tls
 
+# Example of how to generate config map
+# configMapGenerator:
+# - envs:
+#   - ironic_bmo.env
+#   name: ironic-bmo-configmap
+#   behavior: create
+
 # When using TLS, the ironic-httpd container is acting as a reverse-proxy.
 # This means that we need to add the basic-auth related environment
 # variables on ironic-httpd with this patch.


### PR DESCRIPTION
**What this PR does / why we need it**:

Added some comments to instruct secret and configmap generation for `ironic-deployment/overlays/basic-auth_tls` overlay