### PR TITLE
🌱 E2E: Specify checksum for live-iso

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ config/overlays/temp
 .devcontainer
 # Python venv
 .venv
+# Zed editor
+.zed
+.zed_server
 
 # release-notes
 /releasenotes

--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -166,6 +166,8 @@ EOF
 
 ./sysrescue-customize --auto --recipe-dir recipe --source systemrescue-11.00-amd64.iso --dest=sysrescue-out.iso
 export ISO_IMAGE_URL="http://${IP_ADDRESS}/sysrescue-out.iso"
+ISO_IMAGE_CHECKSUM="$(sha256sum sysrescue-out.iso | cut -d ' ' -f 1)"
+export ISO_IMAGE_CHECKSUM
 popd
 
 # Generate credentials

--- a/test/e2e/config/ironic.yaml
+++ b/test/e2e/config/ironic.yaml
@@ -25,8 +25,9 @@ variables:
   UPGRADE_DEPLOY_CERT_MANAGER: "true"
 
   IMAGE_URL: "http://192.168.222.1/cirros-0.6.2-x86_64-disk.img"
-  ISO_IMAGE_URL: "http://192.168.222.1/minimal_linux_live-v2.iso"
   IMAGE_CHECKSUM: "c8fc807773e5354afe61636071771906"
+  ISO_IMAGE_URL: "http://192.168.222.1/minimal_linux_live-v2.iso"
+  ISO_IMAGE_CHECKSUM: "f7600f7a274d974a236c4da5161265859c32da93a7c8de6a77d560378a1384ef"
   CERT_MANAGER_VERSION: "v1.13.1"
   SSH_CHECK_PROVISIONED: "true"
   SSH_USERNAME: "root"

--- a/test/e2e/live_iso_test.go
+++ b/test/e2e/live_iso_test.go
@@ -77,9 +77,10 @@ var _ = Describe("Live-ISO", Label("required", "live-iso"), func() {
 					CredentialsName: secretName,
 				},
 				Image: &metal3api.Image{
-					URL:        imageURL,
-					DiskFormat: pointer.String("live-iso"),
-					Checksum:   e2eConfig.GetVariable("ISO_IMAGE_CHECKSUM"),
+					URL:          imageURL,
+					DiskFormat:   pointer.String("live-iso"),
+					Checksum:     e2eConfig.GetVariable("ISO_IMAGE_CHECKSUM"),
+					ChecksumType: metal3api.SHA256,
 				},
 				BootMode:              metal3api.Legacy,
 				BootMACAddress:        bmc.BootMacAddress,

--- a/test/e2e/live_iso_test.go
+++ b/test/e2e/live_iso_test.go
@@ -79,6 +79,7 @@ var _ = Describe("Live-ISO", Label("required", "live-iso"), func() {
 				Image: &metal3api.Image{
 					URL:        imageURL,
 					DiskFormat: pointer.String("live-iso"),
+					Checksum:   e2eConfig.GetVariable("ISO_IMAGE_CHECKSUM"),
 				},
 				BootMode:              metal3api.Legacy,
 				BootMACAddress:        bmc.BootMacAddress,


### PR DESCRIPTION
**What this PR does / why we need it**:

The test is currently failing because the checksum is missing.
See https://github.com/metal3-io/baremetal-operator/actions/workflows/e2e-test-periodic-main.yml

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
