### PR TITLE
🌱 Use OwnerReference for HostFirmwareComponents

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -1794,8 +1794,8 @@ func (r *BareMetalHostReconciler) createHostFirmwareComponents(info *reconcileIn
 				Updates: []metal3api.FirmwareUpdate{}}
 
 			// Set bmh as owner, this makes sure the resource is deleted when bmh is deleted
-			if err = controllerutil.SetControllerReference(info.host, hfc, r.Scheme()); err != nil {
-				return errors.Wrap(err, "could not set bmh as controller for hostFirmwareComponents")
+			if err = controllerutil.SetOwnerReference(info.host, hfc, r.Scheme()); err != nil {
+				return errors.Wrap(err, "could not set bmh as owner for hostFirmwareComponents")
 			}
 			if err = r.Create(info.ctx, hfc); err != nil {
 				return errors.Wrap(err, "failure creating hostFirmwareComponents resource")
@@ -1810,8 +1810,8 @@ func (r *BareMetalHostReconciler) createHostFirmwareComponents(info *reconcileIn
 	// Necessary in case the CRD is created manually.
 
 	if !ownerReferenceExists(info.host, hfc) {
-		if err := controllerutil.SetControllerReference(info.host, hfc, r.Scheme()); err != nil {
-			return errors.Wrap(err, "could not set bmh as controller for hostFirmwareComponents")
+		if err := controllerutil.SetOwnerReference(info.host, hfc, r.Scheme()); err != nil {
+			return errors.Wrap(err, "could not set bmh as owner for hostFirmwareComponents")
 		}
 		if err := r.Update(info.ctx, hfc); err != nil {
 			return errors.Wrap(err, "failure updating hostFirmwareComponents resource")


### PR DESCRIPTION
We shouldn't set controller reference for HostFirmwareComponents, since they are to solve a problem with ReplicaSet and Pod that doesn't exist here, see [1]

[1] https://github.com/kubernetes/design-proposals-archive/blob/acc25e14ca83dfda4f66d8cb1f1b491f26e78ffe/api-machinery/controller-ref.md


**What this PR does / why we need it**: https://github.com/metal3-io/baremetal-operator/pull/1793#discussion_r1665123646
