### PR TITLE
:sparkles: add image SBOM attestation to image builds

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -15,10 +15,14 @@ jobs:
   build_bmo:
     name: Build BMO container image
     if: github.repository == 'metal3-io/baremetal-operator'
+    permissions:
+      contents: read
+      id-token: write
     uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
     with:
       image-name: 'baremetal-operator'
       pushImage: true
+      generate-sbom: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,6 +125,7 @@ jobs:
   build_bmo:
     permissions:
       contents: read
+      id-token: write
     needs: push_release_tags
     name: Build BMO container image
     if: github.repository == 'metal3-io/baremetal-operator'
@@ -133,6 +134,7 @@ jobs:
       image-name: 'baremetal-operator'
       pushImage: true
       ref: ${{ needs.push_release_tags.outputs.release_tag }}
+      generate-sbom: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
Use reusable container build workflow from project-infra to enable image SBOM attestations to be attached to the image digest when any IPAM image is built.

For this, we need id-token permission for keyless signing and enabling the SBOM generation via flag.
