### PR TITLE
:bug: Fix incorrect htpasswd file generation

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -148,7 +148,7 @@ if [[ "${DEPLOY_BASIC_AUTH}" == "true" ]]; then
     fi
 
     if [[ "${DEPLOY_IRONIC}" == "true" ]]; then
-        echo "IRONIC_HTPASSWD=$(htpasswd -n -b -B "${IRONIC_USERNAME}" "${IRONIC_PASSWORD}")" > \
+        htpasswd -n -b -B "${IRONIC_USERNAME}" "${IRONIC_PASSWORD}" > \
         "${TEMP_IRONIC_OVERLAY}/ironic-htpasswd"
     fi
 fi


### PR DESCRIPTION
This commit:
  - removes the unnecessary parts of the htpasswd file generation and clears up the content of the file

The reason:
   - The original command was designed to generate an env variable but the new ironic-image logic expects the content  to be suitable for a htpasswd file this the variable name and the "=" is not needed.

Fixes: #1785