### PR TITLE
🌱 E2E: Expose more BMC related fields

### DIFF
--- a/test/e2e/bmc.go
+++ b/test/e2e/bmc.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"os"
 
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"gopkg.in/yaml.v2"
 )
 
@@ -18,8 +19,12 @@ type BMC struct {
 	Password string `yaml:"password,omitempty"`
 	// Address of the BMC, e.g. "redfish-virtualmedia+http://192.168.222.1:8000/redfish/v1/Systems/bmo-e2e-1".
 	Address string `yaml:"address,omitempty"`
+	// DisableCertificateVerification indicates whether to disable certificate verification for the BMC connection.
+	DisableCertificateVerification bool `yaml:"disableCertificateVerification,omitempty"`
 	// BootMacAddress is the MAC address of the VMs network interface.
 	BootMacAddress string `yaml:"bootMacAddress,omitempty"`
+	// BootMode is the boot mode for the BareMetalHost, e.g. "UEFI" or "legacy".
+	BootMode metal3api.BootMode `yaml:"bootMode,omitempty"`
 	// Name of the machine associated with this BMC.
 	Name string `yaml:"name,omitempty"`
 	// NetworkName is the name of the network that the new VM should be attached to
@@ -28,6 +33,8 @@ type BMC struct {
 	// This will be paired with the MAC address in the DHCP configuration.
 	// Example: 192.168.222.122
 	IPAddress string `yaml:"ipAddress,omitempty"`
+	// RootDeviceHints provides guidance for where to write the disk image.
+	RootDeviceHints metal3api.RootDeviceHints `yaml:"rootDeviceHints,omitempty"`
 }
 
 func LoadBMCConfig(configPath string) ([]BMC, error) {

--- a/test/e2e/config/bmcs-ipmi.yaml
+++ b/test/e2e/config/bmcs-ipmi.yaml
@@ -4,9 +4,13 @@
   bootMacAddress: "00:60:2f:31:81:01"
   name: "bmo-e2e-0"
   ipAddress: "192.168.222.122"
+  rootDeviceHints:
+    deviceName: "/dev/vda"
 - user: admin
   password: password
   address: "ipmi://192.168.222.1:16231"
   bootMacAddress: "00:60:2f:31:81:02"
   name: "bmo-e2e-1"
   ipAddress: "192.168.222.123"
+  rootDeviceHints:
+    deviceName: "/dev/vda"

--- a/test/e2e/config/bmcs-redfish-virtualmedia.yaml
+++ b/test/e2e/config/bmcs-redfish-virtualmedia.yaml
@@ -4,9 +4,13 @@
   bootMacAddress: "00:60:2f:31:81:01"
   name: "bmo-e2e-0"
   ipAddress: "192.168.222.122"
+  rootDeviceHints:
+    deviceName: "/dev/vda"
 - user: admin
   password: password
   address: "redfish-virtualmedia+http://192.168.222.1:8000/redfish/v1/Systems/bmo-e2e-1"
   bootMacAddress: "00:60:2f:31:81:02"
   name: "bmo-e2e-1"
   ipAddress: "192.168.222.123"
+  rootDeviceHints:
+    deviceName: "/dev/vda"

--- a/test/e2e/config/bmcs-redfish.yaml
+++ b/test/e2e/config/bmcs-redfish.yaml
@@ -4,9 +4,13 @@
   bootMacAddress: "00:60:2f:31:81:01"
   name: "bmo-e2e-0"
   ipAddress: "192.168.222.122"
+  rootDeviceHints:
+    deviceName: "/dev/vda"
 - user: admin
   password: password
   address: "redfish+http://192.168.222.1:8000/redfish/v1/Systems/bmo-e2e-1"
   bootMacAddress: "00:60:2f:31:81:02"
   name: "bmo-e2e-1"
   ipAddress: "192.168.222.123"
+  rootDeviceHints:
+    deviceName: "/dev/vda"

--- a/test/e2e/provisioning_and_annotation_test.go
+++ b/test/e2e/provisioning_and_annotation_test.go
@@ -86,9 +86,7 @@ var _ = Describe("Provision, detach, recreate from status and deprovision", Labe
 				Checksum:     e2eConfig.GetVariable("IMAGE_CHECKSUM"),
 				ChecksumType: metal3api.AutoChecksum,
 			}
-			bmh.Spec.RootDeviceHints = &metal3api.RootDeviceHints{
-				DeviceName: "/dev/vda",
-			}
+			bmh.Spec.RootDeviceHints = &bmc.RootDeviceHints
 			// The ssh check is not possible in all situations (e.g. fixture) so it can be skipped
 			if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
 				userDataSecretName := "user-data"
@@ -216,9 +214,7 @@ var _ = Describe("Provision, detach, recreate from status and deprovision", Labe
 						URL:      e2eConfig.GetVariable("IMAGE_URL"),
 						Checksum: e2eConfig.GetVariable("IMAGE_CHECKSUM"),
 					},
-					RootDeviceHints: &metal3api.RootDeviceHints{
-						DeviceName: "/dev/vda",
-					},
+					RootDeviceHints: &bmc.RootDeviceHints,
 				},
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This makes it possible to specify the rootDeviceHints in the "BMCs" config file for e2e tests. It is necessary when running the tests against real hardware that may have different disk devices.
It also adds bootMode and disableCertificateVerification that may be
needed depending on the hardware.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
