### PR TITLE
🌱 Dockerfile: strip out symbol table by default for public images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY apis/go.mod apis/go.sum apis/
 COPY hack/tools/go.mod hack/tools/go.sum hack/tools/
 COPY pkg/hardwareutils/go.mod pkg/hardwareutils/go.sum pkg/hardwareutils/
 RUN go mod download
-ARG LDFLAGS=-extldflags=-static
+ARG LDFLAGS=-s -w -extldflags=-static
 
 COPY . .
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -ldflags "${LDFLAGS}" -o baremetal-operator main.go

--- a/Makefile
+++ b/Makefile
@@ -263,8 +263,7 @@ generate: $(CONTROLLER_GEN) ## Generate code
 docker: generate manifests ## Build the docker image
 	docker build . -t ${IMG} \
 	--build-arg http_proxy=$(http_proxy) \
-	--build-arg https_proxy=$(https_proxy) \
-	--build-arg LDFLAGS="-s -w -extldflags=-static"
+	--build-arg https_proxy=$(https_proxy)
 
 .PHONY: docker-debug
 docker-debug: generate manifests ## Build the docker image with debug info


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a follow up of https://github.com/metal3-io/baremetal-operator/pull/2709, so that our public images in quay.io also benefit from this change. Since GitHub workflow in project-infra doesn't run the Makefile target but instead uses the Dockerfile directly, fix the defaulting of `-s -w` within the Dockerfile here.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
