### PR TITLE
🌱 Replace github.com/pkg/errors by standard library errors pkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/metal3-io/baremetal-operator/apis v0.5.1
 	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.5.1
 	github.com/onsi/gomega v1.37.0
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/stretchr/testify v1.10.0
 	go.etcd.io/etcd/client/pkg/v3 v3.5.21
@@ -61,6 +60,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect

--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -30,7 +31,6 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/google/go-github/github"
-	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
 )
 
@@ -92,7 +92,7 @@ func lastTag(latestTag string) (string, error) {
 
 		semVersion, err := semver.New(latestTag)
 		if err != nil {
-			return "", errors.Wrapf(err, "parsing semver for %s", latestTag)
+			return "", fmt.Errorf("parsing semver for %s: %w", latestTag, err)
 		}
 		semVersion.Minor--
 		lastReleaseTag := fmt.Sprintf("v%s", semVersion.String())
@@ -103,7 +103,7 @@ func lastTag(latestTag string) (string, error) {
 
 	semVersion, err := semver.New(latestTag)
 	if err != nil {
-		return "", errors.Wrapf(err, "parsing semver for %s", latestTag)
+		return "", fmt.Errorf("parsing semver for %s: %w", latestTag, err)
 	}
 	semVersion.Patch--
 	lastReleaseTag := fmt.Sprintf("v%s", semVersion.String())

--- a/internal/controller/metal3.io/host_config_data.go
+++ b/internal/controller/metal3.io/host_config_data.go
@@ -1,10 +1,11 @@
 package controllers
 
 import (
+	"fmt"
+
 	"github.com/go-logr/logr"
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/secretutils"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -22,7 +23,7 @@ type hostConfigData struct {
 // keys.
 func (hcd *hostConfigData) getSecretData(name, namespace, dataKey string) (string, error) {
 	if namespace != hcd.host.Namespace {
-		return "", errors.Errorf("%s secret must be in same namespace as host %s/%s", dataKey, hcd.host.Namespace, hcd.host.Name)
+		return "", fmt.Errorf("%s secret must be in same namespace as host %s/%s", dataKey, hcd.host.Namespace, hcd.host.Name)
 	}
 
 	key := types.NamespacedName{

--- a/internal/controller/metal3.io/host_state_machine.go
+++ b/internal/controller/metal3.io/host_state_machine.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-logr/logr"
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -88,7 +87,7 @@ func recordStateEnd(info *reconcileInfo, host *metal3api.BareMetalHost, state me
 func (hsm *hostStateMachine) ensureCapacity(info *reconcileInfo, state metal3api.ProvisioningState) actionResult {
 	hasCapacity, err := hsm.Provisioner.HasCapacity()
 	if err != nil {
-		return actionError{errors.Wrap(err, "failed to determine current provisioner capacity")}
+		return actionError{fmt.Errorf("failed to determine current provisioner capacity: %w", err)}
 	}
 
 	if !hasCapacity {

--- a/internal/controller/metal3.io/preprovisioningimage_controller.go
+++ b/internal/controller/metal3.io/preprovisioningimage_controller.go
@@ -18,6 +18,8 @@ package controllers
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -25,7 +27,6 @@ import (
 	"github.com/metal3-io/baremetal-operator/pkg/imageprovider"
 	"github.com/metal3-io/baremetal-operator/pkg/secretutils"
 	"github.com/metal3-io/baremetal-operator/pkg/utils"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -89,7 +90,7 @@ func (r *PreprovisioningImageReconciler) Reconcile(ctx context.Context, req ctrl
 			img.Finalizers, metal3api.PreprovisioningImageFinalizer)
 		err := r.Update(ctx, &img)
 		if err != nil {
-			return ctrl.Result{}, errors.Wrap(err, "failed to remove finalizer")
+			return ctrl.Result{}, fmt.Errorf("failed to remove finalizer %w", err)
 		}
 		return ctrl.Result{}, nil
 	}
@@ -99,7 +100,7 @@ func (r *PreprovisioningImageReconciler) Reconcile(ctx context.Context, req ctrl
 		img.Finalizers = append(img.Finalizers, metal3api.PreprovisioningImageFinalizer)
 		err := r.Update(ctx, &img)
 		if err != nil {
-			return ctrl.Result{}, errors.Wrap(err, "failed to add finalizer")
+			return ctrl.Result{}, fmt.Errorf("failed to add finalizer %w", err)
 		}
 		return ctrl.Result{}, nil
 	}

--- a/main.go
+++ b/main.go
@@ -35,7 +35,6 @@ import (
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic"
 	"github.com/metal3-io/baremetal-operator/pkg/secretutils"
 	"github.com/metal3-io/baremetal-operator/pkg/version"
-	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -445,7 +444,7 @@ func getMaxConcurrentReconciles(controllerConcurrency int) (int, error) {
 	if mcrEnv, ok := os.LookupEnv("BMO_CONCURRENCY"); ok {
 		mcr, err := strconv.Atoi(mcrEnv)
 		if err != nil {
-			return 0, errors.Wrap(err, fmt.Sprintf("BMO_CONCURRENCY value: %s is invalid", mcrEnv))
+			return 0, fmt.Errorf("BMO_CONCURRENCY value: %s is invalid: %w", mcrEnv, err)
 		}
 		if mcr > 0 {
 			ctrl.Log.Info(fmt.Sprintf("BMO_CONCURRENCY of %d is set via an environment variable", mcr))

--- a/test/e2e/cert_manager.go
+++ b/test/e2e/cert_manager.go
@@ -11,7 +11,6 @@ import (
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,16 +26,16 @@ func checkCertManagerAPI(clusterProxy framework.ClusterProxy) error {
 func installCertManager(ctx context.Context, clusterProxy framework.ClusterProxy, cmVersion string) error {
 	response, err := http.Get(fmt.Sprintf("https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml", cmVersion)) //nolint: noctx
 	if err != nil {
-		return errors.Wrapf(err, "Error downloading cert-manager manifest")
+		return fmt.Errorf("error downloading cert-manager manifest: %w", err)
 	}
 	defer response.Body.Close()
 	manifests, err := io.ReadAll(response.Body)
 	if err != nil {
-		return errors.Wrapf(err, "Error reading downloaded cert-manager manifest")
+		return fmt.Errorf("error reading downloaded cert-manager manifest: %w", err)
 	}
 	err = clusterProxy.CreateOrUpdate(ctx, manifests)
 	if err != nil {
-		return errors.Wrapf(err, "Error installing cert-manager from downloaded manifest")
+		return fmt.Errorf("error installing cert-manager from downloaded manifest: %w", err)
 	}
 	return nil
 }
@@ -70,7 +69,7 @@ func checkCertManagerWebhook(ctx context.Context, clusterProxy framework.Cluster
 		},
 	}
 	if err = c.Create(ctx, issuer); err != nil {
-		return errors.Wrapf(err, "cert-manager webhook not ready")
+		return fmt.Errorf("cert-manager webhook not ready: %w", err)
 	}
 	cert := &cmapi.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
@@ -86,7 +85,7 @@ func checkCertManagerWebhook(ctx context.Context, clusterProxy framework.Cluster
 	}
 
 	if err = c.Create(ctx, cert); err != nil {
-		return errors.Wrapf(err, "cert-manager webhook not ready")
+		return fmt.Errorf("cert-manager webhook not ready: %w", err)
 	}
 	return nil
 }

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -21,7 +21,6 @@ import (
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/apps/v1"
@@ -355,13 +354,13 @@ func (input *BuildAndApplyKustomizationInput) validate() error {
 		return nil
 	}
 	if input.WaitForDeployment && input.WaitIntervals == nil {
-		return errors.Errorf("WaitIntervals is expected if WaitForDeployment is set to true")
+		return fmt.Errorf("WaitIntervals is expected if WaitForDeployment is set to true")
 	}
 	if input.WatchDeploymentLogs && input.LogPath == "" {
-		return errors.Errorf("LogPath is expected if WatchDeploymentLogs is set to true")
+		return fmt.Errorf("LogPath is expected if WatchDeploymentLogs is set to true")
 	}
 	if input.DeploymentName == "" || input.DeploymentNamespace == "" {
-		return errors.Errorf("DeploymentName and DeploymentNamespace are expected if WaitForDeployment or WatchDeploymentLogs is true")
+		return fmt.Errorf("DeploymentName and DeploymentNamespace are expected if WaitForDeployment or WatchDeploymentLogs is true")
 	}
 	return nil
 }

--- a/test/e2e/e2e_config.go
+++ b/test/e2e/e2e_config.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
@@ -104,13 +103,13 @@ func (c *Config) Validate() error {
 	// Image should have name and loadBehavior be one of [mustload, tryload].
 	for i, containerImage := range c.Images {
 		if containerImage.Name == "" {
-			return errors.Errorf("Container image is missing name: Images[%d].Name=%q", i, containerImage.Name)
+			return fmt.Errorf("Container image is missing name: Images[%d].Name=%q", i, containerImage.Name)
 		}
 		switch containerImage.LoadBehavior {
 		case clusterctl.MustLoadImage, clusterctl.TryLoadImage:
 			// Valid
 		default:
-			return errors.Errorf("Invalid load behavior: Images[%d].LoadBehavior=%q", i, containerImage.LoadBehavior)
+			return fmt.Errorf("Invalid load behavior: Images[%d].LoadBehavior=%q", i, containerImage.LoadBehavior)
 		}
 	}
 
@@ -118,14 +117,14 @@ func (c *Config) Validate() error {
 	for k, intervals := range c.Intervals {
 		switch len(intervals) {
 		case 0:
-			return errors.Errorf("Invalid interval: Intervals[%s]=%q", k, intervals)
+			return fmt.Errorf("Invalid interval: Intervals[%s]=%q", k, intervals)
 		case 1, 2: //nolint: mnd
 		default:
-			return errors.Errorf("Invalid interval: Intervals[%s]=%q", k, intervals)
+			return fmt.Errorf("Invalid interval: Intervals[%s]=%q", k, intervals)
 		}
 		for _, i := range intervals {
 			if _, err := time.ParseDuration(i); err != nil {
-				return errors.Errorf("Invalid interval: Intervals[%s]=%q", k, intervals)
+				return fmt.Errorf("Invalid interval: Intervals[%s]=%q", k, intervals)
 			}
 		}
 	}

--- a/test/go.mod
+++ b/test/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.5.1
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
-	github.com/pkg/errors v0.9.1
 	golang.org/x/crypto v0.37.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.32.4
@@ -101,6 +100,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.4 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/pkg/errors is deprecated and archived project. Switch to standard library's errors pkg.
