### PR TITLE
:seedling: Pin ironic release-31.0

### DIFF
--- a/ironic-deployment/base/ironic.yaml
+++ b/ironic-deployment/base/ironic.yaml
@@ -20,7 +20,7 @@ spec:
       hostNetwork: true
       containers:
       - name: ironic-dnsmasq
-        image: quay.io/metal3-io/ironic
+        image: quay.io/metal3-io/ironic:release-31.0
         imagePullPolicy: Always
         securityContext:
           # Must be true so dnsmasq may get the capabilities via file caps
@@ -61,7 +61,7 @@ spec:
         - configMapRef:
             name: ironic-bmo-configmap
       - name: ironic
-        image: quay.io/metal3-io/ironic
+        image: quay.io/metal3-io/ironic:release-31.0
         imagePullPolicy: Always
         command:
         - /bin/runironic
@@ -96,7 +96,7 @@ spec:
           runAsUser: 997 # ironic
           runAsGroup: 994 # ironic
       - name: ironic-log-watch
-        image: quay.io/metal3-io/ironic
+        image: quay.io/metal3-io/ironic:release-31.0
         imagePullPolicy: Always
         command:
         - /bin/runlogwatch.sh
@@ -112,7 +112,7 @@ spec:
           runAsUser: 997 # ironic
           runAsGroup: 994 # ironic
       - name: ironic-httpd
-        image: quay.io/metal3-io/ironic
+        image: quay.io/metal3-io/ironic:release-31.0
         imagePullPolicy: Always
         command:
         - /bin/runhttpd


### PR DESCRIPTION
This commit:
 - Sets the default Ironic tag to release-31.0 in the base ironic-deployment overlay
