### PR TITLE
:bug: Fix errors.As usage for NoDataInSecretError

### DIFF
--- a/internal/controller/metal3.io/host_config_data.go
+++ b/internal/controller/metal3.io/host_config_data.go
@@ -90,7 +90,8 @@ func (hcd *hostConfigData) NetworkData() (string, error) {
 		"networkData",
 	)
 	if err != nil {
-		if errors.As(err, new(*NoDataInSecretError)) {
+		var noDataErr NoDataInSecretError
+		if errors.As(err, &noDataErr) {
 			hcd.log.Info("NetworkData key is not set, returning empty data")
 			return "", nil
 		}
@@ -109,7 +110,8 @@ func (hcd *hostConfigData) PreprovisioningNetworkData() (string, error) {
 		"networkData",
 	)
 	if err != nil {
-		if errors.As(err, new(*NoDataInSecretError)) {
+		var noDataErr NoDataInSecretError
+		if errors.As(err, &noDataErr) {
 			hcd.log.Info("PreprovisioningNetworkData networkData key is not set, returning empty data")
 			return "", nil
 		}


### PR DESCRIPTION
The errors.As calls were using new(*NoDataInSecretError) which creates a **NoDataInSecretError, but the error is a value type. This prevented the error from being matched, causing PreprovisioningNetworkData to return an error instead of empty data when the networkData key is missing from a secret.

Signed-off-by: Riccardo Pittau <elfosardo@gmail.com>