### PR TITLE
🌱 Move TLS 1.3 from hardcoded default value to a config flag

### DIFF
--- a/config/base/manager.yaml
+++ b/config/base/manager.yaml
@@ -23,6 +23,7 @@ spec:
             - /baremetal-operator
           args:
             - --enable-leader-election
+            - --tls-min-version=TLS13
           image: quay.io/metal3-io/baremetal-operator
           imagePullPolicy: Always
           env:

--- a/main.go
+++ b/main.go
@@ -154,7 +154,7 @@ func main() {
 		"Maximum queries per second from the controller client to the Kubernetes API server. Default 20")
 	flag.IntVar(&restConfigBurst, "kube-api-burst", 30,
 		"Maximum number of queries that should be allowed in one burst from the controller client to the Kubernetes API server. Default 30")
-	flag.StringVar(&tlsOptions.TLSMinVersion, "tls-min-version", TLSVersion13,
+	flag.StringVar(&tlsOptions.TLSMinVersion, "tls-min-version", TLSVersion12,
 		"The minimum TLS version in use by the webhook server.\n"+
 			fmt.Sprintf("Possible values are %s.", strings.Join(tlsSupportedVersions, ", ")),
 	)


### PR DESCRIPTION
Move TLS 1.3 from hardcoded default value to a config flag.

This aligns BMO implementation to CAPM3/IPAM implementation while keeping TLS 1.3 as default.