### PR TITLE
🌱 backported fixes for Makefile and release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,29 +11,31 @@ permissions:
 
 jobs:
   build:
+    name: tag release
+    runs-on: ubuntu-latest
+
     permissions:
       contents: write
     # This workflow is only of value to the metal3-io/baremetal-operator repository and
     # would always fail in forks
     if: github.repository == 'metal3-io/baremetal-operator'
-    runs-on: ubuntu-latest
     steps:
-      - name: Export RELEASE_TAG var
-        run:  echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
-      - name: checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          fetch-depth: 0
-      - name: Install go
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-        with:
-          go-version: '1.20'
-      - name: Generate release notes
-        run: |
-          make release-notes
-      - name: Release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
-        with:
-          draft: true
-          files: out/*
-          body_path: releasenotes/releasenotes.md
+    - name: Export RELEASE_TAG var
+      run: echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
+    - name: checkout code
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        fetch-depth: 0
+    - name: Install go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version: '1.20'
+    - name: Generate release notes
+      run: |
+        make release-notes
+    - name: Release
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+      with:
+        draft: true
+        files: out/*
+        body_path: releasenotes/${{ env.RELEASE_TAG }}.md

--- a/Makefile
+++ b/Makefile
@@ -326,15 +326,15 @@ mod: ## Clean up go module settings
 ## Release
 ## --------------------------------------
 RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
-PREVIOUS_TAG ?= $(shell git tag -l | grep -B 1 "^$(RELEASE_TAG)" | head -n 1)
 RELEASE_NOTES_DIR := releasenotes
+PREVIOUS_TAG ?= $(shell git tag -l | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" | sort -V | grep -B1 $(RELEASE_TAG) | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$$" | head -n 1 2>/dev/null)
 
 $(RELEASE_NOTES_DIR):
 	mkdir -p $(RELEASE_NOTES_DIR)/
 
 .PHONY: release-notes
 release-notes: $(RELEASE_NOTES_DIR)
-	go run ./hack/tools/release_notes.go --from=$(PREVIOUS_TAG) > $(RELEASE_NOTES_DIR)/releasenotes.md
+	go run ./hack/tools/release/notes.go --from=$(PREVIOUS_TAG) > $(RELEASE_NOTES_DIR)/$(RELEASE_TAG).md
 
 go-version: ## Print the go version we use to compile our binaries and images
 	@echo $(GO_VERSION)


### PR DESCRIPTION
Basically a cherry-pick from CAPM3 PR #1567 originally, and manual cherry-pick of BMO PR #1636 for the release workflow / release note generator.

Support beta and RC releases in release note generator. Move some logic from Makefile to the release note generator, and then add nice unfolding summary section to hide details in beta/rc notes.

Fix previous release tag pattern detection in Makefile.
