### PR TITLE
:seedling: enforce ol-prefix 'one' style for ordered lists

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -4,6 +4,8 @@ config:
   ul-indent:
     # Kramdown wanted us to have 3 earlier, tho this CLI recommends 2 or 4
     indent: 3
+  ol-prefix:
+    style: "one"
   line-length:
     tables: false
     code_blocks: false

--- a/docs/api.md
+++ b/docs/api.md
@@ -17,9 +17,9 @@ Several conditions must be met in order to initiate provisioning.
 1. The host `spec.image.url` field must contain a URL for a valid
    image file that is visible from within the cluster and from the
    host receiving the image.
-2. The host must have `online` set to `true` so that the operator will
+1. The host must have `online` set to `true` so that the operator will
    keep the host powered on.
-3. The host must have all of the BMC details.
+1. The host must have all of the BMC details.
 
 To initiate deprovisioning, clear the image URL from the host spec.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,8 +57,8 @@ It is possible to deploy ```baremetal-operator``` with three different operator
 configurations, namely:
 
 1. operator with ironic
-2. operator without ironic
-3. ironic without operator
+1. operator without ironic
+1. ironic without operator
 
 A detailed overview of the configuration is presented in [Bare Metal Operator
 and Ironic Configuration](https://book.metal3.io/bmo/install_baremetal_operator)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,7 +41,7 @@ of ``podman``. This you can edit to ``docker`` as well.
     export CONTAINER_RUNTIME=docker
     ```
 
-2. From the operator parent dir, you can invoke the hack scripts
+1. From the operator parent dir, you can invoke the hack scripts
 
     ```bash
     ./hack/golint.sh
@@ -55,7 +55,7 @@ of ``podman``. This you can edit to ``docker`` as well.
     sh: 0: Can't open /go/src/github.com/metal3-io/baremetal-operator/hack/golint.sh
     ```
 
-3. Upon successful execution, you should see the following output. I already
+1. Upon successful execution, you should see the following output. I already
     had all the images available from a previous run, you might see the images
     getting downloaded if you're running for the very first time.
 


### PR DESCRIPTION
We have it in metal3-io wide use except couple lists in BMO, and some old design docs, so enforcing it in config in all repos for consistency.