### PR TITLE
:seedling: increase 1 timeout in external-inspection test

### DIFF
--- a/test/e2e/config/fixture.yaml
+++ b/test/e2e/config/fixture.yaml
@@ -38,7 +38,7 @@ intervals:
   inspection/wait-registering: ["5s", "10ms"]
   inspection/wait-registration-error: ["5s", "10ms"]
   inspection/wait-inspecting: ["5s", "10ms"]
-  inspection/wait-available: ["5s", "10ms"]
+  inspection/wait-available: ["1m", "1s"]
   external-inspection/wait-available: ["5s", "1ms"]
   default/wait-deployment: ["5m", "1s"]
   default/wait-namespace-deleted: ["1m", "1s"]


### PR DESCRIPTION
this commit:
  - increases the timeout and refresh interval for the "external-inspection" spec's "waiting for the BMH to become available" test

On some test platforms the previous configuration proved to be insufficient. Tests were failing without any issue simply because of being a bit slower than expected.
