### PR TITLE
🐛 Add missing update permissions for HostUpdatePolicy CR to BMH controller

### DIFF
--- a/config/base/rbac/role.yaml
+++ b/config/base/rbac/role.yaml
@@ -74,4 +74,5 @@ rules:
   verbs:
   - get
   - list
+  - update
   - watch

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -2431,6 +2431,7 @@ rules:
   verbs:
   - get
   - list
+  - update
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -103,7 +103,7 @@ func (info *reconcileInfo) publishEvent(reason, message string) {
 // +kubebuilder:rbac:groups=metal3.io,resources=dataimages/status,verbs=get;update;patch
 
 // Allow for updating hostupdatepolicies
-//+kubebuilder:rbac:groups=metal3.io,resources=hostupdatepolicies,verbs=get;list;watch
+//+kubebuilder:rbac:groups=metal3.io,resources=hostupdatepolicies,verbs=get;list;watch;update
 
 // Reconcile handles changes to BareMetalHost resources.
 func (r *BareMetalHostReconciler) Reconcile(ctx context.Context, request ctrl.Request) (result ctrl.Result, err error) {


### PR DESCRIPTION
This PR fixes node servicing by adding a missing update permission for HostUpdatePolicy CR to BMH controller.

Fixes #2097
