### PR TITLE
Use ubuntu-latest rather than hosted 4-core runner

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -8,7 +8,7 @@ on:
         type: string
       runner:
         type: string
-        default: "ubuntu-latest-4-cores"
+        default: "ubuntu-latest"
       ginkgo-focus:
         type: string
         default: ""


### PR DESCRIPTION
Heya! Friendly neighborhood CNCF staffer here. The ubuntu-latest runner is already a 4-core runner, so using a hosted 4-core runner is unnecessary (and actually costs money). This PR just swaps any 4-core hosted runners to use ubuntu-latest. There should be zero change or impact, functionally this is a SKU change.

Please reach out to me in the CNCF/K8s slack(s) (jeefy) or via email ([jsica@linuxfoundation.org](mailto:jsica@linuxfoundation.org)) with any questions.