### PR TITLE
:seedling: Fix BMO fixture-release-0.8 tag names

### DIFF
--- a/config/overlays/fixture-release-0.8/kustomization.yaml
+++ b/config/overlays/fixture-release-0.8/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/metal3-io/baremetal-operator/config/namespace?ref=release-0.9
-- https://github.com/metal3-io/baremetal-operator/config/default?ref=release-0.9
+- https://github.com/metal3-io/baremetal-operator/config/namespace?ref=release-0.8
+- https://github.com/metal3-io/baremetal-operator/config/default?ref=release-0.8
 patches:
 - patch: |
     # Enable test mode (fixture provider instead of ironic)
@@ -18,4 +18,4 @@ patches:
     name: controller-manager
 images:
 - name: quay.io/metal3-io/baremetal-operator
-  newTag: release-0.9
+  newTag: release-0.8


### PR DESCRIPTION
Fixture overlay for release-0.8 was wrongly tagged with release-0.9 ref. Putting back the correct tags.
