### PR TITLE
🌱 Bump golang to 1.22 in release 0.6

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Install go
       uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
       with:
-        go-version: '1.21'
+        go-version: '1.22'
     - name: Generate release notes
       run: |
         make release-notes

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -45,7 +45,7 @@ linters:
 
 linters-settings:
   gosec:
-    go: "1.21"
+    go: "1.22"
     severity: medium
     confidence: medium
     concurrency: 8
@@ -76,9 +76,9 @@ linters-settings:
     allow-leading-space: false
     require-specific: true
   staticcheck:
-    go: "1.21"
+    go: "1.22"
   stylecheck:
-    go: "1.21"
+    go: "1.22"
   gocritic:
     enabled-tags:
     - experimental
@@ -97,7 +97,7 @@ linters-settings:
     - whyNoLint
     - wrapperFunc
   unused:
-    go: "1.21"
+    go: "1.22"
 issues:
   exclude-rules:
   - path: test/e2e

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.21.11@sha256:a8edec58ba598e2f1259f4ec4ca1b06358468214225e73d7c841ab0980c12367
+ARG BUILD_IMAGE=docker.io/golang:1.22.5@sha256:f47a7952d08277f9816459d851319c9041637022f04517388d9f32e384fc2dab
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ RUN_NAMESPACE = metal3
 GO_TEST_FLAGS = $(TEST_FLAGS)
 DEBUG = --debug
 COVER_PROFILE = cover.out
-GO_VERSION ?= 1.21.11
+GO_VERSION ?= 1.22.5
 
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -61,7 +61,7 @@ def validate_auth():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.21 as tilt-helper
+FROM golang:1.22 as tilt-helper
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \

--- a/hack/e2e/ensure_go.sh
+++ b/hack/e2e/ensure_go.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-MINIMUM_GO_VERSION=go1.21.11
+MINIMUM_GO_VERSION=go1.22.5
 
 # Ensure the go tool exists and is a viable version, or installs it
 verify_go_version()

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -31,6 +31,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/baremetal-operator:rw,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/baremetal-operator \
-    docker.io/golang:1.21 \
+    docker.io/golang:1.22 \
     /go/src/github.com/metal3-io/baremetal-operator/hack/generate.sh "${@}"
 fi;

--- a/hack/golint.sh
+++ b/hack/golint.sh
@@ -15,6 +15,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/baremetal-operator:rw,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/baremetal-operator \
-    docker.io/golang:1.21 \
+    docker.io/golang:1.22 \
     /go/src/github.com/metal3-io/baremetal-operator/hack/golint.sh "${@}"
 fi;

--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -39,6 +39,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.21 \
+        docker.io/golang:1.22 \
         /workdir/hack/gomod.sh "$@"
 fi

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -24,6 +24,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/baremetal-operator:rw,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/baremetal-operator \
-    docker.io/golang:1.21 \
+    docker.io/golang:1.22 \
     /go/src/github.com/metal3-io/baremetal-operator/hack/unit.sh "${@}"
 fi;


### PR DESCRIPTION
This is done since golang 1.21 is deprecating in August 2024

Fixes #1803