### PR TITLE
✨ Add annotation to override Ironic vendor property

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -64,6 +64,11 @@ const (
 	// is disabled.
 	HardwareDetailsAnnotation = InspectAnnotationPrefix + "/hardwaredetails"
 
+	// VendorAnnotation is the annotation that allows users to override the
+	// vendor property on the provisioner's host representation (e.g., Ironic
+	// node properties).
+	VendorAnnotation = "ironic.provisioners.metal3.io/vendor"
+
 	// InspectAnnotationValueDisabled is a constant string="disabled"
 	// This is particularly useful to check if inspect annotation is disabled
 	// inspect.metal3.io=disabled.

--- a/docs/api.md
+++ b/docs/api.md
@@ -115,3 +115,26 @@ See [PreprovisioningImage
 CR](https://doc.crds.dev/github.com/metal3-io/baremetal-operator/metal3.io/PreprovisioningImage/v1alpha1)
 or check the source code at `apis/metal3.io/v1alpha1/preprovisioningimage_types.go`
 for a detailed API description.
+
+## Vendor Annotation
+
+The **BareMetalHost** resource supports overriding the vendor property on the
+Ironic node via the `ironic.provisioners.metal3.io/vendor` annotation. This
+is useful when the vendor detected by Ironic does not match the expected value.
+
+### Example Usage
+
+```yaml
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: gpu-server-01
+  annotations:
+    ironic.provisioners.metal3.io/vendor: "ami"
+spec:
+  online: true
+  bootMACAddress: "00:11:22:33:44:55"
+  bmc:
+    address: redfish-virtualmedia://192.168.1.100/redfish/v1/Systems/1
+    credentialsName: bmc-secret
+```

--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -881,6 +881,7 @@ func (r *BareMetalHostReconciler) registerHost(ctx context.Context, prov provisi
 			HasCustomDeploy:            hasCustomDeploy(info.host),
 			DisablePowerOff:            info.host.Spec.DisablePowerOff,
 			CPUArchitecture:            getHostArchitecture(info.host),
+			Vendor:                     info.host.GetAnnotations()[metal3api.VendorAnnotation],
 		},
 		credsChanged,
 		info.host.Status.ErrorType == metal3api.RegistrationError)

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -336,6 +336,9 @@ func (p *ironicProvisioner) configureNode(ctx context.Context, data provisioner.
 	if data.CPUArchitecture != "" {
 		opts["cpu_arch"] = data.CPUArchitecture
 	}
+	if data.Vendor != "" {
+		opts["vendor"] = data.Vendor
+	}
 	updater.SetPropertiesOpts(opts, ironicNode)
 
 	_, success, result, err := p.tryUpdateNode(ctx, ironicNode, updater)

--- a/pkg/provisioner/ironic/register.go
+++ b/pkg/provisioner/ironic/register.go
@@ -241,6 +241,14 @@ func (p *ironicProvisioner) Register(ctx context.Context, data provisioner.Manag
 }
 
 func (p *ironicProvisioner) enrollNode(ctx context.Context, data provisioner.ManagementAccessData, bmcAccess bmc.AccessDetails, driverInfo map[string]any) (ironicNode *nodes.Node, retry bool, err error) {
+	properties := map[string]any{
+		"capabilities": buildCapabilitiesValue(nil, data.BootMode),
+		"cpu_arch":     data.CPUArchitecture,
+	}
+	if data.Vendor != "" {
+		properties["vendor"] = data.Vendor
+	}
+
 	nodeCreateOpts := nodes.CreateOpts{
 		Driver:              bmcAccess.Driver(),
 		BIOSInterface:       bmcAccess.BIOSInterface(),
@@ -255,10 +263,7 @@ func (p *ironicProvisioner) enrollNode(ctx context.Context, data provisioner.Man
 		RAIDInterface:       bmcAccess.RAIDInterface(),
 		VendorInterface:     bmcAccess.VendorInterface(),
 		DisablePowerOff:     &data.DisablePowerOff,
-		Properties: map[string]any{
-			"capabilities": buildCapabilitiesValue(nil, data.BootMode),
-			"cpu_arch":     data.CPUArchitecture,
-		},
+		Properties:          properties,
 	}
 
 	ironicNode, err = nodes.Create(ctx, p.client, nodeCreateOpts).Extract()

--- a/pkg/provisioner/ironic/register_test.go
+++ b/pkg/provisioner/ironic/register_test.go
@@ -1466,3 +1466,133 @@ func TestRegisterDeprovisioningCleaningDisabledNoPreprovisioningImage(t *testing
 	require.NoError(t, err)
 	assert.Empty(t, result.ErrorMessage)
 }
+
+func TestRegisterCreateNodeWithVendorAnnotation(t *testing.T) {
+	// Test that the vendor annotation is applied when creating a new node
+	host := makeHost()
+	host.Spec.BootMACAddress = ""
+	host.Spec.Image = nil
+	host.Status.Provisioning.ID = "" // so we don't lookup by uuid
+
+	var createdNode *nodes.Node
+
+	createCallback := func(node nodes.Node) {
+		createdNode = &node
+	}
+
+	ironic := testserver.NewIronic(t).WithDrivers().CreateNodes(createCallback).NoNode(host.Namespace + nameSeparator + host.Name).NoNode(host.Name)
+	ironic.AddDefaultResponse("/v1/nodes/node-0", "PATCH", http.StatusOK, "{}")
+	ironic.Start()
+	defer ironic.Stop()
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher, ironic.Endpoint(), auth)
+	if err != nil {
+		t.Fatalf("could not create provisioner: %s", err)
+	}
+
+	result, provID, err := prov.Register(t.Context(), provisioner.ManagementAccessData{
+		Vendor: "ami",
+	}, false, false)
+	if err != nil {
+		t.Fatalf("error from Register: %s", err)
+	}
+	assert.Empty(t, result.ErrorMessage)
+	assert.NotEmpty(t, createdNode.UUID)
+	assert.Equal(t, createdNode.UUID, provID)
+
+	// Verify that the vendor property was set
+	assert.Equal(t, "ami", createdNode.Properties["vendor"])
+}
+
+func TestRegisterCreateNodeWithoutVendorAnnotation(t *testing.T) {
+	// Test that no vendor property is set when annotation is not provided
+	host := makeHost()
+	host.Spec.BootMACAddress = ""
+	host.Spec.Image = nil
+	host.Status.Provisioning.ID = "" // so we don't lookup by uuid
+
+	var createdNode *nodes.Node
+
+	createCallback := func(node nodes.Node) {
+		createdNode = &node
+	}
+
+	ironic := testserver.NewIronic(t).WithDrivers().CreateNodes(createCallback).NoNode(host.Namespace + nameSeparator + host.Name).NoNode(host.Name)
+	ironic.AddDefaultResponse("/v1/nodes/node-0", "PATCH", http.StatusOK, "{}")
+	ironic.Start()
+	defer ironic.Stop()
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher, ironic.Endpoint(), auth)
+	if err != nil {
+		t.Fatalf("could not create provisioner: %s", err)
+	}
+
+	result, provID, err := prov.Register(t.Context(), provisioner.ManagementAccessData{}, false, false)
+	if err != nil {
+		t.Fatalf("error from Register: %s", err)
+	}
+	assert.Empty(t, result.ErrorMessage)
+	assert.NotEmpty(t, createdNode.UUID)
+	assert.Equal(t, createdNode.UUID, provID)
+
+	// Verify that the vendor property was NOT set
+	_, exists := createdNode.Properties["vendor"]
+	assert.False(t, exists, "vendor property should not be set when annotation is absent")
+}
+
+func TestRegisterExistingNodeWithVendorAnnotation(t *testing.T) {
+	// Test that the vendor annotation is applied when updating an existing node
+	host := makeHost()
+	host.Spec.BootMACAddress = ""
+	host.Status.Provisioning.ID = "uuid"
+
+	ironic := testserver.NewIronic(t).
+		Node(nodes.Node{
+			Name:           host.Namespace + nameSeparator + host.Name,
+			UUID:           "uuid",
+			ProvisionState: string(nodes.Manageable),
+			DriverInfo: map[string]any{
+				"deploy_kernel":  "http://deploy.test/ipa.kernel",
+				"deploy_ramdisk": "http://deploy.test/ipa.initramfs",
+				"test_address":   "test.bmc",
+				"test_username":  "",
+				"test_password":  "******",
+				"test_port":      "42",
+			},
+			Properties: map[string]any{"capabilities": ""},
+		}).NodeUpdate(nodes.Node{
+		UUID: "uuid",
+	})
+	ironic.Start()
+	defer ironic.Stop()
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher, ironic.Endpoint(), auth)
+	if err != nil {
+		t.Fatalf("could not create provisioner: %s", err)
+	}
+
+	result, _, err := prov.Register(t.Context(), provisioner.ManagementAccessData{
+		Vendor: "ami",
+	}, false, false)
+	if err != nil {
+		t.Fatalf("error from Register: %s", err)
+	}
+	assert.Empty(t, result.ErrorMessage)
+
+	// Verify that the vendor property was included in the update
+	updates := ironic.GetLastNodeUpdateRequestFor("uuid")
+	require.NotEmpty(t, updates, "expected node updates")
+
+	// Check that vendor was added to properties
+	foundVendorUpdate := false
+	for _, update := range updates {
+		if update.Path == "/properties/vendor" && update.Value == "ami" {
+			foundVendorUpdate = true
+			break
+		}
+	}
+	assert.True(t, foundVendorUpdate, "vendor property should be in /properties/vendor update; got updates: %+v", updates)
+}

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -84,6 +84,7 @@ type ManagementAccessData struct {
 	HasCustomDeploy            bool
 	DisablePowerOff            bool
 	CPUArchitecture            string
+	Vendor                     string
 }
 
 type AdoptData struct {


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

~~This PR adds a new `hostProvisionerProperties` to the `BareMetalHost` CRD as well as the implementation for the Ironic provisioner.~~

~~As discussed during the community meeting, list of possible keys is managed by the provisioner itself to avoid leaking Ironic specific concepts.~~

~~Ironic currently supports setting the following properties:~~
~~- `vendor`~~

Since I'm not an Ironic expert, I'll gladly take feedback on any sane default for the properties allow list.

⚠️ This PR now uses an annotation `ironic.provisioners.metal3.io/vendor` to set the vendor rather for adding an arbitrary metadata map to the BMH specs.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #2978 

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] E2E tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
