### PR TITLE
🐛 Add hack/tools to bed linted and fix errors in deploy-cli

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,6 +18,7 @@ jobs:
         - test
         - apis
         - pkg/hardwareutils
+        - hack/tools
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ lint: $(GOLANGCI_LINT)
 	cd apis; $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) ./... --timeout=10m
 	cd test; $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) ./... --timeout=10m
 	cd pkg/hardwareutils; $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) ./... --timeout=10m
+	cd hack/tools; $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) ./... --timeout=10m
 
 .PHONY: lint-fix
 lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter

--- a/hack/tools/deploy-cli/main.go
+++ b/hack/tools/deploy-cli/main.go
@@ -12,7 +12,6 @@ import (
 var (
 	deployBMOFlag         bool
 	bmoOverlay            string
-	bmoPath               string
 	deployIronicFlag      bool
 	ironicOverlay         string
 	deployTLSFlag         bool
@@ -68,7 +67,6 @@ AVAILABLE ENVIRONMENT VARIABLES:
 			fmt.Fprintf(os.Stderr, "- %s, Default: %s\n", key, val)
 		}
 	}
-
 }
 
 func main() {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This pr fixes errors found by osv-scanner in deploy-cli.
It also adds `hack/tools` package as a linting target, so that
any failure due to dependencies changes will get detected in the future.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2121 
