### PR TITLE
🌱 Enable dupl linter in golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,7 +14,7 @@ linters:
   - copyloopvar
   - decorder
   - dogsled
-  #- dupl
+  - dupl
   - dupword
   - durationcheck
   - errcheck
@@ -142,6 +142,7 @@ issues:
     - gci
     - goconst
     - gosec
+    - dupl
   - path: _test\.go
     linters:
     - errcheck


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

fixes https://github.com/metal3-io/baremetal-operator/issues/2351

> Note: IMO it make sense to disable this linter for test files, cause a little bit duplication in tests is acceptable.