### PR TITLE
:bug: Set ownerReference for dataImage during BMH Reconcile

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -141,6 +141,20 @@ func (r *BareMetalHostReconciler) Reconcile(ctx context.Context, request ctrl.Re
 		}
 	}
 
+	// If DataImage exists, add its ownerReference
+	dataImage := &metal3api.DataImage{}
+	err = r.Get(ctx, request.NamespacedName, dataImage)
+	if !(err != nil || ownerReferenceExists(host, dataImage)) {
+		if err := controllerutil.SetControllerReference(host, dataImage, r.Scheme()); err != nil {
+			return ctrl.Result{}, fmt.Errorf("could not set bmh as controller, %w", err)
+		}
+		if err := r.Update(ctx, dataImage); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failure updating dataImage status, %w", err)
+		}
+
+		return ctrl.Result{Requeue: true}, nil
+	}
+
 	hostData, err := r.reconcileHostData(ctx, host, request)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "Could not reconcile host data")
@@ -1632,18 +1646,6 @@ func (r *BareMetalHostReconciler) handleDataImageActions(prov provisioner.Provis
 		}
 		// Error reading the object - requeue the request.
 		return actionError{fmt.Errorf("could not load dataImage, %w", err)}
-	}
-
-	// Set ControllerReference to DataImage
-	if !ownerReferenceExists(info.host, dataImage) {
-		if err := controllerutil.SetControllerReference(info.host, dataImage, r.Scheme()); err != nil {
-			return actionError{fmt.Errorf("could not set bmh as controller, %w", err)}
-		}
-		if err := r.Update(info.ctx, dataImage); err != nil {
-			return actionError{fmt.Errorf("failure updating dataImage status, %w", err)}
-		}
-
-		return actionContinue{}
 	}
 
 	// Update reconciliation timestamp for dataImage


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the ownerReference for dataImage as soon as its created, so that in case of forced BMH deletion the dataImage is not left orphaned.
