### PR TITLE
:bug: Fix libvirt missing in dependabot build wf

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -38,6 +38,10 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+    - name: Install libvirt
+      run: |
+          sudo apt-get update
+          sudo apt-get install -y libvirt-dev
     - name: Update all modules
       run: make mod
     - name: Update generated code


### PR DESCRIPTION
Dependabot build wf is failing with `Package 'libvirt', required by 'virtual:world', not found`

For e.g. https://github.com/metal3-io/baremetal-operator/actions/runs/10205894991/job/28237655368?pr=1832

This PR should help fixing it.