### PR TITLE
:bug: Add BMH OwnerReference for DataImage right after its creation 

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -141,20 +141,6 @@ func (r *BareMetalHostReconciler) Reconcile(ctx context.Context, request ctrl.Re
 		}
 	}
 
-	// If DataImage exists, add its ownerReference
-	dataImage := &metal3api.DataImage{}
-	err = r.Get(ctx, request.NamespacedName, dataImage)
-	if !(err != nil || ownerReferenceExists(host, dataImage)) {
-		if err := controllerutil.SetControllerReference(host, dataImage, r.Scheme()); err != nil {
-			return ctrl.Result{}, fmt.Errorf("could not set bmh as controller, %w", err)
-		}
-		if err := r.Update(ctx, dataImage); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failure updating dataImage status, %w", err)
-		}
-
-		return ctrl.Result{Requeue: true}, nil
-	}
-
 	hostData, err := r.reconcileHostData(ctx, host, request)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "Could not reconcile host data")


### PR DESCRIPTION
**What this PR does / why we need it**:

This is followup to https://github.com/metal3-io/baremetal-operator/pull/2238, fixing issues raised in the previous pr : https://github.com/metal3-io/baremetal-operator/pull/2238/files/0efbb139a9dfe3b5011780bd725968f7b76c91ff

Also updates the order of checks in the dataImage reconcile ( as per Zane's [comment here](https://github.com/metal3-io/baremetal-operator/pull/2249#discussion_r1955816469) )  :
1. paused annotation
2. owner reference
3. finalizer
4. detached host