### PR TITLE
:seedling: harden github actions workflows

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main # zizmor: ignore[unpinned-uses]
     with:
       image-name: 'baremetal-operator'
       pushImage: true

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -26,13 +26,15 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      with:
+        persist-credentials: false
 
     - name: Calculate go version
       id: vars
       run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
 
     - name: Set up Go
-      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version: ${{ steps.vars.outputs.go_version }}
 

--- a/.github/workflows/e2e-fixture-test.yml
+++ b/.github/workflows/e2e-fixture-test.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Calculate go version
       id: vars
@@ -43,7 +45,7 @@ jobs:
 
     - name: Upload artifacts
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: artifacts-fixture.tar.gz
         path: test/e2e/_artifacts

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -31,6 +31,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.ref }}
+        persist-credentials: false
 
     - name: Install libvirt
       run: |
@@ -57,7 +58,7 @@ jobs:
 
     - name: Upload artifacts
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: artifacts-${{ inputs.bmc-protocol }}.tar.gz
         path: test/e2e/_artifacts

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,6 +21,8 @@ jobs:
         - hack/tools
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Install libvirt
       run: |

--- a/.github/workflows/pr-gh-workflow-approve.yaml
+++ b/.github/workflows/pr-gh-workflow-approve.yaml
@@ -5,7 +5,7 @@
 name: Approve GH Workflows
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [edited, labeled, reopened, synchronize]
 
 permissions: {}

--- a/.github/workflows/pr-link-check.yml
+++ b/.github/workflows/pr-link-check.yml
@@ -9,6 +9,6 @@ permissions:
 
 jobs:
   check-pr-links:
-    uses: metal3-io/project-infra/.github/workflows/pr-link-check.yml@main
+    uses: metal3-io/project-infra/.github/workflows/pr-link-check.yml@main # zizmor: ignore[unpinned-uses]
     with:
       upstream: https://github.com/metal3-io/baremetal-operator.git

--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -3,10 +3,10 @@ name: PR Verifier
 permissions: {}
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, reopened, synchronize, ready_for_review]
 
 jobs:
   verify:
     name: verify PR contents
-    uses: metal3-io/project-infra/.github/workflows/pr-verifier.yaml@main
+    uses: metal3-io/project-infra/.github/workflows/pr-verifier.yaml@main # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,12 +28,15 @@ jobs:
       uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a # v47.0.4
     - name: Get release version
       id: release-version
+      env:
+        STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES_COUNT: ${{ steps.changed-files.outputs.all_changed_files_count }}
+        STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
       run: |
-        if [[ ${{ steps.changed-files.outputs.all_changed_files_count }} != 1 ]]; then
-          echo "1 release notes file should be changed to create a release tag, found ${{ steps.changed-files.outputs.all_changed_files_count }}"
+        if [[ "${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES_COUNT}" != "1" ]]; then
+          echo "1 release notes file should be changed to create a release tag, found ${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES_COUNT}"
           exit 1
         fi
-        for changed_file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+        for changed_file in ${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}; do
           export RELEASE_VERSION=$(echo "${changed_file}" | grep -oP '(?<=/)[^/]+(?=\.md)')
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> ${GITHUB_ENV}
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> ${GITHUB_OUTPUT}
@@ -100,21 +103,23 @@ jobs:
       with:
         fetch-depth: 0
         ref: ${{ env.RELEASE_TAG }}
+        persist-credentials: false
     - name: Calculate go version
       run: echo "go_version=$(make go-version)" >> ${GITHUB_ENV}
     - name: Set up Go
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
       with:
         go-version: ${{ env.go_version }}
+        cache: false
     - name: generate release artifacts
-      run: |
-        make release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        make release
     - name: get release notes
       run: |
-        curl -L "https://raw.githubusercontent.com/${{ github.repository }}/main/releasenotes/${{ env.RELEASE_TAG }}.md" \
-        -o "${{ env.RELEASE_TAG }}.md"
+        curl -fsSL "https://raw.githubusercontent.com/${{ github.repository }}/main/releasenotes/${RELEASE_TAG}.md" \
+        -o "${RELEASE_TAG}.md"
     - name: Release
       uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
       with:
@@ -129,7 +134,7 @@ jobs:
     needs: push_release_tags
     name: Build BMO container image
     if: github.repository == 'metal3-io/baremetal-operator'
-    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main # zizmor: ignore[unpinned-uses]
     with:
       image-name: 'baremetal-operator'
       pushImage: true

--- a/.github/workflows/scheduled-link-check.yml
+++ b/.github/workflows/scheduled-link-check.yml
@@ -16,4 +16,4 @@ permissions:
 # links found but not broken despite no access should be added to a .lycheeignore file
 jobs:
   check-links:
-    uses: metal3-io/project-infra/.github/workflows/scheduled-link-check.yml@main
+    uses: metal3-io/project-infra/.github/workflows/scheduled-link-check.yml@main # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Calculate go version
       id: vars
       run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -10,6 +10,6 @@ on:
 jobs:
   yamllint-check:
     name: yaml-lint
-    uses: metal3-io/project-infra/.github/workflows/yamllint.yaml@main
+    uses: metal3-io/project-infra/.github/workflows/yamllint.yaml@main # zizmor: ignore[unpinned-uses]
     with:
       ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Add persist-credentials: false to checkout actions, switch pr-verifier from pull_request_target to pull_request, add explicit permissions to workflows, bump actions to latest major versions, suppress accepted findings, and apply zizmor safe fixes.
