### PR TITLE
:seedling: Enable exhaustive linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,7 +21,7 @@ linters:
   - errchkjson
   #- errname
   #- errorlint
-  #- exhaustive
+  - exhaustive
   - exptostd
   - fatcontext
   - forbidigo
@@ -78,6 +78,8 @@ linters:
   # Run with --fast=false for more extensive checks
   fast: true
 linters-settings:
+  exhaustive:
+    default-signifies-exhaustive: true
   gosec:
     severity: medium
     confidence: medium

--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -1115,6 +1115,7 @@ func (host *BareMetalHost) OperationMetricForState(operation ProvisioningState) 
 		metric = &history.Provision
 	case StateDeprovisioning:
 		metric = &history.Deprovision
+	default:
 	}
 	return
 }

--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -585,6 +585,7 @@ func getCurrentImage(host *metal3api.BareMetalHost) *metal3api.Image {
 		if host.Spec.Image != nil && host.Spec.Image.URL != "" {
 			return host.Spec.Image.DeepCopy()
 		}
+	default:
 	}
 	return nil
 }
@@ -815,6 +816,7 @@ func (r *BareMetalHostReconciler) registerHost(prov provisioner.Provisioner, inf
 		if info.host.Spec.AutomatedCleaningMode == metal3api.CleaningModeDisabled {
 			preprovImgFormats = nil
 		}
+	default:
 	}
 
 	preprovImg, err := r.getPreprovImage(info, preprovImgFormats)

--- a/internal/controller/metal3.io/host_state_machine.go
+++ b/internal/controller/metal3.io/host_state_machine.go
@@ -110,6 +110,7 @@ func (hsm *hostStateMachine) updateHostStateFrom(initialState metal3api.Provisio
 			if actionRes := hsm.ensureCapacity(info, hsm.NextState); actionRes != nil {
 				return actionRes
 			}
+		default:
 		}
 
 		info.log.Info("changing provisioning state",
@@ -140,6 +141,7 @@ func (hsm *hostStateMachine) updateHostStateFrom(initialState metal3api.Provisio
 				info.log.Info("saving boot mode",
 					"new mode", hsm.Host.Status.Provisioning.BootMode)
 			}
+		default:
 		}
 	}
 
@@ -166,6 +168,7 @@ func (hsm *hostStateMachine) checkDelayedHost(info *reconcileInfo) actionResult 
 		if actionRes := hsm.ensureCapacity(info, info.host.Status.Provisioning.State); actionRes != nil {
 			return actionRes
 		}
+	default:
 	}
 
 	return nil
@@ -302,6 +305,7 @@ func (hsm *hostStateMachine) checkDetachedHost(info *reconcileInfo) (result acti
 		switch info.host.Status.Provisioning.State {
 		case metal3api.StateProvisioned, metal3api.StateExternallyProvisioned, metal3api.StateReady, metal3api.StateAvailable:
 			return hsm.Reconciler.detachHost(hsm.Provisioner, info)
+		default:
 		}
 	}
 	if info.host.Status.ErrorType == metal3api.DetachError {


### PR DESCRIPTION

<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Enable exhaustive linter to check exhaustiveness of switch statements of enum-like constants. Those having only one case are changed into an if-statement. 

**Which issue(s) this PR fixes**:
Fixes #2355
