### PR TITLE
🐛 Provide an error when required checksum is missing

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -16,6 +16,9 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -1118,21 +1121,22 @@ func (host *BareMetalHost) OperationMetricForState(operation ProvisioningState) 
 	return
 }
 
+var supportedChecksums = strings.Join([]string{string(AutoChecksum), string(MD5), string(SHA256), string(SHA512)}, ", ")
+
 // GetChecksum method returns the checksum of an image.
-func (image *Image) GetChecksum() (checksum, checksumType string, ok bool) {
+func (image *Image) GetChecksum() (checksum, checksumType string, err error) {
 	if image == nil {
-		return "", "", false
+		return "", "", errors.New("image is not provided")
 	}
 
 	if image.DiskFormat != nil && *image.DiskFormat == "live-iso" {
 		// Checksum is not required for live-iso
-		ok = true
-		return "", "", ok
+		return "", "", nil
 	}
 
 	if image.Checksum == "" {
 		// Return empty if checksum is not provided
-		return "", "", false
+		return "", "", errors.New("checksum is required for normal images")
 	}
 
 	switch image.ChecksumType {
@@ -1141,12 +1145,11 @@ func (image *Image) GetChecksum() (checksum, checksumType string, ok bool) {
 	case "", AutoChecksum:
 		// No type, let Ironic detect
 	default:
-		return "", "", false
+		return "", "", fmt.Errorf("unknown checksumType %s, supported are %s", image.ChecksumType, supportedChecksums)
 	}
 
 	checksum = image.Checksum
-	ok = true
-	return checksum, checksumType, ok
+	return checksum, checksumType, nil
 }
 
 // +kubebuilder:object:root=true

--- a/apis/metal3.io/v1alpha1/baremetalhost_types_test.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types_test.go
@@ -464,7 +464,7 @@ func TestGetImageChecksum(t *testing.T) {
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			_, checksumType, actual := tc.Host.Spec.Image.GetChecksum()
-			assert.Equal(t, tc.Expected, actual)
+			assert.Equal(t, tc.Expected, actual == nil)
 			if tc.Expected {
 				assert.Equal(t, tc.ExpectedType, checksumType)
 			}

--- a/pkg/provisioner/ironic/provision.go
+++ b/pkg/provisioner/ironic/provision.go
@@ -1,0 +1,18 @@
+package ironic
+
+import (
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
+)
+
+// validateProvisionData provides early validation for provisioning data.
+// The goal is to report errors as early as possible, before the node goes into
+// cleaning and then deployment.
+func validateProvisionData(data provisioner.ProvisionData) error {
+	if data.Image.URL != "" {
+		if _, _, err := data.Image.GetChecksum(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Otherwise, we end up producing an invalid InstanceInfo, and Ironic
rejects it with a confusing message.

Change GetChecksum to return an actual error instead of just ok.

Fixes: #2525 
Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
