### PR TITLE
:sparkles:  Allow configuring different IPA images per architecture

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -847,6 +847,7 @@ func (r *BareMetalHostReconciler) registerHost(prov provisioner.Provisioner, inf
 			PreprovisioningNetworkData: preprovisioningNetworkData,
 			HasCustomDeploy:            hasCustomDeploy(info.host),
 			DisablePowerOff:            info.host.Spec.DisablePowerOff,
+			CPUArchitecture:            getHostArchitecture(info.host),
 		},
 		credsChanged,
 		info.host.Status.ErrorType == metal3api.RegistrationError)

--- a/pkg/imageprovider/imageprovider.go
+++ b/pkg/imageprovider/imageprovider.go
@@ -20,6 +20,7 @@ type ImageData struct {
 type GeneratedImage struct {
 	ImageURL          string
 	KernelURL         string
+	BootloaderURL     string
 	ExtraKernelParams string
 }
 

--- a/pkg/provisioner/ironic/factory_test.go
+++ b/pkg/provisioner/ironic/factory_test.go
@@ -14,6 +14,11 @@ type EnvFixture struct {
 	kernelURL                        string
 	ramdiskURL                       string
 	isoURL                           string
+	bootloaderURL                    string
+	aarch64kernelURL                 string
+	aarch64ramdiskURL                string
+	aarch64isoURL                    string
+	aarch64bootloaderURL             string
 	liveISOForcePersistentBootDevice string
 	ironicCACertFile                 string
 	ironicClientCertFile             string
@@ -49,6 +54,11 @@ func (f *EnvFixture) SetUp() {
 	f.replace("DEPLOY_KERNEL_URL", f.kernelURL)
 	f.replace("DEPLOY_RAMDISK_URL", f.ramdiskURL)
 	f.replace("DEPLOY_ISO_URL", f.isoURL)
+	f.replace("DEPLOY_BOOTLOADER_URL", f.bootloaderURL)
+	f.replace("DEPLOY_KERNEL_URL_AARCH64", f.aarch64kernelURL)
+	f.replace("DEPLOY_RAMDISK_URL_AARCH64", f.aarch64ramdiskURL)
+	f.replace("DEPLOY_ISO_URL_AARCH64", f.aarch64isoURL)
+	f.replace("DEPLOY_BOOTLOADER_URL_AARCH64", f.aarch64bootloaderURL)
 	f.replace("LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE", f.liveISOForcePersistentBootDevice)
 	f.replace("IRONIC_CACERT_FILE", f.ironicCACertFile)
 	f.replace("IRONIC_CLIENT_CERT_FILE", f.ironicClientCertFile)
@@ -58,9 +68,14 @@ func (f *EnvFixture) SetUp() {
 }
 func (f EnvFixture) VerifyConfig(t *testing.T, c ironicConfig, _ string) {
 	t.Helper()
-	assert.Equal(t, f.kernelURL, c.deployKernelURL)
-	assert.Equal(t, f.ramdiskURL, c.deployRamdiskURL)
-	assert.Equal(t, f.isoURL, c.deployISOURL)
+	assert.Equal(t, f.kernelURL, c.defaultDeployConfig.kernelURL)
+	assert.Equal(t, f.ramdiskURL, c.defaultDeployConfig.ramdiskURL)
+	assert.Equal(t, f.isoURL, c.defaultDeployConfig.ISOURL)
+	assert.Equal(t, f.bootloaderURL, c.defaultDeployConfig.bootloaderURL)
+	assert.Equal(t, f.aarch64kernelURL, c.archDeployConfig["aarch64"].kernelURL)
+	assert.Equal(t, f.aarch64ramdiskURL, c.archDeployConfig["aarch64"].ramdiskURL)
+	assert.Equal(t, f.aarch64isoURL, c.archDeployConfig["aarch64"].ISOURL)
+	assert.Equal(t, f.aarch64bootloaderURL, c.archDeployConfig["aarch64"].bootloaderURL)
 	assert.Equal(t, f.liveISOForcePersistentBootDevice, c.liveISOForcePersistentBootDevice)
 }
 
@@ -108,14 +123,14 @@ func TestLoadConfigFromEnv(t *testing.T) {
 			env: EnvFixture{
 				kernelURL: "http://kernel",
 			},
-			expectedError: "either DEPLOY_KERNEL_URL and DEPLOY_RAMDISK_URL or DEPLOY_ISO_URL must be set",
+			expectedError: "DEPLOY_KERNEL_URL and DEPLOY_RAMDISK_URL can only be set together",
 		},
 		{
 			name: "only ramdisk",
 			env: EnvFixture{
 				ramdiskURL: "http://ramdisk",
 			},
-			expectedError:         "either DEPLOY_KERNEL_URL and DEPLOY_RAMDISK_URL or DEPLOY_ISO_URL must be set",
+			expectedError:         "DEPLOY_KERNEL_URL and DEPLOY_RAMDISK_URL can only be set together",
 			expectedImgBuildError: "DEPLOY_RAMDISK_URL requires DEPLOY_KERNEL_URL to be set also",
 		},
 		{

--- a/pkg/provisioner/ironic/ironic_test.go
+++ b/pkg/provisioner/ironic/ironic_test.go
@@ -27,10 +27,12 @@ func newTestProvisionerFactory() ironicProvisionerFactory {
 	return ironicProvisionerFactory{
 		log: logf.Log,
 		config: ironicConfig{
-			deployKernelURL:  "http://deploy.test/ipa.kernel",
-			deployRamdiskURL: "http://deploy.test/ipa.initramfs",
-			deployISOURL:     "http://deploy.test/ipa.iso",
-			maxBusyHosts:     20,
+			defaultDeployConfig: ironicDeployConfig{
+				kernelURL:  "http://deploy.test/ipa.kernel",
+				ramdiskURL: "http://deploy.test/ipa.initramfs",
+				ISOURL:     "http://deploy.test/ipa.iso",
+			},
+			maxBusyHosts: 20,
 		},
 	}
 }

--- a/pkg/provisioner/ironic/register_test.go
+++ b/pkg/provisioner/ironic/register_test.go
@@ -1112,9 +1112,11 @@ func TestSetDeployImage(t *testing.T) {
 			Scenario: "iso no imgbuilder",
 			Config: ironicConfig{
 				havePreprovImgBuilder: false,
-				deployKernelURL:       localKernel,
-				deployRamdiskURL:      localRamdisk,
-				deployISOURL:          localIso,
+				defaultDeployConfig: ironicDeployConfig{
+					kernelURL:  localKernel,
+					ramdiskURL: localRamdisk,
+					ISOURL:     localIso,
+				},
 			},
 			Driver:      isoDriver,
 			ExpectBuild: false,
@@ -1125,8 +1127,10 @@ func TestSetDeployImage(t *testing.T) {
 			Scenario: "no imgbuilder no iso",
 			Config: ironicConfig{
 				havePreprovImgBuilder: false,
-				deployKernelURL:       localKernel,
-				deployRamdiskURL:      localRamdisk,
+				defaultDeployConfig: ironicDeployConfig{
+					kernelURL:  localKernel,
+					ramdiskURL: localRamdisk,
+				},
 			},
 			Driver:      isoDriver,
 			ExpectBuild: false,
@@ -1137,9 +1141,11 @@ func TestSetDeployImage(t *testing.T) {
 			Scenario: "pxe no imgbuilder",
 			Config: ironicConfig{
 				havePreprovImgBuilder: false,
-				deployKernelURL:       localKernel,
-				deployRamdiskURL:      localRamdisk,
-				deployISOURL:          localIso,
+				defaultDeployConfig: ironicDeployConfig{
+					kernelURL:  localKernel,
+					ramdiskURL: localRamdisk,
+					ISOURL:     localIso,
+				},
 			},
 			Driver:      pxeDriver,
 			ExpectBuild: false,
@@ -1150,9 +1156,11 @@ func TestSetDeployImage(t *testing.T) {
 			Scenario: "iso no build",
 			Config: ironicConfig{
 				havePreprovImgBuilder: true,
-				deployKernelURL:       localKernel,
-				deployRamdiskURL:      localRamdisk,
-				deployISOURL:          localIso,
+				defaultDeployConfig: ironicDeployConfig{
+					kernelURL:  localKernel,
+					ramdiskURL: localRamdisk,
+					ISOURL:     localIso,
+				},
 			},
 			Driver:    isoDriver,
 			ExpectISO: false,
@@ -1162,9 +1170,11 @@ func TestSetDeployImage(t *testing.T) {
 			Scenario: "iso build",
 			Config: ironicConfig{
 				havePreprovImgBuilder: true,
-				deployKernelURL:       localKernel,
-				deployRamdiskURL:      localRamdisk,
-				deployISOURL:          localIso,
+				defaultDeployConfig: ironicDeployConfig{
+					kernelURL:  localKernel,
+					ramdiskURL: localRamdisk,
+					ISOURL:     localIso,
+				},
 			},
 			Driver: isoDriver,
 			Image: &provisioner.PreprovisioningImage{
@@ -1181,9 +1191,11 @@ func TestSetDeployImage(t *testing.T) {
 			Scenario: "pxe build",
 			Config: ironicConfig{
 				havePreprovImgBuilder: true,
-				deployKernelURL:       localKernel,
-				deployRamdiskURL:      localRamdisk,
-				deployISOURL:          localIso,
+				defaultDeployConfig: ironicDeployConfig{
+					kernelURL:  localKernel,
+					ramdiskURL: localRamdisk,
+					ISOURL:     localIso,
+				},
 			},
 			Driver: pxeDriver,
 			Image: &provisioner.PreprovisioningImage{
@@ -1200,9 +1212,11 @@ func TestSetDeployImage(t *testing.T) {
 			Scenario: "pxe build with new kernel and kernel params",
 			Config: ironicConfig{
 				havePreprovImgBuilder: true,
-				deployKernelURL:       localKernel,
-				deployRamdiskURL:      localRamdisk,
-				deployISOURL:          localIso,
+				defaultDeployConfig: ironicDeployConfig{
+					kernelURL:  localKernel,
+					ramdiskURL: localRamdisk,
+					ISOURL:     localIso,
+				},
 			},
 			Driver: pxeDriver,
 			Image: &provisioner.PreprovisioningImage{
@@ -1223,9 +1237,11 @@ func TestSetDeployImage(t *testing.T) {
 			Scenario: "pxe iso build",
 			Config: ironicConfig{
 				havePreprovImgBuilder: true,
-				deployKernelURL:       localKernel,
-				deployRamdiskURL:      localRamdisk,
-				deployISOURL:          localIso,
+				defaultDeployConfig: ironicDeployConfig{
+					kernelURL:  localKernel,
+					ramdiskURL: localRamdisk,
+					ISOURL:     localIso,
+				},
 			},
 			Driver: pxeDriver,
 			Image: &provisioner.PreprovisioningImage{
@@ -1242,7 +1258,9 @@ func TestSetDeployImage(t *testing.T) {
 			Scenario: "pxe build no kernel",
 			Config: ironicConfig{
 				havePreprovImgBuilder: true,
-				deployISOURL:          localIso,
+				defaultDeployConfig: ironicDeployConfig{
+					ISOURL: localIso,
+				},
 			},
 			Driver: pxeDriver,
 			Image: &provisioner.PreprovisioningImage{
@@ -1273,7 +1291,9 @@ func TestSetDeployImage(t *testing.T) {
 			Scenario: "pxe iso build no initrd",
 			Config: ironicConfig{
 				havePreprovImgBuilder: true,
-				deployKernelURL:       localKernel,
+				defaultDeployConfig: ironicDeployConfig{
+					kernelURL: localKernel,
+				},
 			},
 			Driver: pxeDriver,
 			Image: &provisioner.PreprovisioningImage{
@@ -1289,7 +1309,9 @@ func TestSetDeployImage(t *testing.T) {
 			Scenario: "no build no initrd",
 			Config: ironicConfig{
 				havePreprovImgBuilder: true,
-				deployKernelURL:       localKernel,
+				defaultDeployConfig: ironicDeployConfig{
+					kernelURL: localKernel,
+				},
 			},
 			Driver:    pxeDriver,
 			ExpectISO: false,
@@ -1299,7 +1321,9 @@ func TestSetDeployImage(t *testing.T) {
 			Scenario: "pxe no imgbuilder no pxe",
 			Config: ironicConfig{
 				havePreprovImgBuilder: false,
-				deployISOURL:          localIso,
+				defaultDeployConfig: ironicDeployConfig{
+					ISOURL: localIso,
+				},
 			},
 			Driver:    pxeDriver,
 			ExpectISO: false,
@@ -1318,7 +1342,7 @@ func TestSetDeployImage(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Scenario, func(t *testing.T) {
-			opts := setDeployImage(tc.Config, tc.Driver, tc.Image)
+			opts := setDeployImage(tc.Config, tc.Driver, tc.Image, "x86_64")
 
 			switch {
 			case tc.ExpectISO:

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -82,6 +82,7 @@ type ManagementAccessData struct {
 	PreprovisioningNetworkData string
 	HasCustomDeploy            bool
 	DisablePowerOff            bool
+	CPUArchitecture            string
 }
 
 type AdoptData struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows one to work with BareMetalHosts of different architectures while using kernel+ramdisk for preprovisioning.

It does this by adding new environment variables to configure the different URLs per target CPU architecture:
 - `DEPLOY_KERNEL_URL_<ARCH>`
 - `DEPLOY_RAMDISK_URL_<ARCH>`
 - `DEPLOY_ISO_URL_<ARCH>`
 - `DEPLOY_BOOTLOADER_URL_<ARCH>`

Non suffixed variables are used as defaults, if there is no architecture specific image(s) defined for the BMH CPU architecture.

It also adds management of the Ironic bootloader option in the operator, so that all elements used by Ironic to build the preprovisioning image are coming from the operator. This goes with the `DEPLOY_BOOTLOADER_URL` variable.

**Note for reviewers:**

The list of "supported" architecture is embedded here, so it will currently only checks for `x86_64` and `aarch64`, while we could potentially find arbitrary architectures by parsing the entire `os.Environ()` slice to lift that limitation I am not sure it would be relevant for now, and would make the code harder to read for that PR in my opinion.
