### PR TITLE
🌱 e2e: wait for detachment to actually happen

### DIFF
--- a/test/e2e/config/fixture.yaml
+++ b/test/e2e/config/fixture.yaml
@@ -53,6 +53,7 @@ intervals:
   default/wait-available: ["5m", "1s"]
   default/wait-deleting: ["5s", "10ms"]
   default/wait-deleted: ["5s", "10ms"]
+  default/wait-detached: ["1s", "10ms"]
   default/wait-secret-deletion: ["5s", "10ms"]
   default/wait-power-state: ["5s", "10ms"]
   default/wait-externally-provisioned: ["1m", "10ms"]

--- a/test/e2e/config/ironic.yaml
+++ b/test/e2e/config/ironic.yaml
@@ -65,6 +65,7 @@ intervals:
   default/wait-provisioned: ["10m", "1s"]
   default/wait-deprovisioning: ["1m", "10ms"]
   default/wait-deleted: ["20s", "10ms"]
+  default/wait-detached: ["20s", "10ms"]
   default/wait-secret-deletion: ["1m", "1s"]
   default/wait-connect-ssh: ["2m", "10s"]
   default/wait-externally-provisioned: ["1m", "10ms"]

--- a/test/e2e/provisioning_and_annotation_test.go
+++ b/test/e2e/provisioning_and_annotation_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
-	"time"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
@@ -140,16 +139,30 @@ var _ = Describe("Provision, detach, recreate from status and deprovision", Labe
 
 			Expect(helper.Patch(ctx, &bmh)).To(Succeed())
 
+			By("Waiting for the BMH to be detached")
+			WaitForBmhInOperationalStatus(ctx, WaitForBmhInOperationalStatusInput{
+				Client: clusterProxy.GetClient(),
+				Bmh:    bmh,
+				State:  metal3api.OperationalStatusDetached,
+				UndesiredStates: []metal3api.OperationalStatus{
+					metal3api.OperationalStatusError,
+				},
+			}, e2eConfig.GetIntervals(specName, "wait-detached")...)
+
+			// Save the status with the current operationalStatus
+			By("Retrieving the latest BMH object")
+			err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmh.Name,
+				Namespace: bmh.Namespace,
+			}, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+
 			By("Saving the status to a JSON string")
 			savedStatus := bmh.Status
 			statusJSON, err := json.Marshal(savedStatus)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Deleting the BMH")
-			// Wait for 2 seconds to allow time to confirm annotation is set
-			// TODO: fix this so we do not need the sleep
-			time.Sleep(2 * time.Second)
-
 			err = clusterProxy.GetClient().Delete(ctx, &bmh)
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Sleeping 2 seconds may not be enough, and it's also not what we document
the users should do. Wait for operationalStatus to become detached.

Fixes: #1729 
Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
