### PR TITLE
🌱Increase optional periodic test time

### DIFF
--- a/.github/workflows/e2e-test-optional-periodic.yml
+++ b/.github/workflows/e2e-test-optional-periodic.yml
@@ -22,6 +22,6 @@ jobs:
     with:
       bmc-protocol: ${{ matrix.bmc-protocol }}
       ginkgo-focus: upgrade
-      timeout-minutes: 120
+      timeout-minutes: 180
     permissions:
       contents: read


### PR DESCRIPTION
Optional periodic test is having timeout in 2 hours. We have decided to give it more time to complete the job.