### PR TITLE
🐛 Pinning ironic image release-24.1 where it was missed

### DIFF
--- a/ironic-deployment/base/ironic.yaml
+++ b/ironic-deployment/base/ironic.yaml
@@ -61,7 +61,7 @@ spec:
         - configMapRef:
             name: ironic-bmo-configmap
       - name: ironic
-        image: quay.io/metal3-io/ironic
+        image: quay.io/metal3-io/ironic:release-24.1
         imagePullPolicy: Always
         command:
         - /bin/runironic
@@ -96,7 +96,7 @@ spec:
           runAsUser: 997 # ironic
           runAsGroup: 994 # ironic
       - name: ironic-log-watch
-        image: quay.io/metal3-io/ironic
+        image: quay.io/metal3-io/ironic:release-24.1
         imagePullPolicy: Always
         command:
         - /bin/runlogwatch.sh
@@ -112,7 +112,7 @@ spec:
           runAsUser: 997 # ironic
           runAsGroup: 994 # ironic
       - name: ironic-httpd
-        image: quay.io/metal3-io/ironic
+        image: quay.io/metal3-io/ironic:release-24.1
         imagePullPolicy: Always
         command:
         - /bin/runhttpd


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
In PR: https://github.com/metal3-io/baremetal-operator/pull/1679 ironic image was not pinned everywhere. This PR is fixing it. 

