### PR TITLE
🐛 Make architecture tests portable across x86_64 and aarch64

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller_test.go
+++ b/internal/controller/metal3.io/baremetalhost_controller_test.go
@@ -2494,7 +2494,8 @@ func TestGetHardwareProfileName(t *testing.T) {
 
 func TestGetHostArchitecture(t *testing.T) {
 	host := newDefaultHost(t)
-	assert.Equal(t, "x86_64", getHostArchitecture(host))
+	// The default architecture comes from the runtime when not specified
+	assert.Equal(t, getControllerArchitecture(), getHostArchitecture(host))
 
 	host.Spec.Architecture = "aarch64"
 	assert.Equal(t, "aarch64", getHostArchitecture(host))
@@ -2550,7 +2551,7 @@ func TestGetPreprovImageCreateUpdate(t *testing.T) {
 		Namespace: host.Namespace,
 	},
 		&img))
-	assert.Equal(t, "x86_64", img.Spec.Architecture)
+	assert.Equal(t, getControllerArchitecture(), img.Spec.Architecture)
 	assert.Equal(t, secretName, img.Spec.NetworkDataName)
 	assert.Equal(t, "42", img.Labels["answer.metal3.io"])
 
@@ -2576,17 +2577,18 @@ func TestGetPreprovImage(t *testing.T) {
 	host := newDefaultHost(t)
 	imageURL := "http://example.test/image.iso"
 	acceptFormats := []metal3api.ImageFormat{metal3api.ImageFormatISO, metal3api.ImageFormatInitRD}
+	arch := getControllerArchitecture()
 	image := &metal3api.PreprovisioningImage{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      host.Name,
 			Namespace: namespace,
 		},
 		Spec: metal3api.PreprovisioningImageSpec{
-			Architecture:  "x86_64",
+			Architecture:  arch,
 			AcceptFormats: acceptFormats,
 		},
 		Status: metal3api.PreprovisioningImageStatus{
-			Architecture: "x86_64",
+			Architecture: arch,
 			Format:       metal3api.ImageFormatISO,
 			ImageUrl:     imageURL,
 			Conditions: []metav1.Condition{
@@ -2614,16 +2616,17 @@ func TestGetPreprovImage(t *testing.T) {
 func TestGetPreprovImageNotCurrent(t *testing.T) {
 	host := newDefaultHost(t)
 	imageURL := "http://example.test/image.iso"
+	arch := getControllerArchitecture()
 	image := &metal3api.PreprovisioningImage{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      host.Name,
 			Namespace: namespace,
 		},
 		Spec: metal3api.PreprovisioningImageSpec{
-			Architecture: "x86_64",
+			Architecture: arch,
 		},
 		Status: metal3api.PreprovisioningImageStatus{
-			Architecture: "x86_64",
+			Architecture: arch,
 			Format:       metal3api.ImageFormatISO,
 			ImageUrl:     imageURL,
 			Conditions: []metav1.Condition{
@@ -2651,6 +2654,7 @@ func TestGetPreprovImageBeingDeleted(t *testing.T) {
 	imageURL := "http://example.test/image.iso"
 	acceptFormats := []metal3api.ImageFormat{metal3api.ImageFormatISO, metal3api.ImageFormatInitRD}
 	now := metav1.Now()
+	arch := getControllerArchitecture()
 	image := &metal3api.PreprovisioningImage{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              host.Name,
@@ -2659,11 +2663,11 @@ func TestGetPreprovImageBeingDeleted(t *testing.T) {
 			Finalizers:        []string{"test-finalizer"},
 		},
 		Spec: metal3api.PreprovisioningImageSpec{
-			Architecture:  "x86_64",
+			Architecture:  arch,
 			AcceptFormats: acceptFormats,
 		},
 		Status: metal3api.PreprovisioningImageStatus{
-			Architecture: "x86_64",
+			Architecture: arch,
 			Format:       metal3api.ImageFormatISO,
 			ImageUrl:     imageURL,
 			Conditions: []metav1.Condition{


### PR DESCRIPTION


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

The tests were hardcoding 'x86_64' as the expected architecture, but on ARM Macs (and other aarch64 systems), the controller returns 'aarch64' as the default architecture when not specified in the host spec.

This change uses getControllerArchitecture() instead of hardcoded values so the tests pass on any platform.

Tests affected:
- TestGetHostArchitecture
- TestGetPreprovImageCreateUpdate
- TestGetPreprovImage
- TestGetPreprovImageNotCurrent
- TestGetPreprovImageBeingDeleted

Fixes #

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] E2E tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
