### PR TITLE
:seedling: add specific time to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,8 @@ updates:
   directory: "/" # Location of package manifests
   schedule:
     interval: "monthly"
-    day: "saturday"
+    day: "sunday"
+    time: "02:30" # 2.30am utc
   target-branch: main
   ## group all action bumps into single PR
   groups:
@@ -33,6 +34,7 @@ updates:
   schedule:
     interval: "weekly"
     day: "sunday"
+    time: "03:00" # 3am utc
   target-branch: main
   groups:
     kubernetes:
@@ -59,7 +61,8 @@ updates:
   directory: "/" # Location of package manifests
   schedule:
     interval: "monthly"
-    day: "saturday"
+    day: "sunday"
+    time: "03:30" # 3.30am utc
   target-branch: release-0.11
   ## group all action bumps into single PR
   groups:
@@ -84,6 +87,7 @@ updates:
   schedule:
     interval: "weekly"
     day: "sunday"
+    time: "04:00" # 4am utc
   target-branch: release-0.11
   groups:
     kubernetes:
@@ -108,7 +112,8 @@ updates:
   directory: "/" # Location of package manifests
   schedule:
     interval: "monthly"
-    day: "saturday"
+    day: "sunday"
+    time: "04:30" # 4.30am utc
   target-branch: release-0.10
   ## group all action bumps into single PR
   groups:
@@ -133,6 +138,7 @@ updates:
   schedule:
     interval: "weekly"
     day: "sunday"
+    time: "05:00" # 5am utc
   target-branch: release-0.10
   groups:
     kubernetes:


### PR DESCRIPTION
Previously Dependabot executed the updates for all branches at the same time (00:00 UTC). If there were enough of the PRs, the Prow would choke, despite it has scaling on as infra provider was sometimes slow to create and provision another Prow worker.

By pacing the updated 1hr apart per branch (we already have repos on separate weekdays), we avoid pod scheduling failures and make merging the updates smoother process.

Align all BMO jobs to be on Sunday.