### PR TITLE
✨: Expose infiniband clientId

### DIFF
--- a/apis/metal3.io/v1alpha1/hardwaredata_types.go
+++ b/apis/metal3.io/v1alpha1/hardwaredata_types.go
@@ -153,6 +153,11 @@ type NIC struct {
 	// +kubebuilder:validation:Pattern=`[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}`
 	MAC string `json:"mac,omitempty"`
 
+	// The client ID (DHCP client identifier) of the network interface, collected
+	// during Ironic discovery (similar to MAC address).
+	// +optional
+	ClientID string `json:"clientID,omitempty"`
+
 	// The IP address of the interface. This will be an IPv4 or IPv6 address
 	// if one is present.  If both IPv4 and IPv6 addresses are present in a
 	// dual-stack environment, two nics will be output, one with each IP.

--- a/config/base/crds/bases/metal3.io_baremetalhosts.yaml
+++ b/config/base/crds/bases/metal3.io_baremetalhosts.yaml
@@ -718,6 +718,11 @@ spec:
                     items:
                       description: NIC describes one network interface on the host.
                       properties:
+                        clientID:
+                          description: |-
+                            The client ID (DHCP client identifier) of the network interface, collected
+                            during Ironic discovery (similar to MAC address).
+                          type: string
                         ip:
                           description: |-
                             The IP address of the interface. This will be an IPv4 or IPv6 address

--- a/config/base/crds/bases/metal3.io_hardwaredata.yaml
+++ b/config/base/crds/bases/metal3.io_hardwaredata.yaml
@@ -92,6 +92,11 @@ spec:
                     items:
                       description: NIC describes one network interface on the host.
                       properties:
+                        clientID:
+                          description: |-
+                            The client ID (DHCP client identifier) of the network interface, collected
+                            during Ironic discovery (similar to MAC address).
+                          type: string
                         ip:
                           description: |-
                             The IP address of the interface. This will be an IPv4 or IPv6 address

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -718,6 +718,11 @@ spec:
                     items:
                       description: NIC describes one network interface on the host.
                       properties:
+                        clientID:
+                          description: |-
+                            The client ID (DHCP client identifier) of the network interface, collected
+                            during Ironic discovery (similar to MAC address).
+                          type: string
                         ip:
                           description: |-
                             The IP address of the interface. This will be an IPv4 or IPv6 address
@@ -1647,6 +1652,11 @@ spec:
                     items:
                       description: NIC describes one network interface on the host.
                       properties:
+                        clientID:
+                          description: |-
+                            The client ID (DHCP client identifier) of the network interface, collected
+                            during Ironic discovery (similar to MAC address).
+                          type: string
                         ip:
                           description: |-
                             The IP address of the interface. This will be an IPv4 or IPv6 address

--- a/pkg/provisioner/ironic/hardwaredetails/hardwaredetails.go
+++ b/pkg/provisioner/ironic/hardwaredetails/hardwaredetails.go
@@ -83,9 +83,16 @@ func getLLDPData(lldp map[string]any) *metal3api.LLDP {
 
 func getNICDetails(ifdata []inventory.InterfaceType, ironicData inventory.StandardPluginData) []metal3api.NIC {
 	var nics []metal3api.NIC
+
 	for _, intf := range ifdata {
 		pxeEnabled := ironicData.AllInterfaces[intf.Name].PXEEnabled
 		lldp := ironicData.ParsedLLDP[intf.Name]
+		// client_id from Ironic inventory (InterfaceType has ClientID with json:"client_id");
+		// same value appears in plugin_data.standard.all_interfaces[ifname], use that as fallback
+		clientID := intf.ClientID
+		if clientID == "" && ironicData.AllInterfaces[intf.Name].ClientID != "" {
+			clientID = ironicData.AllInterfaces[intf.Name].ClientID
+		}
 
 		vlans, vlanid := getVLANs(lldp)
 		lldpData := getLLDPData(lldp)
@@ -97,6 +104,7 @@ func getNICDetails(ifdata []inventory.InterfaceType, ironicData inventory.Standa
 				Model: strings.TrimLeft(fmt.Sprintf("%s %s",
 					intf.Vendor, intf.Product), " "),
 				MAC:       intf.MACAddress,
+				ClientID:  clientID,
 				IP:        intf.IPV4Address,
 				VLANs:     vlans,
 				VLANID:    vlanid,
@@ -111,6 +119,7 @@ func getNICDetails(ifdata []inventory.InterfaceType, ironicData inventory.Standa
 				Model: strings.TrimLeft(fmt.Sprintf("%s %s",
 					intf.Vendor, intf.Product), " "),
 				MAC:       intf.MACAddress,
+				ClientID:  clientID,
 				IP:        intf.IPV6Address,
 				VLANs:     vlans,
 				VLANID:    vlanid,


### PR DESCRIPTION
Ironic collects infiniband client_id this patch makes sure its propagated into hardwaredata.

fixes #2948