### PR TITLE
✨ Allow NIC Firmware Updates

### DIFF
--- a/apis/metal3.io/v1alpha1/hostfirmwarecomponents_types.go
+++ b/apis/metal3.io/v1alpha1/hostfirmwarecomponents_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -101,8 +102,8 @@ func (host *HostFirmwareComponents) ValidateHostFirmwareComponents() error {
 	allowedNames := map[string]struct{}{"bmc": {}, "bios": {}}
 	for _, update := range host.Spec.Updates {
 		componentName := update.Component
-		if _, ok := allowedNames[componentName]; !ok {
-			return fmt.Errorf("component %s is invalid, only 'bmc' or 'bios' are allowed as update names", update.Component)
+		if _, ok := allowedNames[componentName]; !ok && !strings.HasPrefix(componentName, "nic:") {
+			return fmt.Errorf("component %s is invalid, only 'bmc', 'bios', or names starting with 'nic:' are allowed as update names", update.Component)
 		}
 	}
 

--- a/apis/metal3.io/v1alpha1/hostfirmwarecomponents_types_test.go
+++ b/apis/metal3.io/v1alpha1/hostfirmwarecomponents_types_test.go
@@ -53,7 +53,7 @@ func TestValidateHostFirmwareComponents(t *testing.T) {
 			Components: []FirmwareComponentStatus{},
 			Updates: []FirmwareUpdate{
 				{
-					Component: "nic",
+					Component: "something",
 					URL:       "https://example.com/bmcupdate",
 				},
 			},
@@ -64,7 +64,40 @@ func TestValidateHostFirmwareComponents(t *testing.T) {
 					LastTransitionTime: metav1.NewTime(time.Now()),
 				},
 			},
-			ExpectedError: "component nic is invalid, only 'bmc' or 'bios' are allowed as update names",
+			ExpectedError: "component something is invalid, only 'bmc', 'bios', or names starting with 'nic:' are allowed as update names",
+		},
+		{
+			Scenario: "ValidNicPrefixComponent",
+			Components: []FirmwareComponentStatus{
+				{
+					Component:      "nic:NIC.1",
+					InitialVersion: "1.0",
+					CurrentVersion: "1.0",
+				},
+				{
+					Component:      "nic:AD007",
+					InitialVersion: "2.0",
+					CurrentVersion: "2.1",
+				},
+			},
+			Updates: []FirmwareUpdate{
+				{
+					Component: "nic:NIC.1",
+					URL:       "https://example.com/nicupdate",
+				},
+				{
+					Component: "nic:AD007",
+					URL:       "https://example.com/nic2update",
+				},
+			},
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(HostFirmwareComponentsChangeDetected),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(time.Now()),
+				},
+			},
+			ExpectedError: "",
 		},
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {

--- a/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
+++ b/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
@@ -256,12 +256,10 @@ func (r *HostFirmwareComponentsReconciler) updateEventHandler(e event.UpdateEven
 
 func (r *HostFirmwareComponentsReconciler) validateHostFirmwareComponents(info *rhfcInfo) []error {
 	var errors []error
-	allowedNames := map[string]struct{}{"bmc": {}, "bios": {}}
-	for _, update := range info.hfc.Spec.Updates {
-		componentName := update.Component
-		if _, ok := allowedNames[componentName]; !ok {
-			errors = append(errors, fmt.Errorf("component %s is invalid, only 'bmc' or 'bios' are allowed as update names", componentName))
-		}
+
+	// Re-Use the existing validation method
+	if err := info.hfc.ValidateHostFirmwareComponents(); err != nil {
+		errors = append(errors, err)
 	}
 
 	return errors

--- a/internal/controller/metal3.io/hostfirmwarecomponents_test.go
+++ b/internal/controller/metal3.io/hostfirmwarecomponents_test.go
@@ -465,24 +465,35 @@ func TestValidadeHostFirmwareComponents(t *testing.T) {
 			ExpectedErrors: []string{""},
 		},
 		{
-			Scenario: "invalid nic component",
+			Scenario: "valid spec - with nic components",
 			SpecUpdates: metal3api.HostFirmwareComponentsSpec{
 				Updates: []metal3api.FirmwareUpdate{
-					{Component: "nic", URL: "https://myurl/mynicfw"},
+					{Component: "bmc", URL: "https://myurl/mybmcfw"},
+					{Component: "nic:NIC.1", URL: "https://myurl/mynicfw"},
+					{Component: "nic:AD007", URL: "https://myurl/mynic2fw"},
 				},
 			},
-			ExpectedErrors: []string{"component nic is invalid, only 'bmc' or 'bios' are allowed as update names"},
+			ExpectedErrors: []string{""},
 		},
 		{
-			Scenario: "invalid nic component with other valid components",
+			Scenario: "invalid something component",
+			SpecUpdates: metal3api.HostFirmwareComponentsSpec{
+				Updates: []metal3api.FirmwareUpdate{
+					{Component: "something", URL: "https://myurl/myfw"},
+				},
+			},
+			ExpectedErrors: []string{"component something is invalid, only 'bmc', 'bios', or names starting with 'nic:' are allowed as update names"},
+		},
+		{
+			Scenario: "invalid something component with other valid components",
 			SpecUpdates: metal3api.HostFirmwareComponentsSpec{
 				Updates: []metal3api.FirmwareUpdate{
 					{Component: "bmc", URL: "https://myurl/mybmcfw"},
 					{Component: "bios", URL: "https://myurl/mybiosfw"},
-					{Component: "nic", URL: "https://myurl/mynicfw"},
+					{Component: "something", URL: "https://myurl/myfw"},
 				},
 			},
-			ExpectedErrors: []string{"component nic is invalid, only 'bmc' or 'bios' are allowed as update names"},
+			ExpectedErrors: []string{"component something is invalid, only 'bmc', 'bios', or names starting with 'nic:' are allowed as update names"},
 		},
 		{
 			Scenario: "component not in lowercase",
@@ -493,8 +504,8 @@ func TestValidadeHostFirmwareComponents(t *testing.T) {
 				},
 			},
 			ExpectedErrors: []string{
-				"component BMC is invalid, only 'bmc' or 'bios' are allowed as update names",
-				"component BIOS is invalid, only 'bmc' or 'bios' are allowed as update names",
+				"component BMC is invalid, only 'bmc', 'bios', or names starting with 'nic:' are allowed as update names",
+				"component BIOS is invalid, only 'bmc', 'bios', or names starting with 'nic:' are allowed as update names",
 			},
 		},
 	}

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -768,7 +768,7 @@ func (p *ironicProvisioner) GetFirmwareComponents() ([]metal3api.FirmwareCompone
 
 	// Iterate over the list of components to extract their information and update the list.
 	for _, fwc := range componentList {
-		if fwc.Component != "bios" && fwc.Component != "bmc" {
+		if fwc.Component != "bios" && fwc.Component != "bmc" && !strings.HasPrefix(fwc.Component, "nic:") {
 			p.log.Info("ignoring firmware component for node", "component", fwc.Component, "node", ironicNode.UUID)
 			continue
 		}


### PR DESCRIPTION
This commits aims to add support for NIC Firmware Updates via HostFirmwareComponents.

**What this PR does / why we need it**: Extend `HostFirmwareComponents` to allow NIC Firmware Updates.


