### PR TITLE
:seedling:  Fix spelling error metal3.io_baremetalhosts.yaml line 624

### DIFF
--- a/config/base/crds/bases/metal3.io_baremetalhosts.yaml
+++ b/config/base/crds/bases/metal3.io_baremetalhosts.yaml
@@ -621,7 +621,7 @@ spec:
             properties:
               errorCount:
                 default: 0
-                description: ErrorCount records how many times the host has encoutered
+                description: ErrorCount records how many times the host has encountered
                   an error since the last successful operation
                 type: integer
               errorMessage:


### PR DESCRIPTION
Added an "n" that would break spell checkers.