### PR TITLE
:seedling: E2E: Fix race condition in upgrade tests

### DIFF
--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -319,6 +319,14 @@ func RunUpgradeTest(ctx context.Context, input *BMOIronicUpgradeInput, upgradeCl
 		})
 	}
 
+	// After deployment rollout, wait for the BMO controller to actually be processing events.
+	// There's a race condition where the deployment is "available" but the new pod hasn't
+	// acquired the leader lease yet or hasn't started its watches. If we patch the BMH
+	// during this window, the controller may miss the update event.
+	By("Waiting for BMO controller to be ready to process events")
+	WaitForBmhReconciled(ctx, upgradeClusterProxy.GetClient(), bmh,
+		e2eConfig.GetIntervals("default", "wait-deployment")...)
+
 	By("Patching the BMH to test provisioning")
 	// Using Eventually here since the webhook can take some time after the deployment is ready
 	Eventually(func() error {


### PR DESCRIPTION
After BMO deployment rollout, there's a window where the deployment is marked 'available' but the new pod hasn't acquired the leader lease or started its watches yet. If the test patches the BMH during this window, the controller may miss the update event, causing the BMH to remain stuck in 'available' state instead of transitioning to 'provisioning'.

This fix adds WaitForBmhReconciled() which:
1. Adds a test annotation to the BMH to trigger a reconcile
2. Waits for status.lastUpdated to change, proving the controller processed the update

This ensures the controller is actually processing events before the test makes the critical provisioning patch.

Fixes flakiness in optional upgrade tests where BMH gets stuck in 'available' state, causing cascade failures (MAC conflicts) in subsequent tests.
