### PR TITLE
:seedling: e2e: pre-pull images to work around kind ctr import issue

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -88,7 +88,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	} else {
 		clusterProvider = bootstrap.CreateKindBootstrapClusterAndLoadImages(ctx, bootstrap.CreateKindBootstrapClusterAndLoadImagesInput{
 			Name:              "bmo-e2e",
-			Images:            e2eConfig.Images,
+			Images:            e2eConfig.GetClusterctlImages(),
 			ExtraPortMappings: e2eConfig.KindExtraPortMappings,
 		})
 		Expect(clusterProvider).ToNot(BeNil(), "Failed to create a cluster")

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -365,7 +365,7 @@ var _ = Describe("Upgrade", Label("optional", "upgrade"), func() {
 			upgradeClusterName := fmt.Sprintf("bmo-e2e-upgrade-%d", GinkgoParallelProcess())
 			upgradeClusterProvider = bootstrap.CreateKindBootstrapClusterAndLoadImages(ctx, bootstrap.CreateKindBootstrapClusterAndLoadImagesInput{
 				Name:              upgradeClusterName,
-				Images:            e2eConfig.Images,
+				Images:            e2eConfig.GetClusterctlImages(),
 				ExtraPortMappings: e2eConfig.KindExtraPortMappings,
 			})
 			Expect(upgradeClusterProvider).ToNot(BeNil(), "Failed to create a cluster")


### PR DESCRIPTION
The clusterctl.ContainerImage struct from CAPI has no yaml struct tags, so when gopkg.in/yaml.v2 unmarshals the e2e config, the LoadBehavior field remains empty. The Defaults() function then sets LoadBehavior to MustLoadImage, causing all image load failures to be fatal instead of the intended tryLoad (warning only) behavior.
     
This adds a local ContainerImage struct with proper yaml tags and a conversion method to use with CAPI's bootstrap framework.

Fixes: #2832 
