### PR TITLE
:bug: Sync automated_clean before deprovisioning

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -1398,7 +1398,9 @@ func (r *BareMetalHostReconciler) actionDeprovisioning(prov provisioner.Provisio
 
 	info.log.Info("deprovisioning")
 
-	provResult, err := prov.Deprovision(info.host.Status.ErrorType == metal3api.ProvisioningError)
+	provResult, err := prov.Deprovision(
+		info.host.Status.ErrorType == metal3api.ProvisioningError,
+		info.host.Spec.AutomatedCleaningMode)
 	if err != nil {
 		return actionError{fmt.Errorf("failed to deprovision: %w", err)}
 	}

--- a/internal/controller/metal3.io/host_state_machine_test.go
+++ b/internal/controller/metal3.io/host_state_machine_test.go
@@ -1374,7 +1374,7 @@ func (m *mockProvisioner) Provision(_ provisioner.ProvisionData, _ bool) (result
 	return m.getNextResultByMethod("Provision"), err
 }
 
-func (m *mockProvisioner) Deprovision(_ bool) (result provisioner.Result, err error) {
+func (m *mockProvisioner) Deprovision(_ bool, _ metal3api.AutomatedCleaningMode) (result provisioner.Result, err error) {
 	return m.getNextResultByMethod("Deprovision"), err
 }
 

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -269,7 +269,7 @@ func (p *demoProvisioner) Provision(_ provisioner.ProvisionData, _ bool) (result
 // Deprovision removes the host from the image. It may be called
 // multiple times, and should return true for its dirty flag until the
 // deprovisioning operation is completed.
-func (p *demoProvisioner) Deprovision(_ bool) (result provisioner.Result, err error) {
+func (p *demoProvisioner) Deprovision(_ bool, _ metal3api.AutomatedCleaningMode) (result provisioner.Result, err error) {
 	p.log.Info("deprovisioning host")
 	return result, nil
 }

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -296,7 +296,7 @@ func (p *fixtureProvisioner) Provision(data provisioner.ProvisionData, _ bool) (
 // Deprovision removes the host from the image. It may be called
 // multiple times, and should return true for its dirty flag until the
 // deprovisioning operation is completed.
-func (p *fixtureProvisioner) Deprovision(_ bool) (result provisioner.Result, err error) {
+func (p *fixtureProvisioner) Deprovision(_ bool, _ metal3api.AutomatedCleaningMode) (result provisioner.Result, err error) {
 	p.log.Info("ensuring host is deprovisioned")
 
 	result.RequeueAfter = deprovisionRequeueDelay

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -175,7 +175,9 @@ type Provisioner interface {
 	// Deprovision removes the host from the image. It may be called
 	// multiple times, and should return true for its dirty flag until
 	// the deprovisioning operation is completed.
-	Deprovision(restartOnFailure bool) (result Result, err error)
+	// The automatedCleaningMode parameter is used to ensure the Ironic node's
+	// automated_clean setting is synchronized before deprovisioning starts.
+	Deprovision(restartOnFailure bool, automatedCleaningMode metal3api.AutomatedCleaningMode) (result Result, err error)
 
 	// Delete removes the host from the provisioning system. It may be
 	// called multiple times, and should return true for its dirty


### PR DESCRIPTION
When a BMH's automatedCleaningMode is changed right before deletion, there's a race where the PPI gets cascade-deleted before BMO can update Ironic's automated_clean field. This causes Ironic to use the stale cleaning configuration and fail when the PPI is missing.
This commit ensures automated_clean is synchronized with the BMH spec before sending the deletion request to Ironic. If the value needs updating, Deprovision() updates it and requeues, allowing the next reconcile to proceed with the correct cleaning mode.
