### PR TITLE
:book: Add explanation to run verify-release.sh script in releasing.md

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -21,6 +21,19 @@ Things you should check before making a release:
    - Verify any other direct or indirect dependency is uplifted to close any public
      vulnerabilities
 
+  Run the script against the release branch you are releasing from, and pass the
+  version tag as an argument, for example:
+
+```shell
+    git checkout release-0.x
+    ./hack/verify-release.sh 0.x.x
+```
+
+Also, after creating the tag and preparing the draft release, run
+`./hack/verify-release.sh` again right before publishing. This script verifies
+that all required release artifacts exist, the release tags are correct, and
+that the container images were built and pushed successfully.
+
 ## Permissions
 
 Creating a release requires repository `write` permissions for:
@@ -61,10 +74,10 @@ This makes sure that all the tags are accessible.
 - Switch to the main branch: `git checkout main`
 
 - Create a new branch for the release notes**:
-  `git checkout -b release-notes-1.x.x origin/main`
+  `git checkout -b release-notes-0.x.x origin/main`
 
-- Generate the release notes: `RELEASE_TAG=v1.x.x make release-notes`
-   - Replace `v1.x.x` with the new release tag you're creating.
+- Generate the release notes: `RELEASE_TAG=v0.x.x make release-notes`
+   - Replace `v0.x.x` with the new release tag you're creating.
    - This command generates the release notes here
      `releasenotes/<RELEASE_TAG>.md` .
 
@@ -80,8 +93,8 @@ This makes sure that all the tags are accessible.
 
 - Commit your changes, push the new branch and create a pull request:
    - The commit and PR title should be 🚀 Release v1.x.y:
-      -`git commit -S -s -m ":rocket: Release v1.x.x"`
-      -`git push -u origin release-notes-1.x.x`
+      -`git commit -S -s -m ":rocket: Release v0.x.x"`
+      -`git push -u origin release-notes-0.x.x`
    - Important! The commit should only contain the release notes file, nothing
      else, otherwise automation will not work.
 


### PR DESCRIPTION


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:
This PR adds explanation to run verify-release.sh script to releasing.md. Also, changes tag mentions from 1.x.x to 0.x.x to avoid accidental mistakes

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
