### PR TITLE
🐛 Fix the logic that determines previous git tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,7 @@ mod: ## Clean up go module settings
 ## --------------------------------------
 RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
 RELEASE_NOTES_DIR := releasenotes
-PREVIOUS_TAG ?= $(shell git tag -l | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" | sort -V | grep -B1 $(RELEASE_TAG) | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$$" | head -n 1 2>/dev/null)
+PREVIOUS_TAG ?= $(shell git tag -l --merged | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$$" | sort -V | grep -B1 $(RELEASE_TAG) | head -n 1 2>/dev/null)
 
 $(RELEASE_NOTES_DIR):
 	mkdir -p $(RELEASE_NOTES_DIR)/


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the way previous tag is determined to only include those tags that have been merged into the current tree. 
