### PR TITLE
:bug: Make firmware update handle only a subset of `Spec.Updates`

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller_test.go
+++ b/internal/controller/metal3.io/baremetalhost_controller_test.go
@@ -2831,6 +2831,30 @@ func TestPreprovImageAvailable(t *testing.T) {
 	}
 }
 
+func TestGetUpdatesDifference(t *testing.T) {
+	hfc := metal3api.HostFirmwareComponents{
+		Status: metal3api.HostFirmwareComponentsStatus{
+			Updates: []metal3api.FirmwareUpdate{
+				{Component: "bmc", URL: "http://example1.com/bmc.exe"},
+				{Component: "bios", URL: "http://example1.com/bios.exe"},
+			},
+		},
+		Spec: metal3api.HostFirmwareComponentsSpec{
+			Updates: []metal3api.FirmwareUpdate{
+				{Component: "bmc", URL: "http://example1.com/bmc.exe"},
+				{Component: "bios", URL: "http://example1.com/bios.exe"},
+				{Component: "bios", URL: "http://example2.com/bios.exe"}},
+		},
+	}
+
+	expected := []metal3api.FirmwareUpdate{
+		{Component: "bios", URL: "http://example2.com/bios.exe"},
+	}
+	diff := getUpdatesDifference(hfc.Spec.Updates, hfc.Status.Updates)
+
+	assert.Equal(t, expected, diff)
+}
+
 // TestHostFirwmareSettings verifies that a change to the HFS
 // can be detected as it will be used to set state to Preparing.
 func TestHostFirmwareSettings(t *testing.T) {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
When an operator wants to update bare metal firmware, it must pass to `HostFirmwareComponents.Spec` a list of components and URIs for the update. In the old behavior, the controller will try to update the whole list, but it is desired to update only the firmware that was not updated. This PR fixes this passing to `TargetComponents` only the subset of unupdated components.
