### PR TITLE
🌱 Add release manifests

### DIFF
--- a/.github/workflows/e2e-fixture-test.yml
+++ b/.github/workflows/e2e-fixture-test.yml
@@ -29,7 +29,8 @@ jobs:
 
     - name: Build BMO e2e Docker Image
       env:
-        IMG: quay.io/metal3-io/baremetal-operator:e2e
+        IMG: quay.io/metal3-io/baremetal-operator
+        IMG_TAG: e2e
       run: make docker
 
     - name: Set Up Environment and Run BMO e2e Tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,7 +108,7 @@ jobs:
         go-version: ${{ env.go_version }}
     - name: generate release artifacts
       run: |
-        make release-notes
+        make release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: get release notes
@@ -119,6 +119,7 @@ jobs:
       uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836 # v2.3.3
       with:
         draft: true
+        files: out/*
         body_path: ${{ env.RELEASE_TAG }}.md
         tag_name: ${{ env.RELEASE_TAG }}
   build_bmo:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/_test
 _artifacts
 artifacts*.tar.gz
 test/e2e/images
+out
 
 # Created by https://www.gitignore.io/api/go
 ### Go ###

--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,10 @@ help:  ## Display this help
 	@echo "  DEBUG            -- debug flag, if any ($(DEBUG))"
 
 # Image URL to use all building/pushing image targets
+REGISTRY ?= quay.io/metal3-io
 IMG_NAME ?= baremetal-operator
 IMG_TAG ?= latest
-IMG ?= $(IMG_NAME):$(IMG_TAG)
+IMG ?= $(REGISTRY)/$(IMG_NAME)
 
 ## --------------------------------------
 ## Test Targets
@@ -225,10 +226,15 @@ manifests-generate: $(CONTROLLER_GEN)
 manifests-kustomize: $(KUSTOMIZE)
 	$< build config/default > config/render/capm3.yaml
 
+.PHONY: set-manifest-pull-policy
+set-manifest-pull-policy:
+	$(info Updating kustomize pull policy file for manager resource)
+	sed -i'' -e 's@imagePullPolicy: .*@imagePullPolicy: '"$(PULL_POLICY)"'@' ./config/base/manager.yaml
+
 .PHONY: set-manifest-image-bmo
 set-manifest-image-bmo: $(KUSTOMIZE) manifests
 	$(info Updating container image for BMO to use ${MANIFEST_IMG}:${MANIFEST_TAG})
-	cd config/base && $(abspath $(KUSTOMIZE)) edit set image quay.io/metal3-io/baremetal-operator=${MANIFEST_IMG}:${MANIFEST_TAG}
+	sed -i'' -e 's@image: .*@image: \"'"${MANIFEST_IMG}:$(MANIFEST_TAG)"'\"@' ./config/base/manager.yaml
 
 .PHONY: set-manifest-image-ironic
 set-manifest-image-ironic: $(KUSTOMIZE) manifests
@@ -261,13 +267,13 @@ generate: $(CONTROLLER_GEN) ## Generate code
 
 .PHONY: docker
 docker: generate manifests ## Build the docker image
-	docker build . -t ${IMG} \
+	docker build . -t ${IMG}:${IMG_TAG} \
 	--build-arg http_proxy=$(http_proxy) \
 	--build-arg https_proxy=$(https_proxy)
 
 .PHONY: docker-debug
 docker-debug: generate manifests ## Build the docker image with debug info
-	docker build . -t ${IMG} \
+	docker build . -t ${IMG}:${IMG_TAG} \
 	--build-arg http_proxy=$(http_proxy) \
 	--build-arg https_proxy=$(https_proxy) \
 	--build-arg LDFLAGS="-extldflags=-static"
@@ -275,7 +281,7 @@ docker-debug: generate manifests ## Build the docker image with debug info
 # Push the docker image
 .PHONY: docker-push
 docker-push:
-	docker push ${IMG}
+	docker push ${IMG}:${IMG_TAG}
 
 ## --------------------------------------
 ## CI Targets
@@ -366,6 +372,20 @@ $(RELEASE_NOTES_DIR):
 .PHONY: release-notes
 release-notes: $(RELEASE_NOTES_DIR) $(RELEASE_NOTES)
 	cd hack/tools && $(GO) run release/notes.go  --releaseTag=$(RELEASE_TAG) > $(realpath $(RELEASE_NOTES_DIR))/$(RELEASE_TAG).md
+
+.PHONY: release-manifests
+release-manifests: $(KUSTOMIZE) $(RELEASE_DIR) ## Builds the manifests to publish with a release
+	$(KUSTOMIZE) build config > $(RELEASE_DIR)/baremetal-operator.yaml
+
+.PHONY: release
+release:
+	@if [ -z "${RELEASE_TAG}" ]; then echo "RELEASE_TAG is not set"; exit 1; fi
+	@if ! [ -z "$$(git status --porcelain)" ]; then echo "You have uncommitted changes"; exit 1; fi
+	git checkout "${RELEASE_TAG}"
+	MANIFEST_IMG=$(IMG) MANIFEST_TAG=$(RELEASE_TAG) $(MAKE) set-manifest-image-bmo
+	PULL_POLICY=IfNotPresent $(MAKE) set-manifest-pull-policy
+	$(MAKE) release-manifests
+	$(MAKE) release-notes
 
 go-version: ## Print the go version we use to compile our binaries and images
 	@echo $(GO_VERSION)

--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -57,7 +57,7 @@ sudo apt-get update
 sudo apt-get install -y libvirt-dev pkg-config
 
 # Build the container image with e2e tag (used in tests)
-IMG=quay.io/metal3-io/baremetal-operator:e2e make docker
+IMG=quay.io/metal3-io/baremetal-operator IMG_TAG=e2e make docker
 
 if ! sudo virsh net-list --all | grep baremetal-e2e; then
     virsh -c qemu:///system net-define "${REPO_ROOT}/hack/e2e/net.xml"


### PR DESCRIPTION
**What this PR does / why we need it**:

Generate release manifests for BMO and include as release artifacts.
I have followed closely how it is done for CAPM3.

Some things to note:
- Split out image tag from `IMG` variable to keep things similar to CAPM3.
- Add registry to `IMG` so we get a proper URL.
- Switch `set-manifest-image-bmo` to use `sed`. Kustomize is doing all kinds of formatting changes which can be very confusing. Note that I left the rest of the `set-manfest-image-*` targets as is. I think we should get rid of them when metal3-dev-env switches to IrSO. Metal3-dev-env is the only place where they are used as far as I know.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1722
