### PR TITLE
:seedling:  Add more ctrl options flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	metal3iocontroller "github.com/metal3-io/baremetal-operator/controllers/metal3.io"
@@ -125,6 +126,9 @@ func main() {
 	var restConfigQPS float64
 	var restConfigBurst int
 	var controllerConcurrency int
+	var leaseDurationSeconds string
+	var renewDeadlineSeconds string
+	var retryPeriodSeconds string
 
 	// From CAPI point of view, BMO should be able to watch all namespaces
 	// in case of a deployment that is not multi-tenant. If the deployment
@@ -168,6 +172,11 @@ func main() {
 			"Insecure values: "+strings.Join(tlsCipherInsecureValues, ", ")+".")
 	flag.IntVar(&controllerConcurrency, "controller-concurrency", 0,
 		"Number of CRs of each type to process simultaneously")
+
+	flag.StringVar(&leaseDurationSeconds, "lease-duration-seconds", os.Getenv("LEASE_DURATION_SECONDS"), "Leader election duration in seconds.")
+	flag.StringVar(&renewDeadlineSeconds, "renew-deadline-seconds", os.Getenv("RENEW_DEADLINE_SECONDS"), "Leader election renew deadline duration in seconds.")
+	flag.StringVar(&retryPeriodSeconds, "retry-period-seconds", os.Getenv("RETRY_PERIOD_SECONDS"), "Leader election retry period in seconds.")
+
 	flag.Parse()
 
 	logOpts := zap.Options{}
@@ -210,14 +219,47 @@ func main() {
 			Port:    webhookPort,
 			TLSOpts: tlsOptionOverrides,
 		}),
-		LeaderElection:          enableLeaderElection,
-		LeaderElectionID:        leaderElectionID,
-		LeaderElectionNamespace: leaderElectionNamespace,
-		HealthProbeBindAddress:  healthAddr,
+		LeaderElection:                enableLeaderElection,
+		LeaderElectionID:              leaderElectionID,
+		LeaderElectionNamespace:       leaderElectionNamespace,
+		LeaderElectionReleaseOnCancel: true,
+		HealthProbeBindAddress:        healthAddr,
 		Cache: cache.Options{
 			ByObject:          secretutils.AddSecretSelector(nil),
 			DefaultNamespaces: watchNamespaces,
 		},
+	}
+
+	if leaseDurationSeconds != "" {
+		seconds, err := strconv.ParseInt(leaseDurationSeconds, 10, 16)
+		if err != nil {
+			setupLog.Error(err, "failed to parse duration")
+			os.Exit(1)
+		}
+
+		duration := time.Second * time.Duration(seconds)
+		ctrlOpts.LeaseDuration = &duration
+	}
+
+	if renewDeadlineSeconds != "" {
+		seconds, err := strconv.ParseInt(renewDeadlineSeconds, 10, 16)
+		if err != nil {
+			setupLog.Error(err, "failed to parse renew deadline")
+			os.Exit(1)
+		}
+
+		duration := time.Second * time.Duration(seconds)
+		ctrlOpts.RenewDeadline = &duration
+	}
+
+	if retryPeriodSeconds != "" {
+		seconds, err := strconv.ParseInt(retryPeriodSeconds, 10, 16)
+		if err != nil {
+			setupLog.Error(err, "failed to parse retry period")
+			os.Exit(1)
+		}
+		duration := time.Second * time.Duration(seconds)
+		ctrlOpts.RetryPeriod = &duration
 	}
 
 	mgr, err := ctrl.NewManager(restConfig, ctrlOpts)


### PR DESCRIPTION
We add a few command-line flags to the baremetal-operator binary to configure more `ctrl.Options{}`.