### PR TITLE
:bug: Fix race condition where DataImage node-busy blocks power-on

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -1733,9 +1733,25 @@ func (r *BareMetalHostReconciler) handleDataImageActions(ctx context.Context, pr
 	// a longer wait ?
 	isImageAttached, getVmediaError := prov.GetDataImageStatus(ctx)
 	if getVmediaError != nil {
-		info.log.Error(getVmediaError, "Error fetching Virtual Media details")
-
-		if !errors.Is(getVmediaError, provisioner.ErrNodeIsBusy) {
+		if errors.Is(getVmediaError, provisioner.ErrNodeIsBusy) {
+			// When the node is busy (e.g. reservation held by another
+			// operation), we cannot query virtual media status. If the
+			// DataImage is already in the desired state according to our
+			// status, don't block power-on -- let it proceed and verify
+			// attachment on a future reconciliation.
+			deleteDataImage := !dataImage.DeletionTimestamp.IsZero()
+			if !deleteDataImage && dataImage.Spec.URL == dataImage.Status.AttachedImage.URL {
+				info.log.Info("node is busy but DataImage already in desired state, proceeding with power on")
+				dataImage.Status.Error.Message = ""
+				dataImage.Status.Error.Count = 0
+				if err := r.Status().Update(ctx, dataImage); err != nil {
+					return actionError{fmt.Errorf("failed to update DataImage status, %w", err)}
+				}
+				return nil
+			}
+			info.log.Info("node is busy, will retry fetching Virtual Media details")
+		} else {
+			info.log.Error(getVmediaError, "Error fetching Virtual Media details")
 			dataImage.Status.Error.Message = getVmediaError.Error()
 			dataImage.Status.Error.Count++
 

--- a/internal/controller/metal3.io/baremetalhost_controller_test.go
+++ b/internal/controller/metal3.io/baremetalhost_controller_test.go
@@ -11,6 +11,7 @@ import (
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/fixture"
 	"github.com/metal3-io/baremetal-operator/pkg/secretutils"
 	promutil "github.com/prometheus/client_golang/prometheus/testutil"
@@ -1614,6 +1615,51 @@ func TestExternallyProvisionedTransitions(t *testing.T) {
 
 		waitForProvisioningState(t, r, host, metal3api.StateExternallyProvisioned)
 	})
+}
+
+// TestPowerOnWithDataImageNodeBusy verifies that power-on proceeds when the
+// Ironic node is busy but the DataImage is already in the desired state. This
+// covers a race condition where concurrent deployments cause repeated
+// ErrNodeIsBusy from GetDataImageStatus, indefinitely blocking power-on.
+func TestPowerOnWithDataImageNodeBusy(t *testing.T) {
+	host := newDefaultHost(t)
+	host.Spec.Online = true
+	host.Spec.Image = &metal3api.Image{URL: "foo", Checksum: "123"}
+	host.Status.Provisioning.State = metal3api.StateProvisioned
+	host.Status.Provisioning.Image = metal3api.Image{URL: "foo", Checksum: "123"}
+	host.Status.PoweredOn = false
+
+	dataImageURL := "http://example.test/dataimage.iso"
+	dataImage := &metal3api.DataImage{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DataImage",
+			APIVersion: "metal3.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      host.Name,
+			Namespace: host.Namespace,
+		},
+		Spec: metal3api.DataImageSpec{
+			URL: dataImageURL,
+		},
+		Status: metal3api.DataImageStatus{
+			AttachedImage: metal3api.AttachedImageReference{
+				URL: dataImageURL,
+			},
+		},
+	}
+
+	fix := fixture.Fixture{
+		GetDataImageStatusError: provisioner.ErrNodeIsBusy,
+	}
+	r := newTestReconcilerWithFixture(t, &fix, host, dataImage)
+
+	tryReconcile(t, r, host,
+		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
+			t.Logf("power status: %v, state: %v", host.Status.PoweredOn, host.Status.Provisioning.State)
+			return host.Status.PoweredOn
+		},
+	)
 }
 
 // TestPowerOn verifies that the controller turns the host on when it

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -103,6 +103,8 @@ type Fixture struct {
 	HostFirmwareComponents HostFirmwareComponentsMock
 
 	PowerFailed bool
+
+	GetDataImageStatusError error
 }
 
 // NewProvisioner returns a new Fixture Provisioner.
@@ -421,6 +423,9 @@ func (p *fixtureProvisioner) GetFirmwareComponents(_ context.Context) (component
 }
 
 func (p *fixtureProvisioner) GetDataImageStatus(_ context.Context) (isImageAttached bool, err error) {
+	if p.state.GetDataImageStatusError != nil {
+		return false, p.state.GetDataImageStatusError
+	}
 	return false, nil
 }
 


### PR DESCRIPTION
During parallel deployments with high concurrency (1o+), hosts can geti stuck powered off after virtual media is attached. The root cause is in handleDataImageActions: when GetDataImageStatus returns ErrNodeIsBusy (Ironic node has a reservation), the function always returns a requeue, preventing manageHostPower from ever reaching PowerOn.

Under concurrent load, Ironic nodes frequently hold reservations from overlapping operations (virtual media attach, power state sync, manage). This causes repeated 30s+ requeue delays that effectively starve the power-on step, leaving part of the hosts unpowered.

When the node is busy but the DataImage is already in the desired state (Spec.URL matches Status.AttachedImage.URL), skip the status check and let power-on proceed. The attachment will be verified against Ironic on a future reconciliation when the node is no longer busy.

Assisted-By: Claude 4.6 Opus High (Commercial License)

