### PR TITLE
:seedling: make osv-scanner scan run daily

### DIFF
--- a/.github/workflows/osv-scanner-scan.yml
+++ b/.github/workflows/osv-scanner-scan.yml
@@ -5,7 +5,7 @@ name: OSV-Scanner Scan
 on:
   workflow_dispatch:
   schedule:
-  - cron: "24 6 * * 1"
+  - cron: "24 6 * * *"
 
 permissions: {}
 


### PR DESCRIPTION
Now that osv-scanner v2 is configured to announce any findings in Slack, we should be running it daily as weekly is too sparse and we usually fix issues sooner than the weekly job notices them.
