### PR TITLE
🐛 Align BMO e2e optional test to namespace scoped config

### DIFF
--- a/config/overlays/e2e/kustomization.yaml
+++ b/config/overlays/e2e/kustomization.yaml
@@ -10,6 +10,8 @@ resources:
 - ./live-iso-ops
 - ./provisioning-ops
 - ./re-inspection
+- ./upgrade-bmo
+- ./upgrade-ironic
 
 components:
     - ../../components/namespace-scoped

--- a/config/overlays/e2e/namespaced-manager-patch.yaml
+++ b/config/overlays/e2e/namespaced-manager-patch.yaml
@@ -9,5 +9,5 @@ spec:
       containers:
       - env:
         - name: WATCH_NAMESPACE
-          value: basic-ops,external-inspection,externally-provisioned,inspection,live-iso-ops,provisioning-ops,re-inspection,automated-cleaning
+          value: basic-ops,external-inspection,externally-provisioned,inspection,live-iso-ops,provisioning-ops,re-inspection,automated-cleaning,upgrade-bmo,upgrade-ironic
         name: manager

--- a/config/overlays/e2e/upgrade-bmo/kustomization.yaml
+++ b/config/overlays/e2e/upgrade-bmo/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../roles-rolebindings
+- namespace.yaml
+
+namespace: upgrade-bmo

--- a/config/overlays/e2e/upgrade-bmo/namespace.yaml
+++ b/config/overlays/e2e/upgrade-bmo/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: upgrade-bmo

--- a/config/overlays/e2e/upgrade-ironic/kustomization.yaml
+++ b/config/overlays/e2e/upgrade-ironic/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../roles-rolebindings
+- namespace.yaml
+
+namespace: upgrade-ironic

--- a/config/overlays/e2e/upgrade-ironic/namespace.yaml
+++ b/config/overlays/e2e/upgrade-ironic/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: upgrade-ironic

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
-	"sigs.k8s.io/cluster-api/util"
 )
 
 const hardwareDetailsRelease04 = `
@@ -234,10 +233,11 @@ func RunUpgradeTest(ctx context.Context, input *BMOIronicUpgradeInput, upgradeCl
 	}
 
 	namespace, cancelWatches := framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
-		Creator:   upgradeClusterProxy.GetClient(),
-		ClientSet: upgradeClusterProxy.GetClientSet(),
-		Name:      fmt.Sprintf("upgrade-%s-%s", input.UpgradeEntityName, util.RandomString(6)),
-		LogFolder: testCaseArtifactFolder,
+		Creator:             upgradeClusterProxy.GetClient(),
+		ClientSet:           upgradeClusterProxy.GetClientSet(),
+		Name:                "upgrade-" + input.UpgradeEntityName,
+		LogFolder:           testCaseArtifactFolder,
+		IgnoreAlreadyExists: true,
 	})
 
 	By("Creating a secret with BMH credentials")


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions),  (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR fixes  BMO e2e optional test by adding upgrade-bmo and upgrade-ironic to namespace watch list. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
