### PR TITLE
🌱 Fix Set image tag for release branches and tags

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -57,7 +57,10 @@ or if using existing repository, verify your intended remote is set to
   `git push origin release-0.x` to create it
 - If creating a new patch release, use existing branch `release-0.x`:
   `git checkout origin/release-0.x`
-
+- Before creating the release tag, update the image tag in the manifests to match the release version. Run the following command, replacing `<RELEASE_TAG>` with the appropriate tag.
+```bash
+make set-manifest-image-bmo TAG=<RELEASE_TAG> 
+```
 ### Tags
 
 First we create a primary release tag, that triggers release note creation and

--- a/hack/verify-release.sh
+++ b/hack/verify-release.sh
@@ -193,6 +193,34 @@ _version_check()
     [[ "${min_version}" == $(echo -e "${min_version}\n${version}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]
 }
 
+check_image_tag() {
+    if [ -z "$1" ]; then
+        echo "Error: No image tag provided"
+        exit 1
+    fi
+    TAG=$1
+    MANIFEST_FILES=$(find template -type f -name '*.yaml')
+    ERROR=0
+
+    echo "Checking the image tag :TAG"
+
+    for FILE in $MANIFEST_FILES; do
+        if ! grep -q "image: .*/baremetal-operator:$TAG" "$FILE"; then
+            echo "Error: Image tag in $FILE is not set to $TAG"
+            ERROR=1
+        fi
+    done
+
+    if [ $ERROR -ne 0 ]; then
+        echo "Image tag verification failed!"
+        exit 1
+    else
+        echo "Image tag verification passed."
+    fi
+
+    echo -e "Done\n"
+}
+
 check_tools()
 {
     # check that all tools are present, and pass version check too
@@ -677,6 +705,7 @@ check_tools
 detect_remote
 check_input
 check_tag
+check_image_tag
 
 # post-tag verifications
 if [[ -n "${TAG_EXISTS}" ]]; then


### PR DESCRIPTION
✨ 

**What this PR does / why we need it**:
This PR solves image tags, by adding a verification check and also setting the tag automatically 

**Which issue(s) this PR fixes
Fixes #1722
