### PR TITLE
🌱 Make use of the new liveness/readiness probe scripts

### DIFF
--- a/ironic-deployment/base/ironic.yaml
+++ b/ironic-deployment/base/ironic.yaml
@@ -67,7 +67,7 @@ spec:
         - /bin/runironic
         livenessProbe:
           exec:
-            command: ["sh", "-c", "curl -sSf http://127.0.0.1:6385 || curl -sSfk https://127.0.0.1:6385"]
+            command: ["/bin/ironic-liveness"]
           initialDelaySeconds: 30
           periodSeconds: 30
           timeoutSeconds: 10
@@ -75,7 +75,7 @@ spec:
           failureThreshold: 10
         readinessProbe:
           exec:
-            command: ["sh", "-c", "curl -sSf http://127.0.0.1:6385 || curl -sSfk https://127.0.0.1:6385"]
+            command: ["/bin/ironic-readiness"]
           initialDelaySeconds: 30
           periodSeconds: 30
           timeoutSeconds: 10

--- a/ironic-deployment/components/tls/tls.yaml
+++ b/ironic-deployment/components/tls/tls.yaml
@@ -7,12 +7,6 @@ spec:
     spec:
       containers:
       - name: ironic
-        readinessProbe:
-         exec:
-           command: ["sh", "-c", "curl -sSf http://127.0.0.1:6388"]
-        livenessProbe:
-         exec:
-           command: ["sh", "-c", "curl -sSf http://127.0.0.1:6388"]
         env:
         - name: IRONIC_REVERSE_PROXY_SETUP
           value: "true"


### PR DESCRIPTION
Using them allows us not to care about all possible ways Ironic can be
installed. In the future, we can use the mounted secrets to exercise
less trivial API resources such as conductors or drivers
(see https://github.com/metal3-io/baremetal-operator/issues/1528).

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>