### PR TITLE
🌱 Add issue templates for flaky/failing tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/failing-test.yaml
+++ b/.github/ISSUE_TEMPLATE/failing-test.yaml
@@ -1,0 +1,48 @@
+name: Failing Test
+description: Report continuously failing tests or jobs in Metal3 CI
+body:
+  - type: textarea
+    id: jobs
+    attributes:
+      label: Which jobs are failing?
+      placeholder: |
+        Please only use this template for submitting reports about continuously failing tests or jobs in Metal3 CI.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tests
+    attributes:
+      label: Which tests are failing?
+    validations:
+      required: true
+
+  - type: textarea
+    id: since
+    attributes:
+      label: Since when has it been failing?
+    validations:
+      required: true
+
+  - type: input
+    id: Jenkins
+    attributes:
+      label: Jenkins link
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: Reason for failure (if possible)
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else we need to know?
+
+  - type: textarea
+    id: templateLabel
+    attributes:
+      label: Label(s) to be applied
+      value: |
+        /kind failing-test
+        One or more /area label. See https://github.com/metal3-io/baremetal-operator/labels for the list of labels.

--- a/.github/ISSUE_TEMPLATE/flaking-test.yaml
+++ b/.github/ISSUE_TEMPLATE/flaking-test.yaml
@@ -1,0 +1,48 @@
+name: Flaking Test
+description: Report flaky tests or jobs in Metal3 CI
+body:
+  - type: textarea
+    id: jobs
+    attributes:
+      label: Which jobs are flaking?
+      description: |
+        Please only use this template for submitting reports about flaky tests or jobs (pass or fail with no underlying change in code) in Metal3 CI.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tests
+    attributes:
+      label: Which tests are flaking?
+    validations:
+      required: true
+
+  - type: textarea
+    id: since
+    attributes:
+      label: Since when has it been flaking?
+    validations:
+      required: true
+
+  - type: input
+    id: Jenkins
+    attributes:
+      label: Jenkins link
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: Reason for failure (if possible)
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else we need to know?
+
+  - type: textarea
+    id: templateLabel
+    attributes:
+      label: Label(s) to be applied
+      value: |
+        /kind flake
+        One or more /area label. See https://github.com/metal3-io/baremetal-operator/labels for the list of labels.


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds issue templates for failing and flaky tests, consistent with what we have in CAPM3 already.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
