### PR TITLE
⚠️ Remove support for Ironic before 2024.1

### DIFF
--- a/pkg/provisioner/ironic/clients/client.go
+++ b/pkg/provisioner/ironic/clients/client.go
@@ -91,7 +91,7 @@ func IronicClient(ironicEndpoint string, auth AuthConfig, tls TLSConfig) (client
 		return
 	}
 
-	client.Microversion = baseline
+	client.Microversion = baselineVersionString
 
 	err = updateHTTPClient(client, tls)
 	return

--- a/pkg/provisioner/ironic/clients/features_test.go
+++ b/pkg/provisioner/ironic/clients/features_test.go
@@ -16,11 +16,11 @@ func TestAvailableFeatures_ChooseMicroversion(t *testing.T) {
 		want    string
 	}{
 		{
-			name: fmt.Sprintf("MaxVersion < %d return microversion %s", 89, baseline),
+			name: fmt.Sprintf("MaxVersion < %d return microversion %s", 89, baselineVersionString),
 			feature: fields{
 				MaxVersion: 50,
 			},
-			want: baseline,
+			want: baselineVersionString,
 		},
 		{
 			name: fmt.Sprintf("MaxVersion = %d return %s", 89, microVersion),
@@ -44,50 +44,6 @@ func TestAvailableFeatures_ChooseMicroversion(t *testing.T) {
 			}
 			if got := af.ChooseMicroversion(); got != tt.want {
 				t.Errorf("ChooseMicroversion() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestAvailableFeatures_HasFirmwareUpdates(t *testing.T) {
-	maxVersion := 86
-	type fields struct {
-		MaxVersion int
-	}
-	tests := []struct {
-		name    string
-		feature fields
-		want    bool
-	}{
-		{
-			name: fmt.Sprintf("Firmware < %d", maxVersion),
-			feature: fields{
-				MaxVersion: 50,
-			},
-			want: false,
-		},
-		{
-			name: fmt.Sprintf("Firmware = %d", maxVersion),
-			feature: fields{
-				MaxVersion: 86,
-			},
-			want: true,
-		},
-		{
-			name: fmt.Sprintf("Firmware > %d", maxVersion),
-			feature: fields{
-				MaxVersion: 100,
-			},
-			want: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			af := AvailableFeatures{
-				MaxVersion: tt.feature.MaxVersion,
-			}
-			if got := af.HasFirmwareUpdates(); got != tt.want {
-				t.Errorf("HasFirmwareUpdates() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -756,10 +756,6 @@ func (p *ironicProvisioner) GetFirmwareComponents() ([]metal3api.FirmwareCompone
 		return nil, fmt.Errorf("could not get node to retrieve firmware components: %w", err)
 	}
 
-	if !p.availableFeatures.HasFirmwareUpdates() {
-		return nil, errors.New("current ironic version does not support firmware updates")
-	}
-
 	// We support bmc, bios, and multiple NICs components. Starting with 3 slots.
 	componentsInfo := make([]metal3api.FirmwareComponentStatus, 0, 3) //nolint:mnd
 
@@ -1833,12 +1829,6 @@ func (p *ironicProvisioner) GetDataImageStatus() (isImageAttached bool, err erro
 }
 
 func (p *ironicProvisioner) AttachDataImage(url string) (err error) {
-	// Check if Ironic API version supports DataImage API
-	// Needs version >= 1.89
-	if !p.availableFeatures.HasDataImage() {
-		return fmt.Errorf("ironic version=%d doesn't support DataImage API, needs version>=1.89", p.availableFeatures.MaxVersion)
-	}
-
 	err = nodes.AttachVirtualMedia(p.ctx, p.client, p.nodeID, nodes.AttachVirtualMediaOpts{
 		DeviceType: nodes.VirtualMediaCD,
 		ImageURL:   url,
@@ -1851,12 +1841,6 @@ func (p *ironicProvisioner) AttachDataImage(url string) (err error) {
 }
 
 func (p *ironicProvisioner) DetachDataImage() (err error) {
-	// Check if Ironic API version supports DataImage API
-	// Needs version >= 1.89
-	if !p.availableFeatures.HasDataImage() {
-		return fmt.Errorf("ironic version=%d doesn't support DataImage API, needs version>=1.89", p.availableFeatures.MaxVersion)
-	}
-
 	err = nodes.DetachVirtualMedia(p.ctx, p.client, p.nodeID, nodes.DetachVirtualMediaOpts{
 		DeviceTypes: []nodes.VirtualMediaDeviceType{nodes.VirtualMediaCD},
 	}).ExtractErr()

--- a/pkg/provisioner/ironic/register.go
+++ b/pkg/provisioner/ironic/register.go
@@ -245,6 +245,7 @@ func (p *ironicProvisioner) enrollNode(data provisioner.ManagementAccessData, bm
 		BootInterface:       bmcAccess.BootInterface(),
 		Name:                ironicNodeName(p.objectMeta),
 		DriverInfo:          driverInfo,
+		FirmwareInterface:   bmcAccess.FirmwareInterface(),
 		DeployInterface:     p.deployInterface(data),
 		InspectInterface:    inspectInterface,
 		ManagementInterface: bmcAccess.ManagementInterface(),
@@ -256,10 +257,6 @@ func (p *ironicProvisioner) enrollNode(data provisioner.ManagementAccessData, bm
 			"capabilities": buildCapabilitiesValue(nil, data.BootMode),
 			"cpu_arch":     data.CPUArchitecture,
 		},
-	}
-
-	if p.availableFeatures.HasFirmwareUpdates() {
-		nodeCreateOpts.FirmwareInterface = bmcAccess.FirmwareInterface()
 	}
 
 	ironicNode, err = nodes.Create(p.ctx, p.client, nodeCreateOpts).Extract()

--- a/pkg/provisioner/ironic/servicing.go
+++ b/pkg/provisioner/ironic/servicing.go
@@ -77,11 +77,6 @@ func (p *ironicProvisioner) startServicing(bmcAccess bmc.AccessDetails, ironicNo
 }
 
 func (p *ironicProvisioner) Service(data provisioner.ServicingData, unprepared, restartOnFailure bool) (result provisioner.Result, started bool, err error) {
-	if !p.availableFeatures.HasServicing() {
-		result, err = operationFailed(fmt.Sprintf("servicing not supported: requires API version 1.87, available is 1.%d", p.availableFeatures.MaxVersion))
-		return result, started, err
-	}
-
 	bmcAccess, err := p.bmcAccess()
 	if err != nil {
 		result, err = transientError(err)


### PR DESCRIPTION
2024.1 series (Ironic 23.1-24.1) is the oldest series still supported by
OpenStack community. Versions before that receive very little testing,
outside of vendor products. Removing support for API versions that
correspond to old versions of Ironic reduces the untested surface of BMO.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
