### PR TITLE
:sparkles: add support for locally built ironic in e2e test

### DIFF
--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -33,6 +33,8 @@ echo "BMO_E2E_EMULATOR=${BMO_E2E_EMULATOR}"
 export E2E_CONF_FILE="${REPO_ROOT}/test/e2e/config/ironic.yaml"
 export E2E_BMCS_CONF_FILE="${REPO_ROOT}/test/e2e/config/bmcs-${BMC_PROTOCOL}.yaml"
 
+LOAD_LOCAL_IRONIC="${LOAD_LOCAL_IRONIC:-false}"
+
 case "${GINKGO_FOCUS:-}" in
   *upgrade*)
     export DEPLOY_IRONIC="false"
@@ -80,6 +82,13 @@ while ! minikube start; do sleep 30; done
 docker image save -o /tmp/bmo-e2e.tar quay.io/metal3-io/baremetal-operator:e2e
 minikube image load /tmp/bmo-e2e.tar
 rm /tmp/bmo-e2e.tar
+if [[ "${LOAD_LOCAL_IRONIC}" == "true" ]]; then
+    echo "Saving local ironic image!"
+    docker image save -o \
+        "/tmp/ironic-e2e.tar" "quay.io/metal3-io/ironic:local"
+    minikube image load /tmp/ironic-e2e.tar
+    rm /tmp/ironic-e2e.tar
+fi
 
 # This IP is defined by the network we created above.
 IP_ADDRESS="192.168.222.1"

--- a/ironic-deployment/overlays/e2e-local-ironic/ironic-patch.yaml
+++ b/ironic-deployment/overlays/e2e-local-ironic/ironic-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ironic
+spec:
+  template:
+    spec:
+      containers:
+      - name: ironic-dnsmasq
+        $patch: delete

--- a/ironic-deployment/overlays/e2e-local-ironic/kustomization.yaml
+++ b/ironic-deployment/overlays/e2e-local-ironic/kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: baremetal-operator-system
+resources:
+- ../e2e
+
+patches:
+- path: ironic-patch.yaml
+- patch: |
+    # Don't try to pull again the pre-loaded image
+    - op: replace
+      path: /spec/template/spec/containers/0/imagePullPolicy
+      value: IfNotPresent
+    - op: replace
+      path: /spec/template/spec/containers/1/imagePullPolicy
+      value: IfNotPresent
+    - op: replace
+      path: /spec/template/spec/containers/2/imagePullPolicy
+      value: IfNotPresent
+  target:
+    kind: Deployment
+    name: ironic
+
+images:
+- name: quay.io/metal3-io/ironic
+  newTag: local
+


### PR DESCRIPTION
this commit:
  - adds support for running the e2e tests with locally built ironic image
  - adds environment variable to enable the feature on demand

Reason:
There are scenarios outside the CI pipelines when developers need to run the e2e tests and run it with a custom ironic build e.g. to test new features.
