### PR TITLE
:seedling: Bump golangci-lint to v2.5.0 and fix linter findings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ SKIP_RESOURCE_CLEANUP ?= false
 GINKGO_NOCOLOR ?= false
 
 GOLANGCI_LINT_BIN := golangci-lint
-GOLANGCI_LINT_VER := v2.1.6
+GOLANGCI_LINT_VER := v2.5.0
 GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN))
 GOLANGCI_LINT_PKG := github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 

--- a/cmd/make-virt-host/main.go
+++ b/cmd/make-virt-host/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
@@ -148,7 +149,7 @@ func main() {
 	}
 
 	// Figure out the MAC for the VM
-	virshOut, err := exec.Command("sudo", "virsh", "dumpxml", virshDomain).Output() // #nosec
+	virshOut, err := exec.CommandContext(context.Background(), "sudo", "virsh", "dumpxml", virshDomain).Output() // #nosec
 	if err != nil {
 		log.Fatalf("ERROR: Could not get details of domain %s: %s\n",
 			virshDomain, err)
@@ -186,7 +187,7 @@ func main() {
 			virshDomain, *provisionNet)
 	}
 
-	vbmcOut, err := exec.Command(
+	vbmcOut, err := exec.CommandContext(context.Background(),
 		"vbmc", "list", "-f", "json", "-c", "Domain name", "-c", "Port",
 	).Output()
 	if err != nil {

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -419,18 +419,18 @@ func setExternalURL(p *ironicProvisioner, driverInfo map[string]any) map[string]
 	ip := net.ParseIP(parsedURL.Hostname())
 	if ip == nil {
 		// Maybe it's a hostname?
-		ips, err := net.LookupIP(parsedURL.Hostname())
+		ipAddrs, err := net.DefaultResolver.LookupIPAddr(context.Background(), parsedURL.Hostname())
 		if err != nil {
 			p.log.Info("Failed to look up the IP address for BMC hostname", "hostname", p.bmcAddress)
 			return driverInfo
 		}
 
-		if len(ips) == 0 {
+		if len(ipAddrs) == 0 {
 			p.log.Info("Zero IP addresses for BMC hostname", "hostname", p.bmcAddress)
 			return driverInfo
 		}
 
-		ip = ips[0]
+		ip = ipAddrs[0].IP
 	}
 
 	// In the case of IPv4, we don't have to do anything.


### PR DESCRIPTION
v2.1.6–v2.4.0 fail to install via go install because the upstream dependency github.com/tdakkota/asciicheck was deleted from GitHub. v2.5.0 is the minimum version that resolves the install failure.

The bumped linter also surfaced few linter violations, fixed those as well.

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
