### PR TITLE
🌱 VBMCTL: Avoid re-using the default storage pool

### DIFF
--- a/hack/clean-e2e.sh
+++ b/hack/clean-e2e.sh
@@ -21,6 +21,6 @@ virsh -c qemu:///system net-undefine baremetal-e2e
 rm -rf /tmp/pool_oo/*
 
 # Clean volume pool
-virsh pool-destroy default || true
-virsh pool-delete default || true
-virsh pool-undefine default || true
+virsh pool-destroy baremetal-e2e || true
+virsh pool-delete baremetal-e2e || true
+virsh pool-undefine baremetal-e2e || true

--- a/test/vbmctl/main.go
+++ b/test/vbmctl/main.go
@@ -132,13 +132,13 @@ func CreateVolume(conn *libvirt.Connect, volumeName, poolName, poolPath string, 
 
 // CreateLibvirtVM creates a new virtual machine with the given name,
 // network name, and MAC address. It first creates a qcow2 file with a size
-// of 3GB and defines it in the default storage pool. The function then connects
+// of 3GB and defines it in the baremetal-e2e storage pool. The function then connects
 // to the libvirt daemon and uses a template to generate the VM's XML configuration.
 // If the domain is successfully defined and created, the virtual machine is
 // started. Errors during qcow2 file creation, volume creation, libvirt connection,
 // template rendering, or domain creation are returned.
 func CreateLibvirtVM(conn *libvirt.Connect, name, networkName, macAddress string) error {
-	poolName := "default"
+	poolName := "baremetal-e2e"
 	poolPath := "/tmp/pool_oo"
 	opts := make(map[string]any)
 	opts[qcow2.OPT_SIZE] = 3 * (1 << 30) // qcow2 file's size is 3g


### PR DESCRIPTION
**What this PR does / why we need it**:

Using the default pool increases risk of accidentally deleting things that are not related to BMO e2e. Using a separate pool is cleaner.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
