### PR TITLE
:seedling: Fix ensure_kind.sh filename

### DIFF
--- a/hack/e2e/ensure_kind.sh
+++ b/hack/e2e/ensure_kind.sh
@@ -13,7 +13,7 @@ verify_kind_version()
         if [[ "${OSTYPE}" == "linux-gnu" ]]; then
             echo "kind not found, installing"
             curl -LO "https://kind.sigs.k8s.io/dl/${MINIMUM_KIND_VERSION}/kind-linux-amd64"
-            sudo install kind "${USR_LOCAL_BIN}/kind"
+            sudo install kind-linux-amd64 "${USR_LOCAL_BIN}/kind"
         else
             echo "Missing required binary in path: kind"
             return 2


### PR DESCRIPTION
In ensure_kind.sh, the downloaded binary file's name is kind-linux-amd64, so we should run `sudo install kind-linux-amd64` instead of `sudo install kind`.
