### PR TITLE
🌱 E2E: Bump IrSO version to v0.5.2 and unify yaml formatting

### DIFF
--- a/config/base/certmanager/kustomization.yaml
+++ b/config/base/certmanager/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - certificate.yaml
 

--- a/config/base/crds/kustomization.yaml
+++ b/config/base/crds/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # Adds namespace to all resources.
 namespace: baremetal-operator-system
 

--- a/config/base/prometheus/monitor.yaml
+++ b/config/base/prometheus/monitor.yaml
@@ -9,12 +9,12 @@ metadata:
   namespace: system
 spec:
   endpoints:
-    - path: /metrics
-      port: https
-      scheme: https
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tlsConfig:
-        insecureSkipVerify: true
+  - path: /metrics
+    port: https
+    scheme: https
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tlsConfig:
+      insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/config/base/rbac/kustomization.yaml
+++ b/config/base/rbac/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 # All RBAC will be applied under this service account in
 # the deployment namespace. You may comment out this resource

--- a/config/base/webhook/kustomization.yaml
+++ b/config/base/webhook/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - manifests.yaml
 - service_patch.yaml

--- a/config/components/tls/tls_ca_patch.yaml
+++ b/config/components/tls/tls_ca_patch.yaml
@@ -8,9 +8,9 @@ spec:
       containers:
       - name: manager
         volumeMounts:
-          - name: cacert
-            mountPath: "/opt/metal3/certs/ca"
-            readOnly: true
+        - name: cacert
+          mountPath: "/opt/metal3/certs/ca"
+          readOnly: true
       volumes:
       - name: cacert
         secret:

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
-- namespace
-- default
+  - namespace
+  - default

--- a/config/overlays/basic-auth_tls/kustomization.yaml
+++ b/config/overlays/basic-auth_tls/kustomization.yaml
@@ -2,12 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../namespace
-  - ../../base
+- ../../namespace
+- ../../base
 
 components:
-  - ../../components/basic-auth
-  - ../../components/tls
+- ../../components/basic-auth
+- ../../components/tls
 # Example for how to generate the necessary secrets:
 # secretGenerator:
 #   - name: ironic-credentials

--- a/ironic-deployment/components/basic-auth/kustomization.yaml
+++ b/ironic-deployment/components/basic-auth/kustomization.yaml
@@ -14,4 +14,4 @@ kind: Component
 #   IRONIC_HTPASSWD: <base64-encoded-htpasswd-string>
 
 patches:
-  - path: auth.yaml
+- path: auth.yaml

--- a/ironic-deployment/overlays/e2e-local-ironic/kustomization.yaml
+++ b/ironic-deployment/overlays/e2e-local-ironic/kustomization.yaml
@@ -24,4 +24,3 @@ patches:
 images:
 - name: quay.io/metal3-io/ironic
   newTag: local
-

--- a/ironic-deployment/overlays/e2e-release-26.0/ironic-patch.yaml
+++ b/ironic-deployment/overlays/e2e-release-26.0/ironic-patch.yaml
@@ -6,5 +6,5 @@ spec:
   template:
     spec:
       containers:
-        - name: ironic-dnsmasq
-          $patch: delete
+      - name: ironic-dnsmasq
+        $patch: delete

--- a/ironic-deployment/overlays/e2e-release-27.0/ironic-patch.yaml
+++ b/ironic-deployment/overlays/e2e-release-27.0/ironic-patch.yaml
@@ -6,5 +6,5 @@ spec:
   template:
     spec:
       containers:
-        - name: ironic-dnsmasq
-          $patch: delete
+      - name: ironic-dnsmasq
+        $patch: delete

--- a/ironic-deployment/overlays/e2e-release-28.0/ironic-patch.yaml
+++ b/ironic-deployment/overlays/e2e-release-28.0/ironic-patch.yaml
@@ -6,5 +6,5 @@ spec:
   template:
     spec:
       containers:
-        - name: ironic-dnsmasq
-          $patch: delete
+      - name: ironic-dnsmasq
+        $patch: delete

--- a/ironic-deployment/overlays/e2e-release-29.0/ironic-patch.yaml
+++ b/ironic-deployment/overlays/e2e-release-29.0/ironic-patch.yaml
@@ -6,5 +6,5 @@ spec:
   template:
     spec:
       containers:
-        - name: ironic-dnsmasq
-          $patch: delete
+      - name: ironic-dnsmasq
+        $patch: delete

--- a/ironic-deployment/overlays/e2e-release-30.0/ironic-patch.yaml
+++ b/ironic-deployment/overlays/e2e-release-30.0/ironic-patch.yaml
@@ -6,5 +6,5 @@ spec:
   template:
     spec:
       containers:
-        - name: ironic-dnsmasq
-          $patch: delete
+      - name: ironic-dnsmasq
+        $patch: delete

--- a/ironic-deployment/overlays/e2e-release-31.0/ironic-patch.yaml
+++ b/ironic-deployment/overlays/e2e-release-31.0/ironic-patch.yaml
@@ -6,5 +6,5 @@ spec:
   template:
     spec:
       containers:
-        - name: ironic-dnsmasq
-          $patch: delete
+      - name: ironic-dnsmasq
+        $patch: delete

--- a/ironic-deployment/overlays/e2e/ironic-patch.yaml
+++ b/ironic-deployment/overlays/e2e/ironic-patch.yaml
@@ -6,5 +6,5 @@ spec:
   template:
     spec:
       containers:
-        - name: ironic-dnsmasq
-          $patch: delete
+      - name: ironic-dnsmasq
+        $patch: delete

--- a/ironic-deployment/overlays/with-ipxe-builder/ipxe-builder-patch.yaml
+++ b/ironic-deployment/overlays/with-ipxe-builder/ipxe-builder-patch.yaml
@@ -4,7 +4,7 @@
     name: ipxe-builder
     image: quay.io/metal3-io/ipxe-builder
     command:
-      - /bin/buildipxe.sh
+    - /bin/buildipxe.sh
     envFrom:
     - configMapRef:
         name: ipxe-configmap
@@ -19,4 +19,3 @@
       privileged: false
       runAsUser: 997 # ironic
       runAsGroup: 994 # ironic
-

--- a/test/e2e/data/ironic-standalone-operator/components/basic-auth/kustomization.yaml
+++ b/test/e2e/data/ironic-standalone-operator/components/basic-auth/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 patches:
-  - path: auth-patch.yaml
+- path: auth-patch.yaml
 
 generatorOptions:
   disableNameSuffixHash: true
@@ -12,6 +12,6 @@ secretGenerator:
 - name: ironic-auth
   behavior: create
   files:
-    - username=ironic-username
-    - password=ironic-password
+  - username=ironic-username
+  - password=ironic-password
   type: Opaque

--- a/test/e2e/data/ironic-standalone-operator/components/tls/kustomization.yaml
+++ b/test/e2e/data/ironic-standalone-operator/components/tls/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 - certificate.yaml
 
 patches:
-  - path: tls.yaml
+- path: tls.yaml

--- a/test/e2e/data/ironic-standalone-operator/ironic/base/ironic.yaml
+++ b/test/e2e/data/ironic-standalone-operator/ironic/base/ironic.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: ironic.metal3.io/v1alpha1
 kind: Ironic
 metadata:
@@ -21,4 +20,3 @@ spec:
   deployRamdisk:
     sshKey: "SSH_PUB_KEY_CONTENT"
     extraKernelParams: "console=ttyS0"
----

--- a/test/e2e/data/ironic-standalone-operator/ironic/base/kustomization.yaml
+++ b/test/e2e/data/ironic-standalone-operator/ironic/base/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: baremetal-operator-system
 resources:
 - namespace.yaml

--- a/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e-release-27.0/kustomization.yaml
+++ b/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e-release-27.0/kustomization.yaml
@@ -1,17 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: baremetal-operator-system
 
 resources:
-  - ../../base
+- ../../base
 
 components:
-  - ../../../components/tls
-  - ../../../components/basic-auth
+- ../../../components/tls
+- ../../../components/basic-auth
 
 patches:
-  - target:
-      kind: Ironic
-      name: ironic
-    patch: |-
-      - op: replace
-        path: /spec/images/ironic
-        value: "quay.io/metal3-io/ironic:release-27.0"
+- target:
+    kind: Ironic
+    name: ironic
+  patch: |-
+    - op: replace
+      path: /spec/images/ironic
+      value: "quay.io/metal3-io/ironic:release-27.0"

--- a/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e-release-28.0/kustomization.yaml
+++ b/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e-release-28.0/kustomization.yaml
@@ -1,17 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: baremetal-operator-system
 
 resources:
-  - ../../base
+- ../../base
 
 components:
-  - ../../../components/tls
-  - ../../../components/basic-auth
+- ../../../components/tls
+- ../../../components/basic-auth
 
 patches:
-  - target:
-      kind: Ironic
-      name: ironic
-    patch: |-
-      - op: replace
-        path: /spec/images/ironic
-        value: "quay.io/metal3-io/ironic:release-28.0"
+- target:
+    kind: Ironic
+    name: ironic
+  patch: |-
+    - op: replace
+      path: /spec/images/ironic
+      value: "quay.io/metal3-io/ironic:release-28.0"

--- a/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e-release-29.0/kustomization.yaml
+++ b/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e-release-29.0/kustomization.yaml
@@ -1,17 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: baremetal-operator-system
 
 resources:
-  - ../../base
+- ../../base
 
 components:
-  - ../../../components/tls
-  - ../../../components/basic-auth
+- ../../../components/tls
+- ../../../components/basic-auth
 
 patches:
-  - target:
-      kind: Ironic
-      name: ironic
-    patch: |-
-      - op: replace
-        path: /spec/images/ironic
-        value: "quay.io/metal3-io/ironic:release-29.0"
+- target:
+    kind: Ironic
+    name: ironic
+  patch: |-
+    - op: replace
+      path: /spec/images/ironic
+      value: "quay.io/metal3-io/ironic:release-29.0"

--- a/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e-release-30.0/kustomization.yaml
+++ b/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e-release-30.0/kustomization.yaml
@@ -1,17 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: baremetal-operator-system
 
 resources:
-  - ../../base
+- ../../base
 
 components:
-  - ../../../components/tls
-  - ../../../components/basic-auth
+- ../../../components/tls
+- ../../../components/basic-auth
 
 patches:
-  - target:
-      kind: Ironic
-      name: ironic
-    patch: |-
-      - op: replace
-        path: /spec/images/ironic
-        value: "quay.io/metal3-io/ironic:release-30.0"
+- target:
+    kind: Ironic
+    name: ironic
+  patch: |-
+    - op: replace
+      path: /spec/images/ironic
+      value: "quay.io/metal3-io/ironic:release-30.0"

--- a/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e-release-31.0/kustomization.yaml
+++ b/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e-release-31.0/kustomization.yaml
@@ -1,17 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: baremetal-operator-system
 
 resources:
-  - ../../base
+- ../../base
 
 components:
-  - ../../../components/tls
-  - ../../../components/basic-auth
+- ../../../components/tls
+- ../../../components/basic-auth
 
 patches:
-  - target:
-      kind: Ironic
-      name: ironic
-    patch: |-
-      - op: replace
-        path: /spec/images/ironic
-        value: "quay.io/metal3-io/ironic:release-31.0"
+- target:
+    kind: Ironic
+    name: ironic
+  patch: |-
+    - op: replace
+      path: /spec/images/ironic
+      value: "quay.io/metal3-io/ironic:release-31.0"

--- a/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e/kustomization.yaml
+++ b/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e/kustomization.yaml
@@ -1,8 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: baremetal-operator-system
 
 resources:
-  - ../../base
+- ../../base
 
 components:
-  - ../../../components/tls
-  - ../../../components/basic-auth
+- ../../../components/tls
+- ../../../components/basic-auth

--- a/test/e2e/data/ironic-standalone-operator/operator/kustomization.yaml
+++ b/test/e2e/data/ironic-standalone-operator/operator/kustomization.yaml
@@ -3,30 +3,30 @@ kind: Kustomization
 namespace: ironic-standalone-operator-system
 
 resources:
-  - https://github.com/metal3-io/ironic-standalone-operator/releases/download/v0.5.1/install.yaml
+- https://github.com/metal3-io/ironic-standalone-operator/releases/download/v0.5.2/install.yaml
 
 generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-  - name: ironic-operator-config
-    literals:
-      - IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
+- name: ironic-operator-config
+  literals:
+  - IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
 
 patches:
-  - target:
-      kind: Deployment
-      name: ironic-standalone-operator-controller-manager
-    patch: |-
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: ironic-standalone-operator
-      spec:
-        template:
-          spec:
-            containers:
-              - name: manager
-                envFrom:
-                  - configMapRef:
-                      name: ironic-operator-config
+- target:
+    kind: Deployment
+    name: ironic-standalone-operator-controller-manager
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: ironic-standalone-operator
+    spec:
+      template:
+        spec:
+          containers:
+            - name: manager
+              envFrom:
+                - configMapRef:
+                    name: ironic-operator-config


### PR DESCRIPTION
**What this PR does / why we need it**:

This version supports IPA_BASEURI so we download IPA from the Nordix Artifactory.
I also took the chance to unify indentation in the kustomizations and to set the apiVersion and kind for them as well.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2732
