### PR TITLE
🐛 Fix HFC Status

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -1161,6 +1161,10 @@ func (r *BareMetalHostReconciler) actionPreparing(prov provisioner.Provisioner, 
 			info.log.Info("handling cleaning error in controller")
 			clearHostProvisioningSettings(info.host)
 		}
+		if hfcDirty {
+			info.log.Info("handling cleaning error during firmware update")
+			hfc.Status.Updates = nil
+		}
 		return recordActionFailure(info, metal3api.PreparationError, provResult.ErrorMessage)
 	}
 
@@ -1764,9 +1768,7 @@ func (r *BareMetalHostReconciler) saveHostFirmwareComponents(prov provisioner.Pr
 	info.log.Info("saving hostFirmwareComponents information", "spec updates", hfc.Spec.Updates, "status updates", hfc.Status.Updates)
 
 	hfc.Status.Updates = make([]metal3api.FirmwareUpdate, len(hfc.Spec.Updates))
-	for i := range hfc.Spec.Updates {
-		hfc.Spec.Updates[i].DeepCopyInto(&hfc.Status.Updates[i])
-	}
+	hfc.Status.Updates = hfc.Spec.Updates
 
 	// Retrieve new information about the firmware components stored in ironic
 	components, err := prov.GetFirmwareComponents()
@@ -1902,8 +1904,8 @@ func (r *BareMetalHostReconciler) getHostFirmwareComponents(info *reconcileInfo)
 		return false, nil, nil
 	}
 
-	// Check if there are Updates in the Spec that are different than the Status
-	if meta.IsStatusConditionTrue(hfc.Status.Conditions, string(metal3api.HostFirmwareComponentsChangeDetected)) {
+	// Check if the condition matches the current Generation to know if the data is not out of date.
+	if readyCond := meta.FindStatusCondition(hfc.Status.Conditions, string(metal3api.HostFirmwareComponentsChangeDetected)); readyCond != nil && readyCond.Status == metav1.ConditionTrue && readyCond.ObservedGeneration == hfc.Generation {
 		if meta.IsStatusConditionTrue(hfc.Status.Conditions, string(metal3api.HostFirmwareComponentsValid)) {
 			info.log.Info("hostFirmwareComponents indicating ChangeDetected", "namespacename", info.request.NamespacedName)
 			return true, hfc, nil

--- a/controllers/metal3.io/hostfirmwarecomponents_controller.go
+++ b/controllers/metal3.io/hostfirmwarecomponents_controller.go
@@ -192,6 +192,8 @@ func (r *HostFirmwareComponentsReconciler) updateHostFirmware(info *rhfcInfo, co
 	generation := info.hfc.GetGeneration()
 
 	newStatus := info.hfc.Status.DeepCopy()
+	// Check if there is mismatch between ironic information for components and Status.
+	componentInfoMismatch := !reflect.DeepEqual(info.hfc.Status.Components, components)
 	newStatus.Components = components
 
 	if updatesMismatch {
@@ -216,6 +218,10 @@ func (r *HostFirmwareComponentsReconciler) updateHostFirmware(info *rhfcInfo, co
 		if setUpdatesCondition(generation, newStatus, info, metal3api.HostFirmwareComponentsChangeDetected, metav1.ConditionFalse, reason, "") {
 			dirty = true
 		}
+	}
+
+	if componentInfoMismatch {
+		dirty = true
 	}
 
 	// Update Status if has changed


### PR DESCRIPTION
This commit fixes the following cases for HFC:
- Status Components Information using the newer information that ironic contains.
- Clear the Status Updates in case of a failed fiirmware update, so it can retry.

Also change the condition as a follow-up to baremetal-operator#1793

**What this PR does / why we need it**: metal3-io/metal3-docs#364,

