### PR TITLE
:seedling: E2E: Remove gomega in LoadBMCConfig()

### DIFF
--- a/test/e2e/bmc.go
+++ b/test/e2e/bmc.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"os"
 
-	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
 )
 
@@ -28,10 +27,14 @@ type BMC struct {
 	SSHPort string `yaml:"sshPort,omitempty"`
 }
 
-func LoadBMCConfig(configPath string) *[]BMC {
+func LoadBMCConfig(configPath string) (*[]BMC, error) {
 	configData, err := os.ReadFile(configPath) //#nosec
-	Expect(err).ToNot(HaveOccurred(), "Failed to read the bmcs config file")
 	var bmcs []BMC
-	Expect(yaml.Unmarshal(configData, &bmcs)).To(Succeed())
-	return &bmcs
+	if err != nil {
+		return nil, err
+	}
+	if err := yaml.Unmarshal(configData, &bmcs); err != nil {
+		return nil, err
+	}
+	return &bmcs, nil
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -170,7 +170,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	err := metal3api.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 	e2eConfig = LoadE2EConfig(configPath)
-	bmcs = LoadBMCConfig(bmcConfigPath)
+	bmcs, err := LoadBMCConfig(bmcConfigPath)
+	Expect(err).ToNot(HaveOccurred(), "Failed to read the bmcs config file")
 	bmc = (*bmcs)[GinkgoParallelProcess()-1]
 	clusterProxy = framework.NewClusterProxy("bmo-e2e", kubeconfigPath, scheme)
 })


### PR DESCRIPTION
A minor PR to not use gomega's `Expect()` in `LoadBMCConfig()`.

Reason: Using `Expect()` inside the function prevents reusage of the function in locations where ginkgo is not in use (e.g. https://github.com/metal3-io/baremetal-operator/pull/1767). This inclusion is unnecessary anyway, and `Expect()` should be located in the e2e suite.
