### PR TITLE
:seedling: make BMO periodics manually triggerable

### DIFF
--- a/.github/workflows/e2e-test-optional-periodic.yml
+++ b/.github/workflows/e2e-test-optional-periodic.yml
@@ -4,6 +4,7 @@ on:
   schedule:
   # Run every day at 04:20 UTC (it is recommended to avoid running at the start of the hour)
   - cron: '20 4 * * *'
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/e2e-test-periodic-main.yml
+++ b/.github/workflows/e2e-test-periodic-main.yml
@@ -4,6 +4,7 @@ on:
   schedule:
   # Run every day at 02:20 UTC (it is recommended to avoid running at the start of the hour)
   - cron: '20 2 * * *'
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/e2e-test-periodic-release-0.10.yml
+++ b/.github/workflows/e2e-test-periodic-release-0.10.yml
@@ -4,6 +4,7 @@ on:
   schedule:
   # Run every day at 02:50 UTC (it is recommended to avoid running at the start of the hour)
   - cron: '50 2 * * *'
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/e2e-test-periodic-release-0.8.yml
+++ b/.github/workflows/e2e-test-periodic-release-0.8.yml
@@ -4,6 +4,7 @@ on:
   schedule:
   # Run every day at 02:20 UTC (it is recommended to avoid running at the start of the hour)
   - cron: '20 2 * * *'
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/e2e-test-periodic-release-0.9.yml
+++ b/.github/workflows/e2e-test-periodic-release-0.9.yml
@@ -4,6 +4,7 @@ on:
   schedule:
   # Run every day at 03:20 UTC (it is recommended to avoid running at the start of the hour)
   - cron: '20 3 * * *'
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
We sometimes would like to run BMO periodics manually in addition to scheduled actions.