### PR TITLE
:seedling: Enable errorlint linter and fix lints

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,7 +33,7 @@ linters:
   - errcheck
   - errchkjson
   - errname
-  #- errorlint
+  - errorlint
   - exhaustive
   - exptostd
   - fatcontext

--- a/hack/tools/deploy-cli/deploy-cli.go
+++ b/hack/tools/deploy-cli/deploy-cli.go
@@ -278,19 +278,19 @@ func (d *DeployContext) GetEnvOrDefault(key string) (string, error) {
 func CopyFile(src, dst string) error {
 	inputFile, err := os.Open(src)
 	if err != nil {
-		return fmt.Errorf("failed to open source file %s: %v", src, err)
+		return fmt.Errorf("failed to open source file %s: %w", src, err)
 	}
 	defer inputFile.Close()
 
 	outputFile, err := os.Create(dst)
 	if err != nil {
-		return fmt.Errorf("failed to create destination file %s: %v", dst, err)
+		return fmt.Errorf("failed to create destination file %s: %w", dst, err)
 	}
 	defer outputFile.Close()
 
 	_, err = io.Copy(outputFile, inputFile)
 	if err != nil {
-		return fmt.Errorf("failed to copy from %s to %s: %v", src, dst, err)
+		return fmt.Errorf("failed to copy from %s to %s: %w", src, dst, err)
 	}
 
 	return nil
@@ -312,7 +312,7 @@ func GenerateRandomString(length int) (string, error) {
 	b := make([]byte, length)
 	_, err := rand.Read(b)
 	if err != nil {
-		return "", fmt.Errorf("failed to generate random string: %v", err)
+		return "", fmt.Errorf("failed to generate random string: %w", err)
 	}
 
 	return base64.RawURLEncoding.EncodeToString(b)[:length], nil

--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -370,11 +370,10 @@ func recordActionDelayed(info *reconcileInfo, state metal3api.ProvisioningState)
 }
 
 func (r *BareMetalHostReconciler) credentialsErrorResult(ctx context.Context, err error, request ctrl.Request, host *metal3api.BareMetalHost) (ctrl.Result, error) {
-	switch err.(type) {
 	// In the event a credential secret is defined, but we cannot find it
 	// we requeue the host as we will not know if they create the secret
 	// at some point in the future.
-	case *ResolveBMCSecretRefError:
+	if errors.As(err, new(*ResolveBMCSecretRefError)) {
 		credentialsMissing.Inc()
 		saveErr := r.setErrorCondition(ctx, request, host, metal3api.RegistrationError, err.Error())
 		if saveErr != nil {
@@ -383,14 +382,16 @@ func (r *BareMetalHostReconciler) credentialsErrorResult(ctx context.Context, er
 		r.publishEvent(ctx, request, host.NewEvent("BMCCredentialError", err.Error()))
 
 		return ctrl.Result{Requeue: true, RequeueAfter: hostErrorRetryDelay}, nil
+	}
+
 	// If a managed Host is missing a BMC address or secret, or
 	// we have found the secret but it is missing the required fields,
 	// or the BMC address is defined but malformed, we set the
 	// host into an error state but we do not Requeue it
 	// as fixing the secret or the host BMC info will trigger
 	// the host to be reconciled again
-	case *EmptyBMCAddressError, *EmptyBMCSecretError,
-		*bmc.CredentialsValidationError, *bmc.UnknownBMCTypeError:
+	if errors.As(err, new(*EmptyBMCAddressError)) || errors.As(err, new(*EmptyBMCSecretError)) ||
+		errors.As(err, new(*bmc.CredentialsValidationError)) || errors.As(err, new(*bmc.UnknownBMCTypeError)) {
 		credentialsInvalid.Inc()
 		saveErr := r.setErrorCondition(ctx, request, host, metal3api.RegistrationError, err.Error())
 		if saveErr != nil {
@@ -400,10 +401,10 @@ func (r *BareMetalHostReconciler) credentialsErrorResult(ctx context.Context, er
 		// after saving so that we only publish one time.
 		r.publishEvent(ctx, request, host.NewEvent("BMCCredentialError", err.Error()))
 		return ctrl.Result{}, nil
-	default:
-		unhandledCredentialsError.Inc()
-		return ctrl.Result{}, fmt.Errorf("an unhandled failure occurred with the BMC secret: %w", err)
 	}
+
+	unhandledCredentialsError.Inc()
+	return ctrl.Result{}, fmt.Errorf("an unhandled failure occurred with the BMC secret: %w", err)
 }
 
 // hasRebootAnnotation checks for existence of reboot annotations and returns true if at least one exist.

--- a/internal/controller/metal3.io/host_config_data.go
+++ b/internal/controller/metal3.io/host_config_data.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -89,8 +90,7 @@ func (hcd *hostConfigData) NetworkData() (string, error) {
 		"networkData",
 	)
 	if err != nil {
-		_, isNoDataErr := err.(NoDataInSecretError)
-		if isNoDataErr {
+		if errors.As(err, new(*NoDataInSecretError)) {
 			hcd.log.Info("NetworkData key is not set, returning empty data")
 			return "", nil
 		}
@@ -109,8 +109,7 @@ func (hcd *hostConfigData) PreprovisioningNetworkData() (string, error) {
 		"networkData",
 	)
 	if err != nil {
-		_, isNoDataErr := err.(NoDataInSecretError)
-		if isNoDataErr {
+		if errors.As(err, new(*NoDataInSecretError)) {
 			hcd.log.Info("PreprovisioningNetworkData networkData key is not set, returning empty data")
 			return "", nil
 		}

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -278,13 +278,13 @@ func CreateSecret(ctx context.Context, client client.Client, secretNamespace, se
 func executeSSHCommand(client *ssh.Client, command string) (string, error) {
 	session, err := client.NewSession()
 	if err != nil {
-		return "", fmt.Errorf("failed to create SSH session: %v", err)
+		return "", fmt.Errorf("failed to create SSH session: %w", err)
 	}
 	defer session.Close()
 
 	output, err := session.CombinedOutput(command)
 	if err != nil {
-		return "", fmt.Errorf("failed to execute command '%s': %v", command, err)
+		return "", fmt.Errorf("failed to execute command '%s': %w", command, err)
 	}
 
 	return string(output), nil


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:
This enables the errorlint linter and fixes the errors it shows. Based on PR https://github.com/metal3-io/baremetal-operator/pull/2440 which seems to be abandoned.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #2354

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] E2E tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
