### PR TITLE
Expose Infiniband client id

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -709,6 +709,10 @@ type NIC struct {
 	// +kubebuilder:validation:Pattern=`[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}`
 	MAC string `json:"mac,omitempty"`
 
+	// The client ID (DHCP client identifier) of the network interface
+	// +optional
+	ClientID string `json:"clientID,omitempty"`
+
 	// The IP address of the interface. This will be an IPv4 or IPv6 address
 	// if one is present.  If both IPv4 and IPv6 addresses are present in a
 	// dual-stack environment, two nics will be output, one with each IP.


### PR DESCRIPTION
Ironic collects infiniband interface client_id [0] expose this info to baremetalhost nics section.

[0] https://specs.openstack.org/openstack/ironic-specs/specs/6.2/add-infiniband-support.html

