### PR TITLE
🌱 E2E: Avoid net-booting VMs unintentionally

### DIFF
--- a/test/vbmctl/main.go
+++ b/test/vbmctl/main.go
@@ -175,16 +175,10 @@ func CreateLibvirtVM(conn *libvirt.Connect, name, networkName, macAddress string
 		return err
 	}
 
-	dom, err := conn.DomainDefineXML(vmCfg)
+	_, err = conn.DomainDefineXML(vmCfg)
 
 	if err != nil {
 		fmt.Println("Failed to define domain")
-		fmt.Printf("Error occurred: %v\n", err)
-		return err
-	}
-
-	if err := dom.Create(); err != nil {
-		fmt.Println("Failed to create domain")
 		fmt.Printf("Error occurred: %v\n", err)
 		return err
 	}

--- a/test/vbmctl/templates/VM.xml.tpl
+++ b/test/vbmctl/templates/VM.xml.tpl
@@ -5,9 +5,7 @@
   <vcpu placement='static'>2</vcpu>
   <os>
     <type arch='x86_64' machine='pc-q35-6.2'>hvm</type>
-    <boot dev='network'/>
-    <bootmenu enable='no'/>
-    <bios useserial='yes' rebootTimeout='10000'/>
+    <boot dev='hd'/>
   </os>
   <features>
     <acpi/>
@@ -16,9 +14,6 @@
   </features>
   <cpu mode='host-passthrough' check='none' migratable='on'/>
   <clock offset='utc'/>
-  <on_poweroff>destroy</on_poweroff>
-  <on_reboot>restart</on_reboot>
-  <on_crash>restart</on_crash>
   <devices>
     <emulator>/usr/bin/qemu-system-x86_64</emulator>
     <disk type='file' device='cdrom'>
@@ -102,4 +97,3 @@
     </memballoon>
   </devices>
 </domain>
-


### PR DESCRIPTION
**What this PR does / why we need it**:

We should let Ironic take care of booting the VMs and configuring boot order.
Otherwise we may unintentionally do a netboot before ironic is ready and
tries a virtualmedia boot for example.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
