### PR TITLE
🌱 Remove checking keepalived image tag during release

### DIFF
--- a/hack/verify-release.sh
+++ b/hack/verify-release.sh
@@ -97,7 +97,6 @@ declare -a release_artifacts=(
 # quay images
 declare -a container_images=(
     "${ORG}/baremetal-operator:v${VERSION}"
-    "${ORG}/keepalived:v${VERSION}"
 )
 
 # go mod bump checks - must match up to leading space before v


### PR DESCRIPTION
Keepalived image is not tagged anymore while release BMO. Removing the check from verify release script.
