### PR TITLE
🌱 Add Adil and Peppi-lotta as reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,7 +11,9 @@ aliases:
   - zaneb
 
   baremetal-operator-reviewers:
+  - adilGhaffarDev
   - iurygregory
+  - peppi-lotta
   - s3rj1k
   - tuminoid
   - zhouhao3


### PR DESCRIPTION
According to our [community standards ](https://github.com/metal3-io/community/blob/main/CONTRIBUTOR-LADDER.md#reviewer)both Adil and Peppi-lotta has reached the level to be reviewers in BMO. They are also active in reviewing code in metal3.io org in general. Thanks a lot Adil and Peppi. Keep up the good work. 