### PR TITLE
🌱 E2E: Avoid pre-pulling release-0.6 and release-0.8

### DIFF
--- a/test/e2e/config/ironic.yaml
+++ b/test/e2e/config/ironic.yaml
@@ -5,10 +5,6 @@ images:
 # - name: quay.io/metal3-io/ironic:local
 #   loadBehavior: tryLoad
 # Save some time and network by using cached images if available
-- name: quay.io/metal3-io/baremetal-operator:release-0.6
-  loadBehavior: tryLoad
-- name: quay.io/metal3-io/baremetal-operator:release-0.8
-  loadBehavior: tryLoad
 - name: quay.io/metal3-io/baremetal-operator:release-0.9
   loadBehavior: tryLoad
 - name: quay.io/jetstack/cert-manager-cainjector:v1.17.1

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -154,6 +154,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	} else {
 		clusterProvider = bootstrap.CreateKindBootstrapClusterAndLoadImages(ctx, bootstrap.CreateKindBootstrapClusterAndLoadImagesInput{
 			Name:              "bmo-e2e",
+			KubernetesVersion: "v1.34.0",
 			Images:            e2eConfig.Images,
 			ExtraPortMappings: e2eConfig.KindExtraPortMappings,
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

Our tests are failing because pre-pulling this old image fails. It is still used in the upgrade tests but we do not normally run those tests. It is better to skip the pre-pull and keep the periodic jobs green.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
