### PR TITLE
🌱 E2E: Remove libvirt DHCP reservation from VMs

### DIFF
--- a/test/e2e/automated_cleaning_test.go
+++ b/test/e2e/automated_cleaning_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Automated cleaning", Label("required", "automated-cleaning"), 
 		By("Patching the BMH to trigger provisioning")
 		userDataSecretName := "user-data-disk-test"
 		sshPubKeyPath := e2eConfig.GetVariable("SSH_PUB_KEY")
-		createDiskTestUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath)
+		createDiskTestUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
 		userDataSecret := &corev1.SecretReference{
 			Name:      userDataSecretName,
 			Namespace: namespace.Name,
@@ -145,7 +145,6 @@ var _ = Describe("Automated cleaning", Label("required", "automated-cleaning"), 
 
 		By("Patching the BMH again to trigger re-provisioning")
 		userDataSecretName = "user-data-ssh-setup"
-		// Create new userdata secret for only SSH setup
 		createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
 		userDataSecret = &corev1.SecretReference{
 			Name:      userDataSecretName,

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -494,13 +494,13 @@ echo "%s" >> /root/.ssh/authorized_keys`, staticIP, sshPubKeyData)
 }
 
 // createDiskTestUserdata creates a Kubernetes secret with cloud-init userdata for disk operations.
-// This userdata sets up SSH authorized keys and then formats /dev/vdb, mounts it, and creates a test file.
-// Intended for testing automated cleaning of disks.
-func createDiskTestUserdata(ctx context.Context, client client.Client, namespace string, secretName string, sshPubKeyPath string) {
+// This userdata configures a static IP, sets up SSH authorized keys, formats /dev/vdb, mounts it,
+// and creates test files on both disks. Intended for testing automated cleaning of disks.
+func createDiskTestUserdata(ctx context.Context, client client.Client, namespace string, secretName string, sshPubKeyPath string, staticIP string) {
 	sshPubKeyData, err := os.ReadFile(sshPubKeyPath) // #nosec G304
 	Expect(err).NotTo(HaveOccurred(), "Failed to read SSH public key file")
 	userDataContent := fmt.Sprintf(`#!/bin/sh
-# Create the .ssh directory and authorized_keys file
+ip a add %s dev eth0
 mkdir /root/.ssh
 chmod 700 /root/.ssh
 echo "%s" >> /root/.ssh/authorized_keys
@@ -512,7 +512,7 @@ mount /dev/vdb /mnt/data
 
 # Create test files on both disks
 touch /mnt/data/test_file_vdb.txt
-touch /test_file_vda.txt`, sshPubKeyData)
+touch /test_file_vda.txt`, staticIP, sshPubKeyData)
 
 	CreateSecret(ctx, client, namespace, secretName, map[string]string{"userData": userDataContent})
 }

--- a/test/e2e/config/bmcs-ipmi.yaml
+++ b/test/e2e/config/bmcs-ipmi.yaml
@@ -9,7 +9,6 @@
   networks:
   - name: baremetal-e2e
     macAddress: "00:60:2f:31:81:01"
-    ipAddress: "192.168.222.122"
 - user: admin
   password: password
   address: "ipmi://192.168.222.1:16231"
@@ -21,4 +20,3 @@
   networks:
   - name: baremetal-e2e
     macAddress: "00:60:2f:31:81:02"
-    ipAddress: "192.168.222.123"

--- a/test/e2e/config/bmcs-redfish-virtualmedia.yaml
+++ b/test/e2e/config/bmcs-redfish-virtualmedia.yaml
@@ -9,7 +9,6 @@
   networks:
   - name: baremetal-e2e
     macAddress: "00:60:2f:31:81:01"
-    ipAddress: "192.168.222.122"
 - user: admin
   password: password
   address: "redfish-virtualmedia+http://192.168.222.1:8000/redfish/v1/Systems/bmo-e2e-1"
@@ -21,4 +20,3 @@
   networks:
   - name: baremetal-e2e
     macAddress: "00:60:2f:31:81:02"
-    ipAddress: "192.168.222.123"

--- a/test/e2e/config/bmcs-redfish.yaml
+++ b/test/e2e/config/bmcs-redfish.yaml
@@ -9,7 +9,6 @@
   networks:
   - name: baremetal-e2e
     macAddress: "00:60:2f:31:81:01"
-    ipAddress: "192.168.222.122"
 - user: admin
   password: password
   address: "redfish+http://192.168.222.1:8000/redfish/v1/Systems/bmo-e2e-1"
@@ -21,4 +20,3 @@
   networks:
   - name: baremetal-e2e
     macAddress: "00:60:2f:31:81:02"
-    ipAddress: "192.168.222.123"

--- a/test/e2e/data/ironic-standalone-operator/ironic/base/ironic.yaml
+++ b/test/e2e/data/ironic-standalone-operator/ironic/base/ironic.yaml
@@ -10,6 +10,10 @@ spec:
       rangeBegin: "192.168.222.100"
       rangeEnd: "192.168.222.200"
       networkCIDR: "192.168.222.0/24"
+      # Reserve IP addresses so we have a predictable IP, e.g. for the Live-ISO test.
+      hosts:
+      - "00:60:2f:31:81:01,192.168.222.122"
+      - "00:60:2f:31:81:02,192.168.222.123"
     interface: "eth0"
     ipAddress: "192.168.222.2"
     ipAddressManager: "keepalived"

--- a/test/e2e/live_iso_test.go
+++ b/test/e2e/live_iso_test.go
@@ -83,15 +83,6 @@ var _ = Describe("Live-ISO", Label("required", "live-iso"), func() {
 				AutomatedCleaningMode: metal3api.CleaningModeDisabled,
 			},
 		}
-		if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
-			userDataSecretName := "user-data"
-			sshPubKeyPath := e2eConfig.GetVariable("SSH_PUB_KEY")
-			createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
-			bmh.Spec.UserData = &corev1.SecretReference{
-				Name:      userDataSecretName,
-				Namespace: namespace.Name,
-			}
-		}
 		err := clusterProxy.GetClient().Create(ctx, &bmh)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -109,7 +100,10 @@ var _ = Describe("Live-ISO", Label("required", "live-iso"), func() {
 			State:  metal3api.StateProvisioned,
 		}, e2eConfig.GetIntervals(specName, "wait-provisioned")...)
 
-		// The ssh check is not possible in all situations (e.g. fixture) so it can be skipped
+		// The ssh check is not possible in all situations (e.g. fixture) so it can be skipped.
+		// For live ISO boots, userdata is not delivered by Ironic, so we cannot inject a
+		// static IP via userdata. Instead, the VM gets a predictable IP via dnsmasq DHCP
+		// host reservation configured in the Ironic CR (spec.networking.dhcp.hosts).
 		if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
 			By("Verifying the node booted from live ISO image")
 			PerformSSHBootCheck(e2eConfig, "memory", bmc.IPAddress)


### PR DESCRIPTION
**What this PR does / why we need it**:

We used to set DHCP reservations through libvirt in order to get predictable IPs to use
in the tests (ssh check after provisioning). However, we have since a
while already moved to use user-data for this. Now these DHCP
reservations are redundant and potentially harmful, since they may
enable libvirt DHCP during pre-provisioning, which then conflicts with
the Ironic dnsmasq instance.

This DHCP reservation was still used by the automated cleaning test.
This commit also changes the test to use user-data to set the fixed IP,
in the same way as the other tests already did.

There is still one test that needed the DHCP reservation: Live-ISO.
We cannot use user-data there, so instead the reservation is now made
through the Ironic dnsmasq instance.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
