### PR TITLE
:warning:  Enable removal of ExternallyProvisioned attribute from BareMetalHosts

### DIFF
--- a/internal/controller/metal3.io/host_state_machine.go
+++ b/internal/controller/metal3.io/host_state_machine.go
@@ -408,6 +408,9 @@ func (hsm *hostStateMachine) handleRegistering(_ *reconcileInfo) actionResult {
 	// if the credentials change and the Host must be re-registered.
 	if hsm.Host.Spec.ExternallyProvisioned {
 		hsm.NextState = metal3api.StateExternallyProvisioned
+	} else if hsm.Host.Status.Provisioning.State == metal3api.StateExternallyProvisioned {
+		// Removing externallyManaged moves hosts to provisioned state
+		hsm.NextState = metal3api.StateProvisioned
 	} else if inspectionDisabled(hsm.Host) {
 		hsm.NextState = metal3api.StatePreparing
 	} else {

--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation.go
@@ -109,10 +109,6 @@ func (webhook *BareMetalHost) validateChanges(oldObj *metal3api.BareMetalHost, n
 		errs = append(errs, errors.New("bootMACAddress can not be changed once it is set"))
 	}
 
-	if oldObj.Spec.ExternallyProvisioned != newObj.Spec.ExternallyProvisioned {
-		errs = append(errs, errors.New("externallyProvisioned can not be changed"))
-	}
-
 	return errs
 }
 

--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -970,14 +970,6 @@ func TestValidateUpdate(t *testing.T) {
 				TypeMeta: tm, ObjectMeta: om, Spec: metal3api.BareMetalHostSpec{BootMACAddress: "test-mac"}},
 			wantedErr: "bootMACAddress can not be changed once it is set",
 		},
-		{
-			name: "updateExternallyProvisioned",
-			newBMH: &metal3api.BareMetalHost{
-				TypeMeta: tm, ObjectMeta: om, Spec: metal3api.BareMetalHostSpec{}},
-			oldBMH: &metal3api.BareMetalHost{
-				TypeMeta: tm, ObjectMeta: om, Spec: metal3api.BareMetalHostSpec{ExternallyProvisioned: true}},
-			wantedErr: "externallyProvisioned can not be changed",
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:
It enables removing the ExternallyProvisioned attribute, this can be useful if you want to transition hosts from an externally provisioned source into being directly managed.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2465

Signed-off-by: Ethan J. Gallant <ethan.gallant@gmail.com>