### PR TITLE
🐛 fix htpasswd generation in run_local_ironic.sh

### DIFF
--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -173,7 +173,7 @@ IRONIC_HTPASSWD_FILE="${IRONIC_DATA_DIR}/auth/ironic-htpasswd"
 IRONIC_HTPASSWD_MOUNT=""
 set +x
 if [ -n "$IRONIC_USERNAME" ]; then
-     "$(htpasswd -n -b -B "${IRONIC_USERNAME}" "${IRONIC_PASSWORD}")" > "${IRONIC_HTPASSWD_FILE}"
+     htpasswd -n -b -B "${IRONIC_USERNAME}" "${IRONIC_PASSWORD}" > "${IRONIC_HTPASSWD_FILE}"
      IRONIC_HTPASSWD_MOUNT="-v ${IRONIC_HTPASSWD_FILE}:/auth/ironic/htpasswd"
 fi
 set -x


### PR DESCRIPTION
It tries to execute the htpasswd string instead of redirecting it to file, thanks to extra subshell `"$( ... )"`. Removed.

https://jenkins.nordix.org/blue/organizations/jenkins/metal3-dev-env-integration-test-ubuntu-main/detail/metal3-dev-env-integration-test-ubuntu-main/21/pipeline/

```console
[2024-06-11T06:57:16.454Z] /home/metal3ci/go/src/github.com/metal3-io/baremetal-operator/tools/run_local_ironic.sh: line 176: YC76iK4sKn42:$2y$05$DPXYNTSnqeIG9RGFEREgd.we9gOOlFbnsKQPnAPlF2lSzzCotRM6C: command not found
[2024-06-11T06:57:16.454Z] make: *** [Makefile:12: launch_mgmt_cluster] Error 127
```
