### PR TITLE
🐛 Make bootMACAddress webhook validation case-insensitive

### DIFF
--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation.go
@@ -109,7 +109,7 @@ func (webhook *BareMetalHost) validateChanges(oldObj *metal3api.BareMetalHost, n
 		errs = append(errs, errors.New("BMC address can not be changed if the BMH is not in the Registering state, or if the BMH is not detached"))
 	}
 
-	if oldObj.Spec.BootMACAddress != "" && newObj.Spec.BootMACAddress != oldObj.Spec.BootMACAddress {
+	if oldObj.Spec.BootMACAddress != "" && !strings.EqualFold(newObj.Spec.BootMACAddress, oldObj.Spec.BootMACAddress) {
 		errs = append(errs, errors.New("bootMACAddress can not be changed once it is set"))
 	}
 

--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -1055,10 +1055,39 @@ func TestValidateUpdate(t *testing.T) {
 		{
 			name: "updateBootMAC",
 			newBMH: &metal3api.BareMetalHost{
-				TypeMeta: tm, ObjectMeta: om, Spec: metal3api.BareMetalHostSpec{BootMACAddress: "test-mac-changed"}},
+				TypeMeta: tm, ObjectMeta: om, Spec: metal3api.BareMetalHostSpec{BootMACAddress: "00:11:22:33:44:66"}},
 			oldBMH: &metal3api.BareMetalHost{
-				TypeMeta: tm, ObjectMeta: om, Spec: metal3api.BareMetalHostSpec{BootMACAddress: "test-mac"}},
+				TypeMeta: tm, ObjectMeta: om, Spec: metal3api.BareMetalHostSpec{BootMACAddress: "00:11:22:33:44:55"}},
 			wantedErr: "bootMACAddress can not be changed once it is set",
+		},
+		{
+			name: "updateBootMACCaseOnly",
+			newBMH: &metal3api.BareMetalHost{
+				TypeMeta: tm, ObjectMeta: om, Spec: metal3api.BareMetalHostSpec{BootMACAddress: "AA:BB:CC:DD:EE:FF"}},
+			oldBMH: &metal3api.BareMetalHost{
+				TypeMeta: tm, ObjectMeta: om, Spec: metal3api.BareMetalHostSpec{BootMACAddress: "aa:bb:cc:dd:ee:ff"}},
+			wantedErr: "",
+		},
+		{
+			name: "updateBootMACCaseMixed",
+			newBMH: &metal3api.BareMetalHost{
+				TypeMeta: tm, ObjectMeta: om, Spec: metal3api.BareMetalHostSpec{BootMACAddress: "aA:Bb:cC:Dd:Ee:Ff"}},
+			oldBMH: &metal3api.BareMetalHost{
+				TypeMeta: tm, ObjectMeta: om, Spec: metal3api.BareMetalHostSpec{BootMACAddress: "AA:BB:CC:DD:EE:FF"}},
+			wantedErr: "",
+		},
+		{
+			name: "updateBootMACInvalidNew",
+			newBMH: &metal3api.BareMetalHost{
+				TypeMeta: tm, ObjectMeta: om, Spec: metal3api.BareMetalHostSpec{
+					BMC: metal3api.BMCDetails{
+						Address:         "redfish://127.0.0.1",
+						CredentialsName: "test1",
+					},
+					BootMACAddress: "invalid-mac"}},
+			oldBMH: &metal3api.BareMetalHost{
+				TypeMeta: tm, ObjectMeta: om, Spec: metal3api.BareMetalHostSpec{BootMACAddress: "00:11:22:33:44:55"}},
+			wantedErr: "address invalid-mac: invalid MAC address",
 		},
 		{
 			name: "updateExternallyProvisioned",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes the `bootMACAddress` field validation case-insensitive in the BareMetalHost webhook. Previously, the webhook would reject updates to a BareMetalHost if the `bootMACAddress` was changed only in case (e.g., from `00:00:5e:00:53:af` to `00:00:5E:00:53:AF`), even though these represent the same MAC address.

The fix uses `net.ParseMAC()` to normalize MAC addresses before comparing them. This allows case variations of the same MAC address while still enforcing the immutability constraint to prevent actual MAC address changes.

**Changes:**
- Parse both old and new MAC addresses using `net.ParseMAC()`
- Compare the normalized string representations
- Maintain proper error handling for invalid MAC addresses
- Preserve existing validation that prevents actual MAC address changes
- Add validation to prevent unsetting the MAC address once set
