### PR TITLE
🌱 Upload artifacts from fixture tests

### DIFF
--- a/.github/workflows/e2e-fixture-test.yml
+++ b/.github/workflows/e2e-fixture-test.yml
@@ -39,3 +39,11 @@ jobs:
         USE_EXISTING_CLUSTER: "false"
         GINKGO_NODES: 1
       run: make test-e2e
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      with:
+        name: artifacts.tar.gz
+        path: test/e2e/_artifacts
+        if-no-files-found: error
+        overwrite: false


### PR DESCRIPTION
**What this PR does / why we need it**:

This improves the github workflow for fixture tests by uploading the artifacts, similar to what we already have for jenkins jobs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
