### PR TITLE
🌱Add test for baremetalhost controller updateEventHandler

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
@@ -1664,6 +1665,8 @@ func TestProvisionerIsReady(t *testing.T) {
 }
 
 func TestUpdateEventHandler(t *testing.T) {
+	now := metav1.Now()
+	later := metav1.Now().Add(time.Second * 20)
 	cases := []struct {
 		name            string
 		event           event.UpdateEvent
@@ -1765,6 +1768,30 @@ func TestUpdateEventHandler(t *testing.T) {
 			},
 
 			expectedProcess: true,
+		},
+		{
+			name: "do-not-requeue-when-only-status-lastupdated-are-different",
+			event: event.UpdateEvent{
+				ObjectOld: &metal3api.BareMetalHost{ObjectMeta: metav1.ObjectMeta{
+					Generation:  0,
+					Finalizers:  []string{},
+					Annotations: map[string]string{},
+				},
+					Status: metal3api.BareMetalHostStatus{
+						LastUpdated: &metav1.Time{Time: now.Time},
+					},
+				},
+				ObjectNew: &metal3api.BareMetalHost{ObjectMeta: metav1.ObjectMeta{
+					Generation:  0,
+					Finalizers:  []string{},
+					Annotations: map[string]string{},
+				},
+					Status: metal3api.BareMetalHostStatus{
+						LastUpdated: &metav1.Time{Time: later},
+					}},
+			},
+
+			expectedProcess: false,
 		},
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

~~When using this method, the `saveHostStatus` will requeue the object and create more reconciles for the object when the only thing that has changed is the lastupdated field in the status.  This leads to multiple reconciles because this happens during each run through the reconciler.~~

This adds a test to the baremetalhost controller to validate that the saveHostStatus will not requeue the object and create more reconciles when lastUpdated is updated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
~~Fixes https://github.com/metal3-io/baremetal-operator/issues/1253~~
