### PR TITLE
🌱 Add resource dumping to e2e tests

### DIFF
--- a/test/e2e/basic_ops_test.go
+++ b/test/e2e/basic_ops_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"path"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
@@ -107,6 +108,7 @@ var _ = Describe("basic", Label("required", "basic"), func() {
 	})
 
 	AfterEach(func() {
+		DumpResources(ctx, clusterProxy, namespace.Name, path.Join(artifactFolder, specName))
 		if !skipCleanup {
 			cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
 		}

--- a/test/e2e/external_inspection_test.go
+++ b/test/e2e/external_inspection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
@@ -235,6 +236,7 @@ var _ = Describe("External Inspection", Label("required", "external-inspection")
 	})
 
 	AfterEach(func() {
+		DumpResources(ctx, clusterProxy, namespace.Name, path.Join(artifactFolder, specName))
 		if !skipCleanup {
 			cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
 		}

--- a/test/e2e/inspection_test.go
+++ b/test/e2e/inspection_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"path"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
@@ -124,6 +125,7 @@ var _ = Describe("Inspection", Label("required", "inspection"), func() {
 	})
 
 	AfterEach(func() {
+		DumpResources(ctx, clusterProxy, namespace.Name, path.Join(artifactFolder, specName))
 		if !skipCleanup {
 			cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
 		}

--- a/test/e2e/live_iso_test.go
+++ b/test/e2e/live_iso_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	metal3bmc "github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
@@ -134,6 +135,7 @@ var _ = Describe("Live-ISO", Label("required", "live-iso"), func() {
 	})
 
 	AfterEach(func() {
+		DumpResources(ctx, clusterProxy, namespace.Name, path.Join(artifactFolder, specName))
 		if !skipCleanup {
 			cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
 		}

--- a/test/e2e/provisioning_and_annotation_test.go
+++ b/test/e2e/provisioning_and_annotation_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"time"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
@@ -254,6 +255,7 @@ var _ = Describe("Provision, detach, recreate from status and deprovision", Labe
 		})
 
 		AfterEach(func() {
+			DumpResources(ctx, clusterProxy, namespace.Name, path.Join(artifactFolder, specName))
 			if !skipCleanup {
 				cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
 			}

--- a/test/e2e/re_inspection_test.go
+++ b/test/e2e/re_inspection_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"path"
 	"strings"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
@@ -105,6 +106,7 @@ var _ = Describe("Re-Inspection", Label("required", "re-inspection"), func() {
 	})
 
 	AfterEach(func() {
+		DumpResources(ctx, clusterProxy, namespace.Name, path.Join(artifactFolder, specName))
 		if !skipCleanup {
 			cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
 		}

--- a/test/go.mod
+++ b/test/go.mod
@@ -13,6 +13,7 @@ require (
 	golang.org/x/crypto v0.26.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.29.8
+	k8s.io/apiextensions-apiserver v0.29.8
 	k8s.io/apimachinery v0.29.8
 	k8s.io/klog/v2 v2.110.1
 	k8s.io/utils v0.0.0-20231127182322-b307cd553661
@@ -137,8 +138,7 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.5.0 // indirect
-	k8s.io/apiextensions-apiserver v0.29.3 // indirect
-	k8s.io/apiserver v0.29.3 // indirect
+	k8s.io/apiserver v0.29.8 // indirect
 	k8s.io/client-go v0.29.8 // indirect
 	k8s.io/cluster-bootstrap v0.29.3 // indirect
 	k8s.io/component-base v0.29.8 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -471,12 +471,12 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.29.8 h1:ZBKg9clWnIGtQ5yGhNwMw2zyyrsIAQaXhZACcYNflQE=
 k8s.io/api v0.29.8/go.mod h1:XlGIpmpzKGrtVca7GlgNryZJ19SvQdI808NN7fy1SgQ=
-k8s.io/apiextensions-apiserver v0.29.3 h1:9HF+EtZaVpFjStakF4yVufnXGPRppWFEQ87qnO91YeI=
-k8s.io/apiextensions-apiserver v0.29.3/go.mod h1:po0XiY5scnpJfFizNGo6puNU6Fq6D70UJY2Cb2KwAVc=
+k8s.io/apiextensions-apiserver v0.29.8 h1:VkyGgClTTWs8i81O13wsTLSs9Q1PWVr0L880F2GjwUI=
+k8s.io/apiextensions-apiserver v0.29.8/go.mod h1:e6dPglIfPWm9ydsXuNqefecEVDH0uLfzClJEupSk2VU=
 k8s.io/apimachinery v0.29.8 h1:uBHc9WuKiTHClIspJqtR84WNpG0aOGn45HWqxgXkk8Y=
 k8s.io/apimachinery v0.29.8/go.mod h1:i3FJVwhvSp/6n8Fl4K97PJEP8C+MM+aoDq4+ZJBf70Y=
-k8s.io/apiserver v0.29.3 h1:xR7ELlJ/BZSr2n4CnD3lfA4gzFivh0wwfNfz9L0WZcE=
-k8s.io/apiserver v0.29.3/go.mod h1:hrvXlwfRulbMbBgmWRQlFru2b/JySDpmzvQwwk4GUOs=
+k8s.io/apiserver v0.29.8 h1:A1PA+cmSPm2zevCesT+Qsc1NWeucbz88mERd5TA7Ho4=
+k8s.io/apiserver v0.29.8/go.mod h1:jrKeEcCNY0K/lVlZ4gITRVYx5L0pPxj+cOR2MHTAOo0=
 k8s.io/client-go v0.29.8 h1:QMRKcIzqE/qawknXcsi51GdIAYN8UP39S/M5KnFu/J0=
 k8s.io/client-go v0.29.8/go.mod h1:ZzrAAVrqO2jVXMb8My/jTke8n0a/mIynnA3y/1y1UB0=
 k8s.io/cluster-bootstrap v0.29.3 h1:DIMDZSN8gbFMy9CS2mAS2Iqq/fIUG783WN/1lqi5TF8=


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds custom resource collection/dumping to BMO e2e tests. The collection is done at AfterEach of each test case.

It currently collects all CRDs and related CRs, including BMHs, but adding a filter if we one need should be easy.

It also calls framework.DumpAllResources as that was mentioned in the linked issue, but that doesn't seem to do much. I'm not sure if it should be included.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This PR is related to #1383 and fulfills two of the subtasks.
