### PR TITLE
⚠️ Prevent changing ExternallyProvisioned in the webhook

### DIFF
--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation.go
@@ -109,6 +109,10 @@ func (webhook *BareMetalHost) validateChanges(oldObj *metal3api.BareMetalHost, n
 		errs = append(errs, errors.New("bootMACAddress can not be changed once it is set"))
 	}
 
+	if oldObj.Spec.ExternallyProvisioned != newObj.Spec.ExternallyProvisioned {
+		errs = append(errs, errors.New("externallyProvisioned can not be changed"))
+	}
+
 	return errs
 }
 

--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -77,6 +77,11 @@ func TestValidateCreate(t *testing.T) {
 			wantedErr: "",
 		},
 		{
+			name:      "validExternallyProvisioned",
+			newBMH:    &metal3api.BareMetalHost{TypeMeta: tm, ObjectMeta: om, Spec: metal3api.BareMetalHostSpec{ExternallyProvisioned: true}},
+			wantedErr: "",
+		},
+		{
 			name:      "invalidName",
 			newBMH:    &metal3api.BareMetalHost{TypeMeta: tm, ObjectMeta: inom, Spec: metal3api.BareMetalHostSpec{}},
 			oldBMH:    nil,
@@ -894,6 +899,14 @@ func TestValidateUpdate(t *testing.T) {
 			oldBMH: &metal3api.BareMetalHost{
 				TypeMeta: tm, ObjectMeta: om, Spec: metal3api.BareMetalHostSpec{BootMACAddress: "test-mac"}},
 			wantedErr: "bootMACAddress can not be changed once it is set",
+		},
+		{
+			name: "updateExternallyProvisioned",
+			newBMH: &metal3api.BareMetalHost{
+				TypeMeta: tm, ObjectMeta: om, Spec: metal3api.BareMetalHostSpec{}},
+			oldBMH: &metal3api.BareMetalHost{
+				TypeMeta: tm, ObjectMeta: om, Spec: metal3api.BareMetalHostSpec{ExternallyProvisioned: true}},
+			wantedErr: "externallyProvisioned can not be changed",
 		},
 	}
 


### PR DESCRIPTION
Changing ExternallyProvisioned does not actually work. Furthermore, it
results in a host hopelessly stuck in the "inspecting" state (in my
testing, I could not even delete it). Until we sort out this issue, let
us prevent users from getting into a problem.

Workaround for: #2465
Includes:
- https://github.com/metal3-io/baremetal-operator/pull/2471

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
