### PR TITLE
✨ BMO: do not require checksums for OCI images

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	k8s.io/api v0.34.2
 	k8s.io/apimachinery v0.34.2
+	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	sigs.k8s.io/controller-runtime v0.22.4
 )
 
@@ -26,7 +27,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
-	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect

--- a/config/base/crds/bases/metal3.io_baremetalhosts.yaml
+++ b/config/base/crds/bases/metal3.io_baremetalhosts.yaml
@@ -257,7 +257,7 @@ spec:
                   checksum:
                     description: |-
                       Checksum is the checksum for the image. Required for all formats
-                      except for "live-iso".
+                      except for "live-iso" and OCI images (oci://).
                     type: string
                   checksumType:
                     description: |-
@@ -993,7 +993,7 @@ spec:
                       checksum:
                         description: |-
                           Checksum is the checksum for the image. Required for all formats
-                          except for "live-iso".
+                          except for "live-iso" and OCI images (oci://).
                         type: string
                       checksumType:
                         description: |-

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -257,7 +257,7 @@ spec:
                   checksum:
                     description: |-
                       Checksum is the checksum for the image. Required for all formats
-                      except for "live-iso".
+                      except for "live-iso" and OCI images (oci://).
                     type: string
                   checksumType:
                     description: |-
@@ -993,7 +993,7 @@ spec:
                       checksum:
                         description: |-
                           Checksum is the checksum for the image. Required for all formats
-                          except for "live-iso".
+                          except for "live-iso" and OCI images (oci://).
                         type: string
                       checksumType:
                         description: |-


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

This PR makes checksums optional for OCI images in the BareMetalHost spec.
OCI images (oci://...) have built-in content addressing through their manifest digests, making external checksums redundant. Ironic already supports OCI images with embedded checksums natively. This change aligns BMO with Ironic's capabilities and removes an unnecessary barrier for users provisioning with OCI artifacts.

Backward compatibility:

- Existing non-OCI images still require checksums
- OCI images can still optionally provide checksums
- All validation for non-OCI images remains unchanged

Related:
This PR is complementary to #2745 (per-host OCI authentication). While this PR makes checksums optional, #2745 adds authentication support for private registries. They can be merged independently in any order.

Assisted-By: Claude-4.5-sonnet

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
