### PR TITLE
📖 Add alpha release in release documentation

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -41,6 +41,7 @@ given permissions directly.
 BMO uses [semantic versioning](https://semver.org).
 
 - Regular releases: `v0.x.y`
+- Alpha releases: `v0.x.y-alpha.z`
 - Beta releases: `v0.x.y-beta.z`
 - Release candidate releases: `v0.x.y-rc.z`
 
@@ -68,7 +69,7 @@ This makes sure that all the tags are accessible.
      `releasenotes/<RELEASE_TAG>.md` .
 
 - Next step is to clean up the release note manually.
-   - If release is not a beta or release candidate, check for duplicates,
+   - If release is not an alpha or a beta or release candidate, check for duplicates,
      reverts, and incorrect classifications of PRs, and whatever release
      creation tagged to be manually checked.
    - For any superseded PRs (like same dependency uplifted multiple times, or
@@ -99,8 +100,8 @@ Once PR is merged following GitHub actions are triggered:
      [Releases](https://github.com/metal3-io/baremetal-operator/releases).
      If the release you're making is not a new major release, new minor release,
      or a new patch release from the latest release branch, uncheck the box for
-     latest release. If it is a release candidate (RC) or a beta release,
-     tick pre-release box.
+     latest release. If it is a release candidate (RC) or a beta or an alpha
+     release, tick pre-release box.
    - GitHub job `build_bmo` build release images with the
      release tag, and push them to Quay. Make sure the release tags are visible in
      Quay tags pages:


### PR DESCRIPTION
Alpha release mention was missing in release documentation. Alpha release should follow the same convention as beta release.
