### PR TITLE
:seedling: Add maketarget for ensuring docker is present for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,11 @@ fuzz-run: ## Run all fuzz tests sequentially with fuzzing enabled (use FUZZ_TIME
 
 ARTIFACTS ?= ${ROOT_DIR}/test/e2e/_artifacts
 
+.PHONY: verify-e2e-prerequisites
+verify-e2e-prerequisites: ## Check that required tools exist for e2e tests
+	@echo "Ensure the local environment is ready for e2e tests..."
+	VERIFY_ONLY=1 ./hack/e2e/ensure_e2e_prerequisites.sh
+
 .PHONY: test-e2e
 test-e2e: $(GINKGO) ## Run the end-to-end tests
 	$(GINKGO) -v --trace -poll-progress-after=$(GINKGO_POLL_PROGRESS_AFTER) \

--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -35,6 +35,8 @@ echo "BMO_E2E_EMULATOR=${BMO_E2E_EMULATOR}"
 export E2E_CONF_FILE="${REPO_ROOT}/test/e2e/config/ironic.yaml"
 export E2E_BMCS_CONF_FILE="${REPO_ROOT}/test/e2e/config/bmcs-${BMC_PROTOCOL}.yaml"
 
+GINKGO_FOCUS="${GINKGO_FOCUS:-}"
+
 case "${GINKGO_FOCUS,,}" in
   *upgrade*)
     export DEPLOY_IRONIC="false"

--- a/hack/clean-e2e.sh
+++ b/hack/clean-e2e.sh
@@ -11,7 +11,10 @@ docker rm -f sushy-tools
 
 rm -rf "${REPO_ROOT}/test/e2e/_artifacts"
 rm -rf "${REPO_ROOT}"/artifacts-*
-rm -rf "${REPO_ROOT}/test/e2e/images"
+KEEP_E2E_IMAGES="${KEEP_E2E_IMAGES:-false}"
+if [[ "${KEEP_E2E_IMAGES,,}" != "true" ]]; then
+    rm -rf "${REPO_ROOT}/test/e2e/images"
+fi
 
 # Clear network
 virsh -c qemu:///system net-destroy baremetal-e2e

--- a/hack/e2e/ensure_docker.sh
+++ b/hack/e2e/ensure_docker.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Verify mode turned off by default
+VERIFY_ONLY="${VERIFY_ONLY:-false}"
+
+# Source os-release to get ID variable
+# shellcheck source=/dev/null
+. /etc/os-release
+
+# Description:
+#   Prompt the user for a yes/no confirmation.
+#
+# Usage:
+#   confirm <default> <message>
+#   <default> must be "y" or "n" (case-insensitive).
+#
+# Returns:
+#   Exit code 0 (true) if the user confirms; 1 (false) otherwise.
+confirm() {
+    local default message prompt reply
+
+    # normalize to lowercase
+    default="${1,,}"
+    if [[ "${default}" == "y" ]]; then
+        prompt="[Y/n]"
+    else
+        prompt="[y/N]"
+    fi
+
+    message="${2}"
+    while true; do
+        read -r -p "${message} Do you want to continue? ${prompt} " reply
+        # use default if Enter pressed
+        reply="${reply:-${default}}"
+        case "${reply,,}" in
+            y) return 0 ;;
+            n) return 1 ;;
+            *) echo "Please enter y or n." ;;
+        esac
+    done
+}
+
+# Description:
+#   Install Docker on Ubuntu.
+#
+# Usage:
+#   install_docker_ubuntu download_url
+install_docker_ubuntu() {
+    local DOCKER_DOWNLOAD_URL
+
+    DOCKER_DOWNLOAD_URL="${1}"
+
+    sudo apt-get install -y ca-certificates curl
+    sudo install -m 0755 -d /etc/apt/keyrings
+    sudo curl -fsSL \
+        -o /etc/apt/keyrings/docker.asc \
+        "${DOCKER_DOWNLOAD_URL}/gpg"
+    sudo chmod a+r /etc/apt/keyrings/docker.asc
+    echo \
+        "deb [arch=$(dpkg --print-architecture)" \
+        "signed-by=/etc/apt/keyrings/docker.asc]" \
+        "${DOCKER_DOWNLOAD_URL}" \
+        "${UBUNTU_CODENAME:-$VERSION_CODENAME} stable" | \
+        sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    sudo apt-get update
+    sudo apt-get install -y \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io \
+        docker-buildx-plugin \
+        docker-compose-plugin
+    sudo usermod -aG docker "${USER}"
+
+    echo "Docker installed successfully, please log"\
+         "out and log back in to apply the new group membership"
+}
+
+# Description:
+#   Prompt the user for confirmation and execute a function if confirmed.
+#
+# Usage:
+#   confirm_and_run <default> <message> <function> [args...]
+#
+# Returns:
+#   Exit code 0 (true) if confirmed and function ran; 1 (false) if declined.
+confirm_and_run() {
+    local default fn message
+
+    local default="${1}"
+    local message="${2}"
+    local fn="${3}"
+    shift 3
+
+   if confirm "${default}" "${message}"; then
+        set -x
+        "${fn}" "$@"
+        set +x
+    else
+        echo "Aborted."
+        return 1
+    fi
+}
+
+# Check if docker is installed and install it if not
+verify_docker() {
+    local DOCKER URL
+
+    DOCKER="$(command -v docker || true)"
+    if ! [[ -x "${DOCKER}" ]]; then
+        if [[ "${VERIFY_ONLY}" != "false" ]]; then
+            echo "docker is not in PATH"
+            return 0
+        fi
+        echo "docker not found, installing"
+        case "${ID}" in
+            ubuntu)
+                URL="https://download.docker.com/linux/ubuntu"
+                confirm_and_run \
+                    "n" \
+                    "This action will install the latest Docker from ${URL}." \
+                    install_docker_ubuntu \
+                    "${URL}"
+                ;;
+            *)
+                echo "ERROR: Distribution not supported: ${ID}"
+                return 2
+                ;;
+        esac
+    else
+        echo "$(${DOCKER} --version) is installed at ${DOCKER}"
+    fi
+}
+
+verify_docker

--- a/hack/e2e/ensure_e2e_prerequisites.sh
+++ b/hack/e2e/ensure_e2e_prerequisites.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+# -----------------------------------------------------------------------------
+# Description: This script sets up the environment for E2E tests. It can also
+#              be used in verify mode to check if the required tools are installed
+#              without making any changes to the system.
+# Usage:       To set up the environment: ./ensure_e2e_prerequisites.sh
+#              To verify prerequisites without installing:
+#              VERIFY_ONLY=1 ./ensure_e2e_prerequisites.sh
+# -----------------------------------------------------------------------------
+
+set -eu
+
+REPO_ROOT="$(realpath "$(dirname "${BASH_SOURCE[0]}")/../..")"
+VERIFY_ONLY="${VERIFY_ONLY:-false}"
+
+# Source os-release to get ID variable
+# shellcheck source=/dev/null
+. /etc/os-release
+
+declare -A PACKAGES=(
+  [build-essential]=""
+  [tar]=""
+  [libvirt-daemon-system]=""
+  [qemu-kvm]="qemu-system-x86"
+  [virt-manager]=""
+)
+
+declare -A TOOLS=(
+  [ubuntu]="install_pkg_ubuntu dpkg"
+)
+
+# Ensure required tools are available
+ensure_tools() {
+  local missing_tools cmd
+
+  # Ensure required low-level tools are present
+  missing_tools=()
+  for cmd in ${TOOLS[${ID}]}; do
+    if ! command -v "${cmd}" >/dev/null; then
+      missing_tools+=("${cmd}")
+    fi
+  done
+
+  if ((${#missing_tools[@]})); then
+    echo "ERROR: Missing required tools: ${missing_tools[*]}"
+    return 2
+  fi
+
+  return 0
+}
+
+# Install packages using apt-get on Ubuntu
+install_pkg_ubuntu() {
+  local packages
+
+  packages=("$@")
+
+  sudo apt-get update
+  sudo apt-get install -y "${packages[@]}"
+}
+
+# Ensure required packages are installed, or install them if not#
+ensure_packages() {
+  local missing installed packages_to_check alt check_tool install_tool
+  local version tools
+
+  read -ra tools <<< "${TOOLS[${ID}]}"
+
+  install_tool="${tools[0]}"
+  check_tool="${tools[1]}"
+
+  # Collect packages that are not satisfied by any alias
+  missing=()
+  for pkg in "${!PACKAGES[@]}"; do
+    # check any alias is installed
+    installed=""
+    packages_to_check=("${pkg}")
+    if [[ -n "${PACKAGES[${pkg}]}" ]]; then
+      read -ra aliases <<< "${PACKAGES[${pkg}]}"
+      packages_to_check+=("${aliases[@]}")
+    fi
+    for alt in "${packages_to_check[@]}"; do
+      version="$("${check_tool}" -s "${alt}" 2>/dev/null \
+                  | grep '^Version:' \
+                  || true)"
+      if [[ -n "${version}" ]]; then
+        installed="${alt} (${version})"
+        break
+      fi
+    done
+
+    if [[ -n "${installed}" ]]; then
+      echo "Package ${pkg} satisfied by installed package: ${installed}"
+      continue
+    fi
+
+    if [[ "${VERIFY_ONLY}" != "false" ]]; then
+      if [[ -n "${PACKAGES[${pkg}]}" ]]; then
+        echo "Package ${pkg} (aliases: ${PACKAGES[${pkg}]}) is not installed"
+      else
+        echo "Package ${pkg} is not installed"
+      fi
+      continue
+    fi
+
+    missing+=("${pkg}")
+  done
+
+  if [[ "${VERIFY_ONLY}" == "false" && ${#missing[@]} -gt 0 ]]; then
+    echo "Installing missing packages: ${missing[*]}"
+    set -x
+    "${install_tool}" "${missing[@]}"
+    set +x
+  fi
+}
+
+# Ensure all prerequisites are installed
+ensure_components() {
+  export PATH="${PATH}:/usr/local/go/bin"
+  VERIFY_ONLY="${VERIFY_ONLY}" "${REPO_ROOT}/hack/e2e/ensure_kubectl.sh"
+  VERIFY_ONLY="${VERIFY_ONLY}" "${REPO_ROOT}/hack/e2e/ensure_yq.sh"
+  VERIFY_ONLY="${VERIFY_ONLY}" "${REPO_ROOT}/hack/e2e/ensure_go.sh"
+  VERIFY_ONLY="${VERIFY_ONLY}" "${REPO_ROOT}/hack/e2e/ensure_htpasswd.sh"
+  VERIFY_ONLY="${VERIFY_ONLY}" "${REPO_ROOT}/hack/e2e/ensure_docker.sh"
+}
+
+# Main execution
+case "${ID}" in
+  ubuntu)
+    ;;
+  *)
+    echo "ERROR: Distribution not supported: ${ID}"
+    return 2
+    ;;
+esac
+
+ensure_tools
+ensure_packages
+ensure_components

--- a/hack/e2e/ensure_go.sh
+++ b/hack/e2e/ensure_go.sh
@@ -1,34 +1,55 @@
 #!/usr/bin/env bash
 
-set -eux
+set -eu
 
 MINIMUM_GO_VERSION=go1.25.7
 
+# Verify mode turned off by default
+VERIFY_ONLY="${VERIFY_ONLY:-false}"
+
 # Ensure the go tool exists and is a viable version, or installs it
-verify_go_version()
-{
+verify_go_version() {
     # If go is not available on the path, get it
-    if ! [ -x "$(command -v go)" ]; then
+    GO="$(command -v go || true)"
+    if ! [[ -x "${GO}" ]]; then
+        if [[ "${VERIFY_ONLY}" != "false" ]]; then
+            echo "go is not in PATH"
+            return 0
+        fi
         if [[ "${OSTYPE}" == "linux-gnu" ]]; then
-            echo 'go not found, installing'
-            curl -sLo "/tmp/${MINIMUM_GO_VERSION}.linux-amd64.tar.gz" "https://go.dev/dl/${MINIMUM_GO_VERSION}.linux-amd64.tar.gz"
-            sudo tar -C /usr/local -xzf "/tmp/${MINIMUM_GO_VERSION}.linux-amd64.tar.gz"
-            export PATH=/usr/local/go/bin:$PATH
+            echo "go not found, installing"
+            set -x
+            curl -sL \
+                -o "/tmp/${MINIMUM_GO_VERSION}.linux-amd64.tar.gz" \
+                "https://go.dev/dl/${MINIMUM_GO_VERSION}.linux-amd64.tar.gz"
+            sudo tar \
+                -C /usr/local \
+                -xzf "/tmp/${MINIMUM_GO_VERSION}.linux-amd64.tar.gz"
+            set +x
+            export PATH="${PATH}:/usr/local/go/bin"
+            GO="$(command -v go)"
         else
-            echo "Missing required binary in path: go"
+            echo "ERROR: Missing required binary in path: go"
             return 2
         fi
     fi
 
     local go_version
-    IFS=" " read -ra go_version <<< "$(go version)"
-    if [[ "${MINIMUM_GO_VERSION}" != $(echo -e "${MINIMUM_GO_VERSION}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]] && [[ "${go_version[2]}" != "devel" ]]; then
+    IFS=" " read -ra go_version <<< "$("${GO}" version)"
+    if [[ "${MINIMUM_GO_VERSION}" != $(
+        echo -e "${MINIMUM_GO_VERSION}\n${go_version[2]}" \
+        | sort -s -t. -k 1,1 -k 2,2n -k 3,3n \
+        | head -n1
+    ) ]] && \
+       [[ "${go_version[2]}" != "devel" ]]; then
         cat << EOF
 Detected go version: ${go_version[2]}.
 Requires ${MINIMUM_GO_VERSION} or greater.
 Please install ${MINIMUM_GO_VERSION} or later.
 EOF
         return 2
+    else
+        echo "${go_version[2]} is installed at ${GO}"
     fi
 }
 

--- a/hack/e2e/ensure_htpasswd.sh
+++ b/hack/e2e/ensure_htpasswd.sh
@@ -1,14 +1,24 @@
 #!/usr/bin/env bash
 
-set -eux
+set -eu
+
+# Verify mode turned off by default
+VERIFY_ONLY="${VERIFY_ONLY:-false}"
 
 # Check if htpasswd is installed and install it if not
-verify_htpasswd()
-{
-    if ! [ -x "$(command -v htpasswd)" ]; then
+verify_htpasswd() {
+    if ! [[ -x "$(command -v htpasswd)" ]]; then
+        if [[ "${VERIFY_ONLY}" != "false" ]]; then
+            echo "htpasswd is not in PATH"
+            return 0
+        fi
         echo "htpasswd could not be found, installing..."
+        set -x
         sudo apt-get update
         sudo apt-get install -y apache2-utils
+        set +x
+    else
+        echo "htpasswd is installed at $(command -v htpasswd)"
     fi
 }
 

--- a/hack/e2e/ensure_kubectl.sh
+++ b/hack/e2e/ensure_kubectl.sh
@@ -14,35 +14,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eux
+set -eu
 
 USR_LOCAL_BIN="/usr/local/bin"
 MINIMUM_KUBECTL_VERSION=v1.34.1
+KUBECTL_DOWNLOAD_URL="https://dl.k8s.io/release"
+
+# Verify mode turned off by default
+VERIFY_ONLY="${VERIFY_ONLY:-false}"
 
 # Ensure the kubectl tool exists and is a viable version, or installs it
-verify_kubectl_version()
-{
+verify_kubectl_version() {
     # If kubectl is not available on the path, get it
-    if ! [ -x "$(command -v kubectl)" ]; then
+    KUBECTL="$(command -v kubectl || true)"
+    if ! [[ -x "${KUBECTL}" ]]; then
+        if [[ "${VERIFY_ONLY}" != "false" ]]; then
+            echo "kubectl is not in PATH"
+            return 0
+        fi
         if [[ "${OSTYPE}" == "linux-gnu" ]]; then
             echo "kubectl not found, installing"
-            curl -LO "https://dl.k8s.io/release/${MINIMUM_KUBECTL_VERSION}/bin/linux/amd64/kubectl"
-            sudo install kubectl "${USR_LOCAL_BIN}/kubectl"
+            set -x
+            curl -LO \
+                --create-dirs \
+                --output-dir "/tmp" \
+                "${KUBECTL_DOWNLOAD_URL}/${MINIMUM_KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+            sudo install "/tmp/kubectl" "${USR_LOCAL_BIN}/kubectl"
+            set +x
+            KUBECTL="$(command -v kubectl)"
         else
-            echo "Missing required binary in path: kubectl"
+            echo "ERROR: Missing required binary in path: kubectl"
             return 2
         fi
     fi
 
     local kubectl_version
-    IFS=" " read -ra kubectl_version <<< "$(kubectl version --client)"
-    if [[ "${MINIMUM_KUBECTL_VERSION}" != $(echo -e "${MINIMUM_KUBECTL_VERSION}\n${kubectl_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]; then
+    IFS=" " read -ra kubectl_version <<< "$("${KUBECTL}" version --client)"
+    if [[ "${MINIMUM_KUBECTL_VERSION}" != $(
+        echo -e "${MINIMUM_KUBECTL_VERSION}\n${kubectl_version[2]}" \
+        | sort -s -t. -k 1,1 -k 2,2n -k 3,3n \
+        | head -n1
+    ) ]]; then
         cat << EOF
 Detected kubectl version: ${kubectl_version[2]}.
 Requires ${MINIMUM_KUBECTL_VERSION} or greater.
 Please install ${MINIMUM_KUBECTL_VERSION} or later.
 EOF
         return 2
+    else
+        echo "kubectl version ${kubectl_version[2]} is installed at ${KUBECTL}"
     fi
 }
 

--- a/hack/e2e/ensure_yq.sh
+++ b/hack/e2e/ensure_yq.sh
@@ -1,23 +1,39 @@
 #!/usr/bin/env bash
 
-set -eux
+set -eu
 
 USR_LOCAL_BIN="/usr/local/bin"
 YQ_VERSION="v4.40.5"
+YQ_DOWNLOAD_URL="https://github.com/mikefarah/yq/releases/download"
+
+# Verify mode turned off by default
+VERIFY_ONLY="${VERIFY_ONLY:-false}"
 
 # Check if yq tool is installed and install it if not
 verify_yq()
 {
-    if ! [[ -x "$(command -v yq)" ]]; then
+    YQ="$(command -v yq || true)"
+    if ! [[ -x "${YQ}" ]]; then
+        if [[ "${VERIFY_ONLY}" != "false" ]]; then
+            echo "yq is not in PATH"
+            return 0
+        fi
         if [[ "${OSTYPE}" == "linux-gnu" ]]; then
             echo "yq not found, installing"
-            curl -LO "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64.tar.gz"
-            tar xvf yq_linux_amd64.tar.gz
-            sudo install yq_linux_amd64 "${USR_LOCAL_BIN}/yq"
+            set -x
+            curl -LO \
+                --create-dirs \
+                --output-dir "/tmp" \
+                "${YQ_DOWNLOAD_URL}/${YQ_VERSION}/yq_linux_amd64.tar.gz"
+            sudo tar -xvf "/tmp/yq_linux_amd64.tar.gz" -C "/tmp"
+            sudo install "/tmp/yq_linux_amd64" "${USR_LOCAL_BIN}/yq"
+            set +x
         else
-            echo "Missing required binary in path: yq"
+            echo "ERROR: Missing required binary in path: yq"
             return 2
         fi
+    else
+        echo "$(yq --version) is installed at ${YQ}"
     fi
 }
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -15,6 +15,25 @@ as BMC. Ironic runs in the "host network" of the kind cluster in the test. The
 kind cluster is then configured to expose the relevant ports on the actual host
 so that they can be reached from the BareMetalHost VMs.
 
+However, before running the script ensure the environment is setup correctly:
+
+```bash
+make verify-e2e-prerequisites
+```
+
+This check uses a script that currently runs only on Ubuntu. If any required
+components are missing, run the same script to install them:
+
+```bash
+# After running the script, you may need to log out/in (or start a new shell)
+# before docker works without sudo.
+./hack/e2e/ensure_e2e_prerequisites.sh
+```
+
+Please note that the script installs Go in `/usr/local/go`. If you want to invoke
+the e2e Makefile target directly with `make test-e2e`, you may need to adjust your
+`PATH` accordingly.
+
 Currently there are two sets of tests, which cannot be ran together in the same
 cluster. One is the "optional" set, currently consists of only the
 [upgrade tests](upgrade_test.go), and the "main" set, which are the ones
@@ -67,7 +86,7 @@ Skipping tests works otherwise similiarly to adding focus, but in the Makefile
 test-specific words with it or you can add another `--skip=` with a longer
 string to the `test-e2e` target.
 
-`BMC_PROTOCOL` can also be set manually. By default the [ci-e2e.sh](https://github.com/metal3-io/baremetal-operator/blob/main/hack/ci-e2e.sh)
+`BMC_PROTOCOL` can also be set manually. By default the [ci-e2e.sh](../../hack/ci-e2e.sh)
 script runs it as `redfish`, but it can also be set to `redfish-virtualmedia`,
 `redfish`, or `ipmi`. Ipmi uses `vbmc` as the BMO e2e emulator, whereas the
 others use `sushy-tools`.
@@ -77,9 +96,13 @@ The due process for ensuring all is clean for the next run is (in the
 root directory):
 
 ```bash
-./hack/clean-e2e.sh
-make clean
-sudo rm -rf ./test/e2e/images
+make clean-e2e
+```
+
+If you want to keep the image directory, run the following command instead:
+
+```bash
+make KEEP_E2E_IMAGES=true clean-e2e
 ```
 
 In addition, make sure related docker containers are removed as well.


### PR DESCRIPTION
**What this PR does / why we need it**:

Some people may find the installation process and running the hack e2e-scripts a bit difficult, so making a target for the script and fixing the installed packages and dependencies should be done to make it easier to run them on a VM, and documentation should be added as well.

There is some previous discussion in here: #2642 

Fixes: #2707 