### PR TITLE
🌱Uplift go 1.24.9 to address CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.24.7@sha256:5e9d14d681c3224276f0c8e318525ef6fc96b47fbcbb89f8bec0e402e18ea8bf
+ARG BUILD_IMAGE=docker.io/golang:1.24.9@sha256:02ce1d7ea7825dccb7cd10222e44e7c0565a08c5a38795e50fbf43936484507b
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GO_TEST_FLAGS = $(TEST_FLAGS)
 DEBUG = --debug
 COVER_PROFILE = cover.out
 GO := $(shell type -P go)
-GO_VERSION ?= 1.24.7
+GO_VERSION ?= 1.24.9
 
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 

--- a/hack/e2e/ensure_go.sh
+++ b/hack/e2e/ensure_go.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-MINIMUM_GO_VERSION=go1.24.7
+MINIMUM_GO_VERSION=go1.24.9
 
 # Ensure the go tool exists and is a viable version, or installs it
 verify_go_version()

--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -458,7 +458,7 @@ func TestValidateCreate(t *testing.T) {
 					BMC: metal3api.BMCDetails{
 						Address: "ipmi://[fe80::fc33:62ff:fe33:8xff]:6223"}}},
 			oldBMH:    nil,
-			wantedErr: "failed to parse BMC address information: BMC address hostname/IP : [fe80::fc33:62ff:fe33:8xff] is invalid",
+			wantedErr: "failed to parse BMC address information: parse \"ipmi://[fe80::fc33:62ff:fe33:8xff]:6223\": invalid host: ParseAddr(\"fe80::fc33:62ff:fe33:8xff\"): unexpected character, want colon (at \"xff\")",
 		},
 		{
 			name: "validRootDeviceHint",


### PR DESCRIPTION
Uplift go 1.24.9 to address the security vulnerabilities. These minor releases include PRIVATE security fixes to the standard library, covering the following CVEs: [announcement](https://groups.google.com/g/golang-announce/c/ask65OnfzGU)
The CVEs are fixed in 1.24.8 , but as we are having new patch release for go 1.24.9, we are uplifting it to that.
CVE-2025-61724
CVE-2025-61725
CVE-2025-58187
CVE-2025-61723
CVE-2025-47912
CVE-2025-58185
CVE-2025-58186
CVE-2025-58188
CVE-2025-58183