### PR TITLE
:bug: Resolve BMC hostname, not address

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -654,7 +654,7 @@ func setExternalURL(p *ironicProvisioner, driverInfo map[string]interface{}) map
 	ip := net.ParseIP(parsedURL.Hostname())
 	if ip == nil {
 		// Maybe it's a hostname?
-		ips, err := net.LookupIP(p.bmcAddress)
+		ips, err := net.LookupIP(parsedURL.Hostname())
 		if err != nil {
 			p.log.Info("Failed to look up the IP address for BMC hostname", "hostname", p.bmcAddress)
 			return driverInfo


### PR DESCRIPTION
The `net.LookupIP` function expects a hostname and not a full address.