### PR TITLE
🌱 E2E: Make timeout configurable and increase it for optional periodics

### DIFF
--- a/.github/workflows/e2e-test-optional-periodic.yml
+++ b/.github/workflows/e2e-test-optional-periodic.yml
@@ -22,5 +22,6 @@ jobs:
     with:
       bmc-protocol: ${{ matrix.bmc-protocol }}
       ginkgo-focus: upgrade
+      timeout-minutes: 120
     permissions:
       contents: read

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -15,6 +15,9 @@ on:
       ref:
         type: string
         default: ${{ github.ref }}
+      timeout-minutes:
+        type: number
+        default: 90
 
 permissions: {}
 
@@ -22,7 +25,7 @@ jobs:
   test:
     name: E2E test
     runs-on: ${{ inputs.runner }}
-    timeout-minutes: 90
+    timeout-minutes: ${{ inputs.timeout-minutes }}
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -31,8 +34,8 @@ jobs:
 
     - name: Install libvirt
       run: |
-          sudo apt-get update
-          sudo apt-get install -y libvirt-daemon-system qemu-kvm virt-manager libvirt-dev
+        sudo apt-get update
+        sudo apt-get install -y libvirt-daemon-system qemu-kvm virt-manager libvirt-dev
 
     - name: Run BMO e2e Tests
       env:


### PR DESCRIPTION
**What this PR does / why we need it**:

We are hitting the 90 minute timeout in the optional periodics. This PR makes the timeout configurable per workflow and increases it to 120 minutes for the optional periodics.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
