### PR TITLE
:bug: Make custom deploy equivalent to image deploy

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -1036,6 +1036,10 @@ func (host *BareMetalHost) WasProvisioned() bool {
 		// We have an image provisioned.
 		return true
 	}
+	if host.Status.Provisioning.CustomDeploy != nil {
+		// We have a custom deploy provisioned.
+		return true
+	}
 	return false
 }
 

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -1309,7 +1309,7 @@ func clearHostProvisioningSettings(host *metal3api.BareMetalHost) {
 }
 
 func (r *BareMetalHostReconciler) actionDeprovisioning(prov provisioner.Provisioner, info *reconcileInfo) actionResult {
-	if info.host.Status.Provisioning.Image.URL != "" {
+	if info.host.Status.Provisioning.Image.URL != "" || info.host.Status.Provisioning.CustomDeploy != nil {
 		// Adopt the host in case it has been re-registered during the
 		// deprovisioning process before it completed
 		provResult, err := prov.Adopt(


### PR DESCRIPTION
If we have to recreate the provisioner's state during deprovisioning, we must
first call Adopt() to ensure that something will actually happen to deprovision it.
This is the case regardless of provisioning method, but previously only
happened when an image was provisioned. In practice, the ironic provisioner
was attempting to adopt in cases where it was not originally intended to, and
subsequent changes mean it is never necessary.

If an externally provisioned host has a provisioning image set and then
the externallyProvisioned flag is removed, we should not begin an inspection
(which would involve rebooting the host), but instead move directly to
the provisioned state. This is also the case regardless of
provisioning method, but previously only happened when an image was
provisioned.