### PR TITLE
:bug: Enable BMO to abort servicing to back out of failures

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -1462,6 +1462,8 @@ func (r *BareMetalHostReconciler) doServiceIfNeeded(ctx context.Context, prov pr
 			servicingData.FirmwareConfig = info.host.Spec.Firmware
 			fwDirty = true
 		}
+		servicingData.HasFirmwareSpec = fwDirty && info.host.Spec.Firmware != nil
+
 		// handling HFS based FirmwareSettings here
 		var hfs *metal3api.HostFirmwareSettings
 		var err error
@@ -1473,6 +1475,8 @@ func (r *BareMetalHostReconciler) doServiceIfNeeded(ctx context.Context, prov pr
 			servicingData.ActualFirmwareSettings = hfs.Status.Settings
 			servicingData.TargetFirmwareSettings = hfs.Spec.Settings
 		}
+
+		servicingData.HasFirmwareSpec = servicingData.HasFirmwareSpec || (hfs != nil && len(hfs.Spec.Settings) > 0)
 	}
 
 	if liveFirmwareUpdatesAllowed {
@@ -1489,6 +1493,8 @@ func (r *BareMetalHostReconciler) doServiceIfNeeded(ctx context.Context, prov pr
 				servicingData.TargetFirmwareComponents = hfc.Spec.Updates
 			}
 		}
+
+		servicingData.HasFirmwareSpec = servicingData.HasFirmwareSpec || (hfc != nil && len(hfc.Spec.Updates) > 0)
 	}
 
 	hasChanges := fwDirty || hfsDirty || hfcDirty
@@ -2138,7 +2144,8 @@ func hostObjectHasChanges(conditions []metav1.Condition, changedCondition, valid
 	return false, true, nil
 }
 
-// Get the stored firmware settings if there are valid changes.
+// Get the stored firmware settings. Returns dirty=true if there are valid pending changes.
+// The hfs object is returned when available regardless of validity, so callers can inspect spec contents.
 func (r *BareMetalHostReconciler) getHostFirmwareSettings(ctx context.Context, info *reconcileInfo) (dirty bool, hfs *metal3api.HostFirmwareSettings, err error) {
 	hfs = &metal3api.HostFirmwareSettings{}
 	if err = r.Get(ctx, info.request.NamespacedName, hfs); err != nil {
@@ -2158,7 +2165,7 @@ func (r *BareMetalHostReconciler) getHostFirmwareSettings(ctx context.Context, i
 	}
 	if !valid {
 		info.log.Info("hostFirmwareSettings not valid", "namespacename", info.request.NamespacedName)
-		return false, nil, nil
+		return false, hfs, nil
 	}
 
 	if changed {
@@ -2172,11 +2179,11 @@ func (r *BareMetalHostReconciler) getHostFirmwareSettings(ctx context.Context, i
 	}
 
 	info.log.Info("hostFirmwareSettings no updates", "namespacename", info.request.NamespacedName)
-	return false, nil, nil
+	return false, hfs, nil
 }
 
-// Get the stored firmware settings if there are valid changes.
-
+// Get the stored firmware components. Returns dirty=true if there are valid pending changes.
+// The hfc object is returned when available regardless of validity, so callers can inspect spec contents.
 func (r *BareMetalHostReconciler) getHostFirmwareComponents(ctx context.Context, info *reconcileInfo) (dirty bool, hfc *metal3api.HostFirmwareComponents, err error) {
 	hfc = &metal3api.HostFirmwareComponents{}
 	if err = r.Get(ctx, info.request.NamespacedName, hfc); err != nil {
@@ -2196,7 +2203,7 @@ func (r *BareMetalHostReconciler) getHostFirmwareComponents(ctx context.Context,
 	}
 	if !valid {
 		info.log.Info("hostFirmwareComponents not valid", "namespacename", info.request.NamespacedName)
-		return false, nil, nil
+		return false, hfc, nil
 	}
 	if changed {
 		info.log.Info("hostFirmwareComponents indicating ChangeDetected", "namespacename", info.request.NamespacedName)
@@ -2204,7 +2211,7 @@ func (r *BareMetalHostReconciler) getHostFirmwareComponents(ctx context.Context,
 	}
 
 	info.log.Info("hostFirmwareComponents no updates", "namespacename", info.request.NamespacedName)
-	return false, nil, nil
+	return false, hfc, nil
 }
 
 func setConditionTrue(host *metal3api.BareMetalHost, typ, reason string) {

--- a/pkg/provisioner/ironic/servicing.go
+++ b/pkg/provisioner/ironic/servicing.go
@@ -78,6 +78,16 @@ func (p *ironicProvisioner) startServicing(ctx context.Context, bmcAccess bmc.Ac
 	return
 }
 
+func (p *ironicProvisioner) abortServicing(ctx context.Context, ironicNode *nodes.Node) (result provisioner.Result, started bool, err error) {
+	p.log.Info("aborting servicing because firmware spec was removed")
+	started, result, err = p.tryChangeNodeProvisionState(
+		ctx,
+		ironicNode,
+		nodes.ProvisionStateOpts{Target: nodes.TargetAbort},
+	)
+	return
+}
+
 func (p *ironicProvisioner) Service(ctx context.Context, data provisioner.ServicingData, unprepared, restartOnFailure bool) (result provisioner.Result, started bool, err error) {
 	bmcAccess, err := p.bmcAccess()
 	if err != nil {
@@ -93,7 +103,13 @@ func (p *ironicProvisioner) Service(ctx context.Context, data provisioner.Servic
 
 	switch nodes.ProvisionState(ironicNode.ProvisionState) {
 	case nodes.ServiceFail:
-		// When servicing failed, we need to clean host provisioning settings.
+		// When servicing failed and user removed all firmware specs,
+		// abort the servicing operation to back out
+		if !data.HasFirmwareSpec {
+			return p.abortServicing(ctx, ironicNode)
+		}
+
+		// When servicing failed and there are pending updates, we need to clean host provisioning settings
 		// If restartOnFailure is false, it means the settings aren't cleared.
 		if !restartOnFailure {
 			result, err = operationFailed(ironicNode.LastError)
@@ -121,7 +137,18 @@ func (p *ironicProvisioner) Service(ctx context.Context, data provisioner.Servic
 		// Servicing finished
 		p.log.Info("servicing finished on the host")
 		result, err = operationComplete()
-	case nodes.Servicing, nodes.ServiceWait:
+	case nodes.Servicing:
+		p.log.Info("waiting for host to finish servicing",
+			"state", ironicNode.ProvisionState,
+			"serviceStep", ironicNode.ServiceStep)
+		result, err = operationContinuing(provisionRequeueDelay)
+
+	case nodes.ServiceWait:
+		// If user removed all firmware specs while in ServiceWait, abort
+		if !data.HasFirmwareSpec {
+			return p.abortServicing(ctx, ironicNode)
+		}
+
 		p.log.Info("waiting for host to become active",
 			"state", ironicNode.ProvisionState,
 			"serviceStep", ironicNode.ServiceStep)

--- a/pkg/provisioner/ironic/servicing_test.go
+++ b/pkg/provisioner/ironic/servicing_test.go
@@ -87,6 +87,17 @@ func TestService(t *testing.T) {
 			expectedDirty:        false,
 		},
 		{
+			name: "serviceFail state(abort - no firmware spec)",
+			ironic: testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
+				ProvisionState: string(nodes.ServiceFail),
+				UUID:           nodeUUID,
+			}),
+			skipConfig:           true,
+			expectedStarted:      true,
+			expectedRequestAfter: 10,
+			expectedDirty:        true,
+		},
+		{
 			name: "serviceFail state(retry)",
 			ironic: testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
 				ProvisionState: string(nodes.ServiceFail),
@@ -131,6 +142,17 @@ func TestService(t *testing.T) {
 			expectedDirty:        true,
 		},
 		{
+			name: "serviceWait state(abort - no firmware spec)",
+			ironic: testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
+				ProvisionState: string(nodes.ServiceWait),
+				UUID:           nodeUUID,
+			}),
+			skipConfig:           true,
+			expectedStarted:      true,
+			expectedRequestAfter: 10,
+			expectedDirty:        true,
+		},
+		{
 			name: "active state(servicing finished)",
 			ironic: testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
 				ProvisionState: string(nodes.Active),
@@ -164,13 +186,14 @@ func TestService(t *testing.T) {
 			host.Status.Provisioning.ID = nodeUUID
 			prepData := provisioner.ServicingData{}
 			if !tc.skipConfig {
-				host.Spec.BMC.Address = "raid-test://test.bmc/"
+				host.Spec.BMC.Address = "bios-test://test.bmc/"
 				prepData.ActualFirmwareSettings = metal3api.SettingsMap{
 					"Answer": "unknown",
 				}
 				prepData.TargetFirmwareSettings = metal3api.DesiredSettingsMap{
 					"Answer": intstr.FromInt(42),
 				}
+				prepData.HasFirmwareSpec = true
 			}
 
 			publisher := func(reason, message string) {}

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -115,6 +115,9 @@ type ServicingData struct {
 	TargetFirmwareSettings   metal3api.DesiredSettingsMap
 	ActualFirmwareSettings   metal3api.SettingsMap
 	TargetFirmwareComponents []metal3api.FirmwareUpdate
+	// True if any firmware spec exists (settings, components, or legacy FirmwareConfig),
+	// used to distinguish "no updates" from "user cleared spec".
+	HasFirmwareSpec bool
 }
 
 type ProvisionData struct {


### PR DESCRIPTION
When servicing fails (ServiceFail) or the host is in ServiceWait and the user removes firmware settings/components from spec, abort the servicing operation so the host returns to active instead of staying stuck.
    
- Add HasFirmwareSpec to ServicingData to distinguish "no updates" from "user cleared spec". Set from legacy Spec.Firmware (only when dirty), HFS spec settings, and HFC spec updates.
- In ironic provisioner: add abortServicing(); in ServiceFail or ServiceWait, if no firmware spec exists, call abort instead of retrying or waiting.
- Handle Servicing and ServiceWait separately so abort only runs when appropriate in ServiceWait.
- Return hfs/hfc from getHostFirmwareSettings/Components when !valid so callers can still check spec for HasFirmwareSpec; update docstrings.
- Rely on existing prov.Service + controller cleanup flow for recovery from ServicingError when specs are removed (no dedicated controller block).
    
Assisted-by: Claude (Anthropic) version 4.6
Signed-off-by: Jacob Anders <jacob-anders-dev@proton.me>
    
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes # https://github.com/metal3-io/baremetal-operator/issues/3001

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
