### PR TITLE
:seedling: Move container build to gh runner

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -1,5 +1,8 @@
 name: build-images-action
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -8,49 +11,25 @@ on:
     tags:
     - 'v*'
 
-permissions: {}
-
 jobs:
-  build:
-    name: Build container images
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-
-    if: github.repository == 'metal3-io/baremetal-operator'
-    steps:
-    - name: build bmo image
-      uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
-      with:
-        jenkins_url: "https://jenkins.nordix.org/"
-        jenkins_user: "metal3.bot@gmail.com"
-        jenkins_token: ${{ secrets.JENKINS_TOKEN }}
-        job_name: "metal3_baremetal-operator_container_image_building"
-        job_params: |
-          {
-            "BUILD_CONTAINER_IMAGE_GIT_REFERENCE": "${{ github.ref }}"
-          }
-        job_timeout: "1000"
-    - name: build keepalived image
-      uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
-      with:
-        jenkins_url: "https://jenkins.nordix.org/"
-        jenkins_user: "metal3.bot@gmail.com"
-        jenkins_token: ${{ secrets.JENKINS_TOKEN }}
-        job_name: "metal3_keepalived_container_image_building"
-        job_params: |
-          {
-            "BUILD_CONTAINER_IMAGE_GIT_REFERENCE": "${{ github.ref }}"
-          }
-        job_timeout: "1000"
-    - name: Slack Notification on Failure
-      if: ${{ failure() }}
-      uses: rtCamp/action-slack-notify@4e5fb42d249be6a45a298f3c9543b111b02f7907 # 2.3.0
-      env:
-        SLACK_TITLE: 'GitHub Action Failed in ${{ github.repository }}'
-        SLACK_COLOR: '#FF0000'
-        SLACK_MESSAGE: 'The GitHub Action workflow failed for baremetal operator image build.'
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-        SLACK_CHANNEL: metal3-github-actions-notify
-        SLACK_USERNAME: metal3-github-actions-notify
+  build_bmo:
+    name: Build BMO container image
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    with:
+      image-name: "baremetal-operator"
+      pushImage: true
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  build_keepalived:
+    name: Build keepalived container image
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    with:
+      image-name: "keepalived"
+      dockerfile-directory: resources/keepalived-docker
+      pushImage: true
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
This assumes https://github.com/metal3-io/project-infra/pull/833 was merged, and that `QUAY_IO_USERNAME` and `QUAY_IO_TOKEN` secrets exist, for pushing the image to `quay.io`.

An example of complete workflow (except for the push part):
https://github.com/metal3-io/baremetal-operator/actions/runs/10280659565/job/28448467379?pr=1861

/hold to wait for the secrets.