### PR TITLE
:seedling: bump markdownlint-cli2 to v0.12.0

### DIFF
--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -17,6 +17,6 @@ else
         --volume "${PWD}:${WORKDIR}:ro,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        docker.io/pipelinecomponents/markdownlint-cli2:0.9.0@sha256:71370df6c967bae548b0bfd0ae313ddf44bfad87da76f88180eff55c6264098c \
+        docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0 \
         "${WORKDIR}"/hack/markdownlint.sh "$@"
 fi


### PR DESCRIPTION
Bump markdownlint-cli2 linter to v0.12.0, which contains markdownlint-cli2 tool v0.14.0, with plenty of fixes.