### PR TITLE
🌱 Pinning ironic image to release-26.0 branch

### DIFF
--- a/ironic-deployment/base/ironic.yaml
+++ b/ironic-deployment/base/ironic.yaml
@@ -20,7 +20,7 @@ spec:
       hostNetwork: true
       containers:
       - name: ironic-dnsmasq
-        image: quay.io/metal3-io/ironic
+        image: quay.io/metal3-io/ironic:release-26.0
         imagePullPolicy: Always
         securityContext:
           # Must be true so dnsmasq may get the capabilities via file caps
@@ -61,7 +61,7 @@ spec:
         - configMapRef:
             name: ironic-bmo-configmap
       - name: ironic
-        image: quay.io/metal3-io/ironic
+        image: quay.io/metal3-io/ironic:release-26.0
         imagePullPolicy: Always
         command:
         - /bin/runironic
@@ -96,7 +96,7 @@ spec:
           runAsUser: 997 # ironic
           runAsGroup: 994 # ironic
       - name: ironic-log-watch
-        image: quay.io/metal3-io/ironic
+        image: quay.io/metal3-io/ironic:release-26.0
         imagePullPolicy: Always
         command:
         - /bin/runlogwatch.sh
@@ -112,7 +112,7 @@ spec:
           runAsUser: 997 # ironic
           runAsGroup: 994 # ironic
       - name: ironic-httpd
-        image: quay.io/metal3-io/ironic
+        image: quay.io/metal3-io/ironic:release-26.0
         imagePullPolicy: Always
         command:
         - /bin/runhttpd


### PR DESCRIPTION
This PR pins ironic image branch release-26 to BMO release-0.8 branch.
