### PR TITLE
✨ Introduce InspectionMode field

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types_test.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types_test.go
@@ -665,3 +665,55 @@ func TestHasBMCDetails(t *testing.T) {
 		})
 	}
 }
+
+func TestInspectionDisabled(t *testing.T) {
+	for _, tc := range []struct {
+		Scenario       string
+		InspectionMode InspectionMode
+		Annotations    map[string]string
+		Expected       bool
+	}{
+		{
+			Scenario: "default",
+		},
+		{
+			Scenario: "annotation",
+			Annotations: map[string]string{
+				InspectAnnotationPrefix: "disabled",
+			},
+			Expected: true,
+		},
+		{
+			Scenario: "empty annotation value",
+			Annotations: map[string]string{
+				InspectAnnotationPrefix: "",
+			},
+		},
+		{
+			Scenario:       "InspectionMode",
+			InspectionMode: InspectionModeDisabled,
+			Expected:       true,
+		},
+		{
+			Scenario: "both",
+			Annotations: map[string]string{
+				InspectAnnotationPrefix: "disabled",
+			},
+			InspectionMode: InspectionModeDisabled,
+			Expected:       true,
+		},
+	} {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			host := BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tc.Annotations,
+				},
+				Spec: BareMetalHostSpec{
+					InspectionMode: tc.InspectionMode,
+				},
+			}
+			actual := host.InspectionDisabled()
+			assert.Equal(t, tc.Expected, actual)
+		})
+	}
+}

--- a/config/base/crds/bases/metal3.io_baremetalhosts.yaml
+++ b/config/base/crds/bases/metal3.io_baremetalhosts.yaml
@@ -288,6 +288,15 @@ spec:
                 required:
                 - url
                 type: object
+              inspectionMode:
+                description: |-
+                  Specifies the mode for host inspection.
+                  "disabled" - no inspection will be performed
+                  "agent" - normal agent-based inspection will run
+                enum:
+                - disabled
+                - agent
+                type: string
               metaData:
                 description: |-
                   MetaData holds the reference to the Secret containing host metadata

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -288,6 +288,15 @@ spec:
                 required:
                 - url
                 type: object
+              inspectionMode:
+                description: |-
+                  Specifies the mode for host inspection.
+                  "disabled" - no inspection will be performed
+                  "agent" - normal agent-based inspection will run
+                enum:
+                - disabled
+                - agent
+                type: string
               metaData:
                 description: |-
                   MetaData holds the reference to the Secret containing host metadata

--- a/internal/controller/metal3.io/baremetalhost_controller_test.go
+++ b/internal/controller/metal3.io/baremetalhost_controller_test.go
@@ -592,16 +592,6 @@ func TestSetLastUpdated(t *testing.T) {
 	)
 }
 
-func TestInspectionDisabledAnnotation(t *testing.T) {
-	host := newDefaultHost(t)
-	host.Annotations = make(map[string]string)
-
-	assert.False(t, inspectionDisabled(host))
-
-	host.Annotations[metal3api.InspectAnnotationPrefix] = "disabled"
-	assert.True(t, inspectionDisabled(host))
-}
-
 func makeReconcileInfo(host *metal3api.BareMetalHost) *reconcileInfo {
 	return &reconcileInfo{
 		log:  logf.Log.WithName("controllers").WithName("BareMetalHost").WithName("baremetal_controller"),

--- a/internal/controller/metal3.io/host_state_machine.go
+++ b/internal/controller/metal3.io/host_state_machine.go
@@ -408,7 +408,7 @@ func (hsm *hostStateMachine) handleRegistering(_ *reconcileInfo) actionResult {
 	// if the credentials change and the Host must be re-registered.
 	if hsm.Host.Spec.ExternallyProvisioned {
 		hsm.NextState = metal3api.StateExternallyProvisioned
-	} else if inspectionDisabled(hsm.Host) {
+	} else if hsm.Host.InspectionDisabled() {
 		hsm.NextState = metal3api.StatePreparing
 	} else {
 		hsm.NextState = metal3api.StateInspecting
@@ -439,8 +439,7 @@ func (hsm *hostStateMachine) handleExternallyProvisioned(info *reconcileInfo) ac
 		return hsm.Reconciler.actionManageSteadyState(hsm.Provisioner, info)
 	}
 
-	// TODO(dtantsur): move this logic inside NeedsHardwareInspection?
-	if hsm.Host.NeedsHardwareInspection() && !inspectionDisabled(hsm.Host) {
+	if hsm.Host.NeedsHardwareInspection() {
 		hsm.NextState = metal3api.StateInspecting
 	} else {
 		hsm.NextState = metal3api.StatePreparing
@@ -464,7 +463,7 @@ func (hsm *hostStateMachine) handleAvailable(info *reconcileInfo) actionResult {
 		return actionComplete{}
 	}
 
-	if hasInspectAnnotation(hsm.Host) {
+	if inspectionRefreshRequested(hsm.Host) {
 		hsm.NextState = metal3api.StateInspecting
 		return actionComplete{}
 	}

--- a/test/e2e/inspection_test.go
+++ b/test/e2e/inspection_test.go
@@ -127,6 +127,43 @@ var _ = Describe("Inspection", Label("required", "inspection"), func() {
 		}, e2eConfig.GetIntervals(specName, "wait-available")...)
 	})
 
+	It("should skip inspection when disabled", func() {
+		By("Creating a secret with BMH credentials")
+
+		bmcCredentialsData := map[string]string{
+			"username": bmc.User,
+			"password": bmc.Password,
+		}
+		CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+
+		By("creating a BMH")
+		bmh := metal3api.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      specName + "-inspect",
+				Namespace: namespace.Name,
+			},
+			Spec: metal3api.BareMetalHostSpec{
+				BMC: metal3api.BMCDetails{
+					Address:         bmc.Address,
+					CredentialsName: "bmc-credentials",
+				},
+				BootMode:       metal3api.Legacy,
+				BootMACAddress: bmc.BootMacAddress,
+				InspectionMode: metal3api.InspectionModeDisabled,
+			},
+		}
+		err := clusterProxy.GetClient().Create(ctx, &bmh)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("waiting for the BMH to become available")
+		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+			Client:          clusterProxy.GetClient(),
+			Bmh:             bmh,
+			State:           metal3api.StateAvailable,
+			UndesiredStates: []metal3api.ProvisioningState{metal3api.StateInspecting},
+		}, e2eConfig.GetIntervals(specName, "wait-available")...)
+	})
+
 	AfterEach(func() {
 		DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
 		if !skipCleanup {


### PR DESCRIPTION
This change introduces the InspectionMode field from the BMH v1beta1 design proposal. It partly replaces the inspection annotation (namely, its "disabled" value) by something more user-friendly and consistent with AutomatedCleaningMode.

The "disabled" value of the inspection annotation is now deprecated. Other values are not affected by this change.

Assisted-By: Claude Code