### PR TITLE
🌱 Fix link in e2e readme

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -51,7 +51,7 @@ make test-e2e
 In case you want to run the tests with your own hardware, the information
 regarding BMCs should be stored in a yaml file, whose path is exported to
 `E2E_BMCS_CONF_FILE` variable (please take a look at
-[bmcs-sushy-tools.yaml](../../test/e2e/config/bmcs-sushy-tools.yaml)
+[bmcs-redfish-virtualmedia.yaml](config/bmcs-redfish-virtualmedia.yaml)
 to understand the file structure).
 
 ## Tests


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the link to the BMCs configuration file that was renamed in a previous PR.

Thanks to @maxrantil for notifying me of the issue!
