### PR TITLE
:seedling: switch to use new cncf oracle gh runners

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -8,7 +8,7 @@ on:
         type: string
       runner:
         type: string
-        default: "ubuntu-latest-4-cores"
+        default: "oracle-vm-4cpu-16gb-x86-64"
       ginkgo-focus:
         type: string
         default: ""


### PR DESCRIPTION
See [BMO 2599](https://github.com/metal3-io/baremetal-operator/pull/2599) for reference.

/hold
To be merged when all repos show green with new workers.