### PR TITLE
WIP :bug: pin custom metal3-io ipa

### DIFF
--- a/ironic-deployment/default/ironic_bmo_configmap.env
+++ b/ironic-deployment/default/ironic_bmo_configmap.env
@@ -8,3 +8,6 @@ CACHEURL=http://172.22.0.1/images
 IRONIC_KERNEL_PARAMS=console=ttyS0
 IRONIC_INSPECTOR_VLAN_INTERFACES=all
 USE_IRONIC_INSPECTOR=false
+IPA_BASEURI="https://artifactory.nordix.org/artifactory/metal3/images/ipa/pinned/centos/9-stream/20240603T0409Z-422b194/"
+IPA_BRANCH="master"
+IPA_FLAVOR="centos9"


### PR DESCRIPTION
This commit:
 - Pins the version of the IPA used on the 0.6 branch of BMO