### PR TITLE
🌱 limit running BMO e2e periodics to metal3-io repo

### DIFF
--- a/.github/workflows/e2e-test-optional-periodic-release-0.5.yml
+++ b/.github/workflows/e2e-test-optional-periodic-release-0.5.yml
@@ -2,13 +2,14 @@ name: Periodic E2E Test Optional release-0.5
 
 on:
   schedule:
-    # Run every day at 05:20 UTC (it is recommended to avoid running at the start of the hour)
-    - cron: '20 5 * * *'
+  # Run every day at 05:20 UTC (it is recommended to avoid running at the start of the hour)
+  - cron: '20 5 * * *'
 
 permissions: {}
 
 jobs:
   periodic-e2e-test-optional:
+    if: github.repository == 'metal3-io/baremetal-operator'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-test-optional-periodic-release-0.6.yml
+++ b/.github/workflows/e2e-test-optional-periodic-release-0.6.yml
@@ -2,13 +2,14 @@ name: Periodic E2E Test Optional release-0.6
 
 on:
   schedule:
-    # Run every day at 04:50 UTC (it is recommended to avoid running at the start of the hour)
-    - cron: '50 4 * * *'
+  # Run every day at 04:50 UTC (it is recommended to avoid running at the start of the hour)
+  - cron: '50 4 * * *'
 
 permissions: {}
 
 jobs:
   periodic-e2e-test-optional:
+    if: github.repository == 'metal3-io/baremetal-operator'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-test-optional-periodic.yml
+++ b/.github/workflows/e2e-test-optional-periodic.yml
@@ -2,13 +2,14 @@ name: Periodic E2E Test Optional
 
 on:
   schedule:
-    # Run every day at 04:20 UTC (it is recommended to avoid running at the start of the hour)
-    - cron: '20 4 * * *'
+  # Run every day at 04:20 UTC (it is recommended to avoid running at the start of the hour)
+  - cron: '20 4 * * *'
 
 permissions: {}
 
 jobs:
   periodic-e2e-test-optional:
+    if: github.repository == 'metal3-io/baremetal-operator'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-test-periodic-main.yml
+++ b/.github/workflows/e2e-test-periodic-main.yml
@@ -2,13 +2,14 @@ name: Periodic E2E Test
 
 on:
   schedule:
-    # Run every day at 02:20 UTC (it is recommended to avoid running at the start of the hour)
-    - cron: '20 2 * * *'
+  # Run every day at 02:20 UTC (it is recommended to avoid running at the start of the hour)
+  - cron: '20 2 * * *'
 
 permissions: {}
 
 jobs:
   periodic-e2e-test:
+    if: github.repository == 'metal3-io/baremetal-operator'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-test-periodic-release-0.5.yml
+++ b/.github/workflows/e2e-test-periodic-release-0.5.yml
@@ -2,13 +2,14 @@ name: Periodic E2E Test release-0.5
 
 on:
   schedule:
-    # Run every day at 03:20 UTC (it is recommended to avoid running at the start of the hour)
-    - cron: '20 3 * * *'
+  # Run every day at 03:20 UTC (it is recommended to avoid running at the start of the hour)
+  - cron: '20 3 * * *'
 
 permissions: {}
 
 jobs:
   periodic-e2e-test:
+    if: github.repository == 'metal3-io/baremetal-operator'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-test-periodic-release-0.6.yml
+++ b/.github/workflows/e2e-test-periodic-release-0.6.yml
@@ -2,13 +2,14 @@ name: Periodic E2E Test release-0.6
 
 on:
   schedule:
-    # Run every day at 02:50 UTC (it is recommended to avoid running at the start of the hour)
-    - cron: '50 2 * * *'
+  # Run every day at 02:50 UTC (it is recommended to avoid running at the start of the hour)
+  - cron: '50 2 * * *'
 
 permissions: {}
 
 jobs:
   periodic-e2e-test:
+    if: github.repository == 'metal3-io/baremetal-operator'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Otherwise workflows try to run on forks as well, which might not have CNCF (or any matching runners) and they would just keep scheduling and eventually after 30 hours get cancelled and maintainers get spammed.
