### PR TITLE
🌱 e2e: Revert temporary pinning of Ironic

### DIFF
--- a/ironic-deployment/overlays/e2e/kustomization.yaml
+++ b/ironic-deployment/overlays/e2e/kustomization.yaml
@@ -28,12 +28,6 @@ patches:
     kind: Certificate
     name: ironic-cert
 
-# TODO(lentzi90): Remove once issue resolved:
-# https://github.com/metal3-io/baremetal-operator/issues/2110
-images:
-- name: quay.io/metal3-io/ironic
-  newTag: release-26.0
-
 # NOTE: These credentials are generated automatically in hack/ci-e2e.sh
 secretGenerator:
 - name: ironic-htpasswd


### PR DESCRIPTION
**What this PR does / why we need it**:

The issue has been fixed so we can safely revert the workaround.
Revert of https://github.com/metal3-io/baremetal-operator/pull/2112

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/hold
until the issue is properly fixed.
Expecting the live-ISO test to fail here.
