### PR TITLE
:seedling:  Fetch Ironic node list after each e2e test

### DIFF
--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -84,6 +84,10 @@ rm /tmp/bmo-e2e.tar
 # This IP is defined by the network we created above.
 IP_ADDRESS="192.168.222.1"
 
+# This IP is also defined by the network above, and is used consistently in all of
+# our e2e overlays
+export IRONIC_PROVISIONING_IP="192.168.222.199"
+
 pushd "${REPO_ROOT}/test/createVM" || exit 1
 go run main.go --yaml-source-file "${E2E_BMCS_CONF_FILE}"
 popd

--- a/test/e2e/basic_ops_test.go
+++ b/test/e2e/basic_ops_test.go
@@ -108,7 +108,7 @@ var _ = Describe("basic", Label("required", "basic"), func() {
 	})
 
 	AfterEach(func() {
-		DumpResources(ctx, clusterProxy, namespace.Name, path.Join(artifactFolder, specName))
+		DumpResources(ctx, e2eConfig, clusterProxy, namespace.Name, path.Join(artifactFolder, specName))
 		if !skipCleanup {
 			cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
 		}

--- a/test/e2e/config/fixture.yaml
+++ b/test/e2e/config/fixture.yaml
@@ -27,6 +27,7 @@ variables:
   IMAGE_CHECKSUM: "c8fc807773e5354afe61636071771906"
   CERT_MANAGER_VERSION: "v1.13.1"
   SSH_CHECK_PROVISIONED: "false"
+  FETCH_IRONIC_NODES: "false"
 
 intervals:
   inspection/wait-unmanaged: ["1m", "10ms"]

--- a/test/e2e/config/ironic.yaml
+++ b/test/e2e/config/ironic.yaml
@@ -32,6 +32,11 @@ variables:
   SSH_USERNAME: "root"
   SSH_PRIV_KEY: "./images/ssh_testkey"
   SSH_PUB_KEY: "./images/ssh_testkey.pub"
+  FETCH_IRONIC_NODES: "true"
+  IRONIC_USERNAME: "changeme"
+  IRONIC_PASSWORD: "changeme"
+  IRONIC_PROVISIONING_IP: "localhost"
+  IRONIC_PROVISIONING_PORT: "6385"
 
 intervals:
   inspection/wait-unmanaged: ["1m", "5s"]

--- a/test/e2e/e2e_config.go
+++ b/test/e2e/e2e_config.go
@@ -153,3 +153,15 @@ func (c *Config) GetVariable(varName string) string {
 	Expect(ok).To(BeTrue(), fmt.Sprintf("Configuration variable '%s' not found", varName))
 	return value
 }
+
+// GetBoolVariable returns a variable from environment variables or from the e2e config file as boolean.
+func (c *Config) GetBoolVariable(varName string) bool {
+	value := c.GetVariable(varName)
+	falseValues := []string{"", "false", "no"}
+	for _, falseVal := range falseValues {
+		if strings.EqualFold(value, falseVal) {
+			return false
+		}
+	}
+	return true
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -102,7 +102,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	os.Setenv("KUBECONFIG", clusterProxy.GetKubeconfigPath())
 
-	if e2eConfig.GetVariable("DEPLOY_CERT_MANAGER") != "false" {
+	if e2eConfig.GetBoolVariable("DEPLOY_CERT_MANAGER") {
 		// Install cert-manager
 		By("Installing cert-manager")
 		err := checkCertManagerAPI(clusterProxy)
@@ -122,7 +122,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	bmoIronicNamespace := "baremetal-operator-system"
 
-	if e2eConfig.GetVariable("DEPLOY_IRONIC") != "false" {
+	if e2eConfig.GetBoolVariable("DEPLOY_IRONIC") {
 		// Install Ironic
 		By("Installing Ironic")
 		err := FlakeAttempt(2, func() error {
@@ -140,7 +140,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		Expect(err).NotTo(HaveOccurred())
 	}
 
-	if e2eConfig.GetVariable("DEPLOY_BMO") != "false" {
+	if e2eConfig.GetBoolVariable("DEPLOY_BMO") {
 		// Install BMO
 		By("Installing BMO")
 		err := FlakeAttempt(2, func() error {

--- a/test/e2e/external_inspection_test.go
+++ b/test/e2e/external_inspection_test.go
@@ -236,7 +236,7 @@ var _ = Describe("External Inspection", Label("required", "external-inspection")
 	})
 
 	AfterEach(func() {
-		DumpResources(ctx, clusterProxy, namespace.Name, path.Join(artifactFolder, specName))
+		DumpResources(ctx, e2eConfig, clusterProxy, namespace.Name, path.Join(artifactFolder, specName))
 		if !skipCleanup {
 			cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
 		}

--- a/test/e2e/inspection_test.go
+++ b/test/e2e/inspection_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Inspection", Label("required", "inspection"), func() {
 	})
 
 	AfterEach(func() {
-		DumpResources(ctx, clusterProxy, namespace.Name, path.Join(artifactFolder, specName))
+		DumpResources(ctx, e2eConfig, clusterProxy, namespace.Name, path.Join(artifactFolder, specName))
 		if !skipCleanup {
 			cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
 		}

--- a/test/e2e/live_iso_test.go
+++ b/test/e2e/live_iso_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Live-ISO", Label("required", "live-iso"), func() {
 	})
 
 	AfterEach(func() {
-		DumpResources(ctx, clusterProxy, namespace.Name, path.Join(artifactFolder, specName))
+		DumpResources(ctx, e2eConfig, clusterProxy, namespace.Name, path.Join(artifactFolder, specName))
 		if !skipCleanup {
 			cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
 		}

--- a/test/e2e/provisioning_and_annotation_test.go
+++ b/test/e2e/provisioning_and_annotation_test.go
@@ -251,11 +251,10 @@ var _ = Describe("Provision, detach, recreate from status and deprovision", Labe
 				Bmh:    bmh,
 				State:  metal3api.StateAvailable,
 			}, e2eConfig.GetIntervals(specName, "wait-available")...)
-
 		})
 
 		AfterEach(func() {
-			DumpResources(ctx, clusterProxy, namespace.Name, path.Join(artifactFolder, specName))
+			DumpResources(ctx, e2eConfig, clusterProxy, namespace.Name, path.Join(artifactFolder, specName))
 			if !skipCleanup {
 				cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
 			}

--- a/test/e2e/re_inspection_test.go
+++ b/test/e2e/re_inspection_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Re-Inspection", Label("required", "re-inspection"), func() {
 	})
 
 	AfterEach(func() {
-		DumpResources(ctx, clusterProxy, namespace.Name, path.Join(artifactFolder, specName))
+		DumpResources(ctx, e2eConfig, clusterProxy, namespace.Name, path.Join(artifactFolder, specName))
 		if !skipCleanup {
 			cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
 		}

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -382,7 +382,7 @@ var _ = Describe("Upgrade", Label("optional", "upgrade"), func() {
 			upgradeClusterProxy.Dispose(ctx)
 		})
 
-		if e2eConfig.GetVariable("UPGRADE_DEPLOY_CERT_MANAGER") != "false" {
+		if e2eConfig.GetBoolVariable("UPGRADE_DEPLOY_CERT_MANAGER") {
 			By("Installing cert-manager on the upgrade cluster")
 			cmVersion := e2eConfig.GetVariable("CERT_MANAGER_VERSION")
 			err := installCertManager(ctx, upgradeClusterProxy, cmVersion)


### PR DESCRIPTION
Fixes #1383

There will be a new file called "ironic-nodes.json" in the testcase log directory.
