### PR TITLE
🌱 Add manifest generation while generating code

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Update all modules
       run: make mod
     - name: Update generated code
-      run: make generate
+      run: make generate manifests
     - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
       name: Commit changes
       with:


### PR DESCRIPTION
generate test in prow also generates the manifests. This makes sure that manifests are upto date in case any change is needed in them caused by go modules/code changes.
Signed-off-by: Kashif Khan <kashif.khan@est.tech>