### PR TITLE
:seedling: Revert "use ubuntu-latest rather than hosted 4-core runner"

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -8,7 +8,7 @@ on:
         type: string
       runner:
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-latest-4-cores"
       ginkgo-focus:
         type: string
         default: ""


### PR DESCRIPTION
This reverts commit 6aa2b8e71727c1e550e99cafe727e9b0f15dc1e0.

ubuntu-latest only has 14GB disk, while ubuntu-latest-4-cores has 140GB. Our optional e2e tests need more disk for the VM disks than ubuntu-latest can offer, hence reverting.
