### PR TITLE
🌱 schedule dependabot on certain day, and add ok-to-test automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,13 @@ updates:
   directory: "/" # Location of package manifests
   schedule:
     interval: "monthly"
+    day: "saturday"
   target-branch: main
   commit-message:
     prefix: ":seedling:"
-    # Go
+  labels:
+  - "ok-to-test"
+  # Go
 - package-ecosystem: "gomod"
   directories:
   - "/"
@@ -21,6 +24,7 @@ updates:
   - "/test"
   schedule:
     interval: "weekly"
+    day: "sunday"
   target-branch: main
   groups:
     kubernetes:
@@ -36,19 +40,25 @@ updates:
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   commit-message:
     prefix: ":seedling:"
+  labels:
+  - "ok-to-test"
 ## Main branch config ends here
 ## release-0.6  branch config starts here
 - package-ecosystem: "github-actions"
   directory: "/" # Location of package manifests
   schedule:
     interval: "monthly"
+    day: "saturday"
   target-branch: release-0.6
-  commit-message:
-    prefix: ":seedling:"
   ignore:
   # Ignore major and minor bumps for release branch
   - dependency-name: "*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+  - "ok-to-test"
+  # Go
 - package-ecosystem: "gomod"
   directories:
   - "/"
@@ -58,6 +68,7 @@ updates:
   - "/test"
   schedule:
     interval: "weekly"
+    day: "sunday"
   target-branch: release-0.6
   groups:
     kubernetes:
@@ -70,19 +81,25 @@ updates:
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   commit-message:
     prefix: ":seedling:"
+  labels:
+  - "ok-to-test"
 ## release-0.6 branch config ends here
 ## release-0.5  branch config starts here
 - package-ecosystem: "github-actions"
   directory: "/" # Location of package manifests
   schedule:
     interval: "monthly"
+    day: "saturday"
   target-branch: release-0.5
-  commit-message:
-    prefix: ":seedling:"
   ignore:
   # Ignore major and minor bumps for release branch
   - dependency-name: "*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+  - "ok-to-test"
+  # Go
 - package-ecosystem: "gomod"
   directories:
   - "/"
@@ -92,6 +109,7 @@ updates:
   - "/test"
   schedule:
     interval: "weekly"
+    day: "sunday"
   target-branch: release-0.5
   groups:
     kubernetes:
@@ -104,4 +122,6 @@ updates:
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   commit-message:
     prefix: ":seedling:"
+  labels:
+  - "ok-to-test"
 ## release-0.5 branch config ends here


### PR DESCRIPTION
BMO schedule:
- GH actions: saturday
- Gomod: sunday

Automatically add labels:
- ok-to-test

We have dynamic Prow scheduling now and proper requests, we should not suffer from load failures in very basic tests anymore. BMO is scheduled for weekend as it automatically runs BMO e2e etc, which are bit more heavy than the Prow-only linters in CAPM3/IPAM. Also it means they are tested by Monday morning to easier merging.

Fix some formatting and move blocks around so they're consistent with release branches.
