### PR TITLE
🌱 E2E: Set static IPs through user-data

### DIFF
--- a/hack/e2e/net.xml
+++ b/hack/e2e/net.xml
@@ -8,7 +8,7 @@
   <bridge name='metal3'/>
   <ip address='192.168.222.1' netmask='255.255.255.0'>
     <dhcp>
-      <range start='192.168.222.2' end='192.168.222.199'/>
+      <range start='192.168.222.2' end='192.168.222.99'/>
       <bootp file='http://192.168.222.1:6180/boot.ipxe'/>
     </dhcp>
   </ip>

--- a/test/e2e/automated_cleaning_test.go
+++ b/test/e2e/automated_cleaning_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Automated cleaning", Label("required", "automated-cleaning"), 
 		By("Patching the BMH again to trigger re-provisioning")
 		userDataSecretName = "user-data-ssh-setup"
 		// Create new userdata secret for only SSH setup
-		createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath)
+		createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
 		userDataSecret = &corev1.SecretReference{
 			Name:      userDataSecretName,
 			Namespace: namespace.Name,

--- a/test/e2e/bmc.go
+++ b/test/e2e/bmc.go
@@ -21,16 +21,14 @@ type BMC struct {
 	Address string `yaml:"address,omitempty"`
 	// DisableCertificateVerification indicates whether to disable certificate verification for the BMC connection.
 	DisableCertificateVerification bool `yaml:"disableCertificateVerification,omitempty"`
-	// BootMacAddress is the MAC address of the VMs network interface.
+	// BootMacAddress is the MAC address of the BMHs network interface.
 	BootMacAddress string `yaml:"bootMacAddress,omitempty"`
 	// BootMode is the boot mode for the BareMetalHost, e.g. "UEFI" or "legacy".
 	BootMode metal3api.BootMode `yaml:"bootMode,omitempty"`
 	// Name of the machine associated with this BMC.
 	Name string `yaml:"name,omitempty"`
-	// NetworkName is the name of the network that the new VM should be attached to
-	NetworkName string `yaml:"networkName,omitempty"`
-	// IPAddress is a reserved IP address for the VM.
-	// This will be paired with the MAC address in the DHCP configuration.
+	// IPAddress is a reserved IP address for the BMH managed through this BMC.
+	// This is used in tests that make ssh connections to the BMH.
 	// Example: 192.168.222.122
 	IPAddress string `yaml:"ipAddress,omitempty"`
 	// RootDeviceHints provides guidance for where to write the disk image.

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -342,14 +342,15 @@ func EstablishSSHConnection(e2eConfig *Config, ipAddress string) *ssh.Client {
 
 // createSSHSetupUserdata creates a Kubernetes secret intended for cloud-init usage.
 // This userdata sets up SSH authorized keys during BMH's initialization.
-func createSSHSetupUserdata(ctx context.Context, client client.Client, namespace string, secretName string, sshPubKeyPath string) {
+func createSSHSetupUserdata(ctx context.Context, client client.Client, namespace string, secretName string, sshPubKeyPath string, staticIP string) {
 	sshPubKeyData, err := os.ReadFile(sshPubKeyPath) // #nosec G304
 	Expect(err).NotTo(HaveOccurred(), "Failed to read SSH public key file")
 
 	userDataContent := fmt.Sprintf(`#!/bin/sh
+ip a add %s dev eth0
 mkdir /root/.ssh
 chmod 700 /root/.ssh
-echo "%s" >> /root/.ssh/authorized_keys`, sshPubKeyData)
+echo "%s" >> /root/.ssh/authorized_keys`, staticIP, sshPubKeyData)
 
 	CreateSecret(ctx, client, namespace, secretName, map[string]string{"userData": userDataContent})
 }

--- a/test/e2e/external_inspection_test.go
+++ b/test/e2e/external_inspection_test.go
@@ -136,7 +136,7 @@ const hardwareDetails = `
       "version": "1.15.0-1"
     }
   },
-  "hostname": "bmo-e2e-0",
+  "hostname": "localhost.localdomain",
   "nics": [
     {
       "ip": "192.168.222.122",

--- a/test/e2e/live_iso_test.go
+++ b/test/e2e/live_iso_test.go
@@ -83,6 +83,15 @@ var _ = Describe("Live-ISO", Label("required", "live-iso"), func() {
 				AutomatedCleaningMode: metal3api.CleaningModeDisabled,
 			},
 		}
+		if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
+			userDataSecretName := "user-data"
+			sshPubKeyPath := e2eConfig.GetVariable("SSH_PUB_KEY")
+			createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
+			bmh.Spec.UserData = &corev1.SecretReference{
+				Name:      userDataSecretName,
+				Namespace: namespace.Name,
+			}
+		}
 		err := clusterProxy.GetClient().Create(ctx, &bmh)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/provisioning_and_annotation_test.go
+++ b/test/e2e/provisioning_and_annotation_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Provision, detach, recreate from status and deprovision", Labe
 			if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
 				userDataSecretName := "user-data"
 				sshPubKeyPath := e2eConfig.GetVariable("SSH_PUB_KEY")
-				createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath)
+				createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
 				userDataSecret = &corev1.SecretReference{
 					Name:      userDataSecretName,
 					Namespace: namespace.Name,

--- a/test/e2e/re_inspection_test.go
+++ b/test/e2e/re_inspection_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Re-Inspection", Label("required", "re-inspection"), func() {
 		CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
 
 		By("creating a BMH with inspection disabled and hardware details added with wrong HostName")
-		newHardwareDetails := strings.Replace(hardwareDetails, "bmo-e2e-0", wrongHostName, 1)
+		newHardwareDetails := strings.Replace(hardwareDetails, "localhost.localdomain", wrongHostName, 1)
 		bmh := metal3api.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      specName + "-reinspect",


### PR DESCRIPTION
**What this PR does / why we need it**:

We have been "cheating" a bit in CI by configuring static IPs for the VMs through libvirt dhcp. This is not something we can rely on for real hardware. For that, we would either need to manually configure DHCP or make use of cloud-init to configure the IPs. This commit attempts to do the latter.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
