### PR TITLE
✨ Stop requiring DEPLOY_KERNEL/RAMDISK

### DIFF
--- a/config/default/ironic.env
+++ b/config/default/ironic.env
@@ -1,7 +1,5 @@
 HTTP_PORT=6180
 PROVISIONING_INTERFACE=eth2
 DHCP_RANGE=172.22.0.10,172.22.0.100
-DEPLOY_KERNEL_URL=http://172.22.0.2:6180/images/ironic-python-agent.kernel
-DEPLOY_RAMDISK_URL=http://172.22.0.2:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.2:6385/v1/
 CACHEURL=http://172.22.0.1/images

--- a/config/overlays/e2e/ironic.env
+++ b/config/overlays/e2e/ironic.env
@@ -1,3 +1,1 @@
-DEPLOY_KERNEL_URL=http://192.168.222.1:6180/images/ironic-python-agent.kernel
-DEPLOY_RAMDISK_URL=http://192.168.222.1:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=https://192.168.222.1:6385/v1/

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -2510,8 +2510,6 @@ subjects:
 apiVersion: v1
 data:
   CACHEURL: http://172.22.0.1/images
-  DEPLOY_KERNEL_URL: http://172.22.0.2:6180/images/ironic-python-agent.kernel
-  DEPLOY_RAMDISK_URL: http://172.22.0.2:6180/images/ironic-python-agent.initramfs
   DHCP_RANGE: 172.22.0.10,172.22.0.100
   HTTP_PORT: "6180"
   IRONIC_ENDPOINT: http://172.22.0.2:6385/v1/

--- a/pkg/provisioner/ironic/factory.go
+++ b/pkg/provisioner/ironic/factory.go
@@ -114,10 +114,8 @@ func loadConfigFromEnv(havePreprovImgBuilder bool) (ironicConfig, error) {
 	c.deployRamdiskURL = os.Getenv("DEPLOY_RAMDISK_URL")
 	c.deployISOURL = os.Getenv("DEPLOY_ISO_URL")
 	if !havePreprovImgBuilder {
-		if c.deployISOURL == "" &&
-			(c.deployKernelURL == "" || c.deployRamdiskURL == "") {
-			return c, errors.New("either DEPLOY_KERNEL_URL and DEPLOY_RAMDISK_URL or DEPLOY_ISO_URL must be set")
-		}
+		// NOTE(dtantsur): with a PreprovisioningImage controller, it makes sense to set only the kernel.
+		// Without it, either both or neither must be set.
 		if (c.deployKernelURL == "" && c.deployRamdiskURL != "") ||
 			(c.deployKernelURL != "" && c.deployRamdiskURL == "") {
 			return c, errors.New("DEPLOY_KERNEL_URL and DEPLOY_RAMDISK_URL can only be set together")

--- a/pkg/provisioner/ironic/factory_test.go
+++ b/pkg/provisioner/ironic/factory_test.go
@@ -99,23 +99,18 @@ func TestLoadConfigFromEnv(t *testing.T) {
 			},
 		},
 		{
-			name:          "no deploy info",
-			env:           EnvFixture{},
-			expectedError: "either DEPLOY_KERNEL_URL and DEPLOY_RAMDISK_URL or DEPLOY_ISO_URL must be set",
-		},
-		{
 			name: "only kernel",
 			env: EnvFixture{
 				kernelURL: "http://kernel",
 			},
-			expectedError: "either DEPLOY_KERNEL_URL and DEPLOY_RAMDISK_URL or DEPLOY_ISO_URL must be set",
+			expectedError: "DEPLOY_KERNEL_URL and DEPLOY_RAMDISK_URL can only be set together",
 		},
 		{
 			name: "only ramdisk",
 			env: EnvFixture{
 				ramdiskURL: "http://ramdisk",
 			},
-			expectedError:         "either DEPLOY_KERNEL_URL and DEPLOY_RAMDISK_URL or DEPLOY_ISO_URL must be set",
+			expectedError:         "DEPLOY_KERNEL_URL and DEPLOY_RAMDISK_URL can only be set together",
 			expectedImgBuildError: "DEPLOY_RAMDISK_URL requires DEPLOY_KERNEL_URL to be set also",
 		},
 		{

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -352,14 +352,10 @@ func (p *ironicProvisioner) configureImages(data provisioner.ManagementAccessDat
 	switch data.State {
 	case metal3api.StateInspecting,
 		metal3api.StatePreparing:
-		if deployImageInfo == nil {
-			if p.config.havePreprovImgBuilder {
-				result, err = transientError(provisioner.ErrNeedsPreprovisioningImage)
-			} else {
-				result, err = operationFailed("no preprovisioning image available")
-			}
-			return result, err
+		if deployImageInfo == nil && p.config.havePreprovImgBuilder {
+			result, err = transientError(provisioner.ErrNeedsPreprovisioningImage)
 		}
+		return result, err
 	default:
 	}
 


### PR DESCRIPTION
Ironic has global configuration that allows specifying them, even
depending on the architecture. Our ironic-image supports that when
IPA downloader is used (and should start supporting explicit variables
too).

Fixes: #2100 
Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
