### PR TITLE
🌱 E2E: Bump kubectl minimum version to v1.34.1

### DIFF
--- a/hack/e2e/ensure_kubectl.sh
+++ b/hack/e2e/ensure_kubectl.sh
@@ -17,7 +17,7 @@
 set -eux
 
 USR_LOCAL_BIN="/usr/local/bin"
-MINIMUM_KUBECTL_VERSION=v1.28.1
+MINIMUM_KUBECTL_VERSION=v1.34.1
 
 # Ensure the kubectl tool exists and is a viable version, or installs it
 verify_kubectl_version()


### PR DESCRIPTION
**What this PR does / why we need it**:

Keep kubectl up to date. Kind is already on v1.34 so let's have kubectl on the same minor version.

Fixes #2708

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
