### PR TITLE
🌱 Replace custom string utility with standard library

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"reflect"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -321,7 +322,7 @@ func (r *BareMetalHostReconciler) updateHardwareDetails(ctx context.Context, req
 
 func logResult(info *reconcileInfo, result ctrl.Result) {
 	if result.Requeue || result.RequeueAfter != 0 ||
-		!utils.StringInList(info.host.Finalizers,
+		!slices.Contains(info.host.Finalizers,
 			metal3api.BareMetalHostFinalizer) {
 		info.log.Info("done",
 			"requeue", result.Requeue,
@@ -544,7 +545,7 @@ func (r *BareMetalHostReconciler) actionDeleting(prov provisioner.Provisioner, i
 	)
 
 	// no-op if finalizer has been removed.
-	if !utils.StringInList(info.host.Finalizers, metal3api.BareMetalHostFinalizer) {
+	if !slices.Contains(info.host.Finalizers, metal3api.BareMetalHostFinalizer) {
 		info.log.Info("ready to be deleted")
 		return deleteComplete{}
 	}
@@ -2303,7 +2304,7 @@ func (r *BareMetalHostReconciler) hostHasStatus(host *metal3api.BareMetalHost) b
 }
 
 func hostHasFinalizer(host *metal3api.BareMetalHost) bool {
-	return utils.StringInList(host.Finalizers, metal3api.BareMetalHostFinalizer)
+	return slices.Contains(host.Finalizers, metal3api.BareMetalHostFinalizer)
 }
 
 func (r *BareMetalHostReconciler) updateEventHandler(e event.UpdateEvent) bool {

--- a/internal/controller/metal3.io/baremetalhost_controller_test.go
+++ b/internal/controller/metal3.io/baremetalhost_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/fixture"
 	"github.com/metal3-io/baremetal-operator/pkg/secretutils"
-	"github.com/metal3-io/baremetal-operator/pkg/utils"
 	promutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -624,14 +624,14 @@ func TestAddFinalizers(t *testing.T) {
 	tryReconcile(t, r, host,
 		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
 			t.Logf("host finalizers: %v", host.ObjectMeta.Finalizers)
-			if !utils.StringInList(host.ObjectMeta.Finalizers, metal3api.BareMetalHostFinalizer) {
+			if !slices.Contains(host.ObjectMeta.Finalizers, metal3api.BareMetalHostFinalizer) {
 				return false
 			}
 
 			hostSecret := getHostSecret(t, r, host)
 			t.Logf("BMC secret finalizers: %v", hostSecret.ObjectMeta.Finalizers)
 
-			return utils.StringInList(hostSecret.ObjectMeta.Finalizers, secretutils.SecretsFinalizer)
+			return slices.Contains(hostSecret.ObjectMeta.Finalizers, secretutils.SecretsFinalizer)
 		},
 	)
 }
@@ -1710,7 +1710,7 @@ func TestDeleteHost(t *testing.T) {
 
 			tryReconcile(t, r, host,
 				func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
-					return fix.Deleted && host == nil && !utils.StringInList(badSecret.Finalizers, secretutils.SecretsFinalizer)
+					return fix.Deleted && host == nil && !slices.Contains(badSecret.Finalizers, secretutils.SecretsFinalizer)
 				},
 			)
 		})

--- a/internal/controller/metal3.io/bmceventsubscription_controller.go
+++ b/internal/controller/metal3.io/bmceventsubscription_controller.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -301,5 +302,5 @@ func (r *BMCEventSubscriptionReconciler) SetupWithManager(mgr ctrl.Manager, maxC
 }
 
 func subscriptionHasFinalizer(subscription *metal3api.BMCEventSubscription) bool {
-	return utils.StringInList(subscription.Finalizers, metal3api.BMCEventSubscriptionFinalizer)
+	return slices.Contains(subscription.Finalizers, metal3api.BMCEventSubscriptionFinalizer)
 }

--- a/internal/controller/metal3.io/bmceventsubscription_controller_test.go
+++ b/internal/controller/metal3.io/bmceventsubscription_controller_test.go
@@ -1,11 +1,11 @@
 package controllers
 
 import (
+	"slices"
 	"testing"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/fixture"
-	"github.com/metal3-io/baremetal-operator/pkg/utils"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -105,7 +105,7 @@ func TestBMCAddFinalizers(t *testing.T) {
 		t.Error(err)
 	}
 	t.Logf("subscription finalizers: %v", subscription.Finalizers)
-	if !utils.StringInList(subscription.Finalizers, metal3api.BMCEventSubscriptionFinalizer) {
+	if !slices.Contains(subscription.Finalizers, metal3api.BMCEventSubscriptionFinalizer) {
 		t.Error("Expected finalizers to be added")
 	}
 }

--- a/internal/controller/metal3.io/dataimage_controller.go
+++ b/internal/controller/metal3.io/dataimage_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -151,7 +152,7 @@ func (r *DataImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// Add finalizer for newly created DataImage
-	if di.DeletionTimestamp.IsZero() && !utils.StringInList(di.Finalizers, metal3api.DataImageFinalizer) {
+	if di.DeletionTimestamp.IsZero() && !slices.Contains(di.Finalizers, metal3api.DataImageFinalizer) {
 		reqLogger.Info("adding finalizer")
 		di.Finalizers = append(di.Finalizers, metal3api.DataImageFinalizer)
 

--- a/internal/controller/metal3.io/preprovisioningimage_controller.go
+++ b/internal/controller/metal3.io/preprovisioningimage_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -95,7 +96,7 @@ func (r *PreprovisioningImageReconciler) Reconcile(ctx context.Context, req ctrl
 		return ctrl.Result{}, nil
 	}
 
-	if !utils.StringInList(img.Finalizers, metal3api.PreprovisioningImageFinalizer) {
+	if !slices.Contains(img.Finalizers, metal3api.PreprovisioningImageFinalizer) {
 		log.Info("adding finalizer")
 		img.Finalizers = append(img.Finalizers, metal3api.PreprovisioningImageFinalizer)
 		err = r.Update(ctx, &img)

--- a/pkg/secretutils/secret_manager.go
+++ b/pkg/secretutils/secret_manager.go
@@ -3,6 +3,7 @@ package secretutils
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/go-logr/logr"
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
@@ -99,7 +100,7 @@ func (sm *SecretManager) claimSecret(secret *corev1.Secret, owner client.Object,
 		}
 	}
 
-	if addFinalizer && !utils.StringInList(secret.Finalizers, SecretsFinalizer) {
+	if addFinalizer && !slices.Contains(secret.Finalizers, SecretsFinalizer) {
 		log.Info("setting secret finalizer")
 		secret.Finalizers = append(secret.Finalizers, SecretsFinalizer)
 		needsUpdate = true
@@ -148,7 +149,7 @@ func (sm *SecretManager) ObtainSecret(key types.NamespacedName) (*corev1.Secret,
 
 // ReleaseSecret removes secrets manager finalizer from specified secret when needed.
 func (sm *SecretManager) ReleaseSecret(secret *corev1.Secret) error {
-	if !utils.StringInList(secret.Finalizers, SecretsFinalizer) {
+	if !slices.Contains(secret.Finalizers, SecretsFinalizer) {
 		return nil
 	}
 

--- a/pkg/utils/stringlist.go
+++ b/pkg/utils/stringlist.go
@@ -1,16 +1,5 @@
 package utils
 
-// StringInList returns a boolean indicating whether strToSearch is a
-// member of the string slice passed as the first argument.
-func StringInList(list []string, strToSearch string) bool {
-	for _, item := range list {
-		if item == strToSearch {
-			return true
-		}
-	}
-	return false
-}
-
 // FilterStringFromList produces a new string slice that does not
 // include the strToFilter argument.
 func FilterStringFromList(list []string, strToFilter string) (newList []string) {

--- a/pkg/utils/stringlist_test.go
+++ b/pkg/utils/stringlist_test.go
@@ -5,32 +5,6 @@ import (
 	"testing"
 )
 
-func TestStringInList(t *testing.T) {
-	cases := []struct {
-		list   []string
-		str    string
-		expect bool
-	}{
-		{
-			list:   []string{"a", "b", "c"},
-			str:    "a",
-			expect: true,
-		},
-		{
-			list:   []string{"a", "b", "c"},
-			str:    "d",
-			expect: false,
-		},
-	}
-
-	for _, c := range cases {
-		got := StringInList(c.list, c.str)
-		if c.expect != got {
-			t.Errorf("Expected '%t', but got '%t'", c.expect, got)
-		}
-	}
-}
-
 func TestFilterStringFromList(t *testing.T) {
 	cases := []struct {
 		list      []string


### PR DESCRIPTION
Replace `utils.StringInList` with `slices.Contains`. Since Go 1.21, the slices package provides these functions in the standard library, so there is no need for custom wrapper function.

Fixes: https://github.com/metal3-io/baremetal-operator/issues/2818