### PR TITLE
:bug: Abort inspection/cleaning before powering off during deletion

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -503,7 +503,8 @@ func (r *BareMetalHostReconciler) actionPowerOffBeforeDeleting(prov provisioner.
 	info.log.Info("host ready to be powered off")
 	provResult, err := prov.PowerOff(
 		metal3api.RebootModeHard,
-		info.host.Status.ErrorType == metal3api.PowerManagementError)
+		info.host.Status.ErrorType == metal3api.PowerManagementError,
+		info.host.Spec.AutomatedCleaningMode)
 
 	if err != nil {
 		return actionError{fmt.Errorf("failed to power off before deleting node: %w", err)}
@@ -1614,7 +1615,7 @@ func (r *BareMetalHostReconciler) manageHostPower(prov provisioner.Provisioner, 
 		if info.host.Status.ErrorCount > 0 {
 			desiredRebootMode = metal3api.RebootModeHard
 		}
-		provResult, err = prov.PowerOff(desiredRebootMode, info.host.Status.ErrorType == metal3api.PowerManagementError)
+		provResult, err = prov.PowerOff(desiredRebootMode, info.host.Status.ErrorType == metal3api.PowerManagementError, info.host.Spec.AutomatedCleaningMode)
 	}
 	if err != nil {
 		return actionError{fmt.Errorf("failed setting owner reference on hostUpdatePolicy: %w", err)}

--- a/internal/controller/metal3.io/host_state_machine_test.go
+++ b/internal/controller/metal3.io/host_state_machine_test.go
@@ -1391,7 +1391,7 @@ func (m *mockProvisioner) PowerOn(_ bool) (result provisioner.Result, err error)
 	return m.getNextResultByMethod("PowerOn"), err
 }
 
-func (m *mockProvisioner) PowerOff(_ metal3api.RebootMode, _ bool) (result provisioner.Result, err error) {
+func (m *mockProvisioner) PowerOff(_ metal3api.RebootMode, _ bool, _ metal3api.AutomatedCleaningMode) (result provisioner.Result, err error) {
 	return m.getNextResultByMethod("PowerOff"), err
 }
 

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -301,7 +301,7 @@ func (p *demoProvisioner) PowerOn(_ bool) (result provisioner.Result, err error)
 
 // PowerOff ensures the server is powered off independently of any image
 // provisioning operation.
-func (p *demoProvisioner) PowerOff(_ metal3api.RebootMode, _ bool) (result provisioner.Result, err error) {
+func (p *demoProvisioner) PowerOff(_ metal3api.RebootMode, _ bool, _ metal3api.AutomatedCleaningMode) (result provisioner.Result, err error) {
 	p.log.Info("powering off host")
 	return result, nil
 }

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -359,7 +359,7 @@ func (p *fixtureProvisioner) PowerOn(_ bool) (result provisioner.Result, err err
 
 // PowerOff ensures the server is powered off independently of any image
 // provisioning operation.
-func (p *fixtureProvisioner) PowerOff(_ metal3api.RebootMode, _ bool) (result provisioner.Result, err error) {
+func (p *fixtureProvisioner) PowerOff(_ metal3api.RebootMode, _ bool, _ metal3api.AutomatedCleaningMode) (result provisioner.Result, err error) {
 	p.log.Info("ensuring host is powered off")
 
 	if p.state.DisablePowerOff {

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -195,7 +195,9 @@ type Provisioner interface {
 	// PowerOff ensures the server is powered off independently of any image
 	// provisioning operation. The boolean argument may be used to specify
 	// if a hard reboot (force power off) is required - true if so.
-	PowerOff(rebootMode metal3api.RebootMode, force bool) (result Result, err error)
+	// The automatedCleaningMode indicates the user's current intent regarding
+	// automated cleaning, used to determine if cleaning should be aborted during deletion.
+	PowerOff(rebootMode metal3api.RebootMode, force bool, automatedCleaningMode metal3api.AutomatedCleaningMode) (result Result, err error)
 
 	// TryInit checks if the provisioning backend is available to accept
 	// all the incoming requests and configures the available features.


### PR DESCRIPTION
When deleting a host in inspecting or cleaning state, it would get stuck because Ironic rejects power changes while a target provision state is active. This fix detects these states and sends an abort command first, allowing deletion to proceed immediately instead of waiting for inspection/cleaning to complete.

Assisted-By: Claude Sonnet 4.5 (commercial license)

Closes: https://github.com/metal3-io/baremetal-operator/issues/2478
