### PR TITLE
🌱 Bump golang to v1.22

### DIFF
--- a/.github/workflows/e2e-fixture-test.yml
+++ b/.github/workflows/e2e-fixture-test.yml
@@ -28,6 +28,15 @@ jobs:
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
+    - name: Calculate go version
+      id: vars
+      run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
+
+    - name: Set up Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version: ${{ steps.vars.outputs.go_version }}
+
     - name: Build BMO e2e Docker Image
       env:
         IMG: quay.io/metal3-io/baremetal-operator:e2e

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Install go
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: '1.21'
+        go-version: '1.22'
     - name: Generate release notes
       run: |
         make release-notes

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -56,7 +56,7 @@ linters:
   fast: true
 linters-settings:
   gosec:
-    go: "1.21"
+    go: "1.22"
     severity: medium
     confidence: medium
     concurrency: 8
@@ -87,9 +87,9 @@ linters-settings:
     allow-leading-space: false
     require-specific: true
   staticcheck:
-    go: "1.21"
+    go: "1.22"
   stylecheck:
-    go: "1.21"
+    go: "1.22"
   gocritic:
     enabled-tags:
     - experimental
@@ -108,7 +108,7 @@ linters-settings:
     - whyNoLint
     - wrapperFunc
   unused:
-    go: "1.21"
+    go: "1.22"
 issues:
   exclude-rules:
   - path: test/e2e

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.21.9@sha256:7d0dcbe5807b1ad7272a598fbf9d7af15b5e2bed4fd6c4c2b5b3684df0b317dd
+ARG BUILD_IMAGE=docker.io/golang:1.22.2@sha256:450e3822c7a135e1463cd83e51c8e2eb03b86a02113c89424e6f0f8344bb4168
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ RUN_NAMESPACE = metal3
 GO_TEST_FLAGS = $(TEST_FLAGS)
 DEBUG = --debug
 COVER_PROFILE = cover.out
-GO_VERSION ?= 1.21.9
+GO_VERSION ?= 1.22.2
 
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -61,7 +61,7 @@ def validate_auth():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.21 as tilt-helper
+FROM golang:1.22 as tilt-helper
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/baremetal-operator/apis
 
-go 1.21
+go 1.22
 
 require (
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/baremetal-operator
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.4.1

--- a/hack/e2e/ensure_go.sh
+++ b/hack/e2e/ensure_go.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-MINIMUM_GO_VERSION=go1.21.9
+MINIMUM_GO_VERSION=go1.22.2
 
 # Ensure the go tool exists and is a viable version, or installs it
 verify_go_version()

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -31,6 +31,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/baremetal-operator:rw,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/baremetal-operator \
-    docker.io/golang:1.21 \
+    docker.io/golang:1.22 \
     /go/src/github.com/metal3-io/baremetal-operator/hack/generate.sh "${@}"
 fi;

--- a/hack/golint.sh
+++ b/hack/golint.sh
@@ -15,6 +15,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/baremetal-operator:rw,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/baremetal-operator \
-    docker.io/golang:1.21 \
+    docker.io/golang:1.22 \
     /go/src/github.com/metal3-io/baremetal-operator/hack/golint.sh "${@}"
 fi;

--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -39,6 +39,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.21 \
+        docker.io/golang:1.22 \
         /workdir/hack/gomod.sh "$@"
 fi

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/baremetal-operator/tooling
 
-go 1.21
+go 1.22
 
 require (
 	sigs.k8s.io/controller-tools v0.12.1

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -24,6 +24,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/baremetal-operator:rw,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/baremetal-operator \
-    docker.io/golang:1.21 \
+    docker.io/golang:1.22 \
     /go/src/github.com/metal3-io/baremetal-operator/hack/unit.sh "${@}"
 fi;

--- a/pkg/hardwareutils/go.mod
+++ b/pkg/hardwareutils/go.mod
@@ -1,3 +1,3 @@
 module github.com/metal3-io/baremetal-operator/pkg/hardwareutils
 
-go 1.21
+go 1.22

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/baremetal-operator/test
 
-go 1.21
+go 1.22
 
 require (
 	github.com/cert-manager/cert-manager v1.10.0


### PR DESCRIPTION
This PR bumps the golang version to v1.22 in different go modules, tests and Dockerfile.