### PR TITLE
 🌱Add first fuzzing test for bmc address parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,21 @@ unit-cover: ## Run unit tests with code coverage
 unit-verbose: ## Run unit tests with verbose output
 	TEST_FLAGS=-v make unit
 
+FUZZ_TIME ?= 30s
+
+.PHONY: fuzz
+fuzz: ## Run fuzz tests with seed corpus (no fuzzing, regression test only)
+	cd test/fuzz && go test --race -v ./...
+
+.PHONY: fuzz-run
+fuzz-run: ## Run all fuzz tests sequentially with fuzzing enabled (use FUZZ_TIME=duration)
+	@echo "Discovering fuzz tests..."
+	@cd test/fuzz && go test -list='Fuzz.*' | grep '^Fuzz' | while read -r fuzz_test; do \
+		echo "Running $$fuzz_test for $(FUZZ_TIME)..."; \
+		go test -fuzz=$$fuzz_test -fuzztime=$(FUZZ_TIME) || exit 1; \
+	done
+	@echo "All fuzz tests completed successfully!"
+
 ARTIFACTS ?= ${ROOT_DIR}/test/e2e/_artifacts
 
 .PHONY: test-e2e

--- a/test/fuzz/README.md
+++ b/test/fuzz/README.md
@@ -1,0 +1,40 @@
+# Fuzzing
+
+## Running Fuzz Tests
+
+### Quick Start with Makefile
+
+The easiest way to run fuzz tests is using the Makefile targets:
+
+```bash
+# Run fuzz tests as regression tests (using seed corpus only, fast)
+make fuzz
+
+# Run all fuzz tests sequentially with fuzzing enabled (default: 30 seconds each)
+make fuzz-run
+
+# Run all fuzz tests for custom duration (e.g., 5 minutes each)
+make fuzz-run FUZZ_TIME=5m
+```
+
+The `fuzz-run` target automatically discovers and runs all fuzz tests by
+iteration, dedicating the specified time to each test.
+
+### Crash Corpus and Regression Testing
+
+When fuzzing discovers a crash, Go automatically saves the failing input to
+`testdata/fuzz/<FuzzTestName>/` in the test directory. These crash files should
+be committed to the repository:
+
+```bash
+git add test/fuzz/testdata/
+git commit -m "Add fuzz crash corpus"
+```
+
+Once committed, these crashes are automatically replayed as regression tests
+when running `make fuzz` (or `go test` without `-fuzz`).
+
+## Resources
+
+- [Go Fuzzing Documentation](https://go.dev/doc/fuzz/)
+- [Go Fuzzing Tutorial](https://go.dev/security/fuzz/)

--- a/test/fuzz/bmc_fuzz_test.go
+++ b/test/fuzz/bmc_fuzz_test.go
@@ -1,0 +1,73 @@
+package fuzz
+
+import (
+	"testing"
+
+	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
+)
+
+func FuzzGetParsedURL(f *testing.F) {
+	// Add seed corpus
+	f.Add("ipmi://192.168.122.1:6233")
+	f.Add("redfish://192.168.122.1")
+	f.Add("idrac-virtualmedia://192.168.122.1")
+	f.Add("idrac-virtualmedia://192.168.122.1:443")
+	f.Add("ilo5-redfish://192.168.122.1")
+	f.Add("ilo5-redfish://ilo.example.com")
+	f.Add("idrac-redfish://192.168.122.1")
+	f.Add("idrac-redfish://idrac.example.com:443")
+	f.Add("redfish+http://192.168.122.1")
+	f.Add("idrac-virtualmedia+http://192.168.122.1")
+	f.Add("idrac-virtualmedia+http://192.168.122.1:443")
+	f.Add("ilo5-redfish+http://192.168.122.1")
+	f.Add("ilo5-redfish+http://ilo.example.com")
+	f.Add("idrac-redfish+http://192.168.122.1")
+	f.Add("idrac-redfish+http://idrac.example.com:443")
+	f.Add("redfish+https://192.168.122.1")
+	f.Add("redfish+https://redfish.example.com:8443")
+	f.Add("redfish-virtualmedia://192.168.122.1")
+	f.Add("redfish-virtualmedia://192.168.122.1:443/redfish/v1")
+	f.Add("redfish-virtualmedia+http://192.168.122.1")
+	f.Add("redfish-virtualmedia+http://192.168.122.1:443/redfish/v1")
+	f.Add("ilo5-virtualmedia://192.168.122.1")
+	f.Add("ilo5-virtualmedia://ilo.example.com:443")
+	f.Add("ilo5-virtualmedia+http://192.168.122.1")
+	f.Add("ilo5-virtualmedia+http://ilo.example.com:443")
+	f.Add("redfish-uefi+http://192.168.122.1")
+	f.Add("redfish-uefi+http://192.168.122.1:8000/boot")
+	f.Add("redfish-uefi+https://192.168.122.1")
+	f.Add("redfish-uefi+https://192.168.122.1:8000/boot")
+	f.Add("ilo5-virtualmedia+https://192.168.122.1")
+	f.Add("ilo5-virtualmedia+https://ilo.example.com:443")
+	f.Add("redfish-virtualmedia+https://192.168.122.1")
+	f.Add("redfish-virtualmedia+https://192.168.122.1:443/redfish/v1")
+	f.Add("redfish+https://192.168.122.1")
+	f.Add("idrac-virtualmedia+https://192.168.122.1")
+	f.Add("idrac-virtualmedia+https://192.168.122.1:443")
+	f.Add("ilo5-redfish+https://192.168.122.1")
+	f.Add("ilo5-redfish+https://ilo.example.com")
+	f.Add("idrac-redfish+https://192.168.122.1")
+	f.Add("idrac-redfish+https://idrac.example.com:443")
+
+	f.Fuzz(func(t *testing.T, address string) {
+		parsedURL, err := bmc.GetParsedURL(address)
+		if err != nil {
+			// Error is valid, skip
+			return
+		}
+
+		// If no error, URL must be non-nil
+		if parsedURL == nil {
+			t.Fatalf("GetParsedURL(%q) returned nil URL without error", address)
+		}
+
+		// Verify we can safely access URL properties without panicking
+		_ = parsedURL.Scheme
+		_ = parsedURL.Host
+		_ = parsedURL.Hostname()
+		_ = parsedURL.Port()
+		_ = parsedURL.Path
+		_ = parsedURL.RawQuery
+		_ = parsedURL.String()
+	})
+}


### PR DESCRIPTION
This PR will add the following fuzzing test :
`FuzzGetParsedURL` - Tests BMC address parsing with various formats (ipmi, redfish, libvirt, IPv4/IPv6)