### PR TITLE
🐛 Allow setting `force_persistent_boot_device: <value>` for deploy_interface: direct

### DIFF
--- a/pkg/provisioner/ironic/factory.go
+++ b/pkg/provisioner/ironic/factory.go
@@ -101,6 +101,7 @@ func (f *ironicProvisionerFactory) init(havePreprovImgBuilder bool) error {
 		"deployRamdiskURL", f.config.deployRamdiskURL,
 		"deployISOURL", f.config.deployISOURL,
 		"liveISOForcePersistentBootDevice", f.config.liveISOForcePersistentBootDevice,
+		"directDeployForcePersistentBootDevice", f.config.directDeployForcePersistentBootDevice,
 		"CACertFile", tlsConf.TrustedCAFile,
 		"ClientCertFile", tlsConf.ClientCertificateFile,
 		"ClientPrivKeyFile", tlsConf.ClientPrivateKeyFile,
@@ -197,11 +198,17 @@ func loadConfigFromEnv(havePreprovImgBuilder bool) (ironicConfig, error) {
 		c.maxBusyHosts = value
 	}
 
-	if forcePersistentBootDevice := os.Getenv("LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE"); forcePersistentBootDevice != "" {
-		if forcePersistentBootDevice != "Default" && forcePersistentBootDevice != "Always" && forcePersistentBootDevice != "Never" {
+	if liveISOForcePersistentBootDevice := os.Getenv("LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE"); liveISOForcePersistentBootDevice != "" {
+		if liveISOForcePersistentBootDevice != "Default" && liveISOForcePersistentBootDevice != "Always" && liveISOForcePersistentBootDevice != "Never" {
 			return c, errors.New("invalid value for variable LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE, must be one of Default, Always or Never")
 		}
-		c.liveISOForcePersistentBootDevice = forcePersistentBootDevice
+		c.liveISOForcePersistentBootDevice = liveISOForcePersistentBootDevice
+	}
+	if directDeployForcePersistentBootDevice := os.Getenv("DIRECT_DEPLOY_FORCE_PERSISTENT_BOOT_DEVICE"); directDeployForcePersistentBootDevice != "" {
+		if directDeployForcePersistentBootDevice != "Default" && directDeployForcePersistentBootDevice != "Always" && directDeployForcePersistentBootDevice != "Never" {
+			return c, errors.New("invalid value for variable DIRECT_DEPLOY_FORCE_PERSISTENT_BOOT_DEVICE, must be one of Default, Always or Never")
+		}
+		c.directDeployForcePersistentBootDevice = directDeployForcePersistentBootDevice
 	}
 
 	c.externalURL = os.Getenv("IRONIC_EXTERNAL_URL_V6")

--- a/pkg/provisioner/ironic/factory_test.go
+++ b/pkg/provisioner/ironic/factory_test.go
@@ -10,16 +10,17 @@ import (
 )
 
 type EnvFixture struct {
-	ironicEndpoint                   string
-	kernelURL                        string
-	ramdiskURL                       string
-	isoURL                           string
-	liveISOForcePersistentBootDevice string
-	ironicCACertFile                 string
-	ironicClientCertFile             string
-	ironicClientPrivateKeyFile       string
-	ironicInsecure                   string
-	ironicSkipClientSANVerify        string
+	ironicEndpoint                        string
+	kernelURL                             string
+	ramdiskURL                            string
+	isoURL                                string
+	liveISOForcePersistentBootDevice      string
+	directDeployForcePersistentBootDevice string
+	ironicCACertFile                      string
+	ironicClientCertFile                  string
+	ironicClientPrivateKeyFile            string
+	ironicInsecure                        string
+	ironicSkipClientSANVerify             string
 
 	origEnv map[string]string
 }
@@ -50,6 +51,7 @@ func (f *EnvFixture) SetUp() {
 	f.replace("DEPLOY_RAMDISK_URL", f.ramdiskURL)
 	f.replace("DEPLOY_ISO_URL", f.isoURL)
 	f.replace("LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE", f.liveISOForcePersistentBootDevice)
+	f.replace("DIRECT_DEPLOY_FORCE_PERSISTENT_BOOT_DEVICE", f.directDeployForcePersistentBootDevice)
 	f.replace("IRONIC_CACERT_FILE", f.ironicCACertFile)
 	f.replace("IRONIC_CLIENT_CERT_FILE", f.ironicClientCertFile)
 	f.replace("IRONIC_CLIENT_PRIVATE_KEY_FILE", f.ironicClientPrivateKeyFile)
@@ -62,6 +64,7 @@ func (f EnvFixture) VerifyConfig(t *testing.T, c ironicConfig, _ string) {
 	assert.Equal(t, f.ramdiskURL, c.deployRamdiskURL)
 	assert.Equal(t, f.isoURL, c.deployISOURL)
 	assert.Equal(t, f.liveISOForcePersistentBootDevice, c.liveISOForcePersistentBootDevice)
+	assert.Equal(t, f.directDeployForcePersistentBootDevice, c.directDeployForcePersistentBootDevice)
 }
 
 func (f EnvFixture) VerifyEndpoints(t *testing.T, ironic string) {
@@ -131,7 +134,7 @@ func TestLoadConfigFromEnv(t *testing.T) {
 			expectedImgBuildError: "DEPLOY_RAMDISK_URL requires DEPLOY_KERNEL_URL to be set also",
 		},
 		{
-			name: "Force Persistent Default",
+			name: "ISO Force Persistent Default",
 			env: EnvFixture{
 				isoURL:                           "http://iso",
 				liveISOForcePersistentBootDevice: "Default",
@@ -139,7 +142,7 @@ func TestLoadConfigFromEnv(t *testing.T) {
 			forcePersistent: "Default",
 		},
 		{
-			name: "Force Persistent Never",
+			name: "ISO Force Persistent Never",
 			env: EnvFixture{
 				isoURL:                           "http://iso",
 				liveISOForcePersistentBootDevice: "Never",
@@ -147,7 +150,7 @@ func TestLoadConfigFromEnv(t *testing.T) {
 			forcePersistent: "Never",
 		},
 		{
-			name: "Force Persistent Always",
+			name: "ISO Force Persistent Always",
 			env: EnvFixture{
 				isoURL:                           "http://iso",
 				liveISOForcePersistentBootDevice: "Always",
@@ -155,13 +158,50 @@ func TestLoadConfigFromEnv(t *testing.T) {
 			forcePersistent: "Always",
 		},
 		{
-			name: "Force Persistent Invalid",
+			name: "ISO Force Persistent Invalid",
 			env: EnvFixture{
 				isoURL:                           "http://iso",
 				liveISOForcePersistentBootDevice: "NotAValidOption",
 			},
 			expectedError:         "invalid value for variable LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE",
 			expectedImgBuildError: "invalid value for variable LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE",
+		},
+		{
+			name: "kernel/ramdisk Force Persistent Default",
+			env: EnvFixture{
+				kernelURL:                             "http://kernel",
+				ramdiskURL:                            "http://ramdisk",
+				directDeployForcePersistentBootDevice: "Default",
+			},
+			forcePersistent: "Default",
+		},
+		{
+			name: "kernel/ramdisk Force Persistent Never",
+			env: EnvFixture{
+				kernelURL:                             "http://kernel",
+				ramdiskURL:                            "http://ramdisk",
+				directDeployForcePersistentBootDevice: "Never",
+			},
+			forcePersistent: "Never",
+		},
+		{
+			name: "kernel/ramdisk Force Persistent Always",
+			env: EnvFixture{
+				kernelURL:                             "http://kernel",
+				ramdiskURL:                            "http://ramdisk",
+				directDeployForcePersistentBootDevice: "Always",
+			},
+			forcePersistent: "Always",
+		},
+		{
+			name: "kernel/ramdisk Force Persistent Invalid",
+			env: EnvFixture{
+				kernelURL:                             "http://kernel",
+				ramdiskURL:                            "http://ramdisk",
+				directDeployForcePersistentBootDevice: "NotAValidOption",
+			},
+			expectedError:         "invalid value for variable DIRECT_DEPLOY_FORCE_PERSISTENT_BOOT_DEVICE",
+			expectedImgBuildError: "invalid value for variable DIRECT_DEPLOY_FORCE_PERSISTENT_BOOT_DEVICE",
 		},
 	}
 

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -62,14 +62,15 @@ func NewMacAddressConflictError(address, node string) error {
 }
 
 type ironicConfig struct {
-	havePreprovImgBuilder            bool
-	deployKernelURL                  string
-	deployRamdiskURL                 string
-	deployISOURL                     string
-	liveISOForcePersistentBootDevice string
-	maxBusyHosts                     int
-	externalURL                      string
-	provNetDisabled                  bool
+	havePreprovImgBuilder                 bool
+	deployKernelURL                       string
+	deployRamdiskURL                      string
+	deployISOURL                          string
+	liveISOForcePersistentBootDevice      string
+	directDeployForcePersistentBootDevice string
+	maxBusyHosts                          int
+	externalURL                           string
+	provNetDisabled                       bool
 }
 
 // Provisioner implements the provisioning.Provisioner interface
@@ -631,6 +632,11 @@ func (p *ironicProvisioner) setDirectDeployUpdateOptsForNode(ironicNode *nodes.N
 
 	driverOptValues := clients.UpdateOptsData{
 		"force_persistent_boot_device": "Default",
+	}
+	if p.config.directDeployForcePersistentBootDevice != "" {
+		driverOptValues = clients.UpdateOptsData{
+			"force_persistent_boot_device": p.config.directDeployForcePersistentBootDevice,
+		}
 	}
 	updater.SetDriverInfoOpts(driverOptValues, ironicNode)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

It allows configuring the `force_persistent_boot_device: <value>` when `deploy_interface: direct` is used.
It uses the same variable as for `deploy_interface: ramdisk.`

I did not rename the current env var `LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE` to be backwards compatible.
It introduces a new environment variable `DIRECT_DEPLOY_FORCE_PERSISTENT_BOOT_DEVICE` which can be toggled when using the direct interface. 
The default is the same behaviour as before, so people need to actively **opt-in**.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2613 
