### PR TITLE
:seedling: Always upload test artifacts, even if the tests fail

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -45,6 +45,7 @@ jobs:
         sudo -s -u $USER --preserve-env bash ${{ github.workspace }}/hack/ci-e2e.sh
 
     - name: Upload artifacts
+      if: ${{ !cancelled() }}
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: artifacts-${{ inputs.bmc-protocol }}.tar.gz


### PR DESCRIPTION
By default, if a step in github action fails, the subsequent steps won't be run. This is not ideal in case of running e2e tests, as we would like the tests artifacts to be uploaded, even if the tests fail.

This PR enables test artifacts upload for failed tests.