### PR TITLE
:warning: Only accept HTTPHeadersRef in same namespace

### DIFF
--- a/apis/metal3.io/v1alpha1/bmceventsubscription_validation.go
+++ b/apis/metal3.io/v1alpha1/bmceventsubscription_validation.go
@@ -29,6 +29,12 @@ func (s *BMCEventSubscription) validateSubscription() []error {
 		errs = append(errs, errors.New("hostName cannot be empty"))
 	}
 
+	if s.Spec.HTTPHeadersRef != nil {
+		if s.Spec.HTTPHeadersRef.Namespace != s.Namespace {
+			errs = append(errs, errors.New("httpHeadersRef secret must be in the same namespace as the BMCEventSubscription"))
+		}
+	}
+
 	if s.Spec.Destination == "" {
 		errs = append(errs, errors.New("destination cannot be empty"))
 	} else {

--- a/apis/metal3.io/v1alpha1/bmceventsubscription_validation_test.go
+++ b/apis/metal3.io/v1alpha1/bmceventsubscription_validation_test.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -68,6 +69,28 @@ func TestBMCEventSubscriptionValidateCreate(t *testing.T) {
 			},
 			oldS:      nil,
 			wantedErr: "hostname-only destination must have a trailing slash",
+		},
+		{
+			name: "httpHeadersRef valid",
+			newS: &BMCEventSubscription{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: BMCEventSubscriptionSpec{HostName: "worker-01", Destination: "http://localhost/abc/abc.php",
+					HTTPHeadersRef: &corev1.SecretReference{Namespace: om.Namespace, Name: "headers"}},
+			},
+			oldS:      nil,
+			wantedErr: "",
+		},
+		{
+			name: "httpHeadersRef in different namespace",
+			newS: &BMCEventSubscription{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: BMCEventSubscriptionSpec{HostName: "worker-01", Destination: "http://localhost/abc/abc.php",
+					HTTPHeadersRef: &corev1.SecretReference{Namespace: "different", Name: "headers"}},
+			},
+			oldS:      nil,
+			wantedErr: "httpHeadersRef secret must be in the same namespace as the BMCEventSubscription",
 		},
 	}
 

--- a/controllers/metal3.io/bmceventsubscription_controller.go
+++ b/controllers/metal3.io/bmceventsubscription_controller.go
@@ -243,6 +243,10 @@ func (r *BMCEventSubscriptionReconciler) getHTTPHeaders(ctx context.Context, sub
 		return headers, nil
 	}
 
+	if subscription.Spec.HTTPHeadersRef.Namespace != subscription.Namespace {
+		return headers, errors.New("httpHeadersRef secret must be in the same namespace as the BMCEventSubscription")
+	}
+
 	secret := &corev1.Secret{}
 	secretKey := types.NamespacedName{
 		Name:      subscription.Spec.HTTPHeadersRef.Name,


### PR DESCRIPTION
The BMCEventSubscription spec uses a Secret reference for the HTTPHeadersRef field. This allows the user to specify any namespace. To prevent leaking Secrets, this commit restricts the namespace to the same namespace that the BMCEventSubscription is in.