### PR TITLE
🌱 Bump golangci-lint to v1.64.7

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -34,8 +34,8 @@ jobs:
       with:
         go-version: ${{ steps.vars.outputs.go_version }}
     - name: golangci-lint-${{matrix.working-directory}}
-      uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
+      uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
       with:
-        version: v1.60.3
+        version: v1.64.7
         working-directory: ${{matrix.working-directory}}
         args: --timeout=10m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,5 @@
 run:
-  deadline: 10m
+  go: "1.23"
   build-tags:
   - e2e
   - vbmctl
@@ -54,7 +54,6 @@ linters:
   fast: true
 linters-settings:
   gosec:
-    go: "1.23"
     severity: medium
     confidence: medium
     concurrency: 8
@@ -82,7 +81,6 @@ linters-settings:
       alias: metal3api
   nolintlint:
     allow-unused: false
-    allow-leading-space: false
     require-specific: true
   gocritic:
     enabled-tags:
@@ -101,12 +99,10 @@ linters-settings:
     - unnecessaryDefer
     - whyNoLint
     - wrapperFunc
-  unused:
-    go: "1.23"
 issues:
-  skip-dirs:
+  exclude-dirs:
   - mock*
-  skip-files:
+  exclude-files:
   - "zz_generated.*\\.go$"
   - ".*conversion.*\\.go$"
   exclude-rules:

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ SKIP_RESOURCE_CLEANUP ?= false
 GINKGO_NOCOLOR ?= false
 
 GOLANGCI_LINT_BIN := golangci-lint
-GOLANGCI_LINT_VER := v1.60.3
+GOLANGCI_LINT_VER := v1.64.7
 GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN))
 GOLANGCI_LINT_PKG := github.com/golangci/golangci-lint/cmd/golangci-lint
 


### PR DESCRIPTION
This PR also bumps golangci-lint-action to 6.5.2. While doing that it removes some of the old unsupported golangci-lint settings.
Signed-off-by: Kashif Khan <kashif.khan@est.tech>

