### PR TITLE
🌱 fix dependabot config on api directory location

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
 - package-ecosystem: "gomod"
   directories:
   - "/"
-  - "/api"
+  - "/apis"
   - "/hack/tools"
   - "/pkg/hardwareutils"
   - "/test"
@@ -62,7 +62,7 @@ updates:
 - package-ecosystem: "gomod"
   directories:
   - "/"
-  - "/api"
+  - "/apis"
   - "/hack/tools"
   - "/pkg/hardwareutils"
   - "/test"
@@ -103,7 +103,7 @@ updates:
 - package-ecosystem: "gomod"
   directories:
   - "/"
-  - "/api"
+  - "/apis"
   - "/hack/tools"
   - "/pkg/hardwareutils"
   - "/test"


### PR DESCRIPTION
Config has mistakenly listed `/api` as a gomod ecosystem directory, but the correct directory in BMO is `/apis`.
