### PR TITLE
⚠️ Completely remove support for ironic-inspector

### DIFF
--- a/pkg/provisioner/ironic/inspecthardware.go
+++ b/pkg/provisioner/ironic/inspecthardware.go
@@ -3,31 +3,15 @@ package ironic
 import (
 	"fmt"
 	"net/http"
-	"slices"
 	"strings"
 
 	"github.com/gophercloud/gophercloud/v2"
-	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/drivers"
 	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/hardwaredetails"
 )
-
-func (p *ironicProvisioner) getInspectInterface(bmcAccess bmc.AccessDetails) (string, error) {
-	driver, err := drivers.GetDriverDetails(p.ctx, p.client, bmcAccess.Driver()).Extract()
-	if err != nil {
-		return "", fmt.Errorf("cannot load information about driver %s: %w", bmcAccess.Driver(), err)
-	}
-
-	if slices.Contains(driver.EnabledInspectInterfaces, "agent") {
-		return "agent", nil
-	}
-
-	return "inspector", nil // backward compatibility
-}
 
 func (p *ironicProvisioner) abortInspection(ironicNode *nodes.Node) (result provisioner.Result, started bool, details *metal3api.HardwareDetails, err error) {
 	// Set started to let the controller know about the change

--- a/pkg/provisioner/ironic/register.go
+++ b/pkg/provisioner/ironic/register.go
@@ -15,6 +15,10 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+const (
+	defaultInspectInterface = "agent"
+)
+
 func bmcAddressMatches(ironicNode *nodes.Node, driverInfo map[string]interface{}) bool {
 	newAddress := make(map[string]interface{})
 	ironicAddress := make(map[string]interface{})
@@ -234,11 +238,6 @@ func (p *ironicProvisioner) Register(data provisioner.ManagementAccessData, cred
 }
 
 func (p *ironicProvisioner) enrollNode(data provisioner.ManagementAccessData, bmcAccess bmc.AccessDetails, driverInfo map[string]interface{}) (ironicNode *nodes.Node, retry bool, err error) {
-	inspectInterface, err := p.getInspectInterface(bmcAccess)
-	if err != nil {
-		return nil, true, err
-	}
-
 	nodeCreateOpts := nodes.CreateOpts{
 		Driver:              bmcAccess.Driver(),
 		BIOSInterface:       bmcAccess.BIOSInterface(),
@@ -246,7 +245,7 @@ func (p *ironicProvisioner) enrollNode(data provisioner.ManagementAccessData, bm
 		Name:                ironicNodeName(p.objectMeta),
 		DriverInfo:          driverInfo,
 		DeployInterface:     p.deployInterface(data),
-		InspectInterface:    inspectInterface,
+		InspectInterface:    defaultInspectInterface,
 		ManagementInterface: bmcAccess.ManagementInterface(),
 		PowerInterface:      bmcAccess.PowerInterface(),
 		RAIDInterface:       bmcAccess.RAIDInterface(),

--- a/pkg/provisioner/ironic/testserver/ironic.go
+++ b/pkg/provisioner/ironic/testserver/ironic.go
@@ -106,7 +106,7 @@ func (m *IronicMock) WithDrivers() *IronicMock {
 	m.ResponseWithCode("/v1/drivers/test", `
 	{
 	    "enabled_deploy_interfaces": ["direct", "ramdisk", "custom-agent"],
-	    "enabled_inspect_interfaces": ["agent", "inspector", "no-inspect"]
+	    "enabled_inspect_interfaces": ["agent", "no-inspect"]
 	}
 	`, http.StatusOK)
 	return m


### PR DESCRIPTION
The ironic-inspector service will no longer be maintained starting with
the Ironic 2026.1 release series. All maintained Ironic branches support
the new implementation, including, obviously, all Ironic branches that
Metal3 uses.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
