### PR TITLE
🌱 cmd: strip out symbol table & DWARF debugging info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,10 @@ COPY apis/go.mod apis/go.sum apis/
 COPY hack/tools/go.mod hack/tools/go.sum hack/tools/
 COPY pkg/hardwareutils/go.mod pkg/hardwareutils/go.sum pkg/hardwareutils/
 RUN go mod download
+ARG LDFLAGS=-extldflags=-static
 
 COPY . .
-RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o baremetal-operator main.go
+RUN CGO_ENABLED=0 GO111MODULE=on go build -a -ldflags "${LDFLAGS}" -o baremetal-operator main.go
 
 # Copy the controller-manager into a thin image
 # BMO has a dependency preventing us to use the static one,

--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,17 @@ generate: $(CONTROLLER_GEN) ## Generate code
 
 .PHONY: docker
 docker: generate manifests ## Build the docker image
-	docker build . -t ${IMG} --build-arg http_proxy=$(http_proxy) --build-arg https_proxy=$(https_proxy)
+	docker build . -t ${IMG} \
+	--build-arg http_proxy=$(http_proxy) \
+	--build-arg https_proxy=$(https_proxy) \
+	--build-arg LDFLAGS="-s -w -extldflags=-static"
+
+.PHONY: docker-debug
+docker-debug: generate manifests ## Build the docker image with debug info
+	docker build . -t ${IMG} \
+	--build-arg http_proxy=$(http_proxy) \
+	--build-arg https_proxy=$(https_proxy) \
+	--build-arg LDFLAGS="-extldflags=-static"
 
 # Push the docker image
 .PHONY: docker-push


### PR DESCRIPTION
**What this PR does / why we need it**:
DWARF is mostly needed when we are using Delve. DWARF was originally created for C language and the need for it in go and other debugging features is very small in general. As such, switch to using `-ldflags="-s -w"` by default and have an option to opt in for debugging info for those who would really need it. As a real example, we can gain ~30% (i.e. 24,7MB) image size reduction for bmo controller and faster build process.

**Before**
Size profiler comparison:
```
$ bloaty -d sections baremetal-operator
    FILE SIZE        VM SIZE
 --------------  --------------
  32.4%  24.4Mi  47.0%  24.4Mi    .text
  22.8%  17.1Mi  33.0%  17.1Mi    .gopclntab
  12.3%  9.20Mi  17.8%  9.20Mi    .rodata
   8.0%  5.98Mi   0.0%      64    .debug_info
   7.4%  5.55Mi   0.0%      64    .strtab
   5.8%  4.37Mi   0.0%      64    .debug_loc
   4.3%  3.26Mi   0.0%      64    .debug_line
   2.9%  2.15Mi   0.0%      64    .symtab
   1.8%  1.38Mi   0.0%      64    .debug_ranges
   1.1%   857Ki   0.0%      64    .debug_frame
   0.7%   562Ki   1.1%   562Ki    .noptrdata
   0.3%   235Ki   0.4%   235Ki    .data
   0.0%       0   0.4%   218Ki    .bss
   0.1%  73.9Ki   0.1%  73.9Ki    .typelink
   0.0%       0   0.1%  61.0Ki    .noptrbss
   0.0%  33.9Ki   0.1%  33.9Ki    .itablink
   0.0%  9.03Ki   0.0%       0    [Unmapped]
   0.0%  7.98Ki   0.0%  7.98Ki    .go.buildinfo
   0.0%  2.49Ki   0.0%  2.49Ki    [LOAD #2 [RX]]
   0.0%  1.01Ki   0.0%     716    [7 Others]
   0.0%     407   0.0%      64    .debug_abbrev
 100.0%  75.1Mi 100.0%  51.8Mi    TOTAL
```

**After**
```
$ bloaty -d sections baremetal-operator
    FILE SIZE        VM SIZE
 --------------  --------------
  47.2%  24.4Mi  47.0%  24.4Mi    .text
  33.2%  17.1Mi  33.0%  17.1Mi    .gopclntab
  17.8%  9.20Mi  17.8%  9.20Mi    .rodata
   1.1%   562Ki   1.1%   562Ki    .noptrdata
   0.4%   235Ki   0.4%   235Ki    .data
   0.0%       0   0.4%   218Ki    .bss
   0.1%  73.9Ki   0.1%  73.9Ki    .typelink
   0.0%       0   0.1%  61.0Ki    .noptrbss
   0.1%  33.9Ki   0.1%  33.9Ki    .itablink
   0.0%  8.99Ki   0.0%       0    [Unmapped]
   0.0%  8.00Ki   0.0%  8.00Ki    .go.buildinfo
   0.0%  3.05Ki   0.0%  3.05Ki    [LOAD #2 [RX]]
   0.0%     248   0.0%      64    .shstrtab
   0.0%     184   0.0%     184    .go.fipsinfo
   0.0%     164   0.0%     164    .note.go.buildid
   0.0%     100   0.0%     100    .note.gnu.build-id
   0.0%      53   0.0%      69    [LOAD #4 [RW]]
   0.0%      55   0.0%      55    [LOAD #3 [R]]
 100.0%  51.5Mi 100.0%  51.8Mi    TOTAL
```

**Before**
Container image size comparison:
```
docker images --format "{{.Repository}} {{.Size}}" | grep baremetal
baremetal-operator 81.2MB
```

```
docker images --format "{{.Repository}} {{.Size}}" | grep baremetal
baremetal-operator 56.5MB

```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
