### PR TITLE
🌱 E2E: Increase inotify limits

### DIFF
--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -56,6 +56,12 @@ export PATH="/usr/local/go/bin:${PATH}"
 sudo apt-get update
 sudo apt-get install -y libvirt-dev pkg-config
 
+# Increase inotify limits to prevent "too many open files" errors.
+# Kind nodes (Docker containers running systemd) consume inotify resources heavily.
+# See: https://cluster-api.sigs.k8s.io/user/troubleshooting#cluster-api-with-docker----too-many-open-files
+sudo sysctl fs.inotify.max_user_watches=1048576
+sudo sysctl fs.inotify.max_user_instances=8192
+
 # Build the container image with e2e tag (used in tests)
 IMG=quay.io/metal3-io/baremetal-operator IMG_TAG=e2e make docker
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Some of the container logs show "too many open files" errors. Increasing the limits to avoid issues.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Part of #2927. The log watchers restart because of hitting the limits.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
