### PR TITLE
:bug: Require PreprovisioningImage for deprovisioning when cleaning is enabled

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -770,6 +770,12 @@ func (r *BareMetalHostReconciler) getPreprovImage(info *reconcileInfo, formats [
 		return nil, fmt.Errorf("failed to retrieve pre-provisioning image data: %w", err)
 	}
 
+	// If the PreprovisioningImage is being deleted, treat it as unavailable
+	if !preprovImage.DeletionTimestamp.IsZero() {
+		info.log.Info("PreprovisioningImage is being deleted, waiting for new one")
+		return nil, nil //nolint:nilnil
+	}
+
 	needsUpdate := false
 	if preprovImage.Labels == nil && len(info.host.Labels) > 0 {
 		preprovImage.Labels = make(map[string]string, len(info.host.Labels))

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -360,7 +360,8 @@ func (p *ironicProvisioner) configureNode(data provisioner.ManagementAccessData,
 	}
 
 	switch data.State {
-	case metal3api.StateInspecting,
+	case metal3api.StateDeprovisioning,
+		metal3api.StateInspecting,
 		metal3api.StatePreparing:
 		if deployImageInfo == nil && p.config.havePreprovImgBuilder {
 			result, err = transientError(provisioner.ErrNeedsPreprovisioningImage)


### PR DESCRIPTION
When deprovisioning a host with automated cleaning enabled, BMO now checks if a PreprovisioningImage is available before proceeding. Previously, the StateDeprovisioning case was not handled, causing Ironic to fall back to building its own ISO and fail with a misleading "uefi_esp.img not found" error when the PPI was unavailable.

Assisted-By: Claude Sonnet 4.5 (commercial license)
