### PR TITLE
🐛 Update HFC Status when handling error in actionPreparing

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -1178,9 +1178,12 @@ func (r *BareMetalHostReconciler) actionPreparing(prov provisioner.Provisioner, 
 			info.log.Info("handling cleaning error in controller")
 			clearHostProvisioningSettings(info.host)
 		}
-		if hfcDirty {
+		if hfcDirty && hfc.Status.Updates != nil {
 			info.log.Info("handling cleaning error during firmware update")
 			hfc.Status.Updates = nil
+			if err := r.Status().Update(info.ctx, hfc); err != nil {
+				return actionError{errors.Wrap(err, "failed to update hostfirmwarecomponents status")}
+			}
 		}
 		return recordActionFailure(info, metal3api.PreparationError, provResult.ErrorMessage)
 	}


### PR DESCRIPTION
When a provisioning error happens and firmware updates are involved, we should only set the Status Updates of the HFC to nil if they are not nil.