### PR TITLE
🌱 Add IPA_BASEURI to download ipa image from Nordix

### DIFF
--- a/ironic-deployment/overlays/e2e-release-26.0/ironic_bmo_configmap.env
+++ b/ironic-deployment/overlays/e2e-release-26.0/ironic_bmo_configmap.env
@@ -1,6 +1,7 @@
 HTTP_PORT=6180
 PROVISIONING_INTERFACE=eth0
 CACHEURL=http://192.168.222.1/images
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
 IRONIC_HTTP_URL=http://192.168.222.1:6180
 IRONIC_BASE_URL=https://192.168.222.1:6385
 IRONIC_EXTERNAL_CALLBACK_URL=https://192.168.222.1:6385

--- a/ironic-deployment/overlays/e2e-release-27.0/ironic_bmo_configmap.env
+++ b/ironic-deployment/overlays/e2e-release-27.0/ironic_bmo_configmap.env
@@ -1,6 +1,7 @@
 HTTP_PORT=6180
 PROVISIONING_INTERFACE=eth0
 CACHEURL=http://192.168.222.1/images
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
 IRONIC_HTTP_URL=http://192.168.222.1:6180
 IRONIC_BASE_URL=https://192.168.222.1:6385
 IRONIC_EXTERNAL_CALLBACK_URL=https://192.168.222.1:6385

--- a/ironic-deployment/overlays/e2e-release-28.0/ironic_bmo_configmap.env
+++ b/ironic-deployment/overlays/e2e-release-28.0/ironic_bmo_configmap.env
@@ -1,6 +1,7 @@
 HTTP_PORT=6180
 PROVISIONING_INTERFACE=eth0
 CACHEURL=http://192.168.222.1/images
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
 IRONIC_HTTP_URL=http://192.168.222.1:6180
 IRONIC_BASE_URL=https://192.168.222.1:6385
 IRONIC_EXTERNAL_CALLBACK_URL=https://192.168.222.1:6385

--- a/ironic-deployment/overlays/e2e-release-29.0/ironic_bmo_configmap.env
+++ b/ironic-deployment/overlays/e2e-release-29.0/ironic_bmo_configmap.env
@@ -1,6 +1,7 @@
 HTTP_PORT=6180
 PROVISIONING_INTERFACE=eth0
 CACHEURL=http://192.168.222.1/images
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
 IRONIC_HTTP_URL=http://192.168.222.1:6180
 IRONIC_BASE_URL=https://192.168.222.1:6385
 IRONIC_EXTERNAL_CALLBACK_URL=https://192.168.222.1:6385

--- a/ironic-deployment/overlays/e2e-release-30.0/ironic_bmo_configmap.env
+++ b/ironic-deployment/overlays/e2e-release-30.0/ironic_bmo_configmap.env
@@ -1,6 +1,7 @@
 HTTP_PORT=6180
 PROVISIONING_INTERFACE=eth0
 CACHEURL=http://192.168.222.1/images
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
 IRONIC_HTTP_URL=http://192.168.222.1:6180
 IRONIC_BASE_URL=https://192.168.222.1:6385
 IRONIC_EXTERNAL_CALLBACK_URL=https://192.168.222.1:6385

--- a/ironic-deployment/overlays/e2e-release-31.0/ironic_bmo_configmap.env
+++ b/ironic-deployment/overlays/e2e-release-31.0/ironic_bmo_configmap.env
@@ -1,6 +1,7 @@
 HTTP_PORT=6180
 PROVISIONING_INTERFACE=eth0
 CACHEURL=http://192.168.222.1/images
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
 IRONIC_HTTP_URL=http://192.168.222.1:6180
 IRONIC_BASE_URL=https://192.168.222.1:6385
 IRONIC_EXTERNAL_CALLBACK_URL=https://192.168.222.1:6385

--- a/ironic-deployment/overlays/e2e/ironic_bmo_configmap.env
+++ b/ironic-deployment/overlays/e2e/ironic_bmo_configmap.env
@@ -1,6 +1,7 @@
 HTTP_PORT=6180
 PROVISIONING_INTERFACE=eth0
 CACHEURL=http://192.168.222.1/images
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
 IRONIC_HTTP_URL=http://192.168.222.1:6180
 IRONIC_BASE_URL=https://192.168.222.1:6385
 IRONIC_EXTERNAL_CALLBACK_URL=https://192.168.222.1:6385


### PR DESCRIPTION
Tests are having issue when downloading the IPA image from upstream and hits timeout. So here we are passing IPA_BASEURI variable to ironic vars to download the IPA image from Nordix cache.