### PR TITLE
🌱 Bump golang to v1.24

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,5 @@
 run:
-  go: "1.23"
+  go: "1.24"
   build-tags:
   - e2e
   - vbmctl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.23.8@sha256:a5339982f2e78b38b26ebbee35139854e184a4e90e1516f9f636371e720b727b
+ARG BUILD_IMAGE=docker.io/golang:1.24.3@sha256:02a22753ab3426d91ba5ba6f4dfb4ac2454f19b05afdb18d61ab02cbf1a2dffe
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GO_TEST_FLAGS = $(TEST_FLAGS)
 DEBUG = --debug
 COVER_PROFILE = cover.out
 GO := $(shell type -P go)
-GO_VERSION ?= 1.23.8
+GO_VERSION ?= 1.24.3
 
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -61,7 +61,7 @@ def validate_auth():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.23 as tilt-helper
+FROM golang:1.24 as tilt-helper
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \

--- a/hack/e2e/ensure_go.sh
+++ b/hack/e2e/ensure_go.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-MINIMUM_GO_VERSION=go1.23.8
+MINIMUM_GO_VERSION=go1.24.3
 
 # Ensure the go tool exists and is a viable version, or installs it
 verify_go_version()

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -33,6 +33,6 @@ else
         --volume "${PWD}:${WORKDIR}:rw,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        quay.io/metal3-io/basic-checks:golang-1.23 \
+        quay.io/metal3-io/basic-checks:golang-1.24 \
         "${WORKDIR}"/hack/generate.sh "$@"
 fi

--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -42,6 +42,6 @@ else
         --volume "${PWD}:${WORKDIR}:ro,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        quay.io/metal3-io/basic-checks:golang-1.23 \
+        quay.io/metal3-io/basic-checks:golang-1.24 \
         "${WORKDIR}"/hack/gomod.sh "$@"
 fi


### PR DESCRIPTION
- gomods are still using v1.23.x
- Dockerfile and prow jobs are bumped to use v1.24.3
