### PR TITLE
🐛 fix(deploy): include missing namespace in default installation

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: baremetal-operator-system
 resources:
 - ../base
+- ../namespace
 
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
Fix the following failure & try to match the [instructions](https://github.com/metal3-io/baremetal-operator/blob/main/config/README.md) which states the following:

<img width="1019" height="43" alt="image" src="https://github.com/user-attachments/assets/82f4d9e1-e00a-4e12-9b73-841c59c0e5df" />

Otherwise:
```
$ kustomize build config/default/ | kubectl apply -f -

Warning: unrecognized format "int32"
Warning: unrecognized format "int64"
Warning: unrecognized format "double"
customresourcedefinition.apiextensions.k8s.io/baremetalhosts.metal3.io created
customresourcedefinition.apiextensions.k8s.io/bmceventsubscriptions.metal3.io created
customresourcedefinition.apiextensions.k8s.io/dataimages.metal3.io created
customresourcedefinition.apiextensions.k8s.io/firmwareschemas.metal3.io created
customresourcedefinition.apiextensions.k8s.io/hardwaredata.metal3.io created
customresourcedefinition.apiextensions.k8s.io/hostfirmwarecomponents.metal3.io created
customresourcedefinition.apiextensions.k8s.io/hostfirmwaresettings.metal3.io created
customresourcedefinition.apiextensions.k8s.io/hostupdatepolicies.metal3.io created
customresourcedefinition.apiextensions.k8s.io/preprovisioningimages.metal3.io created
clusterrole.rbac.authorization.k8s.io/baremetal-operator-manager-role created
clusterrole.rbac.authorization.k8s.io/baremetal-operator-metrics-auth-role created
clusterrole.rbac.authorization.k8s.io/baremetal-operator-metrics-reader created
clusterrolebinding.rbac.authorization.k8s.io/baremetal-operator-manager-rolebinding created
clusterrolebinding.rbac.authorization.k8s.io/baremetal-operator-metrics-auth-rolebinding created
validatingwebhookconfiguration.admissionregistration.k8s.io/baremetal-operator-validating-webhook-configuration created
Error from server (NotFound): error when creating "STDIN": namespaces "baremetal-operator-system" not found
Error from server (NotFound): error when creating "STDIN": namespaces "baremetal-operator-system" not found
Error from server (NotFound): error when creating "STDIN": namespaces "baremetal-operator-system" not found
Error from server (NotFound): error when creating "STDIN": namespaces "baremetal-operator-system" not found
Error from server (NotFound): error when creating "STDIN": namespaces "baremetal-operator-system" not found
Error from server (NotFound): error when creating "STDIN": namespaces "baremetal-operator-system" not found
Error from server (NotFound): error when creating "STDIN": namespaces "baremetal-operator-system" not found
Error from server (NotFound): error when creating "STDIN": namespaces "baremetal-operator-system" not found
Error from server (NotFound): error when creating "STDIN": namespaces "baremetal-operator-system" not found
```

