### PR TITLE
🐛 Demote frequent routine logging messages to debug level

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -763,13 +763,13 @@ func (r *BareMetalHostReconciler) getPreprovImage(info *reconcileInfo, formats [
 		},
 		Format: preprovImage.Status.Format,
 	}
-	info.log.Info("using PreprovisioningImage")
+	info.log.Info("using PreprovisioningImage", "Image", image)
 	return &image, nil
 }
 
 // Test the credentials by connecting to the management controller.
 func (r *BareMetalHostReconciler) registerHost(prov provisioner.Provisioner, info *reconcileInfo) actionResult {
-	info.log.Info("registering and validating access to management controller",
+	info.log.V(1).Info("registering and validating access to management controller",
 		"credentials", info.host.Status.TriedCredentials)
 	dirty := false
 
@@ -902,7 +902,7 @@ func (r *BareMetalHostReconciler) registerHost(prov provisioner.Provisioner, inf
 		info.publishEvent("BMCAccessValidated", "Verified access to BMC")
 		dirty = true
 	} else {
-		info.log.Info("verified access to the BMC")
+		info.log.V(1).Info("verified access to the BMC")
 	}
 
 	if info.host.Status.ErrorType == metal3api.RegistrationError || registeredNewCreds {
@@ -1076,7 +1076,7 @@ func getHardwareProfileName(host *metal3api.BareMetalHost) string {
 
 func (r *BareMetalHostReconciler) matchProfile(info *reconcileInfo) (dirty bool, err error) {
 	hardwareProfile := getHardwareProfileName(info.host)
-	info.log.Info("using hardware profile", "profile", hardwareProfile)
+	info.log.V(1).Info("using hardware profile", "profile", hardwareProfile)
 
 	_, err = profile.GetProfile(hardwareProfile)
 	if err != nil {

--- a/controllers/metal3.io/hostfirmwarecomponents_controller.go
+++ b/controllers/metal3.io/hostfirmwarecomponents_controller.go
@@ -152,7 +152,7 @@ func (r *HostFirmwareComponentsReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{Requeue: true, RequeueAfter: provisionerRetryDelay}, nil
 	}
 
-	info.log.Info("retrieving firmware components and saving to resource", "Node", bmh.Status.Provisioning.ID)
+	info.log.V(1).Info("retrieving firmware components and saving to resource", "Node", bmh.Status.Provisioning.ID)
 	// Check ironic for the components information if possible
 	components, err := prov.GetFirmwareComponents()
 

--- a/controllers/metal3.io/hostfirmwaresettings_controller.go
+++ b/controllers/metal3.io/hostfirmwaresettings_controller.go
@@ -162,7 +162,7 @@ func (r *HostFirmwareSettingsReconciler) Reconcile(ctx context.Context, req ctrl
 		return ctrl.Result{Requeue: true, RequeueAfter: provisionerRetryDelay}, nil
 	}
 
-	info.log.Info("retrieving firmware settings and saving to resource", "node", bmh.Status.Provisioning.ID)
+	info.log.V(1).Info("retrieving firmware settings and saving to resource", "Node", bmh.Status.Provisioning.ID)
 
 	// Get the current settings and schema, retry if provisioner returns error
 	currentSettings, schema, err := prov.GetFirmwareSettings(true)
@@ -293,7 +293,7 @@ func (r *HostFirmwareSettingsReconciler) updateStatus(info *rInfo, settings meta
 
 // Get a firmware schema that matches the host vendor or create one if it doesn't exist.
 func (r *HostFirmwareSettingsReconciler) getOrCreateFirmwareSchema(info *rInfo, schema map[string]metal3api.SettingSchema) (fSchema *metal3api.FirmwareSchema, err error) {
-	info.log.Info("getting firmwareSchema")
+	info.log.V(1).Info("getting firmwareSchema")
 
 	schemaName := GetSchemaName(schema)
 	firmwareSchema := &metal3api.FirmwareSchema{}
@@ -301,7 +301,7 @@ func (r *HostFirmwareSettingsReconciler) getOrCreateFirmwareSchema(info *rInfo, 
 	// If a schema exists that matches, use that, otherwise create a new one
 	if err = r.Get(info.ctx, client.ObjectKey{Namespace: info.hfs.ObjectMeta.Namespace, Name: schemaName},
 		firmwareSchema); err == nil {
-		info.log.Info("found existing firmwareSchema resource")
+		info.log.V(1).Info("found existing firmwareSchema resource")
 
 		// Add hfs as owner so can be garbage collected on delete, if already an owner it will just be overwritten
 		if err = controllerutil.SetOwnerReference(info.hfs, firmwareSchema, r.Scheme()); err != nil {


### PR DESCRIPTION
Having these on each reconcile makes logs quite unreadable.

Also make the PreprovisioningImage message more useful by including the
actual image.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>