### PR TITLE
:sparkles: Add Healthy condition based on BMC health rollup

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -208,6 +208,17 @@ const (
 	// NotProgressingReason is the reason used when the BareMetalHost is in
 	// a stable state.
 	NotProgressingReason = "NotProgressing"
+
+	// HealthyCondition documents the health of the BareMetalHost as reported by its BMC.
+	HealthyCondition = "Healthy"
+	// HealthyReason is the reason used when the BareMetalHost is healthy.
+	HealthyReason = "Healthy"
+	// UnknownHealthReason is the reason used when health status is not available.
+	UnknownHealthReason = "Unknown"
+	// WarningHealthReason is the reason used when BMC reports warnings.
+	WarningHealthReason = "Warning"
+	// CriticalHealthReason is the reason used when BMC reports critical errors.
+	CriticalHealthReason = "CriticalError"
 )
 
 // OperationalStatus represents the state of the host.

--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -2215,6 +2215,10 @@ func setConditionFalse(host *metal3api.BareMetalHost, typ, reason string) {
 	conditions.Set(host, metav1.Condition{Type: typ, Status: metav1.ConditionFalse, Reason: reason})
 }
 
+func setConditionUnknown(host *metal3api.BareMetalHost, typ, reason string) {
+	conditions.Set(host, metav1.Condition{Type: typ, Status: metav1.ConditionUnknown, Reason: reason})
+}
+
 func setConditionsProgressing(host *metal3api.BareMetalHost, progressingReason string) {
 	setConditionTrue(host, metal3api.ManageableCondition, metal3api.ManageableReason)
 	setConditionFalse(host, metal3api.AvailableForProvisioningCondition, metal3api.NotAvailableReason)
@@ -2279,6 +2283,20 @@ func computeConditions(ctx context.Context, host *metal3api.BareMetalHost, prov 
 	}
 	if prov != nil && prov.HasPowerFailure(ctx) {
 		setConditionFalse(host, metal3api.ManageableCondition, metal3api.PowerFailureReason)
+	}
+	if prov == nil {
+		setConditionUnknown(host, metal3api.HealthyCondition, metal3api.UnknownHealthReason)
+		return
+	}
+	switch prov.GetHealth(ctx) {
+	case provisioner.HealthOK:
+		setConditionTrue(host, metal3api.HealthyCondition, metal3api.HealthyReason)
+	case provisioner.HealthWarning:
+		setConditionFalse(host, metal3api.HealthyCondition, metal3api.WarningHealthReason)
+	case provisioner.HealthCritical:
+		setConditionFalse(host, metal3api.HealthyCondition, metal3api.CriticalHealthReason)
+	default:
+		setConditionUnknown(host, metal3api.HealthyCondition, metal3api.UnknownHealthReason)
 	}
 }
 

--- a/internal/controller/metal3.io/baremetalhost_controller_test.go
+++ b/internal/controller/metal3.io/baremetalhost_controller_test.go
@@ -11,6 +11,7 @@ import (
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/fixture"
 	"github.com/metal3-io/baremetal-operator/pkg/secretutils"
 	promutil "github.com/prometheus/client_golang/prometheus/testutil"
@@ -3178,6 +3179,61 @@ func bmhWithStatus(operStatus metal3api.OperationalStatus, provStatus metal3api.
 		},
 	}
 }
+
+func TestComputeHealthyCondition(t *testing.T) {
+	testCases := []struct {
+		Scenario       string
+		Health         string
+		ExpectedStatus metav1.ConditionStatus
+		ExpectedReason string
+	}{
+		{
+			Scenario:       "empty health reports unknown",
+			Health:         "",
+			ExpectedStatus: metav1.ConditionUnknown,
+			ExpectedReason: metal3api.UnknownHealthReason,
+		},
+		{
+			Scenario:       "OK health",
+			Health:         provisioner.HealthOK,
+			ExpectedStatus: metav1.ConditionTrue,
+			ExpectedReason: metal3api.HealthyReason,
+		},
+		{
+			Scenario:       "Warning health",
+			Health:         provisioner.HealthWarning,
+			ExpectedStatus: metav1.ConditionFalse,
+			ExpectedReason: metal3api.WarningHealthReason,
+		},
+		{
+			Scenario:       "Critical health",
+			Health:         provisioner.HealthCritical,
+			ExpectedStatus: metav1.ConditionFalse,
+			ExpectedReason: metal3api.CriticalHealthReason,
+		},
+		{
+			Scenario:       "unexpected value reports unknown",
+			Health:         "SomeUnexpectedValue",
+			ExpectedStatus: metav1.ConditionUnknown,
+			ExpectedReason: metal3api.UnknownHealthReason,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			host := bmhWithStatus(metal3api.OperationalStatusOK, metal3api.StateAvailable)
+			fix := &fixture.Fixture{Health: tc.Health}
+			prov, err := fix.NewProvisioner(t.Context(), provisioner.BuildHostData(*host, bmc.Credentials{}), nil)
+			require.NoError(t, err)
+			computeConditions(t.Context(), host, prov)
+
+			cond := conditions.Get(host, metal3api.HealthyCondition)
+			require.NotNil(t, cond)
+			assert.Equal(t, tc.ExpectedStatus, cond.Status)
+			assert.Equal(t, tc.ExpectedReason, cond.Reason)
+		})
+	}
+}
+
 func TestComputeConditions(t *testing.T) {
 	testCases := []struct {
 		Scenario      string
@@ -3257,6 +3313,9 @@ func TestComputeConditions(t *testing.T) {
 			} else {
 				assert.True(t, conditions.IsFalse(tc.BareMetalHost, metal3api.ReadyCondition))
 			}
+			cond := conditions.Get(tc.BareMetalHost, metal3api.HealthyCondition)
+			require.NotNil(t, cond, "Healthy condition should always be set")
+			assert.Equal(t, metav1.ConditionUnknown, cond.Status, "Healthy should be Unknown when health is not reported")
 		})
 	}
 }

--- a/internal/controller/metal3.io/host_state_machine_test.go
+++ b/internal/controller/metal3.io/host_state_machine_test.go
@@ -1432,6 +1432,10 @@ func (p *mockProvisioner) HasPowerFailure(_ context.Context) bool {
 	return false
 }
 
+func (p *mockProvisioner) GetHealth(_ context.Context) string {
+	return ""
+}
+
 func TestUpdateBootModeStatus(t *testing.T) {
 	testCases := []struct {
 		Scenario       string

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -343,3 +343,7 @@ func (p *demoProvisioner) DetachDataImage(_ context.Context) (err error) {
 func (p *demoProvisioner) HasPowerFailure(_ context.Context) bool {
 	return false
 }
+
+func (p *demoProvisioner) GetHealth(_ context.Context) string {
+	return ""
+}

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -103,6 +103,8 @@ type Fixture struct {
 	HostFirmwareComponents HostFirmwareComponentsMock
 
 	PowerFailed bool
+
+	Health string
 }
 
 // NewProvisioner returns a new Fixture Provisioner.
@@ -434,4 +436,11 @@ func (p *fixtureProvisioner) DetachDataImage(_ context.Context) (err error) {
 
 func (p *fixtureProvisioner) HasPowerFailure(_ context.Context) bool {
 	return p.state != nil && p.state.PowerFailed
+}
+
+func (p *fixtureProvisioner) GetHealth(_ context.Context) string {
+	if p.state == nil {
+		return ""
+	}
+	return p.state.Health
 }

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1990,3 +1990,15 @@ func (p *ironicProvisioner) HasPowerFailure(ctx context.Context) bool {
 	}
 	return node.Fault == "power failure"
 }
+
+// TODO(jacobanders): GetHealth calls getNode() which makes an additional HTTP
+// request to Ironic on every reconcile. Consider passing the node object through
+// computeConditions or caching it per reconcile cycle to avoid redundant calls.
+func (p *ironicProvisioner) GetHealth(ctx context.Context) string {
+	node, err := p.getNode(ctx)
+	if err != nil {
+		p.log.Error(err, "ignored error while checking health status")
+		return ""
+	}
+	return node.Health
+}

--- a/pkg/provisioner/ironic/power_test.go
+++ b/pkg/provisioner/ironic/power_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/testserver"
 	"github.com/stretchr/testify/assert"
@@ -461,4 +462,66 @@ func TestSoftPowerOffFallback(t *testing.T) {
 	_, err = prov.changePower(t.Context(), &node, nodes.SoftPowerOff)
 	require.Error(t, err)
 	assert.ErrorAs(t, err, &softPowerOffUnsupportedError{})
+}
+
+func TestGetHealth(t *testing.T) {
+	nodeUUID := "33ce8659-7400-4c68-9535-d10766f07a58"
+	cases := []struct {
+		name           string
+		ironic         *testserver.IronicMock
+		expectedHealth string
+	}{
+		{
+			name: "healthy node",
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
+				UUID:   nodeUUID,
+				Health: provisioner.HealthOK,
+			}),
+			expectedHealth: provisioner.HealthOK,
+		},
+		{
+			name: "warning health",
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
+				UUID:   nodeUUID,
+				Health: provisioner.HealthWarning,
+			}),
+			expectedHealth: provisioner.HealthWarning,
+		},
+		{
+			name: "critical health",
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
+				UUID:   nodeUUID,
+				Health: provisioner.HealthCritical,
+			}),
+			expectedHealth: provisioner.HealthCritical,
+		},
+		{
+			name: "empty health",
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
+				UUID: nodeUUID,
+			}),
+			expectedHealth: "",
+		},
+		{
+			name:           "node not found returns empty",
+			ironic:         testserver.NewIronic(t).NoNode(nodeUUID),
+			expectedHealth: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.ironic.Start()
+			defer tc.ironic.Stop()
+
+			host := makeHost()
+			host.Status.Provisioning.ID = nodeUUID
+			auth := clients.AuthConfig{Type: clients.NoAuth}
+			prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher, tc.ironic.Endpoint(), auth)
+			require.NoError(t, err)
+
+			health := prov.GetHealth(t.Context())
+			assert.Equal(t, tc.expectedHealth, health)
+		})
+	}
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -231,9 +231,21 @@ type Provisioner interface {
 	DetachDataImage(ctx context.Context) (err error)
 
 	HasPowerFailure(ctx context.Context) bool
+
+	// GetHealth returns the health status of the node from the provisioner.
+	// Possible values are HealthOK, HealthWarning, HealthCritical, or
+	// empty string if unavailable.
+	GetHealth(ctx context.Context) string
 }
 
-// Result holds the response from a call in the Provsioner API.
+// Health status values returned by GetHealth().
+const (
+	HealthOK       = "OK"
+	HealthWarning  = "Warning"
+	HealthCritical = "Critical"
+)
+
+// Result holds the response from a call in the Provisioner API.
 type Result struct {
 	// Dirty indicates whether the host object needs to be saved.
 	Dirty bool


### PR DESCRIPTION
## Summary
Adds a sixth Healthy condition to BareMetalHosts reflecting the BMC-reported
health status via Ironic's health rollup feature.

## Changes
- HealthyCondition with OK/Warning/Critical/Unknown mapping
- GetHealth() on the provisioner interface (ironic, demo, fixture)
- ConditionUnknown when health is unavailable or provisioner is nil
- Unit tests at controller and ironic provisioner levels

Depends on gophercloud/gophercloud#3619 (merged).

Partially implements #2888