### PR TITLE
:seedling: bump local hack scripts to basic-checks:golang-1.23

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -33,6 +33,6 @@ else
         --volume "${PWD}:${WORKDIR}:rw,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        quay.io/metal3-io/basic-checks:golang-1.22 \
+        quay.io/metal3-io/basic-checks:golang-1.23 \
         "${WORKDIR}"/hack/generate.sh "$@"
 fi

--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -42,6 +42,6 @@ else
         --volume "${PWD}:${WORKDIR}:ro,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        quay.io/metal3-io/basic-checks:golang-1.22 \
+        quay.io/metal3-io/basic-checks:golang-1.23 \
         "${WORKDIR}"/hack/gomod.sh "$@"
 fi


### PR DESCRIPTION
We forgot to bump these local scripts to go 1.23 long time ago.
