### PR TITLE
:sparkles: Use standard GetVirtualMedia API for checking dataImage status

### DIFF
--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -1403,7 +1403,7 @@ func (p *mockProvisioner) GetFirmwareComponents() (components []metal3api.Firmwa
 	return components, nil
 }
 
-func (m *mockProvisioner) IsDataImageReady() (isNodeBusy bool, nodeError error) {
+func (p *mockProvisioner) GetDataImageStatus() (isImageAttached bool, err error) {
 	return false, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/google/safetext v0.0.0-20230106111101-7156a760e523
 	github.com/google/uuid v1.6.0
-	github.com/gophercloud/gophercloud/v2 v2.6.0
+	github.com/gophercloud/gophercloud/v2 v2.7.0
 	github.com/metal3-io/baremetal-operator/apis v0.5.1
 	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.5.1
 	github.com/onsi/gomega v1.37.0

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/google/safetext v0.0.0-20230106111101-7156a760e523 h1:i4NsbmB9pD5+Ggp
 github.com/google/safetext v0.0.0-20230106111101-7156a760e523/go.mod h1:mJNEy0r5YPHC7ChQffpOszlGB4L1iqjXWpIEKcFpr9s=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gophercloud/gophercloud/v2 v2.6.0 h1:XJKQ0in3iHOZHVAFMXq/OhjCuvvG+BKR0unOqRfG1EI=
-github.com/gophercloud/gophercloud/v2 v2.6.0/go.mod h1:Ki/ILhYZr/5EPebrPL9Ej+tUg4lqx71/YH2JWVeU+Qk=
+github.com/gophercloud/gophercloud/v2 v2.7.0 h1:o0m4kgVcPgHlcXiWAjoVxGd8QCmvM5VU+YM71pFbn0E=
+github.com/gophercloud/gophercloud/v2 v2.7.0/go.mod h1:Ki/ILhYZr/5EPebrPL9Ej+tUg4lqx71/YH2JWVeU+Qk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1YCS1PXdKYWi8FsN0=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0/go.mod h1:P+Lt/0by1T8bfcF3z737NnSbmxQAppXMRziHUxPOC8k=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -327,7 +327,7 @@ func (p *demoProvisioner) GetFirmwareComponents() (components []metal3api.Firmwa
 	return components, nil
 }
 
-func (p *demoProvisioner) IsDataImageReady() (isNodeBusy bool, nodeError error) {
+func (p *demoProvisioner) GetDataImageStatus() (isImageAttached bool, err error) {
 	return false, nil
 }
 

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -400,7 +400,7 @@ func (p *fixtureProvisioner) GetFirmwareComponents() (components []metal3api.Fir
 	return p.state.HostFirmwareComponents.Components, nil
 }
 
-func (p *fixtureProvisioner) IsDataImageReady() (isNodeBusy bool, nodeError error) {
+func (p *fixtureProvisioner) GetDataImageStatus() (isImageAttached bool, err error) {
 	return false, nil
 }
 

--- a/pkg/provisioner/ironic/clients/features.go
+++ b/pkg/provisioner/ironic/clients/features.go
@@ -58,6 +58,10 @@ func (af AvailableFeatures) HasDataImage() bool {
 	return af.MaxVersion >= 89
 }
 
+func (af AvailableFeatures) HasVirtualMediaGetAPI() bool {
+	return af.MaxVersion >= 93
+}
+
 func (af AvailableFeatures) HasDisablePowerOff() bool {
 	return af.MaxVersion >= 95
 }
@@ -65,6 +69,10 @@ func (af AvailableFeatures) HasDisablePowerOff() bool {
 func (af AvailableFeatures) ChooseMicroversion() string {
 	if af.HasDisablePowerOff() {
 		return "1.95"
+	}
+
+	if af.HasVirtualMediaGetAPI() {
+		return "1.93"
 	}
 
 	if af.HasDataImage() {

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -216,8 +216,8 @@ type Provisioner interface {
 	// GetFirmwareComponents gets all firmware components available from a note
 	GetFirmwareComponents() (components []metal3api.FirmwareComponentStatus, err error)
 
-	// Check if DataImage attach/detach was successful
-	IsDataImageReady() (isNodeBusy bool, nodeError error)
+	// Get DataImage
+	GetDataImageStatus() (isImageAttached bool, err error)
 
 	// Attach DataImage
 	AttachDataImage(URL string) (err error)
@@ -254,3 +254,7 @@ var ErrNeedsPreprovisioningImage = errors.New("no suitable Preprovisioning image
 
 // ErrFirmwareUpdateUnsupported is returned if the host can't execute firmware updates.
 var ErrFirmwareUpdateUnsupported = errors.New("host does not support Firmware Updates")
+
+// ErrNodeIsBusy is returned when the node is busy due to being reserved for another
+// task.
+var ErrNodeIsBusy = errors.New("node is busy")


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the newly introduced [virtual media get api](https://github.com/gophercloud/gophercloud/pull/3303) to get the current dataImage status.
