### PR TITLE
:sparkles:  Add multi-architecture PXE boot support

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -1021,7 +1021,8 @@ func (r *BareMetalHostReconciler) actionInspecting(ctx context.Context, prov pro
 	provResult, started, details, err := prov.InspectHardware(
 		ctx,
 		provisioner.InspectData{
-			BootMode: info.host.Status.Provisioning.BootMode,
+			BootMode:        info.host.Status.Provisioning.BootMode,
+			CPUArchitecture: getHostArchitecture(info.host),
 		},
 		info.host.Status.ErrorType == metal3api.InspectionError,
 		refresh,

--- a/pkg/imageprovider/default.go
+++ b/pkg/imageprovider/default.go
@@ -3,6 +3,7 @@ package imageprovider
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-logr/logr"
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
@@ -18,6 +19,50 @@ func NewDefaultImageProvider() ImageProvider {
 		isoURL:    os.Getenv("DEPLOY_ISO_URL"),
 		initrdURL: os.Getenv("DEPLOY_RAMDISK_URL"),
 	}
+}
+
+// lookupByArch parses a BY_ARCH variable value (comma-separated arch:url pairs,
+// e.g. "x86_64:http://example.com/kernel,aarch64:http://example.com/kernel-arm")
+// and returns the URL for the given architecture, or empty string if not found.
+func lookupByArch(byArchValue, arch string) string {
+	if byArchValue == "" || arch == "" {
+		return ""
+	}
+	for _, entry := range strings.Split(byArchValue, ",") {
+		entryArch, entryURL, found := strings.Cut(entry, ":")
+		if found && strings.EqualFold(entryArch, arch) {
+			return entryURL
+		}
+	}
+	return ""
+}
+
+// envWithArchFallback returns the URL for the given architecture by checking
+// multiple environment variable formats in order of priority, matching the
+// conventions used by ironic-image:
+//
+//  1. Per-arch variable: DEPLOY_KERNEL_URL_AARCH64
+//  2. BY_ARCH variable:  DEPLOY_KERNEL_BY_ARCH=aarch64:http://...
+//  3. Base variable:     DEPLOY_KERNEL_URL
+//
+// The BY_ARCH variable name is derived by replacing the _URL suffix with
+// _BY_ARCH (e.g. DEPLOY_KERNEL_URL -> DEPLOY_KERNEL_BY_ARCH).
+func envWithArchFallback(base, arch string) string {
+	if arch != "" {
+		// 1. Per-arch variable (e.g. DEPLOY_KERNEL_URL_AARCH64)
+		if v := os.Getenv(base + "_" + strings.ToUpper(arch)); v != "" {
+			return v
+		}
+
+		// 2. BY_ARCH variable (e.g. DEPLOY_KERNEL_BY_ARCH)
+		byArchVar := strings.TrimSuffix(base, "_URL") + "_BY_ARCH"
+		if v := lookupByArch(os.Getenv(byArchVar), arch); v != "" {
+			return v
+		}
+	}
+
+	// 3. Base variable (e.g. DEPLOY_KERNEL_URL)
+	return os.Getenv(base)
 }
 
 func (eip envImageProvider) SupportsArchitecture(_ string) bool {
@@ -43,9 +88,10 @@ func (eip envImageProvider) SupportsFormat(format metal3api.ImageFormat) bool {
 func (eip envImageProvider) BuildImage(data ImageData, _ NetworkData, _ logr.Logger) (image GeneratedImage, err error) {
 	switch data.Format {
 	case metal3api.ImageFormatISO:
-		image.ImageURL = eip.isoURL
+		image.ImageURL = envWithArchFallback("DEPLOY_ISO_URL", data.Architecture)
 	case metal3api.ImageFormatInitRD:
-		image.ImageURL = eip.initrdURL
+		image.KernelURL = envWithArchFallback("DEPLOY_KERNEL_URL", data.Architecture)
+		image.ImageURL = envWithArchFallback("DEPLOY_RAMDISK_URL", data.Architecture)
 	default:
 		err = BuildInvalidError(fmt.Errorf("unsupported image format \"%s\"", data.Format))
 	}

--- a/pkg/imageprovider/default_test.go
+++ b/pkg/imageprovider/default_test.go
@@ -1,0 +1,270 @@
+package imageprovider
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+)
+
+func TestBuildImageInitRDArchSpecific(t *testing.T) {
+	testCases := []struct {
+		Scenario          string
+		Arch              string
+		EnvVars           map[string]string
+		ExpectedKernelURL string
+		ExpectedImageURL  string
+	}{
+		{
+			Scenario: "default arch uses default env vars",
+			Arch:     "x86_64",
+			EnvVars: map[string]string{
+				"DEPLOY_KERNEL_URL":  "http://example.com/kernel",
+				"DEPLOY_RAMDISK_URL": "http://example.com/ramdisk",
+			},
+			ExpectedKernelURL: "http://example.com/kernel",
+			ExpectedImageURL:  "http://example.com/ramdisk",
+		},
+		{
+			Scenario: "aarch64 with arch-specific env vars",
+			Arch:     "aarch64",
+			EnvVars: map[string]string{
+				"DEPLOY_KERNEL_URL":          "http://example.com/kernel",
+				"DEPLOY_RAMDISK_URL":         "http://example.com/ramdisk",
+				"DEPLOY_KERNEL_URL_AARCH64":  "http://example.com/kernel-aarch64",
+				"DEPLOY_RAMDISK_URL_AARCH64": "http://example.com/ramdisk-aarch64",
+			},
+			ExpectedKernelURL: "http://example.com/kernel-aarch64",
+			ExpectedImageURL:  "http://example.com/ramdisk-aarch64",
+		},
+		{
+			Scenario: "aarch64 falls back to default when no arch-specific env vars",
+			Arch:     "aarch64",
+			EnvVars: map[string]string{
+				"DEPLOY_KERNEL_URL":  "http://example.com/kernel",
+				"DEPLOY_RAMDISK_URL": "http://example.com/ramdisk",
+			},
+			ExpectedKernelURL: "http://example.com/kernel",
+			ExpectedImageURL:  "http://example.com/ramdisk",
+		},
+		{
+			Scenario: "empty arch uses default env vars",
+			Arch:     "",
+			EnvVars: map[string]string{
+				"DEPLOY_KERNEL_URL":  "http://example.com/kernel",
+				"DEPLOY_RAMDISK_URL": "http://example.com/ramdisk",
+			},
+			ExpectedKernelURL: "http://example.com/kernel",
+			ExpectedImageURL:  "http://example.com/ramdisk",
+		},
+		{
+			Scenario: "only kernel is arch-specific",
+			Arch:     "aarch64",
+			EnvVars: map[string]string{
+				"DEPLOY_KERNEL_URL":         "http://example.com/kernel",
+				"DEPLOY_RAMDISK_URL":        "http://example.com/ramdisk",
+				"DEPLOY_KERNEL_URL_AARCH64": "http://example.com/kernel-aarch64",
+			},
+			ExpectedKernelURL: "http://example.com/kernel-aarch64",
+			ExpectedImageURL:  "http://example.com/ramdisk",
+		},
+		{
+			Scenario: "aarch64 via BY_ARCH variables",
+			Arch:     "aarch64",
+			EnvVars: map[string]string{
+				"DEPLOY_KERNEL_URL":      "http://example.com/kernel",
+				"DEPLOY_RAMDISK_URL":     "http://example.com/ramdisk",
+				"DEPLOY_KERNEL_BY_ARCH":  "x86_64:http://example.com/kernel-x86,aarch64:http://example.com/kernel-aarch64",
+				"DEPLOY_RAMDISK_BY_ARCH": "x86_64:http://example.com/ramdisk-x86,aarch64:http://example.com/ramdisk-aarch64",
+			},
+			ExpectedKernelURL: "http://example.com/kernel-aarch64",
+			ExpectedImageURL:  "http://example.com/ramdisk-aarch64",
+		},
+		{
+			Scenario: "per-arch variable takes priority over BY_ARCH",
+			Arch:     "aarch64",
+			EnvVars: map[string]string{
+				"DEPLOY_KERNEL_URL":          "http://example.com/kernel",
+				"DEPLOY_RAMDISK_URL":         "http://example.com/ramdisk",
+				"DEPLOY_KERNEL_URL_AARCH64":  "http://example.com/kernel-per-arch",
+				"DEPLOY_KERNEL_BY_ARCH":      "aarch64:http://example.com/kernel-by-arch",
+				"DEPLOY_RAMDISK_URL_AARCH64": "http://example.com/ramdisk-per-arch",
+				"DEPLOY_RAMDISK_BY_ARCH":     "aarch64:http://example.com/ramdisk-by-arch",
+			},
+			ExpectedKernelURL: "http://example.com/kernel-per-arch",
+			ExpectedImageURL:  "http://example.com/ramdisk-per-arch",
+		},
+		{
+			Scenario: "BY_ARCH falls back to base when arch not listed",
+			Arch:     "ppc64le",
+			EnvVars: map[string]string{
+				"DEPLOY_KERNEL_URL":     "http://example.com/kernel",
+				"DEPLOY_RAMDISK_URL":    "http://example.com/ramdisk",
+				"DEPLOY_KERNEL_BY_ARCH": "x86_64:http://example.com/kernel-x86,aarch64:http://example.com/kernel-aarch64",
+			},
+			ExpectedKernelURL: "http://example.com/kernel",
+			ExpectedImageURL:  "http://example.com/ramdisk",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			for k, v := range tc.EnvVars {
+				t.Setenv(k, v)
+			}
+
+			provider := envImageProvider{
+				initrdURL: tc.EnvVars["DEPLOY_RAMDISK_URL"],
+			}
+
+			image, err := provider.BuildImage(
+				ImageData{
+					Format:       metal3api.ImageFormatInitRD,
+					Architecture: tc.Arch,
+				},
+				nil,
+				logr.Discard(),
+			)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if image.KernelURL != tc.ExpectedKernelURL {
+				t.Errorf("expected KernelURL %q, got %q", tc.ExpectedKernelURL, image.KernelURL)
+			}
+			if image.ImageURL != tc.ExpectedImageURL {
+				t.Errorf("expected ImageURL %q, got %q", tc.ExpectedImageURL, image.ImageURL)
+			}
+		})
+	}
+}
+
+func TestLookupByArch(t *testing.T) {
+	testCases := []struct {
+		Scenario string
+		Value    string
+		Arch     string
+		Expected string
+	}{
+		{
+			Scenario: "match first entry",
+			Value:    "x86_64:http://example.com/kernel-x86,aarch64:http://example.com/kernel-arm",
+			Arch:     "x86_64",
+			Expected: "http://example.com/kernel-x86",
+		},
+		{
+			Scenario: "match second entry",
+			Value:    "x86_64:http://example.com/kernel-x86,aarch64:http://example.com/kernel-arm",
+			Arch:     "aarch64",
+			Expected: "http://example.com/kernel-arm",
+		},
+		{
+			Scenario: "no match",
+			Value:    "x86_64:http://example.com/kernel-x86,aarch64:http://example.com/kernel-arm",
+			Arch:     "ppc64le",
+			Expected: "",
+		},
+		{
+			Scenario: "empty value",
+			Value:    "",
+			Arch:     "x86_64",
+			Expected: "",
+		},
+		{
+			Scenario: "empty arch",
+			Value:    "x86_64:http://example.com/kernel-x86",
+			Arch:     "",
+			Expected: "",
+		},
+		{
+			Scenario: "single entry",
+			Value:    "aarch64:http://example.com/kernel-arm",
+			Arch:     "aarch64",
+			Expected: "http://example.com/kernel-arm",
+		},
+		{
+			Scenario: "file URL with triple slash",
+			Value:    "x86_64:file:///shared/html/images/ipa_x86.kernel,aarch64:file:///shared/html/images/ipa_arm64.kernel",
+			Arch:     "aarch64",
+			Expected: "file:///shared/html/images/ipa_arm64.kernel",
+		},
+		{
+			Scenario: "case-insensitive arch match",
+			Value:    "AARCH64:http://example.com/kernel-arm",
+			Arch:     "aarch64",
+			Expected: "http://example.com/kernel-arm",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			result := lookupByArch(tc.Value, tc.Arch)
+			if result != tc.Expected {
+				t.Errorf("expected %q, got %q", tc.Expected, result)
+			}
+		})
+	}
+}
+
+func TestBuildImageISOArchSpecific(t *testing.T) {
+	testCases := []struct {
+		Scenario         string
+		Arch             string
+		EnvVars          map[string]string
+		ExpectedImageURL string
+	}{
+		{
+			Scenario: "default arch uses default ISO URL",
+			Arch:     "x86_64",
+			EnvVars: map[string]string{
+				"DEPLOY_ISO_URL": "http://example.com/image.iso",
+			},
+			ExpectedImageURL: "http://example.com/image.iso",
+		},
+		{
+			Scenario: "aarch64 with arch-specific ISO URL",
+			Arch:     "aarch64",
+			EnvVars: map[string]string{
+				"DEPLOY_ISO_URL":         "http://example.com/image.iso",
+				"DEPLOY_ISO_URL_AARCH64": "http://example.com/image-aarch64.iso",
+			},
+			ExpectedImageURL: "http://example.com/image-aarch64.iso",
+		},
+		{
+			Scenario: "aarch64 falls back to default ISO URL",
+			Arch:     "aarch64",
+			EnvVars: map[string]string{
+				"DEPLOY_ISO_URL": "http://example.com/image.iso",
+			},
+			ExpectedImageURL: "http://example.com/image.iso",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			for k, v := range tc.EnvVars {
+				t.Setenv(k, v)
+			}
+
+			provider := envImageProvider{
+				isoURL: tc.EnvVars["DEPLOY_ISO_URL"],
+			}
+
+			image, err := provider.BuildImage(
+				ImageData{
+					Format:       metal3api.ImageFormatISO,
+					Architecture: tc.Arch,
+				},
+				nil,
+				logr.Discard(),
+			)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if image.ImageURL != tc.ExpectedImageURL {
+				t.Errorf("expected ImageURL %q, got %q", tc.ExpectedImageURL, image.ImageURL)
+			}
+		})
+	}
+}

--- a/pkg/provisioner/ironic/inspecthardware.go
+++ b/pkg/provisioner/ironic/inspecthardware.go
@@ -26,13 +26,17 @@ func (p *ironicProvisioner) abortInspection(ctx context.Context, ironicNode *nod
 }
 
 func (p *ironicProvisioner) startInspection(ctx context.Context, data provisioner.InspectData, ironicNode *nodes.Node) (result provisioner.Result, started bool, err error) {
+	opts := clients.UpdateOptsData{
+		"capabilities": buildCapabilitiesValue(ironicNode, data.BootMode),
+	}
+	if data.CPUArchitecture != "" {
+		opts["cpu_arch"] = data.CPUArchitecture
+	}
 	_, started, result, err = p.tryUpdateNode(
 		ctx,
 		ironicNode,
 		clients.UpdateOptsBuilder(p.log).
-			SetPropertiesOpts(clients.UpdateOptsData{
-				"capabilities": buildCapabilitiesValue(ironicNode, data.BootMode),
-			}, ironicNode),
+			SetPropertiesOpts(opts, ironicNode),
 	)
 	if !started {
 		return

--- a/pkg/provisioner/ironic/register.go
+++ b/pkg/provisioner/ironic/register.go
@@ -154,6 +154,15 @@ func (p *ironicProvisioner) Register(ctx context.Context, data provisioner.Manag
 		// The updater only updates disable_power_off if it has changed
 		updater.SetTopLevelOpt("disable_power_off", data.DisablePowerOff, ironicNode.DisablePowerOff)
 
+		// Update cpu_arch in Properties if specified.
+		// This is important for multi-arch deployments to ensure the correct
+		// architecture-specific IPA kernel/ramdisk is used via deploy_kernel_by_arch.
+		if data.CPUArchitecture != "" {
+			updater.SetPropertiesOpts(clients.UpdateOptsData{
+				"cpu_arch": data.CPUArchitecture,
+			}, ironicNode)
+		}
+
 		// We don't return here because we also have to set the
 		// target provision state to manageable, which happens
 		// below.

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -91,7 +91,8 @@ type AdoptData struct {
 }
 
 type InspectData struct {
-	BootMode metal3api.BootMode
+	BootMode        metal3api.BootMode
+	CPUArchitecture string
 }
 
 // FirmwareConfig and FirmwareSettings are used for implementation of similar functionality


### PR DESCRIPTION
Enable aarch64 workers to be provisioned from an x86_64 control plane.

Architecture-aware default image provider:

The built-in PreprovisioningImage provider (pkg/imageprovider/default.go)
now selects architecture-specific IPA images. It supports multiple
environment variable formats, following the ironic-image conventions:

  1. Per-arch variable (e.g. `DEPLOY_KERNEL_URL_AARCH64`)
  2. BY_ARCH variable  (e.g. `DEPLOY_KERNEL_BY_ARCH=aarch64:http://...`)
  3. Base variable     (e.g. `DEPLOY_KERNEL_URL`)

Per-arch variable names use uppercase architecture suffixes to match the
ironic-image convention (e.g. `DEPLOY_KERNEL_URL_X86_64`,
`DEPLOY_RAMDISK_URL_AARCH64`). The BY_ARCH format uses comma-separated
`arch:url` pairs, allowing a single variable that both ironic-image and
BMO can consume. Architecture matching in the BY_ARCH value is
case-insensitive. The `BY_ARCH` variable name is derived by replacing
the `_URL` suffix with `_BY_ARCH` (e.g. `DEPLOY_KERNEL_URL ->
DEPLOY_KERNEL_BY_ARCH`).

For InitRD format, the provider now returns both KernelURL and ImageURL,
so the PreprovisioningImage status carries the correct
architecture-specific URLs.

Setting cpu_arch on Ironic nodes:

The cpu_arch property is set on Ironic nodes during both registration and
inspection, based on the host's architecture (from Spec.Architecture,
HardwareDetails, or the controller's own architecture as fallback).
This allows Ironic to select architecture-specific IPA images via its
deploy_kernel_by_arch and deploy_ramdisk_by_arch conductor configuration
when PreprovisioningImage is not in use.

By handling architecture-specific image selection in the image provider
layer rather than the ironic provisioner, we avoid mixed per-node and
by_arch configurations that Ironic considers invalid. Both kernel and
ramdisk URLs are set per-node from the PreprovisioningImage, so there is
no conflict with Ironic's conductor-level by_arch settings.

Depends on https://github.com/metal3-io/ironic-image/pull/898