### PR TITLE
:seedling: Make container build only run for metal3.io repo

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -14,9 +14,10 @@ on:
 jobs:
   build_bmo:
     name: Build BMO container image
+    if: github.repository == 'metal3-io/baremetal-operator'
     uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
     with:
-      image-name: "baremetal-operator"
+      image-name: 'baremetal-operator'
       pushImage: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
@@ -24,9 +25,10 @@ jobs:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
   build_keepalived:
     name: Build keepalived container image
+    if: github.repository == 'metal3-io/baremetal-operator'
     uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
     with:
-      image-name: "keepalived"
+      image-name: 'keepalived'
       dockerfile-directory: resources/keepalived-docker
       pushImage: true
     secrets:


### PR DESCRIPTION
The container build github workflow should be triggered only if it's running on the upstream.