### PR TITLE
:seedling: Accept uppercase format in upgrade focus

### DIFF
--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -33,7 +33,7 @@ echo "BMO_E2E_EMULATOR=${BMO_E2E_EMULATOR}"
 export E2E_CONF_FILE="${REPO_ROOT}/test/e2e/config/ironic.yaml"
 export E2E_BMCS_CONF_FILE="${REPO_ROOT}/test/e2e/config/bmcs-${BMC_PROTOCOL}.yaml"
 
-case "${GINKGO_FOCUS:-}" in
+ case "${GINKGO_FOCUS,,}" in
   *upgrade*)
     export DEPLOY_IRONIC="false"
     export DEPLOY_BMO="false"


### PR DESCRIPTION
**What this PR does / why we need it**:
In ci-e2e.sh if GINKGO_FOCUS is set to "Upgrade" the skip flag is still set to "upgrade", so tests are skipped. "Describe("-sections use upper case and "Upgrade" is written in upper case there so user might use that as per README instructions where it seems like that formatting could be used to set the focus as well.

Avoids this situation:
`+ make test-e2e
tools/bin/ginkgo -vv --trace -poll-progress-after=60m \
	-poll-progress-interval=5m --tags=e2e,vbmctl --focus="Upgrade" \
	-skip="upgrade"   --nodes=2 --timeout=2h --no-color=false \
`