### PR TITLE
🌱 E2E: Avoid BMO < 0.11 and Ironic > 30 together

### DIFF
--- a/test/e2e/config/ironic.yaml
+++ b/test/e2e/config/ironic.yaml
@@ -115,27 +115,28 @@ bmoIronicUpgradeSpecs:
   initIronicKustomization: "data/ironic-standalone-operator/ironic/overlays/e2e"
   upgradeEntityKustomization: "../../config/overlays/e2e"
   upgradeEntityName: "bmo"
-# Upgrade Ironic 27.0 -> latest | BMO 0.9
+# Upgrade Ironic 27.0 -> 29.0 | BMO 0.9
 - deployIronic: true
   deployBMO: true
   initBMOKustomization: "../../config/overlays/e2e-release-0.9"
   initIronicKustomization: "data/ironic-standalone-operator/ironic/overlays/e2e-release-27.0"
-  upgradeEntityKustomization: "data/ironic-standalone-operator/ironic/overlays/e2e"
+  upgradeEntityKustomization: "data/ironic-standalone-operator/ironic/overlays/e2e-release-29.0"
   upgradeEntityName: "ironic"
-# Upgrade Ironic 28.0 -> latest | BMO 0.10
+# Upgrade Ironic 28.0 -> 29.0 | BMO 0.10
 - deployIronic: true
   deployBMO: true
   initBMOKustomization: "../../config/overlays/e2e-release-0.10"
   initIronicKustomization: "data/ironic-standalone-operator/ironic/overlays/e2e-release-28.0"
-  upgradeEntityKustomization: "data/ironic-standalone-operator/ironic/overlays/e2e"
+  upgradeEntityKustomization: "data/ironic-standalone-operator/ironic/overlays/e2e-release-29.0"
   upgradeEntityName: "ironic"
 # Upgrade Ironic 29.0 -> latest | BMO 0.10
-- deployIronic: true
-  deployBMO: true
-  initBMOKustomization: "../../config/overlays/e2e-release-0.10"
-  initIronicKustomization: "data/ironic-standalone-operator/ironic/overlays/e2e-release-29.0"
-  upgradeEntityKustomization: "data/ironic-standalone-operator/ironic/overlays/e2e"
-  upgradeEntityName: "ironic"
+# Broken. See https://github.com/metal3-io/baremetal-operator/issues/2909
+# - deployIronic: true
+#   deployBMO: true
+#   initBMOKustomization: "../../config/overlays/e2e-release-0.10"
+#   initIronicKustomization: "data/ironic-standalone-operator/ironic/overlays/e2e-release-29.0"
+#   upgradeEntityKustomization: "data/ironic-standalone-operator/ironic/overlays/e2e"
+#   upgradeEntityName: "ironic"
 # Upgrade Ironic 30.0 -> latest | BMO 0.11
 - deployIronic: true
   deployBMO: true

--- a/test/e2e/data/ironic-standalone-operator/ironic/base/ironic.yaml
+++ b/test/e2e/data/ironic-standalone-operator/ironic/base/ironic.yaml
@@ -4,10 +4,6 @@ metadata:
   name: ironic
   namespace: baremetal-operator-system
 spec:
-  images:
-    deployRamdiskDownloader: "quay.io/metal3-io/ironic-ipa-downloader:main"
-    ironic: "quay.io/metal3-io/ironic:main"
-    keepalived: "quay.io/metal3-io/keepalived"
   version: "latest"
   networking:
     dhcp:

--- a/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e/ironic.yaml
+++ b/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e/ironic.yaml
@@ -1,0 +1,10 @@
+apiVersion: ironic.metal3.io/v1alpha1
+kind: Ironic
+metadata:
+  name: ironic
+  namespace: baremetal-operator-system
+spec:
+  images:
+    deployRamdiskDownloader: "quay.io/metal3-io/ironic-ipa-downloader:main"
+    ironic: "quay.io/metal3-io/ironic:main"
+    keepalived: "quay.io/metal3-io/keepalived"

--- a/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e/kustomization.yaml
+++ b/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e/kustomization.yaml
@@ -8,3 +8,7 @@ resources:
 components:
 - ../../../components/tls
 - ../../../components/basic-auth
+
+patches:
+# Use main tag of images
+- path: ironic.yaml

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -430,7 +430,7 @@ var _ = Describe("Upgrade", Label("optional", "upgrade"), func() {
 			case ironicString:
 				upgradeFromKustomization = input.InitIronicKustomization
 			}
-			return fmt.Sprintf("Should upgrade %s from %s to latest version", input.UpgradeEntityName, upgradeFromKustomization)
+			return fmt.Sprintf("Should upgrade %s from %s to %s", input.UpgradeEntityName, upgradeFromKustomization, input.UpgradeEntityKustomization)
 		},
 		entries,
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adjust the upgrade jobs to avoid broken combo when paired with redfish-virtualmedia and UEFI.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->
Related to https://github.com/metal3-io/baremetal-operator/issues/2909

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
