### PR TITLE
🌱 bump cert-manager to 1.10.2

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -3,7 +3,7 @@ module github.com/metal3-io/baremetal-operator/test
 go 1.20
 
 require (
-	github.com/cert-manager/cert-manager v1.10.0
+	github.com/cert-manager/cert-manager v1.10.2
 	github.com/metal3-io/baremetal-operator/apis v0.4.2
 	github.com/metal3-io/cluster-api-provider-metal3/test v1.5.3
 	github.com/onsi/ginkgo/v2 v2.13.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -80,8 +80,8 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cert-manager/cert-manager v1.10.0 h1:qWMM2nqt3pyCVKTWoS645PORJpK5XvtE0iImk9qTPsc=
-github.com/cert-manager/cert-manager v1.10.0/go.mod h1:xKakpUDYRHgUry/DkvcCCgQDRSwVSeSXTlw7slT+AYo=
+github.com/cert-manager/cert-manager v1.10.2 h1:2/QH9C8ffeB+t8xHYsITkY2d9ulye9a5mi1F7o+MmC0=
+github.com/cert-manager/cert-manager v1.10.2/go.mod h1:v3T3yAt5ASv4/9cbO42EilLsoZDlybQrh8o6RhTw/vo=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=


### PR DESCRIPTION
Dependabot has issues bumping this for some reason in https://github.com/metal3-io/baremetal-operator/pull/1857 ,  doing it manually.
