### PR TITLE
:bug: Add IPv6 address check to run local

### DIFF
--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -15,7 +15,14 @@ IRONIC_DATA_DIR=${IRONIC_DATA_DIR:-"/opt/metal3-dev-env/ironic"}
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 HTTP_PORT=${HTTP_PORT:-"6180"}
 PROVISIONING_IP="${PROVISIONING_IP:-"172.22.0.1"}"
+# Provisioning IP can be either IPv4 or IPv6. In case of IPv6, the address needs
+# brackets around it to work in http-addresses.
 CLUSTER_PROVISIONING_IP="${CLUSTER_PROVISIONING_IP:-"172.22.0.2"}"
+if [[ "${CLUSTER_PROVISIONING_IP}" = *":"* ]]; then
+    CLUSTER_PROVISIONING_HOST="[${CLUSTER_PROVISIONING_IP}]"
+else
+    CLUSTER_PROVISIONING_HOST="${CLUSTER_PROVISIONING_IP}"
+fi
 # ironicendpoint is used in the CI setup
 if ip link show ironicendpoint > /dev/null; then
     PROVISIONING_INTERFACE="${PROVISIONING_INTERFACE:-ironicendpoint}"
@@ -69,16 +76,16 @@ if [ "$IRONIC_TLS_SETUP" = "true" ]; then
             -out "${IRONIC_CERT_FILE}" -keyout "${IRONIC_KEY_FILE}"
     fi
 
-    export IRONIC_BASE_URL="https://${CLUSTER_PROVISIONING_IP}"
+    export IRONIC_BASE_URL="https://${CLUSTER_PROVISIONING_HOST}"
     if [ -z "$IRONIC_CACERT_FILE" ]; then
         export IRONIC_CACERT_FILE=$IRONIC_CERT_FILE
     fi
 else
-    export IRONIC_BASE_URL="http://${CLUSTER_PROVISIONING_IP}"
+    export IRONIC_BASE_URL="http://${CLUSTER_PROVISIONING_HOST}"
 fi
 
-DEPLOY_KERNEL_URL="${DEPLOY_KERNEL_URL:-"http://${CLUSTER_PROVISIONING_IP}:${HTTP_PORT}/images/ironic-python-agent.kernel"}"
-DEPLOY_RAMDISK_URL="${DEPLOY_RAMDISK_URL:-"http://${CLUSTER_PROVISIONING_IP}:${HTTP_PORT}/images/ironic-python-agent.initramfs"}"
+DEPLOY_KERNEL_URL="${DEPLOY_KERNEL_URL:-"http://${CLUSTER_PROVISIONING_HOST}:${HTTP_PORT}/images/ironic-python-agent.kernel"}"
+DEPLOY_RAMDISK_URL="${DEPLOY_RAMDISK_URL:-"http://${CLUSTER_PROVISIONING_HOST}:${HTTP_PORT}/images/ironic-python-agent.initramfs"}"
 DEPLOY_ISO_URL=${DEPLOY_ISO_URL:-}
 IRONIC_ENDPOINT="${IRONIC_ENDPOINT:-"${IRONIC_BASE_URL}:6385/v1/"}"
 CACHEURL="${CACHEURL:-"http://${PROVISIONING_IP}/images"}"


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
After adding IPv6 support to dev env, it is possible that the used IP addresses are v6. In this case the address needs to be surrounded by brackets when using as a host address. This PR adds a check for IPv6 address and proper surrounding to IPv6 addresses in the `run_local_ironic.sh`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
