### PR TITLE
🌱 E2E: Bump cert-manager to v1.19.2

### DIFF
--- a/test/e2e/config/fixture.yaml
+++ b/test/e2e/config/fixture.yaml
@@ -9,11 +9,11 @@ images:
   loadBehavior: tryLoad
 - name: quay.io/metal3-io/baremetal-operator:release-0.11
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-cainjector:v1.17.1
+- name: quay.io/jetstack/cert-manager-cainjector:v1.19.2
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-webhook:v1.17.1
+- name: quay.io/jetstack/cert-manager-webhook:v1.19.2
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-controller:v1.17.1
+- name: quay.io/jetstack/cert-manager-controller:v1.19.2
   loadBehavior: tryLoad
 
 variables:
@@ -32,7 +32,7 @@ variables:
   IMAGE_URL: "http://192.168.222.1/cirros-0.6.2-x86_64-disk.img"
   ISO_IMAGE_URL: "http://192.168.222.1/cirros.iso"
   IMAGE_CHECKSUM: "c8fc807773e5354afe61636071771906"
-  CERT_MANAGER_VERSION: "v1.17.1"
+  CERT_MANAGER_VERSION: "v1.19.2"
   SSH_CHECK_PROVISIONED: "false"
   FETCH_IRONIC_NODES: "false"
   IRONIC_PROVISIONING_IP: "192.168.222.2"

--- a/test/e2e/config/ironic.yaml
+++ b/test/e2e/config/ironic.yaml
@@ -11,11 +11,11 @@ images:
   loadBehavior: tryLoad
 - name: quay.io/metal3-io/baremetal-operator:release-0.11
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-cainjector:v1.17.1
+- name: quay.io/jetstack/cert-manager-cainjector:v1.19.2
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-webhook:v1.17.1
+- name: quay.io/jetstack/cert-manager-webhook:v1.19.2
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-controller:v1.17.1
+- name: quay.io/jetstack/cert-manager-controller:v1.19.2
   loadBehavior: tryLoad
 - name: quay.io/metal3-io/ironic-standalone-operator:v0.5.1
   loadBehavior: tryLoad
@@ -44,7 +44,7 @@ variables:
   IMAGE_URL: "http://192.168.222.1/cirros-0.6.2-x86_64-disk.img"
   ISO_IMAGE_URL: "http://192.168.222.1/minimal_linux_live-v2.iso"
   IMAGE_CHECKSUM: "c8fc807773e5354afe61636071771906"
-  CERT_MANAGER_VERSION: "v1.17.1"
+  CERT_MANAGER_VERSION: "v1.19.2"
   SSH_CHECK_PROVISIONED: "true"
   SSH_USERNAME: "root"
   SSH_PORT: "22"


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump cert-manager used in e2e tests from v1.17.1 to v1.19.2.

Fixes #2950

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.