### PR TITLE
🌱 E2E: Pre-download IPA and serve from disk image server

### DIFF
--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -151,6 +151,16 @@ if [[ ! -f "${IMAGE_DIR}/${IMAGE_FILE}" ]]; then
     wget --quiet -P "${IMAGE_DIR}/" https://artifactory.nordix.org/artifactory/metal3/images/sysrescue/systemrescue-11.00-amd64.iso
 fi
 
+## Download IPA (Ironic Python Agent) image
+# Ironic IPA downloader is configured to use this local image in the tests.
+# This saves time, especially during ironic upgrade tests and also
+# gives us early failure in case there is some issue downloading it.
+IPA_FILE="ipa-centos9-master.tar.gz"
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib/
+if [[ ! -f "${IMAGE_DIR}/${IPA_FILE}" ]]; then
+    wget --quiet -P "${IMAGE_DIR}/" "${IPA_BASEURI}/${IPA_FILE}"
+fi
+
 ## Start the image server
 docker start image-server-e2e || docker run --name image-server-e2e -d \
   -p 80:8080 \

--- a/test/e2e/data/ironic-standalone-operator/operator/kustomization.yaml
+++ b/test/e2e/data/ironic-standalone-operator/operator/kustomization.yaml
@@ -11,7 +11,7 @@ generatorOptions:
 configMapGenerator:
 - name: ironic-operator-config
   literals:
-  - IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
+  - IPA_BASEURI=http://192.168.222.1
 
 patches:
 - target:


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

This will save us time especially in upgrade tests where IPA is downloaded multiple times. It should also make the tests more stable since we avoid slow or broken downloads mid-test.

Fixes #2730

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
