### PR TITLE
✨ Allow forced detachment of a host from Ironic

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -699,6 +699,10 @@ const (
 type DetachedAnnotationArguments struct {
 	// DeleteAction indicates the desired delete logic when the detached annotation is present
 	DeleteAction DetachedDeleteAction `json:"deleteAction,omitempty"`
+
+	// Force indicates if detaching should be forced regardless of the host's state
+	// +optional
+	Force bool `json:"force,omitempty"`
 }
 
 // Match compares the saved status information with the name and

--- a/internal/controller/metal3.io/annotations.go
+++ b/internal/controller/metal3.io/annotations.go
@@ -1,0 +1,53 @@
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+)
+
+// hasDetachedAnnotation checks for existence of baremetalhost.metal3.io/detached.
+func hasDetachedAnnotation(host *metal3api.BareMetalHost) bool {
+	annotations := host.GetAnnotations()
+	if annotations != nil {
+		if _, ok := annotations[metal3api.DetachedAnnotation]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// getDetachedAnnotation gets JSON argument of the annotation or nil.
+func getDetachedAnnotation(host *metal3api.BareMetalHost) (*metal3api.DetachedAnnotationArguments, error) {
+	value, present := host.GetAnnotations()[metal3api.DetachedAnnotation]
+	if !present {
+		return nil, nil //nolint:nilnil
+	}
+
+	result := &metal3api.DetachedAnnotationArguments{}
+	if value != "" {
+		if err := json.Unmarshal([]byte(value), result); err != nil {
+			return nil, fmt.Errorf("unable to parse the content of the detached annotation: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
+func delayDeleteForDetachedHost(host *metal3api.BareMetalHost) bool {
+	args, err := getDetachedAnnotation(host)
+
+	// if the host is detached, but missing the annotation, also delay delete
+	// to allow for the host to be re-attached
+	if args == nil && err == nil && host.OperationalStatus() == metal3api.OperationalStatusDetached {
+		return true
+	}
+
+	if args != nil {
+		return args.DeleteAction == metal3api.DetachedDeleteActionDelay
+	}
+
+	// default behavior if these are missing or not json is to not delay
+	return false
+}

--- a/internal/controller/metal3.io/annotations_test.go
+++ b/internal/controller/metal3.io/annotations_test.go
@@ -1,0 +1,129 @@
+package controllers
+
+import (
+	"testing"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newHostWithAnnotations(annotations map[string]string) *metal3api.BareMetalHost {
+	return &metal3api.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: annotations,
+		},
+	}
+}
+
+func TestDetachedAnnotation(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		hasIt       bool
+		expectArgs  bool
+		expectForce bool
+		expectErr   bool
+	}{
+		{
+			name:        "no annotations",
+			annotations: nil,
+			hasIt:       false,
+		},
+		{
+			name:        "other annotation",
+			annotations: map[string]string{"foo": "bar"},
+			hasIt:       false,
+		},
+		{
+			name:        "valid with delay and force",
+			annotations: map[string]string{metal3api.DetachedAnnotation: `{"deleteAction":"delay","force":true}`},
+			hasIt:       true,
+			expectArgs:  true,
+			expectForce: true,
+		},
+		{
+			name:        "valid with defaults",
+			annotations: map[string]string{metal3api.DetachedAnnotation: `{}`},
+			hasIt:       true,
+			expectArgs:  true,
+		},
+		{
+			name:        "invalid JSON",
+			annotations: map[string]string{metal3api.DetachedAnnotation: "not-json"},
+			hasIt:       true,
+			expectErr:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			host := newHostWithAnnotations(tc.annotations)
+
+			assert.Equal(t, tc.hasIt, hasDetachedAnnotation(host))
+
+			args, err := getDetachedAnnotation(host)
+			if tc.expectErr {
+				require.Error(t, err)
+				assert.Nil(t, args)
+			} else {
+				require.NoError(t, err)
+				if tc.expectArgs {
+					assert.NotNil(t, args)
+					assert.Equal(t, tc.expectForce, args.Force)
+				} else {
+					assert.Nil(t, args)
+				}
+			}
+		})
+	}
+}
+
+func TestDelayDeleteForDetachedHost(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		status      metal3api.OperationalStatus
+		expectDelay bool
+	}{
+		{
+			name:        "no annotation, not detached",
+			status:      metal3api.OperationalStatusOK,
+			expectDelay: false,
+		},
+		{
+			name:        "no annotation, detached status",
+			status:      metal3api.OperationalStatusDetached,
+			expectDelay: true,
+		},
+		{
+			name:        "delay action",
+			annotations: map[string]string{metal3api.DetachedAnnotation: `{"deleteAction":"delay"}`},
+			expectDelay: true,
+		},
+		{
+			name:        "delete action",
+			annotations: map[string]string{metal3api.DetachedAnnotation: `{"deleteAction":"delete"}`},
+			expectDelay: false,
+		},
+		{
+			name:        "empty JSON defaults to no delay",
+			annotations: map[string]string{metal3api.DetachedAnnotation: `{}`},
+			expectDelay: false,
+		},
+		{
+			name:        "invalid JSON defaults to no delay",
+			annotations: map[string]string{metal3api.DetachedAnnotation: "bad"},
+			expectDelay: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			host := newHostWithAnnotations(tc.annotations)
+			host.Status.OperationalStatus = tc.status
+			assert.Equal(t, tc.expectDelay, delayDeleteForDetachedHost(host))
+		})
+	}
+}

--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -622,8 +622,8 @@ func hasCustomDeploy(host *metal3api.BareMetalHost) bool {
 }
 
 // detachHost() detaches the host from the Provisioner.
-func (r *BareMetalHostReconciler) detachHost(ctx context.Context, prov provisioner.Provisioner, info *reconcileInfo) actionResult {
-	provResult, err := prov.Detach(ctx)
+func (r *BareMetalHostReconciler) detachHost(ctx context.Context, prov provisioner.Provisioner, info *reconcileInfo, force bool) actionResult {
+	provResult, err := prov.Detach(ctx, force)
 	if err != nil {
 		return actionError{fmt.Errorf("failed to detach: %w", err)}
 	}

--- a/internal/controller/metal3.io/host_state_machine.go
+++ b/internal/controller/metal3.io/host_state_machine.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -266,17 +265,6 @@ func (hsm *hostStateMachine) checkInitiateDelete(log logr.Logger) bool {
 	return true
 }
 
-// hasDetachedAnnotation checks for existence of baremetalhost.metal3.io/detached.
-func hasDetachedAnnotation(host *metal3api.BareMetalHost) bool {
-	annotations := host.GetAnnotations()
-	if annotations != nil {
-		if _, ok := annotations[metal3api.DetachedAnnotation]; ok {
-			return true
-		}
-	}
-	return false
-}
-
 // skipReconcileSubresource checks if the applied annotations and status
 // prevent a subresource (HFS/HFC) from being reconciled.
 func skipReconcileSubresource(host *metal3api.BareMetalHost, logger logr.Logger) bool {
@@ -300,27 +288,6 @@ func skipReconcileSubresource(host *metal3api.BareMetalHost, logger logr.Logger)
 	return false
 }
 
-func delayDeleteForDetachedHost(host *metal3api.BareMetalHost) bool {
-	annotations := host.GetAnnotations()
-	args := metal3api.DetachedAnnotationArguments{}
-	val, present := annotations[metal3api.DetachedAnnotation]
-
-	// if the host is detached, but missing the annotation, also delay delete
-	// to allow for the host to be re-attached
-	if !present && host.OperationalStatus() == metal3api.OperationalStatusDetached {
-		return true
-	}
-
-	if present {
-		if err := json.Unmarshal([]byte(val), &args); err != nil {
-			// default behavior if these are missing or not json is to not delay
-			return false
-		}
-	}
-
-	return args.DeleteAction == metal3api.DetachedDeleteActionDelay
-}
-
 func (hsm *hostStateMachine) checkDetachedHost(ctx context.Context, info *reconcileInfo) (result actionResult) {
 	// If the detached annotation is set we remove any host from the
 	// provisioner and take no further action
@@ -333,7 +300,14 @@ func (hsm *hostStateMachine) checkDetachedHost(ctx context.Context, info *reconc
 		case metal3api.StateDeleting:
 			// No point in detaching a host that is being deleted already
 		default:
-			if hasForceDetachAnnotation(hsm.Host) {
+			annotation, err := getDetachedAnnotation(hsm.Host)
+			if err != nil {
+				// FIXME(dtantsur): ignoring errors is not great and can cause a lot of confusion.
+				// However, we even document (in https://book.metal3.io/bmo/detached_annotation.html)
+				// that the value can be anything, so starting failing is a breaking change.
+				info.log.Error(err, "ignoring detached annotation value")
+			}
+			if annotation != nil && annotation.Force {
 				info.log.Info("forcing detach of host", "provisioningState", info.host.Status.Provisioning.State)
 				return hsm.Reconciler.detachHost(ctx, hsm.Provisioner, info, true)
 			}
@@ -356,20 +330,6 @@ func (hsm *hostStateMachine) checkDetachedHost(ctx context.Context, info *reconc
 		return actionUpdate{}
 	}
 	return nil
-}
-
-func hasForceDetachAnnotation(host *metal3api.BareMetalHost) bool {
-	annotations := host.GetAnnotations()
-	if annotations != nil {
-		if val, ok := annotations[metal3api.DetachedAnnotation]; ok {
-			args := metal3api.DetachedAnnotationArguments{}
-			if err := json.Unmarshal([]byte(val), &args); err != nil {
-				return false
-			}
-			return args.Force
-		}
-	}
-	return false
 }
 
 func (hsm *hostStateMachine) ensureRegistered(ctx context.Context, info *reconcileInfo) (result actionResult) {

--- a/internal/controller/metal3.io/host_state_machine.go
+++ b/internal/controller/metal3.io/host_state_machine.go
@@ -226,6 +226,17 @@ func (hsm *hostStateMachine) checkInitiateDelete(log logr.Logger) bool {
 		return false
 	}
 
+	if hsm.NextState != metal3api.StateDeleting && hsm.Host.OperationalStatus() == metal3api.OperationalStatusDetached {
+		if delayDeleteForDetachedHost(hsm.Host) {
+			log.Info("delaying detached host deletion")
+			deleteDelayedForDetached.Inc()
+			return false
+		}
+		log.Info("requested deletion of a detached host, skipping power off and deprovisioning", "currentState", hsm.NextState)
+		hsm.NextState = metal3api.StateDeleting
+		return true
+	}
+
 	switch hsm.NextState {
 	default:
 		hsm.NextState = metal3api.StatePoweringOffBeforeDelete
@@ -233,29 +244,7 @@ func (hsm *hostStateMachine) checkInitiateDelete(log logr.Logger) bool {
 		// Skip the power off before delete
 		hsm.NextState = metal3api.StateDeleting
 	case metal3api.StateProvisioning, metal3api.StateProvisioned:
-		if hsm.Host.OperationalStatus() == metal3api.OperationalStatusDetached {
-			if delayDeleteForDetachedHost(hsm.Host) {
-				log.Info("Delaying detached host deletion")
-				deleteDelayedForDetached.Inc()
-				return false
-			}
-			// We cannot power off a detached host.  Skip to delete.
-			hsm.NextState = metal3api.StateDeleting
-		} else {
-			hsm.NextState = metal3api.StateDeprovisioning
-		}
-	case metal3api.StateExternallyProvisioned:
-		if hsm.Host.OperationalStatus() == metal3api.OperationalStatusDetached {
-			if delayDeleteForDetachedHost(hsm.Host) {
-				log.Info("Delaying detached host deletion")
-				deleteDelayedForDetached.Inc()
-				return false
-			}
-			// We cannot power off a detached host.  Skip to delete.
-			hsm.NextState = metal3api.StateDeleting
-		} else {
-			hsm.NextState = metal3api.StatePoweringOffBeforeDelete
-		}
+		hsm.NextState = metal3api.StateDeprovisioning
 	case metal3api.StateDeprovisioning:
 		if hsm.Host.Status.ErrorType == metal3api.RegistrationError && hsm.Host.Status.ErrorCount > 3 {
 			hsm.NextState = metal3api.StateDeleting

--- a/internal/controller/metal3.io/host_state_machine.go
+++ b/internal/controller/metal3.io/host_state_machine.go
@@ -337,11 +337,17 @@ func (hsm *hostStateMachine) checkDetachedHost(ctx context.Context, info *reconc
 	// provisioner and take no further action
 	// Note this doesn't change the current state, only the OperationalStatus
 	if hasDetachedAnnotation(hsm.Host) {
-		// Only allow detaching hosts in Provisioned/ExternallyProvisioned/Ready/Available states
+		// Only allow detaching hosts in Provisioned/ExternallyProvisioned/Ready/Available states unless forced
 		switch info.host.Status.Provisioning.State {
 		case metal3api.StateProvisioned, metal3api.StateExternallyProvisioned, metal3api.StateReady, metal3api.StateAvailable:
-			return hsm.Reconciler.detachHost(ctx, hsm.Provisioner, info)
+			return hsm.Reconciler.detachHost(ctx, hsm.Provisioner, info, false)
+		case metal3api.StateDeleting:
+			// No point in detaching a host that is being deleted already
 		default:
+			if hasForceDetachAnnotation(hsm.Host) {
+				info.log.Info("forcing detach of host", "provisioningState", info.host.Status.Provisioning.State)
+				return hsm.Reconciler.detachHost(ctx, hsm.Provisioner, info, true)
+			}
 			info.log.Info("host cannot be detached yet, waiting for the current operation to finish", "provisioningState", info.host.Status.Provisioning.State)
 		}
 	}
@@ -361,6 +367,20 @@ func (hsm *hostStateMachine) checkDetachedHost(ctx context.Context, info *reconc
 		return actionUpdate{}
 	}
 	return nil
+}
+
+func hasForceDetachAnnotation(host *metal3api.BareMetalHost) bool {
+	annotations := host.GetAnnotations()
+	if annotations != nil {
+		if val, ok := annotations[metal3api.DetachedAnnotation]; ok {
+			args := metal3api.DetachedAnnotationArguments{}
+			if err := json.Unmarshal([]byte(val), &args); err != nil {
+				return false
+			}
+			return args.Force
+		}
+	}
+	return false
 }
 
 func (hsm *hostStateMachine) ensureRegistered(ctx context.Context, info *reconcileInfo) (result actionResult) {

--- a/internal/controller/metal3.io/host_state_machine_test.go
+++ b/internal/controller/metal3.io/host_state_machine_test.go
@@ -1352,11 +1352,11 @@ func (m *mockProvisioner) Deprovision(_ context.Context, _ bool, _ metal3api.Aut
 	return m.getNextResultByMethod("Deprovision"), err
 }
 
-func (m *mockProvisioner) Delete(context.Context) (result provisioner.Result, err error) {
+func (m *mockProvisioner) Delete(_ context.Context) (result provisioner.Result, err error) {
 	return m.getNextResultByMethod("Delete"), err
 }
 
-func (m *mockProvisioner) Detach(context.Context) (result provisioner.Result, err error) {
+func (m *mockProvisioner) Detach(_ context.Context, _ bool) (result provisioner.Result, err error) {
 	res := m.getNextResultByMethod("Detach")
 	return res, err
 }

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -287,7 +287,7 @@ func (p *demoProvisioner) Delete(_ context.Context) (result provisioner.Result, 
 // for the target system.  It may be called multiple times,
 // and should return true for its dirty  flag until the
 // deletion operation is completed.
-func (p *demoProvisioner) Detach(_ context.Context) (result provisioner.Result, err error) {
+func (p *demoProvisioner) Detach(_ context.Context, _ bool) (result provisioner.Result, err error) {
 	p.log.Info("detaching host")
 	return result, nil
 }

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -351,7 +351,7 @@ func (p *fixtureProvisioner) Delete(_ context.Context) (result provisioner.Resul
 // for the target system.  It may be called multiple times,
 // and should return true for its dirty  flag until the
 // deletion operation is completed.
-func (p *fixtureProvisioner) Detach(ctx context.Context) (result provisioner.Result, err error) {
+func (p *fixtureProvisioner) Detach(ctx context.Context, _ bool) (result provisioner.Result, err error) {
 	return p.Delete(ctx)
 }
 

--- a/pkg/provisioner/ironic/clients/features.go
+++ b/pkg/provisioner/ironic/clients/features.go
@@ -46,7 +46,8 @@ func (af AvailableFeatures) Log(logger logr.Logger) {
 		"chosenVersion", af.ChooseMicroversion(),
 		"virtualMediaGET", af.HasVirtualMediaGetAPI(),
 		"disablePowerOff", af.HasDisablePowerOff(),
-		"healthAPI", af.HasHealthAPI())
+		"healthAPI", af.HasHealthAPI(),
+		"deploymentAbort", af.HasDeploymentAbort())
 }
 
 func (af AvailableFeatures) HasVirtualMediaGetAPI() bool {
@@ -61,7 +62,15 @@ func (af AvailableFeatures) HasHealthAPI() bool {
 	return af.MaxVersion >= 109 //nolint:mnd
 }
 
+func (af AvailableFeatures) HasDeploymentAbort() bool {
+	return af.MaxVersion >= 110 //nolint:mnd
+}
+
 func (af AvailableFeatures) ChooseMicroversion() string {
+	if af.HasDeploymentAbort() {
+		return "1.110"
+	}
+
 	if af.HasHealthAPI() {
 		return "1.109"
 	}

--- a/pkg/provisioner/ironic/clients/features_test.go
+++ b/pkg/provisioner/ironic/clients/features_test.go
@@ -43,11 +43,11 @@ func TestAvailableFeatures_ChooseMicroversion(t *testing.T) {
 			want: "1.109",
 		},
 		{
-			name: "MaxVersion > 109 return 1.109",
+			name: "MaxVersion > 109 return 1.110",
 			feature: fields{
 				MaxVersion: 115,
 			},
-			want: "1.109",
+			want: "1.110",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/provisioner/ironic/delete_test.go
+++ b/pkg/provisioner/ironic/delete_test.go
@@ -24,6 +24,127 @@ func TestDetach(t *testing.T) {
 	deleteTest(t, true)
 }
 
+func TestForceDetach(t *testing.T) {
+	nodeUUID := "33ce8659-7400-4c68-9535-d10766f07a58"
+
+	cases := []struct {
+		name              string
+		ironic            *testserver.IronicMock
+		maxVersion        int
+		expectedDirty     bool
+		expectedRequeue   time.Duration
+		expectedProvState nodes.TargetProvisionState
+	}{
+		{
+			name: "deploywait-abort",
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
+				UUID:           nodeUUID,
+				ProvisionState: string(nodes.DeployWait),
+			}).WithNodeStatesProvisionUpdate(nodeUUID),
+			maxVersion:        110,
+			expectedDirty:     true,
+			expectedRequeue:   provisionRequeueDelay,
+			expectedProvState: nodes.TargetAbort,
+		},
+		{
+			name: "deploywait-no-abort-api",
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
+				UUID:           nodeUUID,
+				ProvisionState: string(nodes.DeployWait),
+			}).WithNodeStatesProvisionUpdate(nodeUUID),
+			maxVersion:        95,
+			expectedDirty:     true,
+			expectedRequeue:   provisionRequeueDelay,
+			expectedProvState: nodes.TargetDeleted,
+		},
+		{
+			name: "inspectwait-abort",
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
+				UUID:           nodeUUID,
+				ProvisionState: string(nodes.InspectWait),
+			}).WithNodeStatesProvisionUpdate(nodeUUID),
+			expectedDirty:     true,
+			expectedRequeue:   provisionRequeueDelay,
+			expectedProvState: nodes.TargetAbort,
+		},
+		{
+			name: "cleanwait-abort",
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
+				UUID:           nodeUUID,
+				ProvisionState: string(nodes.CleanWait),
+			}).WithNodeStatesProvisionUpdate(nodeUUID),
+			expectedDirty:     true,
+			expectedRequeue:   provisionRequeueDelay,
+			expectedProvState: nodes.TargetAbort,
+		},
+		{
+			name: "servicewait-abort",
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
+				UUID:           nodeUUID,
+				ProvisionState: string(nodes.ServiceWait),
+			}).WithNodeStatesProvisionUpdate(nodeUUID),
+			expectedDirty:     true,
+			expectedRequeue:   provisionRequeueDelay,
+			expectedProvState: nodes.TargetAbort,
+		},
+		{
+			name: "deploying-waits",
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
+				UUID:           nodeUUID,
+				ProvisionState: string(nodes.Deploying),
+			}),
+			expectedDirty:   true,
+			expectedRequeue: provisionRequeueDelay,
+		},
+		{
+			name: "cleaning-waits",
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
+				UUID:           nodeUUID,
+				ProvisionState: string(nodes.Cleaning),
+			}),
+			expectedDirty:   true,
+			expectedRequeue: provisionRequeueDelay,
+		},
+		{
+			name: "inspecting-waits",
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
+				UUID:           nodeUUID,
+				ProvisionState: string(nodes.Inspecting),
+			}),
+			expectedDirty:   true,
+			expectedRequeue: provisionRequeueDelay,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.ironic.Start()
+			defer tc.ironic.Stop()
+
+			host := makeHost()
+			host.Status.Provisioning.ID = nodeUUID
+
+			auth := clients.AuthConfig{Type: clients.NoAuth}
+			prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher, tc.ironic.Endpoint(), auth)
+			require.NoError(t, err)
+
+			if tc.maxVersion > 0 {
+				prov.availableFeatures = clients.AvailableFeatures{MaxVersion: tc.maxVersion}
+			}
+
+			result, err := prov.Detach(t.Context(), true)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedDirty, result.Dirty)
+			assert.Equal(t, tc.expectedRequeue, result.RequeueAfter)
+
+			if tc.expectedProvState != "" {
+				update := tc.ironic.GetLastNodeStatesProvisionUpdateRequestFor(nodeUUID)
+				assert.Equal(t, tc.expectedProvState, update.Target)
+			}
+		})
+	}
+}
+
 func deleteTest(t *testing.T, detach bool) {
 	t.Helper()
 	nodeUUID := "33ce8659-7400-4c68-9535-d10766f07a58"
@@ -217,7 +338,7 @@ func deleteTest(t *testing.T, detach bool) {
 
 			var result provisioner.Result
 			if detach {
-				result, err = prov.Detach(t.Context())
+				result, err = prov.Detach(t.Context(), false)
 			} else {
 				result, err = prov.Delete(t.Context())
 			}

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1527,23 +1527,27 @@ func (p *ironicProvisioner) Delete(ctx context.Context) (result provisioner.Resu
 		"target", ironicNode.TargetProvisionState,
 		"deploy step", ironicNode.DeployStep,
 	)
+	return p.realDelete(ctx, ironicNode, false)
+}
 
+func (p *ironicProvisioner) realDelete(ctx context.Context, ironicNode *nodes.Node, force bool) (result provisioner.Result, err error) {
 	currentProvState := nodes.ProvisionState(ironicNode.ProvisionState)
 
-	// Handle verifying state specially: Ironic holds an exclusive lock during
-	// verification, so we can't set maintenance mode or delete until it completes.
-	// Just wait for the verification to finish (success or timeout).
-	if currentProvState == nodes.Verifying {
+	switch currentProvState {
+	case nodes.Verifying:
+		// Handle verifying state specially: Ironic holds an exclusive lock during
+		// verification, so we can't set maintenance mode or delete until it completes.
+		// Just wait for the verification to finish (success or timeout).
 		p.log.Info("node is verifying, waiting for verification to complete before deletion")
 		return operationContinuing(provisionRequeueDelay)
-	}
 
-	// For enroll state, the node can be deleted directly without maintenance mode
-	// since it has no Nova associations and isn't locked.
-	if currentProvState == nodes.Enroll {
+	case nodes.Enroll:
+		// For enroll state, the node can be deleted directly without maintenance mode
+		// since it has no Nova associations and isn't locked.
 		p.log.Info("node is in enroll state, proceeding to delete directly")
 		// Fall through to deletion
-	} else if currentProvState == nodes.Available || currentProvState == nodes.Manageable {
+
+	case nodes.Available, nodes.Manageable:
 		// Make sure we don't have a stale instance UUID
 		if ironicNode.InstanceUUID != "" {
 			var success bool
@@ -1555,20 +1559,51 @@ func (p *ironicProvisioner) Delete(ctx context.Context) (result provisioner.Resu
 				return result, err
 			}
 		}
-	} else if !ironicNode.Maintenance {
-		// If we see an active node and the controller doesn't think
-		// we need to deprovision it, that means the node was
-		// ExternallyProvisioned and we should remove it from Ironic
-		// without deprovisioning it.
-		//
-		// If we see a node with an error, we will have to set the
-		// maintenance flag before deleting it.
-		//
-		// Any other state requires us to use maintenance mode to
-		// delete while bypassing Ironic's internal checks related to
-		// Nova.
-		p.log.Info("setting host maintenance flag to force image delete")
-		return p.setMaintenanceFlag(ctx, ironicNode, true, "forcing deletion in baremetal-operator")
+
+	case nodes.Deploying, nodes.Cleaning, nodes.Inspecting, nodes.Servicing, nodes.Deleting:
+		p.log.Info("node is in state that does not allow deletion, waiting", "currentState", currentProvState)
+		return operationContinuing(provisionRequeueDelay)
+
+	case nodes.DeployWait:
+		if force && !p.availableFeatures.HasDeploymentAbort() {
+			p.log.Info("deprovisioning to force deletion")
+			// No new API - fall back to deprovisioning and wait for CLEANWAIT
+			return p.changeNodeProvisionState(ctx, ironicNode,
+				nodes.ProvisionStateOpts{Target: nodes.TargetDeleted},
+			)
+		}
+
+		// Otherwise, use the abort API as well
+		fallthrough
+
+	case nodes.InspectWait, nodes.CleanWait, nodes.ServiceWait:
+		if force {
+			p.log.Info("aborting the current operation to force deletion", "currentState", currentProvState)
+			return p.changeNodeProvisionState(ctx, ironicNode,
+				nodes.ProvisionStateOpts{Target: nodes.TargetAbort},
+			)
+		}
+
+		// Normal deletion won't work in these states, so wait
+		p.log.Info("node is in state that does not allow deletion, waiting", "currentState", currentProvState)
+		return operationContinuing(provisionRequeueDelay)
+
+	default:
+		if !ironicNode.Maintenance {
+			// If we see an active node and the controller doesn't think
+			// we need to deprovision it, that means the node was
+			// ExternallyProvisioned and we should remove it from Ironic
+			// without deprovisioning it.
+			//
+			// If we see a node with an error, we will have to set the
+			// maintenance flag before deleting it.
+			//
+			// Any other state requires us to use maintenance mode to
+			// delete while bypassing Ironic's internal checks related to
+			// Nova.
+			p.log.Info("setting host maintenance flag to force image delete", "currentState", currentProvState)
+			return p.setMaintenanceFlag(ctx, ironicNode, true, "forcing deletion in baremetal-operator")
+		}
 	}
 
 	p.log.Info("host ready to be removed")
@@ -1592,10 +1627,25 @@ func (p *ironicProvisioner) Delete(ctx context.Context) (result provisioner.Resu
 // for the target system.  It may be called multiple times,
 // and should return true for its dirty  flag until the
 // deletion operation is completed.
-func (p *ironicProvisioner) Detach(ctx context.Context) (result provisioner.Result, err error) {
-	// Currently the same behavior as Delete()
-	p.log.Info("removing the node for detachment", "node", p.nodeID)
-	return p.Delete(ctx)
+func (p *ironicProvisioner) Detach(ctx context.Context, force bool) (result provisioner.Result, err error) {
+	ironicNode, err := p.getNode(ctx)
+	if err != nil {
+		if errors.Is(err, provisioner.ErrNeedsRegistration) {
+			p.log.Info("no node found, already deleted")
+			return operationComplete()
+		}
+		return transientError(err)
+	}
+
+	p.log.Info("deleting host for detachment",
+		"ID", ironicNode.UUID,
+		"lastError", ironicNode.LastError,
+		"current", ironicNode.ProvisionState,
+		"target", ironicNode.TargetProvisionState,
+		"deploy step", ironicNode.DeployStep,
+		"force", force,
+	)
+	return p.realDelete(ctx, ironicNode, force)
 }
 
 // softPowerOffUnsupportedError is returned when the BMC does not

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1623,10 +1623,12 @@ func (p *ironicProvisioner) realDelete(ctx context.Context, ironicNode *nodes.No
 }
 
 // Detach removes the host from the provisioning system.
-// Similar to Delete, but ensures non-interruptive behavior
-// for the target system.  It may be called multiple times,
-// and should return true for its dirty  flag until the
-// deletion operation is completed.
+// With force set to false, it ensures non-interruptive behavior
+// for the target system. When force is set to true, provisioning
+// processes may be interrupted to speed up the removal. Otherwise,
+// the provisioner must wait for a stable state before the removal.
+// This method may be called multiple times, and should return true
+// for its dirty flag until the detachment operation is completed.
 func (p *ironicProvisioner) Detach(ctx context.Context, force bool) (result provisioner.Result, err error) {
 	ironicNode, err := p.getNode(ctx)
 	if err != nil {

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -189,10 +189,12 @@ type Provisioner interface {
 	Delete(ctx context.Context) (result Result, err error)
 
 	// Detach removes the host from the provisioning system.
-	// Similar to Delete, but ensures non-interruptive behavior
-	// for the target system.  It may be called multiple times,
-	// and should return true for its dirty  flag until the
-	// deletion operation is completed.
+	// With force set to false, it ensures non-interruptive behavior
+	// for the target system. When force is set to true, provisioning
+	// processes may be interrupted to speed up the removal. Otherwise,
+	// the provisioner must wait for a stable state before the removal.
+	// This method may be called multiple times, and should return true
+	// for its dirty flag until the detachment operation is completed.
 	Detach(ctx context.Context, force bool) (result Result, err error)
 
 	// PowerOn ensures the server is powered on independently of any image

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -193,7 +193,7 @@ type Provisioner interface {
 	// for the target system.  It may be called multiple times,
 	// and should return true for its dirty  flag until the
 	// deletion operation is completed.
-	Detach(ctx context.Context) (result Result, err error)
+	Detach(ctx context.Context, force bool) (result Result, err error)
 
 	// PowerOn ensures the server is powered on independently of any image
 	// provisioning operation.


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:
Introduces the `force` argument for detaching. If set to true, it would bypass whichever status the host is currently in, abort the action in Ironic, and force the host's detachment.

Note: there is a soft dependency on the [new feature in Ironic](https://review.opendev.org/c/openstack/ironic/+/973279) that allows the `abort` action on deploying nodes. Without it, deprovisioning will be triggered first, which won't preserve the exact host's state.

Finally, I have prepared e2e tests for this change, but they ended up being timing-dependent. To fix this dependency, I need direct access to Ironic Node record, which is going to greatly increase the already large size of this change. The tests will be proposed separately.

Fixes #2923 

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
