### PR TITLE
:seedling: Use basic-checks image in generate and gomod tests

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -32,6 +32,7 @@ else
         --volume "${PWD}:${WORKDIR}:rw,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        docker.io/golang:1.22 \
+        quay.io/metal3-io/basic-checks:golang-1.22 \
+        --pull=always \
         "${WORKDIR}"/hack/generate.sh "$@"
 fi

--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -41,6 +41,7 @@ else
         --volume "${PWD}:{WORKDIR}:ro,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        docker.io/golang:1.22 \
+        quay.io/metal3-io/basic-checks:golang-1.22 \
+        --pull=always \
         "${WORKDIR}"/hack/gomod.sh "$@"
 fi


### PR DESCRIPTION
As a continuation of https://github.com/metal3-io/project-infra/pull/797, we use basic-checks image in local tests too for BMO.
