### PR TITLE
:seedling: Separate metric service e2e

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -5,16 +5,11 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
-	"fmt"
-	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
@@ -82,70 +77,6 @@ func TestE2e(t *testing.T) {
 	Expect(configPath).To(BeAnExistingFile(), "Invalid test suite argument. e2e.config should be an existing file.")
 	e2eConfig = LoadE2EConfig(configPath)
 	RunSpecs(t, "E2e Suite")
-}
-
-const namespace = "baremetal-operator-system"
-const serviceAccountName = "baremetal-operator-controller-manager"
-const metricsServiceName = "baremetal-operator-controller-manager-metrics-service"
-const metricsRoleBindingName = "baremetal-operator-metrics-binding"
-
-// serviceAccountToken returns a token for the specified service account in the given namespace.
-// It uses the Kubernetes TokenRequest API to generate a token by directly sending a request
-// and parsing the resulting token from the API response.
-func serviceAccountToken() (string, error) {
-	const tokenRequestRawString = `{
-		"apiVersion": "authentication.k8s.io/v1",
-		"kind": "TokenRequest"
-	}`
-
-	// Temporary file to store the token request
-	secretName := serviceAccountName + "-token-request"
-	tokenRequestFile := filepath.Join("/tmp", secretName) //nolint: gocritic
-	err := os.WriteFile(tokenRequestFile, []byte(tokenRequestRawString), os.FileMode(0o644))
-	if err != nil {
-		return "", err
-	}
-
-	var out string
-	verifyTokenCreation := func(g Gomega) {
-		var output []byte
-		// Execute kubectl command to create the token
-		cmd := exec.Command("kubectl", "create", "--raw", fmt.Sprintf(
-			"/api/v1/namespaces/%s/serviceaccounts/%s/token",
-			namespace,
-			serviceAccountName,
-		), "-f", tokenRequestFile)
-
-		output, err = cmd.CombinedOutput()
-		g.Expect(err).NotTo(HaveOccurred())
-
-		// Parse the JSON output to extract the token
-		var token tokenRequest
-		err = json.Unmarshal(output, &token)
-		g.Expect(err).NotTo(HaveOccurred())
-
-		out = token.Status.Token
-	}
-	Eventually(verifyTokenCreation).Should(Succeed())
-
-	return out, err
-}
-
-// tokenRequest is a simplified representation of the Kubernetes TokenRequest API response,
-// containing only the token field that we need to extract.
-type tokenRequest struct {
-	Status struct {
-		Token string `json:"token"`
-	} `json:"status"`
-}
-
-// getMetricsOutput retrieves and returns the logs from the curl pod used to access the metrics endpoint.
-func getMetricsOutput() string {
-	By("getting the curl-metrics logs")
-	cmd := exec.Command("kubectl", "logs", "curl-metrics", "-n", namespace)
-	metricsOutput, err := cmd.CombinedOutput()
-	Expect(err).NotTo(HaveOccurred(), "Failed to retrieve logs from curl pod")
-	return string(metricsOutput)
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {
@@ -229,72 +160,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 			})
 		})
 		Expect(err).NotTo(HaveOccurred())
-
-		// Metrics test start
-		By("creating a ClusterRoleBinding for the service account to allow access to metrics")
-		cmd := exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
-			"--clusterrole=baremetal-operator-metrics-reader",
-			fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName),
-		)
-		_, err = cmd.CombinedOutput()
-		Expect(err).NotTo(HaveOccurred(), "Failed to create ClusterRoleBinding")
-
-		By("validating that the metrics service is available")
-		Eventually(func() error {
-			var output []byte
-			cmd = exec.Command("kubectl", "get", "service", metricsServiceName, "-n", namespace)
-			output, err = cmd.CombinedOutput()
-			if err != nil {
-				log.Printf("Service check output: %s\n", string(output))
-				return err
-			}
-			return nil
-		}, "30s", "5s").Should(Succeed(), "Metrics service is not available")
-
-		By("getting the service account token")
-		token, err := serviceAccountToken()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(token).NotTo(BeEmpty())
-
-		By("waiting for the metrics endpoint to be ready")
-		verifyMetricsEndpointReady := func(g Gomega) {
-			var output []byte
-			cmd = exec.Command("kubectl", "get", "endpoints", metricsServiceName, "-n", namespace)
-			output, err = cmd.CombinedOutput()
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(output).To(ContainSubstring("8443"), "Metrics endpoint is not ready")
-		}
-		Eventually(verifyMetricsEndpointReady).Should(Succeed())
-
-		By("creating the curl-metrics pod to access the metrics endpoint")
-		cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
-			"--namespace", namespace,
-			"--image=curlimages/curl:7.87.0",
-			"--command",
-			"--", "curl", "-v", "--tlsv1.3", "-k", "-H", "Authorization:Bearer "+token,
-			fmt.Sprintf("https://%s.%s.svc.cluster.local:8443/metrics", metricsServiceName, namespace))
-		_, err = cmd.CombinedOutput()
-		Expect(err).NotTo(HaveOccurred(), "Failed to create curl-metrics pod")
-
-		By("waiting for the curl-metrics pod to complete.")
-		verifyCurlUp := func(g Gomega) {
-			var output []byte
-			cmd = exec.Command("kubectl", "get", "pods", "curl-metrics",
-				"-o", "jsonpath={.status.phase}",
-				"-n", namespace)
-			output, err = cmd.CombinedOutput()
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(string(output)).To(Equal("Succeeded"), "curl pod in wrong status")
-		}
-		Eventually(verifyCurlUp, 5*time.Minute).Should(Succeed())
-
-		By("getting the metrics by checking curl-metrics logs")
-		metricsOutput := getMetricsOutput()
-		Expect(metricsOutput).To(ContainSubstring(
-			"controller_runtime_reconcile_total",
-		))
-		// Metrics test end
-
 	}
 
 	return []byte(strings.Join([]string{clusterProxy.GetKubeconfigPath()}, ","))

--- a/test/e2e/metrics_service_test.go
+++ b/test/e2e/metrics_service_test.go
@@ -1,0 +1,148 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/cluster-api/test/framework"
+)
+
+var _ = Describe("Metrics Service", Label("required", "metrics-service"), func() {
+	var (
+		existingNamespace      = "baremetal-operator-system"
+		serviceAccountName     = "baremetal-operator-controller-manager"
+		metricsServiceName     = "baremetal-operator-controller-manager-metrics-service"
+		metricsRoleBindingName = "baremetal-operator-metrics-binding"
+	)
+
+	BeforeEach(func() {
+		go func() {
+			defer GinkgoRecover()
+			framework.WatchNamespaceEvents(ctx, framework.WatchNamespaceEventsInput{
+				ClientSet: clusterProxy.GetClientSet(),
+				Name:      "baremetal-operator-system",
+				LogFolder: artifactFolder,
+			})
+		}()
+	})
+	It("should verify metrics are accessible and validate functionality", func() {
+		client := clusterProxy.GetClient()
+		clientSet := clusterProxy.GetClientSet()
+
+		By("Creating a ClusterRoleBinding for the service account to allow access to metrics")
+		metricsRoleBinding := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: metricsRoleBindingName,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccountName,
+					Namespace: existingNamespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				Kind:     "ClusterRole",
+				Name:     "baremetal-operator-metrics-reader",
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		}
+		err := client.Create(ctx, metricsRoleBinding)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create ClusterRoleBinding")
+
+		By("Waiting for the metrics service to be available")
+		Eventually(func() error {
+			key := types.NamespacedName{Name: metricsServiceName, Namespace: existingNamespace}
+			metricsService := &corev1.Service{}
+			return client.Get(ctx, key, metricsService)
+		}, "30s", "5s").Should(Succeed(), "Metrics service is not available")
+
+		By("Creating a service account token to access the metrics endpoint")
+		var token string
+		var result *authenticationv1.TokenRequest
+		Eventually(func(g Gomega) {
+			result, err = clientSet.CoreV1().ServiceAccounts(existingNamespace).CreateToken(
+				ctx,
+				serviceAccountName,
+				&authenticationv1.TokenRequest{},
+				metav1.CreateOptions{},
+			)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(result.Status.Token).NotTo(BeEmpty())
+			token = result.Status.Token
+		}).Should(Succeed())
+
+		By("Waiting for the metrics endpoint to be ready")
+		Eventually(func(g Gomega) {
+			key := types.NamespacedName{
+				Name:      metricsServiceName,
+				Namespace: existingNamespace,
+			}
+			metricsService := &corev1.Service{}
+			err = client.Get(ctx, key, metricsService)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(metricsService.Spec.Ports[0].Port).To(Equal(int32(8443)), "Metrics endpoint is not ready")
+		}).Should(Succeed())
+
+		By("Creating the curl-metrics pod to access the metrics endpoint")
+		curlPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "curl-metrics",
+				Namespace: existingNamespace,
+			},
+			Spec: corev1.PodSpec{
+				RestartPolicy: corev1.RestartPolicyNever,
+				Containers: []corev1.Container{
+					{
+						Name:  "curl",
+						Image: "curlimages/curl:7.87.0",
+						Command: []string{
+							"curl",
+							"-v",
+							"--tlsv1.3",
+							"-k",
+							"-H", "Authorization:Bearer " + token,
+							fmt.Sprintf("https://%s.%s.svc.cluster.local:8443/metrics", metricsServiceName, existingNamespace),
+						},
+					},
+				},
+			},
+		}
+		err = client.Create(ctx, curlPod)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create curl-metrics pod")
+
+		By("Waiting for the curl-metrics pod to complete")
+		Eventually(func(g Gomega) {
+			key := types.NamespacedName{Name: "curl-metrics", Namespace: existingNamespace}
+			pod := &corev1.Pod{}
+			err = client.Get(ctx, key, pod)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(pod.Status.Phase).To(Equal(corev1.PodSucceeded), "curl-metrics pod in wrong status")
+		}, 5*time.Minute).Should(Succeed())
+
+		By("Getting the metrics by checking curl-metrics logs")
+		req := clientSet.CoreV1().Pods(existingNamespace).GetLogs("curl-metrics", &corev1.PodLogOptions{})
+		logs, err := req.Stream(ctx)
+		Expect(err).NotTo(HaveOccurred(), "Failed to get log stream")
+		defer logs.Close()
+
+		buf, err := io.ReadAll(logs)
+		Expect(err).NotTo(HaveOccurred(), "Failed to read logs")
+		metricsOutput := string(buf)
+
+		Expect(metricsOutput).To(ContainSubstring(
+			"controller_runtime_reconcile_total",
+		), "Expected metrics not found in output")
+	})
+})


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Separate metric service test from SynchronizedBeforeSuite and change it to use Kubernetes API instead of kubectl commads.

**Which issue(s) this PR fixes**:
Fixes #2173
