### PR TITLE
:seedling: Export BuildKustomizeManifest and GetKubeconfigPath functions in E2E

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -145,7 +145,7 @@ func WaitForBmhInPowerState(ctx context.Context, input WaitForBmhInPowerStateInp
 	}, intervals...).Should(Succeed())
 }
 
-func buildKustomizeManifest(source string) ([]byte, error) {
+func BuildKustomizeManifest(source string) ([]byte, error) {
 	kustomizer := krusty.MakeKustomizer(krusty.MakeDefaultOptions())
 	fSys := filesys.MakeFsOnDisk()
 	resources, err := kustomizer.Run(fSys, source)
@@ -332,7 +332,7 @@ func BuildAndApplyKustomization(ctx context.Context, input *BuildAndApplyKustomi
 	var err error
 	kustomization := input.Kustomization
 	clusterProxy := input.ClusterProxy
-	manifest, err := buildKustomizeManifest(kustomization)
+	manifest, err := BuildKustomizeManifest(kustomization)
 	if err != nil {
 		return err
 	}
@@ -411,7 +411,7 @@ func KubectlDelete(ctx context.Context, kubeconfigPath string, resources []byte,
 // BuildAndRemoveKustomization builds the provided kustomization to resources and removes them from the cluster
 // provided by clusterProxy.
 func BuildAndRemoveKustomization(ctx context.Context, kustomization string, clusterProxy framework.ClusterProxy) error {
-	manifest, err := buildKustomizeManifest(kustomization)
+	manifest, err := BuildKustomizeManifest(kustomization)
 	if err != nil {
 		return err
 	}
@@ -450,4 +450,13 @@ func FlakeAttempt(attempts int, f func() error) error {
 		Logf("Attempt %d failed: %v", i+1, err)
 	}
 	return err
+}
+
+// GetKubeconfigPath returns the path to the kubeconfig file.
+func GetKubeconfigPath() string {
+	kubeconfigPath := os.Getenv("KUBECONFIG")
+	if kubeconfigPath == "" {
+		kubeconfigPath = os.Getenv("HOME") + "/.kube/config"
+	}
+	return kubeconfigPath
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -80,10 +80,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	var kubeconfigPath string
 
 	if useExistingCluster {
-		kubeconfigPath = os.Getenv("KUBECONFIG")
-		if kubeconfigPath == "" {
-			kubeconfigPath = os.Getenv("HOME") + "/.kube/config"
-		}
+		kubeconfigPath = GetKubeconfigPath()
 	} else {
 		clusterProvider = bootstrap.CreateKindBootstrapClusterAndLoadImages(ctx, bootstrap.CreateKindBootstrapClusterAndLoadImagesInput{
 			Name:   "bmo-e2e",

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -358,10 +357,7 @@ var _ = Describe("Upgrade", Label("optional", "upgrade"), func() {
 		upgradeClusterName := "bmo-e2e-upgrade"
 
 		if useExistingCluster {
-			kubeconfigPath = os.Getenv("KUBECONFIG")
-			if kubeconfigPath == "" {
-				kubeconfigPath = os.Getenv("HOME") + "/.kube/config"
-			}
+			kubeconfigPath = GetKubeconfigPath()
 		} else {
 			By("Creating a separate cluster for upgrade tests")
 			upgradeClusterName = fmt.Sprintf("bmo-e2e-upgrade-%d", GinkgoParallelProcess())


### PR DESCRIPTION
These functions are useful and can be used in other packages as well. For e.g. https://github.com/metal3-io/baremetal-operator/pull/1669
