### PR TITLE
🌱 E2E serial logs per test

### DIFF
--- a/test/e2e/automated_cleaning_test.go
+++ b/test/e2e/automated_cleaning_test.go
@@ -211,6 +211,7 @@ var _ = Describe("Automated cleaning", Label("required", "automated-cleaning"), 
 		}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
 	})
 	AfterEach(func() {
+		CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
 		DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
 		if !skipCleanup {
 			isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")

--- a/test/e2e/basic_ops_test.go
+++ b/test/e2e/basic_ops_test.go
@@ -122,6 +122,7 @@ var _ = Describe("basic", Label("required", "basic"), func() {
 	})
 
 	AfterEach(func() {
+		CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
 		DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
 		if !skipCleanup {
 			isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	irsov1alpha1 "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
@@ -50,8 +51,83 @@ const (
 	PoweredOff PowerState = "off"
 
 	filePerm600 = 0600
+	filePerm644 = 0644
 	filePerm750 = 0750
+	filePerm755 = 0755
 )
+
+// vmLogPositions tracks the last read position for each VM's serial log.
+// This enables incremental log collection per test.
+var vmLogPositions = make(map[string]int64)
+var vmLogPositionsMu sync.Mutex
+
+// CollectSerialLogs copies incremental VM serial log content for the current test.
+// It appends to the log file so that multiple It blocks within the same specName
+// accumulate their logs in one place. The logs are written to destFolder.
+func CollectSerialLogs(vmName, destFolder string) {
+	if vmName == "" {
+		return
+	}
+	err := CopyIncrementalVMLog(vmName, destFolder)
+	if err != nil {
+		Logf("Warning: Failed to copy VM serial log for %s: %v", vmName, err)
+	}
+}
+
+// CopyIncrementalVMLog copies new content from a VM's serial log since last collection.
+// It tracks the read position per VM to enable per-test log separation.
+// New content is appended to the destination file so that sequential It blocks
+// within the same test accumulate their logs.
+func CopyIncrementalVMLog(vmName, destFolder string) error {
+	vmLogPositionsMu.Lock()
+	defer vmLogPositionsMu.Unlock()
+
+	sourcePath := fmt.Sprintf("/var/log/libvirt/qemu/%s-serial0.log", vmName)
+	destPath := filepath.Join(destFolder, vmName+"-serial0.log")
+
+	// Create destination folder
+	if err := os.MkdirAll(destFolder, filePerm755); err != nil {
+		return fmt.Errorf("mkdir: %w", err)
+	}
+
+	// Read source file using sudo (VM logs are owned by libvirt-qemu)
+	cmd := testexec.NewCommand(
+		testexec.WithCommand("sudo"),
+		testexec.WithArgs("cat", sourcePath),
+	)
+	stdout, stderr, err := cmd.Run(context.Background())
+	if err != nil {
+		return fmt.Errorf("read source %s (stderr: %s): %w", sourcePath, string(stderr), err)
+	}
+	sourceBytes := stdout
+
+	// Get last position
+	lastPos := vmLogPositions[vmName]
+	currentSize := int64(len(sourceBytes))
+
+	// Extract incremental content
+	var incrementalContent []byte
+	if lastPos < currentSize {
+		incrementalContent = sourceBytes[lastPos:]
+	}
+
+	// Append to destination
+	if len(incrementalContent) > 0 {
+		f, err := os.OpenFile(destPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, filePerm644)
+		if err != nil {
+			return fmt.Errorf("open dest: %w", err)
+		}
+		defer f.Close()
+		if _, err := f.Write(incrementalContent); err != nil {
+			return fmt.Errorf("write dest: %w", err)
+		}
+	}
+
+	// Update position
+	vmLogPositions[vmName] = currentSize
+
+	return nil
+}
 
 func isUndesiredState(currentState metal3api.ProvisioningState, undesiredStates []metal3api.ProvisioningState) bool {
 	if undesiredStates == nil {

--- a/test/e2e/external_inspection_test.go
+++ b/test/e2e/external_inspection_test.go
@@ -322,6 +322,7 @@ var _ = Describe("External Inspection", Label("required", "external-inspection")
 	})
 
 	AfterEach(func() {
+		CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
 		DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
 		if !skipCleanup {
 			isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")

--- a/test/e2e/externally_provisioned_test.go
+++ b/test/e2e/externally_provisioned_test.go
@@ -234,6 +234,7 @@ var _ = Describe("Create as externally provisioned, deprovision", Label("require
 		})
 
 		AfterEach(func() {
+			CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
 			DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
 			if !skipCleanup {
 				isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")

--- a/test/e2e/inspection_test.go
+++ b/test/e2e/inspection_test.go
@@ -174,6 +174,7 @@ var _ = Describe("Inspection", Label("required", "inspection"), func() {
 	})
 
 	AfterEach(func() {
+		CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
 		DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
 		if !skipCleanup {
 			isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")

--- a/test/e2e/live_iso_test.go
+++ b/test/e2e/live_iso_test.go
@@ -150,6 +150,7 @@ var _ = Describe("Live-ISO", Label("required", "live-iso"), func() {
 	})
 
 	AfterEach(func() {
+		CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
 		DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
 		if !skipCleanup {
 			isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")

--- a/test/e2e/provisioning_and_annotation_test.go
+++ b/test/e2e/provisioning_and_annotation_test.go
@@ -268,6 +268,7 @@ var _ = Describe("Provision, detach, recreate from status and deprovision", Labe
 		})
 
 		AfterEach(func() {
+			CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
 			DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
 			if !skipCleanup {
 				isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")

--- a/test/e2e/re_inspection_test.go
+++ b/test/e2e/re_inspection_test.go
@@ -121,6 +121,7 @@ var _ = Describe("Re-Inspection", Label("required", "re-inspection"), func() {
 	})
 
 	AfterEach(func() {
+		CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
 		DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
 		if !skipCleanup {
 			isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -303,6 +303,7 @@ var _ = Describe("Upgrade", Ordered, Label("optional", "upgrade"), func() {
 	)
 
 	AfterEach(func() {
+		CollectSerialLogs(bmc.Name, testArtifactFolder)
 		upgradeIronicIP := ""
 		if e2eConfig.HasVariable("UPGRADE_IRONIC_PROVISIONING_IP") {
 			upgradeIronicIP = e2eConfig.GetVariable("UPGRADE_IRONIC_PROVISIONING_IP")


### PR DESCRIPTION
**What this PR does / why we need it**:

We collect serial logs from the VMs, but these are reused for all the tests so it is hard to tell which part of the logs belong to what test. This PR aims to fix that by extracting the part of the logs that were created during the test, for each test. We still collect the complete logs at the end.

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

This is a draft for now. It is meant as a follow up to https://github.com/metal3-io/baremetal-operator/pull/2905.