### PR TITLE
:seedling: Remove capm3_e2e dependency from bmo E2E

### DIFF
--- a/test/e2e/basic_ops_test.go
+++ b/test/e2e/basic_ops_test.go
@@ -12,8 +12,6 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/util"
 
-	capm3_e2e "github.com/metal3-io/cluster-api-provider-metal3/test/e2e"
-
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 )
 
@@ -75,7 +73,7 @@ var _ = Describe("basic", Label("required", "basic"), func() {
 		}, e2eConfig.GetIntervals(specName, "wait-available")...)
 
 		By("setting the reboot annotation and checking that the BMH was rebooted")
-		capm3_e2e.AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, rebootAnnotation, pointer.String("{\"force\": true}"))
+		AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, rebootAnnotation, pointer.String("{\"force\": true}"))
 
 		WaitForBmhInPowerState(ctx, WaitForBmhInPowerStateInput{
 			Client: clusterProxy.GetClient(),
@@ -90,7 +88,7 @@ var _ = Describe("basic", Label("required", "basic"), func() {
 		}, e2eConfig.GetIntervals(specName, "wait-power-state")...)
 
 		By("setting the power off annotation on the BMH and checking that it worked")
-		capm3_e2e.AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, poweroffAnnotation, pointer.String("{\"force\": true}"))
+		AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, poweroffAnnotation, pointer.String("{\"force\": true}"))
 
 		WaitForBmhInPowerState(ctx, WaitForBmhInPowerStateInput{
 			Client: clusterProxy.GetClient(),
@@ -100,7 +98,7 @@ var _ = Describe("basic", Label("required", "basic"), func() {
 
 		// power on
 		By("removing the power off annotation and checking that the BMH powers on")
-		capm3_e2e.AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, poweroffAnnotation, nil)
+		AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, poweroffAnnotation, nil)
 
 		WaitForBmhInPowerState(ctx, WaitForBmhInPowerStateInput{
 			Client: clusterProxy.GetClient(),

--- a/test/e2e/live_iso_test.go
+++ b/test/e2e/live_iso_test.go
@@ -18,8 +18,6 @@ import (
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	metal3bmc "github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
-
-	capm3_e2e "github.com/metal3-io/cluster-api-provider-metal3/test/e2e"
 )
 
 var _ = Describe("Live-ISO", Label("required", "live-iso"), func() {
@@ -113,7 +111,7 @@ var _ = Describe("Live-ISO", Label("required", "live-iso"), func() {
 			auth := ssh.PublicKeys(signer)
 			PerformSSHBootCheck(e2eConfig, "memory", auth, fmt.Sprintf("%s:%s", bmc.IPAddress, bmc.SSHPort))
 		} else {
-			capm3_e2e.Logf("WARNING: Skipping SSH check since SSH_CHECK_PROVISIONED != true")
+			Logf("WARNING: Skipping SSH check since SSH_CHECK_PROVISIONED != true")
 		}
 
 		By("Triggering the deprovisioning of the BMH")

--- a/test/e2e/provisioning_and_annotation_test.go
+++ b/test/e2e/provisioning_and_annotation_test.go
@@ -20,8 +20,6 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-
-	capm3_e2e "github.com/metal3-io/cluster-api-provider-metal3/test/e2e"
 )
 
 var _ = Describe("Provision, detach, recreate from status and deprovision", Label("required", "provision", "detach", "status", "deprovision"),
@@ -131,7 +129,7 @@ var _ = Describe("Provision, detach, recreate from status and deprovision", Labe
 				auth := ssh.PublicKeys(signer)
 				PerformSSHBootCheck(e2eConfig, "disk", auth, fmt.Sprintf("%s:%s", bmc.IPAddress, bmc.SSHPort))
 			} else {
-				capm3_e2e.Logf("WARNING: Skipping SSH check since SSH_CHECK_PROVISIONED != true")
+				Logf("WARNING: Skipping SSH check since SSH_CHECK_PROVISIONED != true")
 			}
 
 			By("Retrieving the latest BMH object")

--- a/test/e2e/re_inspection_test.go
+++ b/test/e2e/re_inspection_test.go
@@ -14,8 +14,6 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/util"
 
-	capm3_e2e "github.com/metal3-io/cluster-api-provider-metal3/test/e2e"
-
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 )
 
@@ -82,10 +80,10 @@ var _ = Describe("Re-Inspection", Label("required", "re-inspection"), func() {
 		Expect(bmh.Status.HardwareDetails.Hostname).To(Equal(wrongHostName))
 
 		By("removing HardwareDetailsAnnotation")
-		capm3_e2e.AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, metal3api.HardwareDetailsAnnotation, nil)
+		AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, metal3api.HardwareDetailsAnnotation, nil)
 
 		By("adding InspectAnnotation to re-inspect")
-		capm3_e2e.AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, metal3api.InspectAnnotationPrefix, pointer.String(""))
+		AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, metal3api.InspectAnnotationPrefix, pointer.String(""))
 
 		By("waiting for the BMH to be in inspecting state after inspection annotaion")
 		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{

--- a/test/go.mod
+++ b/test/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/cert-manager/cert-manager v1.10.0
 	github.com/metal3-io/baremetal-operator/apis v0.5.1
 	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.5.1
-	github.com/metal3-io/cluster-api-provider-metal3/test v1.6.1
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
 	github.com/pkg/errors v0.9.1
@@ -39,6 +38,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
+	github.com/coredns/caddy v1.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
@@ -80,8 +80,6 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
-	github.com/metal3-io/cluster-api-provider-metal3/api v1.5.1 // indirect
-	github.com/metal3-io/ip-address-manager/api v1.6.2 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
@@ -111,6 +109,7 @@ require (
 	github.com/valyala/fastjson v1.6.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
+	go.uber.org/goleak v1.3.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/mod v0.14.0 // indirect
@@ -130,6 +129,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gotest.tools/v3 v3.5.0 // indirect
 	k8s.io/apiextensions-apiserver v0.29.3 // indirect
 	k8s.io/apiserver v0.29.3 // indirect
 	k8s.io/client-go v0.29.3 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -128,6 +128,7 @@ github.com/evanphx/json-patch/v5 v5.8.0 h1:lRj6N9Nci7MvzrXuX6HFzU8XjmhPiXPlsKEy1
 github.com/evanphx/json-patch/v5 v5.8.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
 github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
@@ -258,8 +259,6 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
-github.com/jinzhu/copier v0.4.0 h1:w3ciUoD19shMCRargcpm0cm91ytaBhDvuRpz1ODO/U8=
-github.com/jinzhu/copier v0.4.0/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -286,12 +285,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
-github.com/metal3-io/cluster-api-provider-metal3/api v1.5.1 h1:IS7g5VUG7truCFUtdTlJ9eG+yPYoiZ0fOFDVfcz160U=
-github.com/metal3-io/cluster-api-provider-metal3/api v1.5.1/go.mod h1:r1CAUr9WA0Ar26YszPLpLtivER6z/8Yh6gQvv5UD8rw=
-github.com/metal3-io/cluster-api-provider-metal3/test v1.6.1 h1:UaTb1Wd+AXulNvyP/7peQ19mOt4U+/Vw09eOH445Eug=
-github.com/metal3-io/cluster-api-provider-metal3/test v1.6.1/go.mod h1:cmWUg8raOTOypLz9iA49Q1DOkytBfOM6HKl966ycbXc=
-github.com/metal3-io/ip-address-manager/api v1.6.2 h1:YPndsZoqYBFlMYQWjbB5DkrRSr0Jr1gZthx0H0xCoEA=
-github.com/metal3-io/ip-address-manager/api v1.6.2/go.mod h1:vf+6KPKpmzOIdR62WJ9u6ck7PT6oUUIPyjcGRvmjpBU=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=


### PR DESCRIPTION
BMO E2E is using some functions from CAPM3-E2E. This likely causes circular imports in the future.