### PR TITLE
:seedling: Bump Go to 1.23.3 and golangci-lint to 1.60.3

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -3,7 +3,7 @@ name: golangci-lint
 on:
   workflow_call:
 
-# Remove all permissions from GITHUB_TOKEN except metadata.
+
 permissions: {}
 
 jobs:
@@ -23,9 +23,8 @@ jobs:
 
     - name: Install libvirt
       run: |
-          sudo apt-get update
-          sudo apt-get install -y libvirt-dev
-
+        sudo apt-get update
+        sudo apt-get install -y libvirt-dev
     - name: Calculate go version
       id: vars
       run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
@@ -36,5 +35,6 @@ jobs:
     - name: golangci-lint-${{matrix.working-directory}}
       uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
       with:
-        version: v1.56.2
+        version: v1.60.3
         working-directory: ${{matrix.working-directory}}
+        args: --timeout=10m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,10 +1,8 @@
 run:
-  deadline: 5m
-  skip-dirs:
-  - mock*
-  skip-files:
-  - "zz_generated.*\\.go$"
-  - ".*conversion.*\\.go$"
+  deadline: 10m
+  build-tags:
+  - e2e
+  - vbmctl
 linters:
   disable-all: true
   enable:
@@ -13,12 +11,12 @@ linters:
   - bidichk
   - bodyclose
   #- containedctx
+  - copyloopvar
   - dogsled
   - dupword
   - durationcheck
   - errcheck
   - errchkjson
-  - exportloopref
   - gci
   - ginkgolinter
   - goconst
@@ -56,7 +54,7 @@ linters:
   fast: true
 linters-settings:
   gosec:
-    go: "1.22"
+    go: "1.23"
     severity: medium
     confidence: medium
     concurrency: 8
@@ -86,10 +84,6 @@ linters-settings:
     allow-unused: false
     allow-leading-space: false
     require-specific: true
-  staticcheck:
-    go: "1.22"
-  stylecheck:
-    go: "1.22"
   gocritic:
     enabled-tags:
     - experimental
@@ -108,8 +102,13 @@ linters-settings:
     - whyNoLint
     - wrapperFunc
   unused:
-    go: "1.22"
+    go: "1.23"
 issues:
+  skip-dirs:
+  - mock*
+  skip-files:
+  - "zz_generated.*\\.go$"
+  - ".*conversion.*\\.go$"
   exclude-rules:
   - path: test/e2e
     linters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.22.8@sha256:b274ff14d8eb9309b61b1a45333bf0559a554ebcf6732fa2012dbed9b01ea56f
+ARG BUILD_IMAGE=docker.io/golang:1.23.3@sha256:d56c3e08fe5b27729ee3834854ae8f7015af48fd651cd25d1e3bcf3c19830174
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ RUN_NAMESPACE = metal3
 GO_TEST_FLAGS = $(TEST_FLAGS)
 DEBUG = --debug
 COVER_PROFILE = cover.out
-GO_VERSION ?= 1.22.8
+GO_VERSION ?= 1.23.3
 
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
@@ -59,7 +59,7 @@ SKIP_RESOURCE_CLEANUP ?= false
 GINKGO_NOCOLOR ?= false
 
 GOLANGCI_LINT_BIN := golangci-lint
-GOLANGCI_LINT_VER := v1.56.2
+GOLANGCI_LINT_VER := v1.60.3
 GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN))
 GOLANGCI_LINT_PKG := github.com/golangci/golangci-lint/cmd/golangci-lint
 
@@ -138,10 +138,10 @@ $(GOLANGCI_LINT_BIN): $(GOLANGCI_LINT) ## Build a local copy of golangci-lint.
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT)
-	$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) ./...
-	cd apis; $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) ./...
-	cd test; $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) ./...
-	cd pkg/hardwareutils; $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) ./...
+	$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) ./... --timeout=10m
+	cd apis; $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) ./... --timeout=10m
+	cd test; $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) ./... --timeout=10m
+	cd pkg/hardwareutils; $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) ./... --timeout=10m
 
 .PHONY: lint-fix
 lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter

--- a/Tiltfile
+++ b/Tiltfile
@@ -61,7 +61,7 @@ def validate_auth():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.22 as tilt-helper
+FROM golang:1.23 as tilt-helper
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \

--- a/cmd/make-bm-worker/templates/templates_test.go
+++ b/cmd/make-bm-worker/templates/templates_test.go
@@ -14,12 +14,12 @@ func compareStrings(t *testing.T, s1, s2 string) bool {
 	s1Lines := strings.Split(s1, "\n")
 	s2Lines := strings.Split(s2, "\n")
 
-	max := len(s1Lines)
-	if len(s2Lines) < max {
-		max = len(s2Lines)
+	maxLines := len(s1Lines)
+	if len(s2Lines) < maxLines {
+		maxLines = len(s2Lines)
 	}
 
-	for i := 0; i < max; i++ {
+	for i := 0; i < maxLines; i++ {
 		if s1Lines[i] != s2Lines[i] {
 			t.Logf("line %d differ: %q != %q", i, s1Lines[i], s2Lines[i])
 		}

--- a/hack/e2e/ensure_go.sh
+++ b/hack/e2e/ensure_go.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-MINIMUM_GO_VERSION=go1.22.8
+MINIMUM_GO_VERSION=go1.23.3
 
 # Ensure the go tool exists and is a viable version, or installs it
 verify_go_version()

--- a/pkg/provisioner/ironic/hardwaredetails/hardwaredetails.go
+++ b/pkg/provisioner/ironic/hardwaredetails/hardwaredetails.go
@@ -42,14 +42,14 @@ func getVLANs(lldp map[string]interface{}) (vlans []metal3api.VLAN, vlanid metal
 				vid, _ := vlan["id"].(int)
 				name, _ := vlan["name"].(string)
 				vlans[i] = metal3api.VLAN{
-					ID:   metal3api.VLANID(vid),
+					ID:   metal3api.VLANID(vid), //#nosec G115:gosec
 					Name: name,
 				}
 			}
 		}
 	}
 	if vid, ok := lldp["switch_port_untagged_vlan_id"].(int); ok {
-		vlanid = metal3api.VLANID(vid)
+		vlanid = metal3api.VLANID(vid) //#nosec G115:gosec
 	}
 	return
 }
@@ -151,8 +151,8 @@ func getSystemVendorDetails(vendor inventory.SystemVendorType) metal3api.Hardwar
 
 func getCPUDetails(cpudata *inventory.CPUType) metal3api.CPU {
 	var freq float64
-	fmt.Sscanf(cpudata.Frequency, "%f", &freq)
-	freq = math.Round(freq) // Ensure freq has no fractional part
+	fmt.Sscanf(cpudata.Frequency, "%f", &freq) //nolint:errcheck
+	freq = math.Round(freq)                    // Ensure freq has no fractional part
 	sort.Strings(cpudata.Flags)
 	cpu := metal3api.CPU{
 		Arch:           cpudata.Architecture,


### PR DESCRIPTION
Bump Go to 1.23.3 and golangci-lint to 1.60.3 which supports Go 1.23.

Ignore couple new warnings that are generated, as there is no immediate good options.

Cleanup golangci-lint config from deprecated configs.

Include timeouts where needed, golangci-lint 1.60 is defaulting to real short runs and failing otherwise.

Manual cherry-pick of #2069 due conflict in golangci-lint config.

/hold
until #2069 is merged, so they can be merged as identical.