### PR TITLE
🌱 E2E: Fix ironic overlays for 25.0 and 26.0

### DIFF
--- a/ironic-deployment/overlays/e2e-release-25.0/kustomization.yaml
+++ b/ironic-deployment/overlays/e2e-release-25.0/kustomization.yaml
@@ -27,13 +27,6 @@ patches:
   target:
     kind: Certificate
     name: ironic-cert
-- patch: |-
-    - op: replace
-      path: /spec/ipAddresses/0
-      value: 192.168.222.1
-  target:
-    kind: Certificate
-    name: ironic-cacert
 
 images:
 - name: quay.io/metal3-io/ironic

--- a/ironic-deployment/overlays/e2e-release-26.0/kustomization.yaml
+++ b/ironic-deployment/overlays/e2e-release-26.0/kustomization.yaml
@@ -27,13 +27,6 @@ patches:
   target:
     kind: Certificate
     name: ironic-cert
-- patch: |-
-    - op: replace
-      path: /spec/ipAddresses/0
-      value: 192.168.222.1
-  target:
-    kind: Certificate
-    name: ironic-cacert
 
 images:
 - name: quay.io/metal3-io/ironic


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

These were missed when backporting a change to the certificates to BMO
0.8. The CA certificiate no longer has an IP address, so the patch must
be adjusted for that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
