### PR TITLE
:seedling: move security-insights.yml to .github/ and use upstream validator

### DIFF
--- a/.github/security-insights.yml
+++ b/.github/security-insights.yml
@@ -2,8 +2,8 @@ header:
   schema-version: 2.2.0
   last-updated: '2026-02-24'
   last-reviewed: '2026-02-24'
-  url: https://raw.githubusercontent.com/metal3-io/baremetal-operator/main/SECURITY_INSIGHTS.yml
-  project-si-source: https://raw.githubusercontent.com/metal3-io/community/main/SECURITY_INSIGHTS.yml
+  url: https://raw.githubusercontent.com/metal3-io/baremetal-operator/main/.github/security-insights.yml
+  project-si-source: https://raw.githubusercontent.com/metal3-io/community/main/.github/security-insights.yml
 repository:
   url: https://github.com/metal3-io/baremetal-operator
   status: active

--- a/.github/workflows/validate-security-insights.yml
+++ b/.github/workflows/validate-security-insights.yml
@@ -1,23 +1,19 @@
-name: Validate SECURITY_INSIGHTS.yml
+name: Validate security-insights.yml
 on:
   pull_request:
     paths:
-    - SECURITY_INSIGHTS.yml
+    - .github/security-insights.yml
+
+permissions: {}
 
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
-    - name: Install CUE
-      uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
-
-    - name: Fetch Security Insights schema
-      run: |
-        mkdir -p /tmp/si-spec
-        curl -sSfL -o /tmp/si-spec/schema.cue \
-          https://raw.githubusercontent.com/ossf/security-insights/v2.2.0/spec/schema.cue
-
-    - name: Validate schema
-      run: cue vet -d '#SecurityInsights' /tmp/si-spec/schema.cue SECURITY_INSIGHTS.yml
+    - uses: revanite-io/security-insights-action@85c35a5b75f2772e0462323d7b4fcbab5fc1aff2 # v1.0.0


### PR DESCRIPTION
- Rename SECURITY_INSIGHTS.yml to .github/security-insights.yml to follow OSSF convention
- Update self-referencing URLs in the file to match new path
- Replace self-rolled CUE validation with revanite-io/security-insights-action, which auto-detects the schema version from the file (just rolled out but endorsed by ossf)
- Bump actions/checkout from v4.3.1 to v6.0.2

This makes the repo root less congested as well as insights moves to .github and is "hidden".