### PR TITLE
🌱 Avoid meaningless logging when a secret is owned by another controller

### DIFF
--- a/pkg/secretutils/secret_manager.go
+++ b/pkg/secretutils/secret_manager.go
@@ -83,11 +83,13 @@ func (sm *SecretManager) claimSecret(secret *corev1.Secret, owner client.Object,
 		for _, ref := range secret.GetOwnerReferences() {
 			// We used to add controller references to BMC
 			// secrets. This was wrong, update.
-			if ref.UID == ownerUID && ref.Controller == nil {
-				alreadyOwned = true
+			if ref.UID == ownerUID {
+				if ref.Controller == nil {
+					alreadyOwned = true
+				} else if *ref.Controller {
+					ownerLog.Info("updating secret to no longer have an owner of type controller")
+				}
 				break
-			} else if ref.Controller != nil && *ref.Controller {
-				ownerLog.Info("updating secret to no longer have an owner of type controller")
 			}
 		}
 		if !alreadyOwned {


### PR DESCRIPTION
Currently, BMO logs that it's going to update the secret, even though
it's not the case when the owner is not BMH.

Add missing unit tests.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
