### PR TITLE
🌱 shellcheck only files

### DIFF
--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -7,7 +7,7 @@ CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
   TOP_DIR="${1:-.}"
-  find "${TOP_DIR}" \( -path ./vendor -prune \) -o -name '*.sh' -exec shellcheck -s bash {} \+
+  find "${TOP_DIR}" -path ./vendor -prune -o -name '*.sh' -type f -exec shellcheck -s bash {} \+
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \


### PR DESCRIPTION
Make shellcheck consider only files.

If branch name ended with .sh or .sh/something, it was found on the filesystem as something ending with .sh, and shellcheck picked it up, and linting failed obviously.
