### PR TITLE
🌱 E2E: Run as github workflow

### DIFF
--- a/.github/workflows/e2e-test-periodic.yml
+++ b/.github/workflows/e2e-test-periodic.yml
@@ -1,0 +1,23 @@
+name: Periodic E2E Test
+
+on:
+  schedule:
+    # Run every day at 02:20 UTC (it is recommended to avoid running at the start of the hour)
+    - cron: '20 2 * * *'
+
+permissions: {}
+
+jobs:
+  periodic-e2e-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        bmc-protocol:
+        - redfish
+        - redfish-virtualmedia
+        - ipmi
+    uses: ./.github/workflows/e2e-test.yml
+    with:
+      bmc-protocol: ${{ matrix.bmc-protocol }}
+    permissions:
+      contents: read

--- a/.github/workflows/e2e-test-pull.yaml
+++ b/.github/workflows/e2e-test-pull.yaml
@@ -1,0 +1,32 @@
+name: E2E Test
+
+on:
+  pull_request:
+    branches:
+    - 'main'
+    - 'release-*'
+    paths-ignore:
+    - '**/*.md'
+    - 'docs/**'
+    - '.gitignore'
+    - 'hack/*.sh'
+    - 'LICENSE'
+    - 'SECURITY_CONTACTS'
+    - 'DCO'
+    - 'OWNERS'
+
+permissions: {}
+
+jobs:
+  e2e-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        bmc-protocol:
+        - redfish-virtualmedia
+        - ipmi
+    uses: ./.github/workflows/e2e-test.yml
+    with:
+      bmc-protocol: ${{ matrix.bmc-protocol }}
+    permissions:
+      contents: read

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,47 @@
+name: E2E Test
+
+on:
+  workflow_call:
+    inputs:
+      bmc-protocol:
+        required: true
+        type: string
+      runner:
+        type: string
+        default: "ubuntu-latest-4-cores"
+
+permissions: {}
+
+jobs:
+  test:
+    name: e2e test
+    runs-on: ${{ inputs.runner }}
+
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
+    - name: Install libvirt
+      run: |
+          sudo apt-get update
+          sudo apt-get install -y libvirt-daemon-system qemu-kvm virt-manager
+
+    - name: Run BMO e2e Tests
+      env:
+        BMC_PROTOCOL: ${{ inputs.bmc-protocol }}
+      # We need a new shell to pick up the new group. That is why we do the sudo -s -u $USER ...
+      # Remove the pre-installed go version. We install the exact version we need.
+      run: |
+        sudo usermod -a -G libvirt $USER
+        sudo rm /usr/bin/go
+        sudo -s -u $USER bash ${{ github.workspace }}/hack/ci-e2e.sh
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      with:
+        name: artifacts-${{ inputs.bmc-protocol }}.tar.gz
+        path: test/e2e/_artifacts
+        if-no-files-found: error
+        overwrite: false

--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -48,7 +48,7 @@ export USE_EXISTING_CLUSTER="true"
 
 # Ensure requirements are installed
 "${REPO_ROOT}/hack/e2e/ensure_go.sh"
-export PATH="${PATH}:/usr/local/go/bin"
+export PATH="/usr/local/go/bin:${PATH}"
 "${REPO_ROOT}/hack/e2e/ensure_minikube.sh"
 "${REPO_ROOT}/hack/e2e/ensure_htpasswd.sh"
 # CAPI test framework uses kubectl in the background
@@ -155,10 +155,10 @@ popd
 BMO_OVERLAYS=("${REPO_ROOT}/config/overlays/e2e" "${REPO_ROOT}/config/overlays/e2e-release-0.4" "${REPO_ROOT}/config/overlays/e2e-release-0.5" "${REPO_ROOT}/config/overlays/e2e-release-0.6")
 IRONIC_OVERLAYS=("${REPO_ROOT}/ironic-deployment/overlays/e2e" "${REPO_ROOT}/ironic-deployment/overlays/e2e-with-inspector" "${REPO_ROOT}/ironic-deployment/overlays/e2e-release-24.0-with-inspector" "${REPO_ROOT}/ironic-deployment/overlays/e2e-release-24.1")
 
-IRONIC_USERNAME="$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 12 | head -n 1)"
-IRONIC_PASSWORD="$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 12 | head -n 1)"
-IRONIC_INSPECTOR_USERNAME="$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 12 | head -n 1)"
-IRONIC_INSPECTOR_PASSWORD="$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 12 | head -n 1)"
+IRONIC_USERNAME="$(uuidgen)"
+IRONIC_PASSWORD="$(uuidgen)"
+IRONIC_INSPECTOR_USERNAME="$(uuidgen)"
+IRONIC_INSPECTOR_PASSWORD="$(uuidgen)"
 
 # These must be exported so that envsubst can pick them up below
 export IRONIC_USERNAME
@@ -182,7 +182,7 @@ for overlay in "${IRONIC_OVERLAYS[@]}"; do
   "${overlay}/ironic-auth-config"
   if [[ "${overlay}" =~ -with-inspector ]]; then
     IRONIC_INSPECTOR_AUTH_CONFIG_TPL="/tmp/ironic-inspector-auth-config-tpl"
-    curl -o "${IRONIC_INSPECTOR_AUTH_CONFIG_TPL}" https://raw.githubusercontent.com/metal3-io/baremetal-operator/release-0.5/ironic-deployment/components/basic-auth/ironic-inspector-auth-config-tpl 
+    curl -o "${IRONIC_INSPECTOR_AUTH_CONFIG_TPL}" https://raw.githubusercontent.com/metal3-io/baremetal-operator/release-0.5/ironic-deployment/components/basic-auth/ironic-inspector-auth-config-tpl
     envsubst < "${IRONIC_INSPECTOR_AUTH_CONFIG_TPL}" > \
       "${overlay}/ironic-inspector-auth-config"
     echo "INSPECTOR_HTPASSWD=$(htpasswd -n -b -B "${IRONIC_INSPECTOR_USERNAME}" \

--- a/hack/e2e/ensure_go.sh
+++ b/hack/e2e/ensure_go.sh
@@ -13,7 +13,7 @@ verify_go_version()
             echo 'go not found, installing'
             curl -sLo "/tmp/${MINIMUM_GO_VERSION}.linux-amd64.tar.gz" "https://go.dev/dl/${MINIMUM_GO_VERSION}.linux-amd64.tar.gz"
             sudo tar -C /usr/local -xzf "/tmp/${MINIMUM_GO_VERSION}.linux-amd64.tar.gz"
-            export PATH=$PATH:/usr/local/go/bin
+            export PATH=/usr/local/go/bin:$PATH
         else
             echo "Missing required binary in path: go"
             return 2


### PR DESCRIPTION
**What this PR does / why we need it**:

Run the E2E tests as github workflows. This adds one reusable workflow (test-e2e.yml) that can be called by other workflows, in this PR test-e2e-pull.yml and test-e2e-periodic.yml. This way we avoid duplication and can have different configuration for pull requests and periodics.

- test-e2e-periodic.yml runs the e2e suite for redfish, redfish-virtualmedia and ipmi
- test-e2e-pull.yml runs the e2e suite for redfish-virtualmedia and ipmi

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
