### PR TITLE
✨ Allow enabling ExternallyProvisioned for available hosts

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -160,6 +160,7 @@ linters:
     - std-error-handling
     rules:
     - linters:
+      - dupl
       - goconst
       - gosec
       path: test/e2e

--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -471,8 +471,16 @@ type BareMetalHostSpec struct {
 	// ExternallyProvisioned means something else has provisioned the
 	// image running on the host, and the operator should only manage
 	// the power status. This field is used for integration with already
-	// provisioned hosts and when pivoting hosts between clusters. If
-	// unsure, leave this field as false.
+	// provisioned hosts and when pivoting hosts between clusters.
+	//
+	// This field can be set to true either:
+	// 1. During initial host creation (e.g., for pre-provisioned hosts)
+	// 2. After inspection completes when the host reaches Available state
+	//
+	// When used in environments with Cluster API Provider Metal3 (CAPM3),
+	// ensure hosts are labeled appropriately so CAPM3's host selector can
+	// distinguish them from CAPM3-managed hosts. If unsure, leave this
+	// field as false.
 	ExternallyProvisioned bool `json:"externallyProvisioned,omitempty"`
 
 	// When set to disabled, automated cleaning will be skipped

--- a/config/base/crds/bases/metal3.io_baremetalhosts.yaml
+++ b/config/base/crds/bases/metal3.io_baremetalhosts.yaml
@@ -209,8 +209,16 @@ spec:
                   ExternallyProvisioned means something else has provisioned the
                   image running on the host, and the operator should only manage
                   the power status. This field is used for integration with already
-                  provisioned hosts and when pivoting hosts between clusters. If
-                  unsure, leave this field as false.
+                  provisioned hosts and when pivoting hosts between clusters.
+
+                  This field can be set to true either:
+                  1. During initial host creation (e.g., for pre-provisioned hosts)
+                  2. After inspection completes when the host reaches Available state
+
+                  When used in environments with Cluster API Provider Metal3 (CAPM3),
+                  ensure hosts are labeled appropriately so CAPM3's host selector can
+                  distinguish them from CAPM3-managed hosts. If unsure, leave this
+                  field as false.
                 type: boolean
               firmware:
                 description: |-

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -209,8 +209,16 @@ spec:
                   ExternallyProvisioned means something else has provisioned the
                   image running on the host, and the operator should only manage
                   the power status. This field is used for integration with already
-                  provisioned hosts and when pivoting hosts between clusters. If
-                  unsure, leave this field as false.
+                  provisioned hosts and when pivoting hosts between clusters.
+
+                  This field can be set to true either:
+                  1. During initial host creation (e.g., for pre-provisioned hosts)
+                  2. After inspection completes when the host reaches Available state
+
+                  When used in environments with Cluster API Provider Metal3 (CAPM3),
+                  ensure hosts are labeled appropriately so CAPM3's host selector can
+                  distinguish them from CAPM3-managed hosts. If unsure, leave this
+                  field as false.
                 type: boolean
               firmware:
                 description: |-

--- a/docs/baremetalhost-states.md
+++ b/docs/baremetalhost-states.md
@@ -24,6 +24,19 @@ then a host object was created with the externallyProvisioned flag
 set. Hosts in this state are monitored, and only their power status is
 managed.
 
+The externallyProvisioned field can also be set to true after inspection
+is completed (when the host is in Available state). This workflow allows
+collecting hardware information via BMO's inspection process before
+handing off provisioning to an external tool (e.g., Image-based Installer
+for O-RAN deployments).
+
+### Using with Cluster API Provider Metal3 (CAPM3)
+
+When using externallyProvisioned hosts in environments with CAPM3, ensure
+that these hosts are labeled appropriately so that CAPM3's host selector
+can distinguish them from hosts managed by CAPM3. This prevents CAPM3 from
+attempting to claim hosts that are managed by external provisioners.
+
 ## Registering
 
 The host will stay in the Registering state while the BMC access

--- a/test/e2e/externally_provisioned_test.go
+++ b/test/e2e/externally_provisioned_test.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Create as externally provisioned, deprovision", Label("required", "provision", "deprovision"),
@@ -37,25 +38,26 @@ var _ = Describe("Create as externally provisioned, deprovision", Label("require
 			})
 		})
 
-		It("provisions a BMH as externally provisioned, then deprovisions", func() {
+		It("provisions a BMH as externally provisioned, validates state immutability, then deprovisions", func() {
+			testSecretName := secretName + "-external"
 			By("Creating a secret with BMH credentials")
 			bmcCredentialsData := map[string]string{
 				"username": bmc.User,
 				"password": bmc.Password,
 			}
-			CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+			CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, testSecretName, bmcCredentialsData)
 
 			By("Creating a BMH as externally provisioned")
 			bmh := metal3api.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      specName,
+					Name:      specName + "-external",
 					Namespace: namespace.Name,
 				},
 				Spec: metal3api.BareMetalHostSpec{
 					Online: true,
 					BMC: metal3api.BMCDetails{
 						Address:                        bmc.Address,
-						CredentialsName:                "bmc-credentials",
+						CredentialsName:                testSecretName,
 						DisableCertificateVerification: bmc.DisableCertificateVerification,
 					},
 					BootMACAddress:        bmc.BootMacAddress,
@@ -83,6 +85,28 @@ var _ = Describe("Create as externally provisioned, deprovision", Label("require
 			Expect(bmh.Status.OperationHistory.Inspect.Start.IsZero()).To(BeTrue())
 			Expect(bmh.Status.OperationHistory.Provision.Start.IsZero()).To(BeTrue())
 
+			By("Attempting to set ExternallyProvisioned to false (should be blocked by webhook)")
+			err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmh.Name,
+				Namespace: bmh.Namespace,
+			}, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+
+			patch := client.MergeFrom(bmh.DeepCopy())
+			bmh.Spec.ExternallyProvisioned = false
+			err = clusterProxy.GetClient().Patch(ctx, &bmh, patch)
+			Expect(err).To(HaveOccurred(), "Webhook should reject transition from true to false")
+			Expect(err.Error()).To(ContainSubstring("externallyProvisioned can not be changed from true to false"))
+
+			By("Verifying BMH remains in ExternallyProvisioned state")
+			err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmh.Name,
+				Namespace: bmh.Namespace,
+			}, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bmh.Spec.ExternallyProvisioned).To(BeTrue(), "ExternallyProvisioned should still be true")
+			Expect(bmh.Status.Provisioning.State).To(Equal(metal3api.StateExternallyProvisioned))
+
 			By("Deleting the BMH")
 			// Wait for 2 seconds to allow time to confirm annotation is set
 			// TODO: fix this so we do not need the sleep
@@ -107,7 +131,102 @@ var _ = Describe("Create as externally provisioned, deprovision", Label("require
 			By("Waiting for the secret to be deleted")
 			Eventually(func() bool {
 				err := clusterProxy.GetClient().Get(ctx, types.NamespacedName{
-					Name:      "bmc-credentials",
+					Name:      testSecretName,
+					Namespace: namespace.Name,
+				}, &corev1.Secret{})
+				return k8serrors.IsNotFound(err)
+			}, e2eConfig.GetIntervals(specName, "wait-secret-deletion")...).Should(BeTrue())
+		})
+
+		It("transitions from Available to ExternallyProvisioned", func() {
+			testSecretName := secretName + "-available-to-ext"
+			By("Creating a secret with BMH credentials")
+			bmcCredentialsData := map[string]string{
+				"username": bmc.User,
+				"password": bmc.Password,
+			}
+			CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, testSecretName, bmcCredentialsData)
+
+			By("Creating a BMH without ExternallyProvisioned to allow inspection")
+			bmh := metal3api.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      specName + "-available-to-ext",
+					Namespace: namespace.Name,
+				},
+				Spec: metal3api.BareMetalHostSpec{
+					BMC: metal3api.BMCDetails{
+						Address:                        bmc.Address,
+						CredentialsName:                testSecretName,
+						DisableCertificateVerification: bmc.DisableCertificateVerification,
+					},
+					BootMode:              metal3api.Legacy,
+					BootMACAddress:        bmc.BootMacAddress,
+					ExternallyProvisioned: false, // Start with false to allow inspection
+				},
+			}
+			err := clusterProxy.GetClient().Create(ctx, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for the BMH to be in inspecting state")
+			WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+				Client: clusterProxy.GetClient(),
+				Bmh:    bmh,
+				State:  metal3api.StateInspecting,
+			}, e2eConfig.GetIntervals(specName, "wait-inspecting")...)
+
+			By("Waiting for the BMH to complete inspection and reach Available state")
+			WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+				Client: clusterProxy.GetClient(),
+				Bmh:    bmh,
+				State:  metal3api.StateAvailable,
+			}, e2eConfig.GetIntervals(specName, "wait-available")...)
+
+			By("Retrieving the BMH to verify inspection completed")
+			err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmh.Name,
+				Namespace: bmh.Namespace,
+			}, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying that inspection was performed")
+			Expect(bmh.Status.OperationHistory.Inspect.Start.IsZero()).To(BeFalse(), "Inspection should have been performed")
+			Expect(bmh.Status.HardwareDetails).NotTo(BeNil(), "Hardware details should be available after inspection")
+
+			By("Setting ExternallyProvisioned to true from Available state (allowed by webhook)")
+			patch := client.MergeFrom(bmh.DeepCopy())
+			bmh.Spec.ExternallyProvisioned = true
+			err = clusterProxy.GetClient().Patch(ctx, &bmh, patch)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the BMH to transition to ExternallyProvisioned state")
+			WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+				Client: clusterProxy.GetClient(),
+				Bmh:    bmh,
+				State:  metal3api.StateExternallyProvisioned,
+			}, e2eConfig.GetIntervals(specName, "wait-externally-provisioned")...)
+
+			By("Verifying that no BMO provisioning occurred after transition")
+			err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmh.Name,
+				Namespace: bmh.Namespace,
+			}, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bmh.Status.OperationHistory.Provision.Start.IsZero()).To(BeTrue(), "BMO provisioning should not have occurred")
+
+			By("Cleaning up the BMH")
+			err = clusterProxy.GetClient().Delete(ctx, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+
+			WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
+				Client:    clusterProxy.GetClient(),
+				BmhName:   bmh.Name,
+				Namespace: bmh.Namespace,
+			}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
+
+			By("Waiting for the secret to be deleted")
+			Eventually(func() bool {
+				err := clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+					Name:      testSecretName,
 					Namespace: namespace.Name,
 				}, &corev1.Secret{})
 				return k8serrors.IsNotFound(err)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR relaxes the webhook validation for the `ExternallyProvisioned` field to allow it to be changed from `false` to `true` when the host is in an `Available` state, while still blocking changes in any other state.

Previously, the webhook rejected any change to `ExternallyProvisioned`. This prevented a critical workflow for O-RAN deployments using Red Hat's Image-based Installer (IBI).

IBI is used for deploying single-node OpenShift clusters in edge/O-RAN environments. The required workflow is:
1. Create BMH with `ExternallyProvisioned: false` to enable Ironic inspection
   - When `ExternallyProvisioned: true`, the [`NeedsHardwareInspection()`](https://github.com/metal3-io/baremetal-operator/blob/main/apis/metal3.io/v1alpha1/baremetalhost_types.go#L1031) function returns `false` (preventing inspection)
   - The controller state machine bypasses the Inspecting state entirely when the field is `true`
2. Ironic performs hardware inspection to gather CPU, memory, disk, and NIC details
3. Hardware data is used for O-RAN resource selection
4. Update BMH to `ExternallyProvisioned: true` to enable IBI provisioning
   - IBI requires `ExternallyProvisioned: true` as it handles provisioning externally
   - This signals to BMO that provisioning is managed outside the operator

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.