### PR TITLE
🌱 Disable name suffix hash

### DIFF
--- a/ironic-deployment/components/keepalived/kustomization.yaml
+++ b/ironic-deployment/components/keepalived/kustomization.yaml
@@ -4,6 +4,9 @@ kind: Component
 patches:
 - path: keepalived_patch.yaml
 
+generatorOptions:
+  disableNameSuffixHash: true
+
 configMapGenerator:
 - envs:
   - ironic_bmo_configmap.env

--- a/ironic-deployment/default/kustomization.yaml
+++ b/ironic-deployment/default/kustomization.yaml
@@ -4,6 +4,10 @@ namespace: baremetal-operator-system
 namePrefix: baremetal-operator-
 resources:
 - ../base
+
+generatorOptions:
+  disableNameSuffixHash: true
+
 configMapGenerator:
 - envs:
   - ironic_bmo_configmap.env

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -164,7 +164,7 @@ if [[ "${DEPLOY_IRONIC}" == "true" ]]; then
     --namespace=baremetal-operator-system --nameprefix=baremetal-operator-
 
     if [ "${DEPLOY_BASIC_AUTH}" == "true" ]; then
-        ${KUSTOMIZE} edit add secret ironic-htpasswd --from-env-file=ironic-htpasswd
+        ${KUSTOMIZE} edit add secret ironic-htpasswd --disableNameSuffixHash --from-env-file=ironic-htpasswd
 
         if [[ "${DEPLOY_TLS}" == "true" ]]; then
             # Basic-auth + TLS is special since TLS also means reverse proxy, which affects basic-auth.
@@ -203,7 +203,7 @@ if [[ "${DEPLOY_BMO}" == "true" ]]; then
     if [ "${DEPLOY_BASIC_AUTH}" == "true" ]; then
         ${KUSTOMIZE} edit add component ../../components/basic-auth
         # These files are created below
-        ${KUSTOMIZE} edit add secret ironic-credentials \
+        ${KUSTOMIZE} edit add secret ironic-credentials --disableNameSuffixHash \
             --from-file=username=ironic-username --from-file=password=ironic-password
     fi
 
@@ -221,7 +221,7 @@ if [[ "${DEPLOY_BMO}" == "true" ]]; then
     pushd "${TEMP_BMO_OVERLAY}"
     # This is to keep the current behavior of using the ironic.env file for the configmap
     cp "${SCRIPTDIR}/config/default/ironic.env" "${TEMP_BMO_OVERLAY}/ironic.env"
-    ${KUSTOMIZE} edit add configmap ironic --behavior=create --from-env-file=ironic.env
+    ${KUSTOMIZE} edit add configmap ironic --disableNameSuffixHash --behavior=create --from-env-file=ironic.env
     # shellcheck disable=SC2086
     ${KUSTOMIZE} build "${TEMP_BMO_OVERLAY}" | kubectl apply ${KUBECTL_ARGS} -f -
     popd
@@ -248,9 +248,9 @@ if [[ "${DEPLOY_IRONIC}" == "true" ]]; then
     # The keepalived component has its own configmap,
     # but we are overriding depending on environment here so we must replace it.
     if [[ "${DEPLOY_KEEPALIVED}" == "true" ]]; then
-        ${KUSTOMIZE} edit add configmap ironic-bmo-configmap --behavior=replace --from-env-file=ironic_bmo_configmap.env
+        ${KUSTOMIZE} edit add configmap ironic-bmo-configmap --disableNameSuffixHash --behavior=replace --from-env-file=ironic_bmo_configmap.env
     else
-        ${KUSTOMIZE} edit add configmap ironic-bmo-configmap --behavior=create --from-env-file=ironic_bmo_configmap.env
+        ${KUSTOMIZE} edit add configmap ironic-bmo-configmap --disableNameSuffixHash --behavior=create --from-env-file=ironic_bmo_configmap.env
     fi
     # shellcheck disable=SC2086
     ${KUSTOMIZE} build "${TEMP_IRONIC_OVERLAY}" | kubectl apply ${KUBECTL_ARGS} -f -


### PR DESCRIPTION
**What this PR does / why we need it**:

We need deterministic resource names to ease diffing between versions.

Also, we plan to install bmo using Helm, and test that the Helm chart produces the same output as the reference implementation (which uses kustomize).