### PR TITLE
🌱 Add missing comment tags

### DIFF
--- a/apis/metal3.io/v1alpha1/doc.go
+++ b/apis/metal3.io/v1alpha1/doc.go
@@ -15,5 +15,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the metal3.io v1alpha1 API group
 // +kubebuilder:object:generate=true
+// +k8s:openapi-gen=true
 // +groupName=metal3.io
 package v1alpha1

--- a/apis/metal3.io/v1alpha1/doc.go
+++ b/apis/metal3.io/v1alpha1/doc.go
@@ -1,0 +1,19 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v1alpha1 contains API Schema definitions for the metal3.io v1alpha1 API group
+// +kubebuilder:object:generate=true
+// +groupName=metal3.io
+package v1alpha1

--- a/apis/metal3.io/v1alpha1/hostfirmwaresettings_types.go
+++ b/apis/metal3.io/v1alpha1/hostfirmwaresettings_types.go
@@ -48,7 +48,7 @@ type HostFirmwareSettingsSpec struct {
 
 	// Settings are the desired firmware settings stored as name/value pairs.
 	// +patchStrategy=merge
-	Settings DesiredSettingsMap `json:"settings" required:"true"`
+	Settings DesiredSettingsMap `json:"settings" patchStrategy:"merge" required:"true"`
 }
 
 // HostFirmwareSettingsStatus defines the observed state of HostFirmwareSettings.


### PR DESCRIPTION
**What this PR does / why we need it**:

- fix: add json tags to match field annotation tag `+patchStrategy`
- fix: add missing doc.go for proper groupName inference
  Most go code generators such as kube-openapi rely on gengo [[1](https://github.com/kubernetes/gengo/)] to infer the annotated tags.
  When dealing with package annotations, gengo extracts them from the doc.go file [[2](https://github.com/kubernetes/gengo/blob/2b36238f13e9b8aebe4c286c2ffb2fc71f4be3c5/types/types.go#L121-L126)].
  
  The types defined in `apis/metal3.io/v1alpha1` do have a package annotated with `+groupName`.
  However, the annotation is in the `groupversion_info.go` file instead.
  
  You can see comments that refer to this issue [[3](https://github.com/kubernetes/code-generator/issues/150#issuecomment-1773718101)] [[4](https://github.com/kubernetes/code-generator/issues/135)]
  
  [1] https://github.com/kubernetes/gengo/
  [2] https://github.com/kubernetes/gengo/blob/2b36238f13e9b8aebe4c286c2ffb2fc71f4be3c5/types/types.go#L121-L126
  [3] https://github.com/kubernetes/code-generator/issues/150#issuecomment-1773718101
  [4] https://github.com/kubernetes/code-generator/issues/135

