### PR TITLE
🌱 Do not mark hardwareProfile as required in the status

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -780,7 +780,8 @@ type BareMetalHostStatus struct {
 	LastUpdated *metav1.Time `json:"lastUpdated,omitempty"`
 
 	// The name of the profile matching the hardware details.
-	HardwareProfile string `json:"hardwareProfile"`
+	// Hardware profiles are deprecated and should not be relied on.
+	HardwareProfile string `json:"hardwareProfile,omitempty"`
 
 	// The hardware discovered to exist on the host.
 	HardwareDetails *HardwareDetails `json:"hardware,omitempty"`

--- a/config/base/crds/bases/metal3.io_baremetalhosts.yaml
+++ b/config/base/crds/bases/metal3.io_baremetalhosts.yaml
@@ -732,6 +732,7 @@ spec:
                 type: object
               hardwareProfile:
                 description: The name of the profile matching the hardware details.
+                  Hardware profiles are deprecated and should not be relied on.
                 type: string
               lastUpdated:
                 description: LastUpdated identifies when this status was last observed.
@@ -1128,7 +1129,6 @@ spec:
             required:
             - errorCount
             - errorMessage
-            - hardwareProfile
             - operationalStatus
             - poweredOn
             - provisioning

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -732,6 +732,7 @@ spec:
                 type: object
               hardwareProfile:
                 description: The name of the profile matching the hardware details.
+                  Hardware profiles are deprecated and should not be relied on.
                 type: string
               lastUpdated:
                 description: LastUpdated identifies when this status was last observed.
@@ -1128,7 +1129,6 @@ spec:
             required:
             - errorCount
             - errorMessage
-            - hardwareProfile
             - operationalStatus
             - poweredOn
             - provisioning


### PR DESCRIPTION
It does not change anything for v1alpha1 (it is always populated)
but may send a wrong message about the field we're going to deprecate.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>