### PR TITLE
🌱Bump golang version to 1.24.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.24.11@sha256:cf1272dbf972a94f39a81dcb9dc243a8d2f981e5dd3b5a5c965f6d9ab9268b26
+ARG BUILD_IMAGE=docker.io/golang:1.24.12@sha256:3cf75037b466628dd35fe88065e475463bd5083075ff0a8962cbfb4327423ee3
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GO_TEST_FLAGS = $(TEST_FLAGS)
 DEBUG = --debug
 COVER_PROFILE = cover.out
 GO := $(shell type -P go)
-GO_VERSION ?= 1.24.11
+GO_VERSION ?= 1.24.12
 
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 

--- a/hack/e2e/ensure_go.sh
+++ b/hack/e2e/ensure_go.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-MINIMUM_GO_VERSION=go1.24.11
+MINIMUM_GO_VERSION=go1.24.12
 
 # Ensure the go tool exists and is a viable version, or installs it
 verify_go_version()


### PR DESCRIPTION
Uplift go version to 1.24.12 to address some new vulnerabilities 
This is CVE-2025-68119 and Go issue https://go.dev/issue/77099
This is CVE-2025-61731 and Go issue https://go.dev/issue/77100
This is CVE-2025-61728 and Go issue https://go.dev/issue/77102
This is CVE-2025-61726 and Go issue https://go.dev/issue/77101
This is CVE-2025-68121 and Go issue https://go.dev/issue/77113.


