### PR TITLE
✨ Prevent BMH from transitioning when an invalid BIOS setting is detected

### DIFF
--- a/controllers/metal3.io/errors.go
+++ b/controllers/metal3.io/errors.go
@@ -37,6 +37,15 @@ func (e ResolveBMCSecretRefError) Error() string {
 		e.message)
 }
 
+type ConfigurationError struct {
+	message string
+}
+
+func (e ConfigurationError) Error() string {
+	return fmt.Sprintf("User configuration error: %s",
+		e.message)
+}
+
 // NoDataInSecretError is returned when host configuration
 // data were not found in referenced secret.
 type NoDataInSecretError struct {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Currently, the installation process ignores invalid BIOS settings, which can result in a system booting without the desired configuration. This commit ensures that the process halts when an invalid BIOS setting is detected, allowing the user to correct the issue before proceeding, thereby preventing unintended configurations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
