### PR TITLE
:bug: bump golang to 1.23.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.23.3@sha256:d56c3e08fe5b27729ee3834854ae8f7015af48fd651cd25d1e3bcf3c19830174
+ARG BUILD_IMAGE=docker.io/golang:1.23.5@sha256:8c10f21bec412f08f73aa7b97ca5ac5f28a39d8a88030ad8a339fd0a781d72b4
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ RUN_NAMESPACE = metal3
 GO_TEST_FLAGS = $(TEST_FLAGS)
 DEBUG = --debug
 COVER_PROFILE = cover.out
-GO_VERSION ?= 1.23.3
+GO_VERSION ?= 1.23.5
 
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 

--- a/hack/e2e/ensure_go.sh
+++ b/hack/e2e/ensure_go.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-MINIMUM_GO_VERSION=go1.23.3
+MINIMUM_GO_VERSION=go1.23.5
 
 # Ensure the go tool exists and is a viable version, or installs it
 verify_go_version()


### PR DESCRIPTION
Golang stdlib has issue in crypto/x509, fixed in golang 1.23.5. https://osv.dev/GO-2025-3373

Golang stdlib has issue in net/http, fixed in golang 1.23.5. https://osv.dev/vulnerability/GO-2025-3420

Both codepaths are used in the code.
