### PR TITLE
:seedling: Improve behavior on deletion of BMH with unreachable BMC in verifying state

### DIFF
--- a/pkg/provisioner/ironic/delete_test.go
+++ b/pkg/provisioner/ironic/delete_test.go
@@ -167,6 +167,32 @@ func deleteTest(t *testing.T, detach bool) {
 			expectedDirty:        true,
 			expectedRequestAfter: 0,
 		},
+		{
+			name: "verifying-node-waits",
+			ironic: testserver.NewIronic(t).Node(
+				nodes.Node{
+					UUID:           nodeUUID,
+					ProvisionState: string(nodes.Verifying),
+					Maintenance:    false,
+				},
+			),
+			// Should wait for verification to complete, not try to set maintenance
+			expectedDirty:        true,
+			expectedRequestAfter: provisionRequeueDelay,
+		},
+		{
+			name: "enroll-node-deletes-directly",
+			ironic: testserver.NewIronic(t).Node(
+				nodes.Node{
+					UUID:           nodeUUID,
+					ProvisionState: string(nodes.Enroll),
+					Maintenance:    false,
+				},
+			).Delete(nodeUUID),
+			// Should delete directly without setting maintenance mode
+			expectedDirty:        true,
+			expectedRequestAfter: 0,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
When deleting a BareMetalHost while Ironic is in the 'verifying' state
(validating BMC credentials with an unreachable BMC), the deletion would
take nearly an hour.
- Ironic holds an exclusive lock during verification
- BMO's Delete() tries to set maintenance mode, getting 409 Conflict
- BMO keeps retrying until Ironic's verification times out (~50 minutes)

This change improves the behavior for verifying and enroll states:
- Verifying: Wait for verification to complete/timeout instead of
  trying to set maintenance mode (which will always fail due to lock)
- Enroll: Delete directly without maintenance mode since nodes in this
  state don't need the bypass

The total deletion time is still bounded by Ironic's verification
timeout, but the behavior is now correct and logs are cleaner.

Signed-off-by: Riccardo Pittau <elfosardo@gmail.com>
