### PR TITLE
:seedling: Enable variable shadowing check in govet linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -124,6 +124,9 @@ linters-settings:
     - unnecessaryDefer
     - whyNoLint
     - wrapperFunc
+  govet:
+    enable:
+    - shadow
   tagliatelle:
     case:
       rules:

--- a/hack/tools/deploy-cli/deploy-cli.go
+++ b/hack/tools/deploy-cli/deploy-cli.go
@@ -80,7 +80,7 @@ func (d *DeployContext) determineIronicAuth() error {
 	ironicAuthDir := filepath.Join(ironicDataDir, "auth")
 	ironicUsernameFile := filepath.Join(ironicAuthDir, "ironic-username")
 
-	if err := os.MkdirAll(ironicAuthDir, filePerm755); err != nil {
+	if err = os.MkdirAll(ironicAuthDir, filePerm755); err != nil {
 		return err
 	}
 
@@ -119,7 +119,6 @@ func (d *DeployContext) determineIronicAuth() error {
 // deployIronic configures the kustomize overlay for ironic
 // based on the configuration, then install ironic with that overlay.
 func (d *DeployContext) deployIronic() error {
-	var err error
 	ironicDataDir, err := d.GetEnvOrDefault("IRONIC_DATA_DIR")
 	if err != nil {
 		return err
@@ -127,7 +126,7 @@ func (d *DeployContext) deployIronic() error {
 	configMapFileName := "ironic_bmo_configmap.env"
 	configMapInDataDir := filepath.Join(ironicDataDir, configMapFileName)
 
-	if _, err := os.Stat(configMapInDataDir); err == nil && d.IronicBMOConfigMapEnvFile == "" {
+	if _, err = os.Stat(configMapInDataDir); err == nil && d.IronicBMOConfigMapEnvFile == "" {
 		log.Printf("Detected ironic_bmo_configmap.env file in IRONIC_DATA_DIR: %s. Taken into use.", configMapInDataDir)
 		d.IronicBMOConfigMapEnvFile = configMapInDataDir
 	}
@@ -149,14 +148,14 @@ func (d *DeployContext) deployIronic() error {
 
 		kustomizeFile := filepath.Join(ironicOverlay, "kustomization.yaml")
 
-		if err := RenderEmbedTemplateToFile(d.TemplateFiles, ironicKustomizeTpl, kustomizeFile, d); err != nil {
+		if err = RenderEmbedTemplateToFile(d.TemplateFiles, ironicKustomizeTpl, kustomizeFile, d); err != nil {
 			return err
 		}
 
 		ironicBMOConfigMapTpl := "templates/ironic_bmo_configmap_env.tpl"
 		ironicBMOConfigMapOutput := filepath.Join(ironicOverlay, configMapFileName)
 
-		if err := RenderEmbedTemplateToFile(d.TemplateFiles, ironicBMOConfigMapTpl, ironicBMOConfigMapOutput, d); err != nil {
+		if err = RenderEmbedTemplateToFile(d.TemplateFiles, ironicBMOConfigMapTpl, ironicBMOConfigMapOutput, d); err != nil {
 			return err
 		}
 
@@ -168,7 +167,7 @@ func (d *DeployContext) deployIronic() error {
 
 	if d.IronicBMOConfigMapEnvFile != "" {
 		log.Printf("Using custom ironic_bmo_configmap.env file: %s", d.IronicBMOConfigMapEnvFile)
-		if err := CopyFile(d.IronicBMOConfigMapEnvFile, filepath.Join(ironicOverlay, "ironic_bmo_configmap.env")); err != nil {
+		if err = CopyFile(d.IronicBMOConfigMapEnvFile, filepath.Join(ironicOverlay, "ironic_bmo_configmap.env")); err != nil {
 			return err
 		}
 	}
@@ -176,7 +175,8 @@ func (d *DeployContext) deployIronic() error {
 	username, password := d.IronicUsername, d.IronicPassword
 
 	if username != "" && password != "" {
-		ironicHtpasswd, err := GenerateHtpasswd(username, password)
+		var ironicHtpasswd string
+		ironicHtpasswd, err = GenerateHtpasswd(username, password)
 		if err != nil {
 			return err
 		}
@@ -200,7 +200,7 @@ func (d *DeployContext) deployBMO() error {
 	ironicEnvFileName := "ironic.env"
 	ironicEnvInDataDir := filepath.Join(ironicDataDir, ironicEnvFileName)
 
-	if _, err := os.Stat(ironicEnvInDataDir); err == nil && d.IronicEnvFile == "" {
+	if _, err = os.Stat(ironicEnvInDataDir); err == nil && d.IronicEnvFile == "" {
 		log.Printf("Detected ironic.env file in IRONIC_DATA_DIR: %s. Taken into use.", ironicEnvInDataDir)
 		d.IronicEnvFile = ironicEnvInDataDir
 	}

--- a/hack/tools/deploy-cli/main.go
+++ b/hack/tools/deploy-cli/main.go
@@ -117,7 +117,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := dc.determineIronicAuth(); err != nil {
+	if err = dc.determineIronicAuth(); err != nil {
 		log.Fatalf("Error retrieving Ironic username/password: %v", err)
 	}
 

--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -170,7 +170,7 @@ func (r *BareMetalHostReconciler) Reconcile(ctx context.Context, request ctrl.Re
 		)
 		host.Finalizers = append(host.Finalizers,
 			metal3api.BareMetalHostFinalizer)
-		err := r.Update(ctx, host)
+		err = r.Update(ctx, host)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 		}
@@ -1015,7 +1015,7 @@ func (r *BareMetalHostReconciler) actionInspecting(prov provisioner.Provisioner,
 		}
 
 		if dirty {
-			if err := r.Update(info.ctx, info.host); err != nil {
+			if err = r.Update(info.ctx, info.host); err != nil {
 				return actionError{fmt.Errorf("failed to update the host after inspection start: %w", err)}
 			}
 			return actionContinue{}
@@ -1067,10 +1067,10 @@ func (r *BareMetalHostReconciler) actionInspecting(prov provisioner.Provisioner,
 		if controllerutil.ContainsFinalizer(hardwareData, hardwareDataFinalizer) {
 			controllerutil.RemoveFinalizer(hardwareData, hardwareDataFinalizer)
 		}
-		if err := r.Update(info.ctx, hardwareData); err != nil {
+		if err = r.Update(info.ctx, hardwareData); err != nil {
 			return actionError{fmt.Errorf("failed to remove hardwareData finalizer: %w", err)}
 		}
-		if err := r.Client.Delete(info.ctx, hd); err != nil {
+		if err = r.Client.Delete(info.ctx, hd); err != nil {
 			return actionError{fmt.Errorf("failed to delete hardwareData: %w", err)}
 		}
 	}
@@ -1480,7 +1480,7 @@ func (r *BareMetalHostReconciler) doServiceIfNeeded(prov provisioner.Provisioner
 		info.host.Status.Provisioning.Firmware = nil
 		if hfcDirty && hfc.Status.Updates != nil {
 			hfc.Status.Updates = nil
-			if err := r.Status().Update(info.ctx, hfc); err != nil {
+			if err = r.Status().Update(info.ctx, hfc); err != nil {
 				return actionError{fmt.Errorf("failed to update hostfirmwarecomponents status: %w", err)}
 			}
 		}
@@ -1576,7 +1576,8 @@ func (r *BareMetalHostReconciler) manageHostPower(prov provisioner.Provisioner, 
 
 	servicingAllowed := isProvisioned && !info.host.Status.PoweredOn && desiredPowerOnState
 	if servicingAllowed || info.host.Status.OperationalStatus == metal3api.OperationalStatusServicing || info.host.Status.ErrorType == metal3api.ServicingError {
-		hup, err := r.acquireHostUpdatePolicy(info)
+		var hup *metal3api.HostUpdatePolicy
+		hup, err = r.acquireHostUpdatePolicy(info)
 		if err != nil {
 			info.log.Info("failed setting owner reference on hostupdatepolicy")
 			return actionError{fmt.Errorf("failed setting owner reference on hostUpdatePolicy: %w", err)}
@@ -1808,8 +1809,8 @@ func (r *BareMetalHostReconciler) attachDataImage(prov provisioner.Provisioner, 
 		dataImage.Status.Error.Count++
 		dataImage.Status.Error.Message = err.Error()
 		// Error updating DataImage Status
-		if err := r.Status().Update(info.ctx, dataImage); err != nil {
-			return fmt.Errorf("failed to update DataImage status, %w", err)
+		if errOnUpdate := r.Status().Update(info.ctx, dataImage); errOnUpdate != nil {
+			return fmt.Errorf("failed to update DataImage status, %w", errOnUpdate)
 		}
 
 		return fmt.Errorf("failed to attach dataImage, %w", err)
@@ -1838,8 +1839,8 @@ func (r *BareMetalHostReconciler) detachDataImage(prov provisioner.Provisioner, 
 		dataImage.Status.Error.Count++
 		dataImage.Status.Error.Message = err.Error()
 		// Error updating DataImage Status
-		if err := r.Status().Update(info.ctx, dataImage); err != nil {
-			return fmt.Errorf("failed to update DataImage status, %w", err)
+		if errOnUpdate := r.Status().Update(info.ctx, dataImage); errOnUpdate != nil {
+			return fmt.Errorf("failed to update DataImage status, %w", errOnUpdate)
 		}
 
 		return fmt.Errorf("failed to detach dataImage, %w", err)

--- a/internal/controller/metal3.io/dataimage_controller.go
+++ b/internal/controller/metal3.io/dataimage_controller.go
@@ -119,7 +119,7 @@ func (r *DataImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			di.Finalizers = utils.FilterStringFromList(
 				di.Finalizers, metal3api.DataImageFinalizer)
 
-			if err := r.Update(ctx, di); err != nil {
+			if err = r.Update(ctx, di); err != nil {
 				return ctrl.Result{Requeue: true, RequeueAfter: dataImageRetryDelay}, fmt.Errorf("failed to update resource after remove finalizer, %w", err)
 			}
 			return ctrl.Result{}, nil

--- a/internal/controller/metal3.io/preprovisioningimage_controller.go
+++ b/internal/controller/metal3.io/preprovisioningimage_controller.go
@@ -83,12 +83,12 @@ func (r *PreprovisioningImageReconciler) Reconcile(ctx context.Context, req ctrl
 
 	if !img.DeletionTimestamp.IsZero() {
 		log.Info("cleaning up deleted resource")
-		if err := r.discardExistingImage(&img, log); err != nil {
+		if err = r.discardExistingImage(&img, log); err != nil {
 			return ctrl.Result{}, err
 		}
 		img.Finalizers = utils.FilterStringFromList(
 			img.Finalizers, metal3api.PreprovisioningImageFinalizer)
-		err := r.Update(ctx, &img)
+		err = r.Update(ctx, &img)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
 		}
@@ -98,7 +98,7 @@ func (r *PreprovisioningImageReconciler) Reconcile(ctx context.Context, req ctrl
 	if !utils.StringInList(img.Finalizers, metal3api.PreprovisioningImageFinalizer) {
 		log.Info("adding finalizer")
 		img.Finalizers = append(img.Finalizers, metal3api.PreprovisioningImageFinalizer)
-		err := r.Update(ctx, &img)
+		err = r.Update(ctx, &img)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 		}
@@ -174,7 +174,7 @@ func (r *PreprovisioningImageReconciler) update(ctx context.Context, img *metal3
 			// from the image cache.
 			setUnready(generation, &img.Status, reason)
 		} else {
-			if err := r.discardExistingImage(img, log); err != nil {
+			if err = r.discardExistingImage(img, log); err != nil {
 				return false, err
 			}
 			// Set up all the data before building the image and adding the URL,

--- a/main.go
+++ b/main.go
@@ -231,7 +231,8 @@ func main() {
 	}
 
 	if leaseDurationSeconds != "" {
-		seconds, err := strconv.ParseInt(leaseDurationSeconds, 10, 16)
+		var seconds int64
+		seconds, err = strconv.ParseInt(leaseDurationSeconds, 10, 16)
 		if err != nil {
 			setupLog.Error(err, "failed to parse duration")
 			os.Exit(1)
@@ -242,7 +243,8 @@ func main() {
 	}
 
 	if renewDeadlineSeconds != "" {
-		seconds, err := strconv.ParseInt(renewDeadlineSeconds, 10, 16)
+		var seconds int64
+		seconds, err = strconv.ParseInt(renewDeadlineSeconds, 10, 16)
 		if err != nil {
 			setupLog.Error(err, "failed to parse renew deadline")
 			os.Exit(1)
@@ -253,7 +255,8 @@ func main() {
 	}
 
 	if retryPeriodSeconds != "" {
-		seconds, err := strconv.ParseInt(retryPeriodSeconds, 10, 16)
+		var seconds int64
+		seconds, err = strconv.ParseInt(retryPeriodSeconds, 10, 16)
 		if err != nil {
 			setupLog.Error(err, "failed to parse retry period")
 			os.Exit(1)

--- a/pkg/provisioner/ironic/clients/auth.go
+++ b/pkg/provisioner/ironic/clients/auth.go
@@ -43,7 +43,7 @@ func readAuthFile(filename string) (string, error) {
 func LoadAuth() (auth AuthConfig, err error) {
 	authPath := path.Join(authRoot(), "ironic")
 
-	if _, err := os.Stat(authPath); err != nil {
+	if _, err = os.Stat(authPath); err != nil {
 		if os.IsNotExist(err) {
 			auth.Type = NoAuth
 			return auth, nil

--- a/pkg/provisioner/ironic/testserver/server.go
+++ b/pkg/provisioner/ironic/testserver/server.go
@@ -91,8 +91,8 @@ func (m *MockServer) Handler(pattern string, handlerFunc http.HandlerFunc) *Mock
 
 func (m *MockServer) buildHandler(_ string) func(http.ResponseWriter, *http.Request) {
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		if response, ok := m.responsesByMethod[r.URL.Path][r.Method]; ok {
-			m.sendData(w, r, response.code, response.payload)
+		if resp, ok := m.responsesByMethod[r.URL.Path][r.Method]; ok {
+			m.sendData(w, r, resp.code, resp.payload)
 			return
 		}
 
@@ -203,7 +203,7 @@ func (m *MockServer) AddDefaultResponse(patternWithVars string, httpMethod strin
 	pattern := "^" + regexp.MustCompile("{(.[^}]*)}").ReplaceAllString(patternWithVars, "(?P<$1>.[^/]*)") + "$"
 	m.t.Logf("%s: adding default response for %s (%s) -> {%d, %s}", m.name, patternWithVars, pattern, code, payload)
 
-	defaultResponse := defaultResponse{
+	defaultResp := defaultResponse{
 		re:     regexp.MustCompile(pattern),
 		method: httpMethod,
 		response: response{
@@ -212,7 +212,7 @@ func (m *MockServer) AddDefaultResponse(patternWithVars string, httpMethod strin
 		},
 	}
 
-	m.defaultResponses = append(m.defaultResponses, defaultResponse)
+	m.defaultResponses = append(m.defaultResponses, defaultResp)
 	return m
 }
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -108,6 +108,7 @@ func serviceAccountToken() (string, error) {
 
 	var out string
 	verifyTokenCreation := func(g Gomega) {
+		var output []byte
 		// Execute kubectl command to create the token
 		cmd := exec.Command("kubectl", "create", "--raw", fmt.Sprintf(
 			"/api/v1/namespaces/%s/serviceaccounts/%s/token",
@@ -115,7 +116,7 @@ func serviceAccountToken() (string, error) {
 			serviceAccountName,
 		), "-f", tokenRequestFile)
 
-		output, err := cmd.CombinedOutput()
+		output, err = cmd.CombinedOutput()
 		g.Expect(err).NotTo(HaveOccurred())
 
 		// Parse the JSON output to extract the token
@@ -165,7 +166,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	scheme := runtime.NewScheme()
 	framework.TryAddDefaultSchemes(scheme)
-	clusterProxy := framework.NewClusterProxy("bmo-e2e", kubeconfigPath, scheme)
+	clusterProxy = framework.NewClusterProxy("bmo-e2e", kubeconfigPath, scheme)
 	Expect(clusterProxy).ToNot(BeNil(), "Failed to get a cluster proxy")
 
 	DeferCleanup(func() {
@@ -240,8 +241,9 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 		By("validating that the metrics service is available")
 		Eventually(func() error {
-			cmd := exec.Command("kubectl", "get", "service", metricsServiceName, "-n", namespace)
-			output, err := cmd.CombinedOutput()
+			var output []byte
+			cmd = exec.Command("kubectl", "get", "service", metricsServiceName, "-n", namespace)
+			output, err = cmd.CombinedOutput()
 			if err != nil {
 				log.Printf("Service check output: %s\n", string(output))
 				return err
@@ -256,8 +258,9 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 		By("waiting for the metrics endpoint to be ready")
 		verifyMetricsEndpointReady := func(g Gomega) {
-			cmd := exec.Command("kubectl", "get", "endpoints", metricsServiceName, "-n", namespace)
-			output, err := cmd.CombinedOutput()
+			var output []byte
+			cmd = exec.Command("kubectl", "get", "endpoints", metricsServiceName, "-n", namespace)
+			output, err = cmd.CombinedOutput()
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(output).To(ContainSubstring("8443"), "Metrics endpoint is not ready")
 		}
@@ -275,10 +278,11 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 		By("waiting for the curl-metrics pod to complete.")
 		verifyCurlUp := func(g Gomega) {
-			cmd := exec.Command("kubectl", "get", "pods", "curl-metrics",
+			var output []byte
+			cmd = exec.Command("kubectl", "get", "pods", "curl-metrics",
 				"-o", "jsonpath={.status.phase}",
 				"-n", namespace)
-			output, err := cmd.CombinedOutput()
+			output, err = cmd.CombinedOutput()
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(string(output)).To(Equal("Succeeded"), "curl pod in wrong status")
 		}

--- a/test/e2e/provisioning_and_annotation_test.go
+++ b/test/e2e/provisioning_and_annotation_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Provision, detach, recreate from status and deprovision", Labe
 
 			By("Waiting for the secret to be deleted")
 			Eventually(func() bool {
-				err := clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{
 					Name:      "bmc-credentials",
 					Namespace: namespace.Name,
 				}, &corev1.Secret{})


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable variable shadowing check in govet linter. Fix warnings caused by running the linter.

**Which issue(s) this PR fixes**:
Fixes #2460