### PR TITLE
🐛 Do not log firmware components on each BMH reconciliation

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -1992,8 +1992,14 @@ func (r *BareMetalHostReconciler) saveHostFirmwareComponents(prov provisioner.Pr
 		info.log.Error(err, "failed to get new information for firmware components in ironic")
 		return dirty, err
 	}
-	hfc.Status.Components = components
 	dirty = true
+
+	if !reflect.DeepEqual(hfc.Status.Components, components) {
+		hfc.Status.Components = components
+		for _, fwc := range components {
+			r.Log.Info("firmware component added for host", "component", fwc.Component)
+		}
+	}
 
 	return dirty, nil
 }

--- a/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
+++ b/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
@@ -221,6 +221,9 @@ func (r *HostFirmwareComponentsReconciler) updateHostFirmware(info *rhfcInfo, co
 	}
 
 	if componentInfoMismatch {
+		for _, fwc := range components {
+			r.Log.Info("firmware component added for host", "component", fwc.Component)
+		}
 		dirty = true
 	}
 

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -803,7 +803,7 @@ func (p *ironicProvisioner) GetFirmwareComponents() ([]metal3api.FirmwareCompone
 			}
 		}
 		componentsInfo = append(componentsInfo, component)
-		p.log.Info("firmware component added for node", "component", fwc.Component, "node", ironicNode.UUID)
+		p.log.V(1).Info("firmware component found for node", "component", fwc.Component, "node", ironicNode.UUID)
 	}
 
 	return componentsInfo, componentListErr


### PR DESCRIPTION
GetFirmwareComponents is called each time, which creates a lot of
logging. Only log the components when the list changes.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
