### PR TITLE
🌱 Exclude revive var-naming check for test/vbmctl/pkg/api

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -229,6 +229,11 @@ linters:
     - linters:
       - tagliatelle
       text: RAID|MAC|BMO
+    # Exclude for now to get linters green. We may consider a different package name in the future.
+    - linters:
+      - revive
+      path: test/vbmctl/pkg/api
+      text: 'var-naming: avoid meaningless package names'
     paths:
     - zz_generated.*\.go$
     - .*conversion.*\.go$


### PR DESCRIPTION
**What this PR does / why we need it**:

Not sure what changed, but this started failing on multiple PRs now. Maybe we had some version change?
Anyway, ignoring the package name for now to unblock. We may consider a different name in the future.

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
