### PR TITLE
🌱 add OWNERS_ALIASES support

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,28 +1,20 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
- - dtantsur
- - honza
- - kashifest
- - lentzi90
- - zaneb
+- baremetal-operator-maintainers
 
 reviewers:
- - elfosardo
- - mquhuy
- - Rozzii
- - s3rj1k
- - tuminoid
- - zhouhao3
+- baremetal-operator-maintainers
+- baremetal-operator-reviewers
 
 emeritus_approvers:
- - andfasano
- - fmuyassarov
- - hardys
- - maelk
+- andfasano
+- fmuyassarov
+- hardys
+- maelk
 
 emeritus_reviewers:
- - ardaguclu
- - bfournie
- - dukov
- - furkatgofurov7
+- ardaguclu
+- bfournie
+- dukov
+- furkatgofurov7

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,17 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  baremetal-operator-maintainers:
+  - dtantsur
+  - honza
+  - kashifest
+  - lentzi90
+  - zaneb
+
+  baremetal-operator-reviewers:
+  - elfosardo
+  - mquhuy
+  - Rozzii
+  - s3rj1k
+  - tuminoid
+  - zhouhao3


### PR DESCRIPTION
OWNERS_ALIASES groups are needed for fair blunderbuss review requests, allowing approvers also to be requested and not only reviewers.
