### PR TITLE
🐛 Create a PreprovisioningImage for servicing if needed

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -807,10 +807,14 @@ func (r *BareMetalHostReconciler) registerHost(prov provisioner.Provisioner, inf
 		return actionError{err}
 	}
 	switch info.host.Status.Provisioning.State {
-	case metal3api.StateRegistering, metal3api.StateExternallyProvisioned, metal3api.StateDeleting, metal3api.StatePoweringOffBeforeDelete:
+	case metal3api.StateRegistering, metal3api.StateDeleting, metal3api.StatePoweringOffBeforeDelete:
 		// No need to create PreprovisioningImage if host is not yet registered
-		// or is externally provisioned
 		preprovImgFormats = nil
+	case metal3api.StateProvisioned, metal3api.StateExternallyProvisioned:
+		// Provisioned hosts only need the image for servicing
+		if info.host.Status.OperationalStatus != metal3api.OperationalStatusServicing {
+			preprovImgFormats = nil
+		}
 	case metal3api.StateDeprovisioning:
 		// PreprovisioningImage is not required for deprovisioning when cleaning is disabled
 		if info.host.Spec.AutomatedCleaningMode == metal3api.CleaningModeDisabled {
@@ -842,6 +846,7 @@ func (r *BareMetalHostReconciler) registerHost(prov provisioner.Provisioner, inf
 			BootMode:                   info.host.Status.Provisioning.BootMode,
 			AutomatedCleaningMode:      info.host.Spec.AutomatedCleaningMode,
 			State:                      info.host.Status.Provisioning.State,
+			OperationalStatus:          info.host.Status.OperationalStatus,
 			CurrentImage:               getCurrentImage(info.host),
 			PreprovisioningImage:       preprovImg,
 			PreprovisioningNetworkData: preprovisioningNetworkData,
@@ -1467,6 +1472,8 @@ func (r *BareMetalHostReconciler) doServiceIfNeeded(prov provisioner.Provisioner
 	// going to impact a small subset of Firmware Settings implementations.
 	if info.host.Status.OperationalStatus != metal3api.OperationalStatusServicing {
 		info.host.Status.OperationalStatus = metal3api.OperationalStatusServicing
+		// NOTE(dtantsur): it's very important to yield to the controller and retry before actually calling Ironic:
+		// a PreprovisioningImage may be missing until we get to the registration code.
 		return actionUpdate{}
 	}
 

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -363,6 +363,13 @@ func (p *ironicProvisioner) configureNode(data provisioner.ManagementAccessData,
 			result, err = transientError(provisioner.ErrNeedsPreprovisioningImage)
 		}
 		return result, err
+	case metal3api.StateProvisioned,
+		metal3api.StateExternallyProvisioned:
+		if data.OperationalStatus == metal3api.OperationalStatusServicing &&
+			deployImageInfo == nil && p.config.havePreprovImgBuilder {
+			result, err = transientError(provisioner.ErrNeedsPreprovisioningImage)
+		}
+		return result, err
 	default:
 	}
 

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -77,6 +77,7 @@ type ManagementAccessData struct {
 	BootMode                   metal3api.BootMode
 	AutomatedCleaningMode      metal3api.AutomatedCleaningMode
 	State                      metal3api.ProvisioningState
+	OperationalStatus          metal3api.OperationalStatus
 	CurrentImage               *metal3api.Image
 	PreprovisioningImage       *PreprovisioningImage
 	PreprovisioningNetworkData string


### PR DESCRIPTION
The current code ignores PreprovisioningImages for provisioned nodes. While normally there is a leftover PreprovisioningImage from the deployment, it's not the case for externally provisioned hosts.

Fixes #2689
