### PR TITLE
🌱 Adjust test and linter timings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,5 @@
 run:
-  deadline: 5m
+  deadline: 10m
   skip-dirs:
   - mock*
   skip-files:

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -14,7 +14,7 @@ import (
 var log = logz.New().WithName("provisioner").WithName("fixture")
 var deprovisionRequeueDelay = time.Second * 10
 var provisionRequeueDelay = time.Second * 10
-var inspectionRequeueDelay = time.Second * 5
+var inspectionRequeueDelay = time.Second * 2
 
 type fixtureHostConfigData struct {
 	userData    string

--- a/test/e2e/config/fixture.yaml
+++ b/test/e2e/config/fixture.yaml
@@ -34,7 +34,7 @@ intervals:
   inspection/wait-registering: ["5s", "10ms"]
   inspection/wait-registration-error: ["5s", "10ms"]
   inspection/wait-inspecting: ["5s", "10ms"]
-  inspection/wait-available: ["5s", "1ms"]
+  inspection/wait-available: ["5s", "10ms"]
   external-inspection/wait-available: ["5s", "1ms"]
   default/wait-deployment: ["5m", "1s"]
   default/wait-namespace-deleted: ["1m", "1s"]


### PR DESCRIPTION
**What this PR does / why we need it**:

We have started hitting the deadline for golangci-lint. This commit doubles it from 5m to 10m. It also adjusts the fixture provisioners artificial inspection delay and the interval that is used when checking for it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
