### PR TITLE
🌱 Update vbmctlapi package name to fix lint error

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -229,11 +229,6 @@ linters:
     - linters:
       - tagliatelle
       text: RAID|MAC|BMO
-    # Exclude for now to get linters green. We may consider a different package name in the future.
-    - linters:
-      - revive
-      path: test/vbmctl/pkg/api
-      text: 'var-naming: avoid meaningless package names'
     paths:
     - zz_generated.*\.go$
     - .*conversion.*\.go$

--- a/test/vbmctl/cmd/vbmctl/main.go
+++ b/test/vbmctl/cmd/vbmctl/main.go
@@ -12,7 +12,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
+	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
 	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/config"
 	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/libvirt"
 	"github.com/spf13/cobra"
@@ -128,18 +128,18 @@ func newCreateVMCmd() *cobra.Command {
 				return fmt.Errorf("failed to create VM manager: %w", err)
 			}
 
-			vmCfg := api.VMConfig{
+			vmCfg := vbmctlapi.VMConfig{
 				Name:   name,
 				Memory: memory,
 				VCPUs:  vcpus,
-				Volumes: []api.VolumeConfig{
+				Volumes: []vbmctlapi.VolumeConfig{
 					{Name: "1", Size: volumeSize},
 					{Name: "2", Size: volumeSize},
 				},
 			}
 
 			if network != "" {
-				vmCfg.Networks = []api.NetworkAttachment{
+				vmCfg.Networks = []vbmctlapi.NetworkAttachment{
 					{
 						Network:    network,
 						MACAddress: macAddress,

--- a/test/vbmctl/main.go
+++ b/test/vbmctl/main.go
@@ -11,7 +11,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
+	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
 	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/config"
 	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/libvirt"
 	"gopkg.in/yaml.v2"
@@ -67,19 +67,19 @@ func main() {
 	ctx := context.Background()
 
 	// Build list of VMs to create
-	vmConfigs := []api.VMConfig{}
+	vmConfigs := []vbmctlapi.VMConfig{}
 
 	if *configFile == "" {
 		// Single VM from command-line flags
-		vmCfg := api.VMConfig{
+		vmCfg := vbmctlapi.VMConfig{
 			Name:   *name,
 			Memory: *memory,
 			VCPUs:  *vcpus,
-			Volumes: []api.VolumeConfig{
+			Volumes: []vbmctlapi.VolumeConfig{
 				{Name: "1", Size: *volumeSize},
 				{Name: "2", Size: *volumeSize},
 			},
-			Networks: []api.NetworkAttachment{
+			Networks: []vbmctlapi.NetworkAttachment{
 				{
 					Network:    *networkName,
 					MACAddress: *macAddress,
@@ -146,21 +146,21 @@ func loadBMCConfig(configPath string) ([]BMCConfig, error) {
 }
 
 // convertBMCToVMConfig converts a legacy BMCConfig to the new api.VMConfig format.
-func convertBMCToVMConfig(bmc BMCConfig, memory, vcpus, volumeSize int) api.VMConfig {
-	networks := make([]api.NetworkAttachment, len(bmc.Networks))
+func convertBMCToVMConfig(bmc BMCConfig, memory, vcpus, volumeSize int) vbmctlapi.VMConfig {
+	networks := make([]vbmctlapi.NetworkAttachment, len(bmc.Networks))
 	for i, net := range bmc.Networks {
-		networks[i] = api.NetworkAttachment{
+		networks[i] = vbmctlapi.NetworkAttachment{
 			Network:    net.Name,
 			MACAddress: net.MacAddress,
 			IPAddress:  net.IPAddress,
 		}
 	}
 
-	return api.VMConfig{
+	return vbmctlapi.VMConfig{
 		Name:   bmc.Name,
 		Memory: memory,
 		VCPUs:  vcpus,
-		Volumes: []api.VolumeConfig{
+		Volumes: []vbmctlapi.VolumeConfig{
 			{Name: "1", Size: volumeSize},
 			{Name: "2", Size: volumeSize},
 		},

--- a/test/vbmctl/pkg/api/types.go
+++ b/test/vbmctl/pkg/api/types.go
@@ -1,6 +1,6 @@
 // Package api defines the core types used by vbmctl for managing virtual
 // bare metal environments.
-package api
+package vbmctlapi
 
 // VMConfig represents the configuration for a virtual machine.
 type VMConfig struct {

--- a/test/vbmctl/pkg/api/types_test.go
+++ b/test/vbmctl/pkg/api/types_test.go
@@ -1,4 +1,4 @@
-package api
+package vbmctlapi
 
 import (
 	"testing"

--- a/test/vbmctl/pkg/config/config.go
+++ b/test/vbmctl/pkg/config/config.go
@@ -61,10 +61,10 @@ type Spec struct {
 	Libvirt LibvirtConfig `json:"libvirt,omitempty" yaml:"libvirt,omitempty"`
 
 	// Pool contains storage pool configuration.
-	Pool api.PoolConfig `json:"pool,omitempty" yaml:"pool,omitempty"`
+	Pool vbmctlapi.PoolConfig `json:"pool,omitempty" yaml:"pool,omitempty"`
 
 	// VMs is a list of VM configurations to create.
-	VMs []api.VMConfig `json:"vms,omitempty" yaml:"vms,omitempty"`
+	VMs []vbmctlapi.VMConfig `json:"vms,omitempty" yaml:"vms,omitempty"`
 }
 
 // LibvirtConfig contains libvirt connection settings.
@@ -83,7 +83,7 @@ func Default() *Config {
 			Libvirt: LibvirtConfig{
 				URI: DefaultLibvirtURI,
 			},
-			Pool: api.PoolConfig{
+			Pool: vbmctlapi.PoolConfig{
 				Name: DefaultPoolName,
 				Path: DefaultPoolPath,
 			},
@@ -220,7 +220,7 @@ func (c *Config) ApplyDefaults() {
 }
 
 // WithVMs returns a copy of the config with the specified VMs.
-func (c *Config) WithVMs(vms ...api.VMConfig) *Config {
+func (c *Config) WithVMs(vms ...vbmctlapi.VMConfig) *Config {
 	cfg := *c
 	cfg.Spec.VMs = vms
 	return &cfg

--- a/test/vbmctl/pkg/config/config_test.go
+++ b/test/vbmctl/pkg/config/config_test.go
@@ -76,7 +76,7 @@ func TestLoadAndSave(t *testing.T) {
 
 	// Create a config
 	cfg := Default()
-	cfg.Spec.VMs = []api.VMConfig{
+	cfg.Spec.VMs = []vbmctlapi.VMConfig{
 		{Name: "saved-vm", Memory: 2048, VCPUs: 1},
 	}
 
@@ -162,7 +162,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "VM without name",
 			modify: func(c *Config) {
-				c.Spec.VMs = []api.VMConfig{{Memory: 1024}}
+				c.Spec.VMs = []vbmctlapi.VMConfig{{Memory: 1024}}
 			},
 			wantErr: true,
 		},
@@ -195,7 +195,7 @@ func TestApplyDefaults(t *testing.T) {
 
 func TestWithVMs(t *testing.T) {
 	cfg := Default()
-	vms := []api.VMConfig{
+	vms := []vbmctlapi.VMConfig{
 		{Name: "vm1", Memory: 1024},
 		{Name: "vm2", Memory: 2048},
 	}

--- a/test/vbmctl/pkg/libvirt/pool.go
+++ b/test/vbmctl/pkg/libvirt/pool.go
@@ -10,7 +10,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
+	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
 	"libvirt.org/go/libvirt"
 )
 
@@ -38,7 +38,7 @@ func NewPoolManager(conn *libvirt.Connect) (*PoolManager, error) {
 }
 
 // EnsurePool ensures a storage pool exists, creating it if necessary.
-func (m *PoolManager) EnsurePool(_ context.Context, cfg api.PoolConfig) (*api.Pool, error) {
+func (m *PoolManager) EnsurePool(_ context.Context, cfg vbmctlapi.PoolConfig) (*vbmctlapi.Pool, error) {
 	// Check if pool already exists
 	existingPool, err := m.conn.LookupStoragePoolByName(cfg.Name)
 	if err == nil {
@@ -82,7 +82,7 @@ func (m *PoolManager) EnsurePool(_ context.Context, cfg api.PoolConfig) (*api.Po
 }
 
 // ensurePoolActive ensures an existing pool is active and returns its info.
-func (m *PoolManager) ensurePoolActive(existingPool *libvirt.StoragePool, cfg api.PoolConfig) (*api.Pool, error) {
+func (m *PoolManager) ensurePoolActive(existingPool *libvirt.StoragePool, cfg vbmctlapi.PoolConfig) (*vbmctlapi.Pool, error) {
 	defer func() { _ = existingPool.Free() }()
 
 	active, err := existingPool.IsActive()
@@ -182,7 +182,7 @@ func (m *PoolManager) tryDeleteVolume(pool *libvirt.StoragePool, poolName, volum
 }
 
 // ListVolumes lists all volumes in a storage pool.
-func (m *PoolManager) ListVolumes(_ context.Context, poolName string) ([]*api.Volume, error) {
+func (m *PoolManager) ListVolumes(_ context.Context, poolName string) ([]*vbmctlapi.Volume, error) {
 	pool, err := m.conn.LookupStoragePoolByName(poolName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to lookup pool %s: %w", poolName, err)
@@ -194,7 +194,7 @@ func (m *PoolManager) ListVolumes(_ context.Context, poolName string) ([]*api.Vo
 		return nil, fmt.Errorf("failed to list volumes: %w", err)
 	}
 
-	result := make([]*api.Volume, 0, len(volumes))
+	result := make([]*vbmctlapi.Volume, 0, len(volumes))
 	for _, vol := range volumes {
 		name, err := vol.GetName()
 		if err != nil {
@@ -205,8 +205,8 @@ func (m *PoolManager) ListVolumes(_ context.Context, poolName string) ([]*api.Vo
 		path, _ := vol.GetPath()
 		info, _ := vol.GetInfo()
 
-		result = append(result, &api.Volume{
-			Config: api.VolumeConfig{
+		result = append(result, &vbmctlapi.Volume{
+			Config: vbmctlapi.VolumeConfig{
 				Name: name,
 			},
 			Path:       path,
@@ -221,7 +221,7 @@ func (m *PoolManager) ListVolumes(_ context.Context, poolName string) ([]*api.Vo
 }
 
 // getPoolInfo extracts pool information from a libvirt pool.
-func (m *PoolManager) getPoolInfo(pool *libvirt.StoragePool, cfg api.PoolConfig) (*api.Pool, error) {
+func (m *PoolManager) getPoolInfo(pool *libvirt.StoragePool, cfg vbmctlapi.PoolConfig) (*vbmctlapi.Pool, error) {
 	uuid, err := pool.GetUUIDString()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pool UUID: %w", err)
@@ -237,7 +237,7 @@ func (m *PoolManager) getPoolInfo(pool *libvirt.StoragePool, cfg api.PoolConfig)
 		return nil, fmt.Errorf("failed to get pool info: %w", err)
 	}
 
-	return &api.Pool{
+	return &vbmctlapi.Pool{
 		Config:    cfg,
 		UUID:      uuid,
 		Active:    active,

--- a/test/vbmctl/pkg/libvirt/templates.go
+++ b/test/vbmctl/pkg/libvirt/templates.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
+	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
 )
 
 const (
@@ -138,7 +138,7 @@ func RenderTemplate(inputFile string, data interface{}) (string, error) {
 }
 
 // VMConfigToTemplateData converts a VMConfig to VMTemplateData.
-func VMConfigToTemplateData(cfg api.VMConfig, poolPath string) VMTemplateData {
+func VMConfigToTemplateData(cfg vbmctlapi.VMConfig, poolPath string) VMTemplateData {
 	// Apply defaults
 	cfg = cfg.Defaults()
 
@@ -181,7 +181,7 @@ func VMConfigToTemplateData(cfg api.VMConfig, poolPath string) VMTemplateData {
 }
 
 // PoolConfigToTemplateData converts a PoolConfig to PoolTemplateData.
-func PoolConfigToTemplateData(cfg api.PoolConfig) PoolTemplateData {
+func PoolConfigToTemplateData(cfg vbmctlapi.PoolConfig) PoolTemplateData {
 	return PoolTemplateData{
 		PoolName: cfg.Name,
 		PoolPath: cfg.Path,
@@ -189,7 +189,7 @@ func PoolConfigToTemplateData(cfg api.PoolConfig) PoolTemplateData {
 }
 
 // VolumeConfigToTemplateData converts a VolumeConfig to VolumeTemplateData.
-func VolumeConfigToTemplateData(cfg api.VolumeConfig) VolumeTemplateData {
+func VolumeConfigToTemplateData(cfg vbmctlapi.VolumeConfig) VolumeTemplateData {
 	cfg = cfg.Defaults()
 	return VolumeTemplateData{
 		VolumeName:         cfg.Name,

--- a/test/vbmctl/pkg/libvirt/vm.go
+++ b/test/vbmctl/pkg/libvirt/vm.go
@@ -10,7 +10,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
+	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
 	"libvirt.org/go/libvirt"
 )
 
@@ -66,12 +66,12 @@ func NewVMManager(conn *libvirt.Connect, opts VMManagerOptions) (*VMManager, err
 
 // Create creates a new virtual machine from the given configuration.
 // The VM is defined but not started.
-func (m *VMManager) Create(ctx context.Context, cfg api.VMConfig) (*api.VM, error) {
+func (m *VMManager) Create(ctx context.Context, cfg vbmctlapi.VMConfig) (*vbmctlapi.VM, error) {
 	// Apply defaults
 	cfg = cfg.Defaults()
 
 	// Ensure storage pool exists
-	if _, err := m.pool.EnsurePool(ctx, api.PoolConfig{
+	if _, err := m.pool.EnsurePool(ctx, vbmctlapi.PoolConfig{
 		Name: m.opts.PoolName,
 		Path: m.opts.PoolPath,
 	}); err != nil {
@@ -116,10 +116,10 @@ func (m *VMManager) Create(ctx context.Context, cfg api.VMConfig) (*api.VM, erro
 
 	log.Printf("Created VM %s with UUID %s\n", cfg.Name, uuid)
 
-	return &api.VM{
+	return &vbmctlapi.VM{
 		Config: cfg,
 		UUID:   uuid,
-		State:  api.VMStateStopped,
+		State:  vbmctlapi.VMStateStopped,
 	}, nil
 }
 
@@ -204,8 +204,8 @@ func (m *VMManager) deleteVMVolumes(ctx context.Context, vmName string) error {
 
 // CreateAll creates multiple VMs from a list of configurations.
 // If VM creation fails midway, previously created VMs and their volumes are cleaned up.
-func (m *VMManager) CreateAll(ctx context.Context, configs []api.VMConfig) ([]*api.VM, error) {
-	vms := make([]*api.VM, 0, len(configs))
+func (m *VMManager) CreateAll(ctx context.Context, configs []vbmctlapi.VMConfig) ([]*vbmctlapi.VM, error) {
+	vms := make([]*vbmctlapi.VM, 0, len(configs))
 
 	for _, cfg := range configs {
 		vm, err := m.Create(ctx, cfg)
@@ -238,13 +238,13 @@ func (m *VMManager) DeleteAll(ctx context.Context, names []string, deleteVolumes
 }
 
 // List returns all virtual machines.
-func (m *VMManager) List(_ context.Context) ([]*api.VM, error) {
+func (m *VMManager) List(_ context.Context) ([]*vbmctlapi.VM, error) {
 	domains, err := m.conn.ListAllDomains(0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list domains: %w", err)
 	}
 
-	vms := make([]*api.VM, 0, len(domains))
+	vms := make([]*vbmctlapi.VM, 0, len(domains))
 	for _, domain := range domains {
 		name, err := domain.GetName()
 		if err != nil {
@@ -275,8 +275,8 @@ func (m *VMManager) List(_ context.Context) ([]*api.VM, error) {
 			vcpus = int(info.NrVirtCpu)            //nolint:gosec // vCPU count from libvirt is always reasonable
 		}
 
-		vms = append(vms, &api.VM{
-			Config: api.VMConfig{
+		vms = append(vms, &vbmctlapi.VM{
+			Config: vbmctlapi.VMConfig{
 				Name:   name,
 				Memory: memoryMB,
 				VCPUs:  vcpus,
@@ -292,26 +292,26 @@ func (m *VMManager) List(_ context.Context) ([]*api.VM, error) {
 }
 
 // getDomainState converts libvirt domain state to api.VMState.
-func (m *VMManager) getDomainState(domain *libvirt.Domain) (api.VMState, error) {
+func (m *VMManager) getDomainState(domain *libvirt.Domain) (vbmctlapi.VMState, error) {
 	state, _, err := domain.GetState()
 	if err != nil {
-		return api.VMStateUnknown, fmt.Errorf("failed to get domain state: %w", err)
+		return vbmctlapi.VMStateUnknown, fmt.Errorf("failed to get domain state: %w", err)
 	}
 
 	switch state {
 	case libvirt.DOMAIN_RUNNING:
-		return api.VMStateRunning, nil
+		return vbmctlapi.VMStateRunning, nil
 	case libvirt.DOMAIN_PAUSED:
-		return api.VMStatePaused, nil
+		return vbmctlapi.VMStatePaused, nil
 	case libvirt.DOMAIN_SHUTDOWN, libvirt.DOMAIN_SHUTOFF:
-		return api.VMStateStopped, nil
+		return vbmctlapi.VMStateStopped, nil
 	default:
-		return api.VMStateUnknown, nil
+		return vbmctlapi.VMStateUnknown, nil
 	}
 }
 
 // reserveIPAddresses reserves IP addresses in DHCP for the VM's network interfaces.
-func (m *VMManager) reserveIPAddresses(cfg api.VMConfig) error {
+func (m *VMManager) reserveIPAddresses(cfg vbmctlapi.VMConfig) error {
 	for i, net := range cfg.Networks {
 		if net.IPAddress == "" {
 			continue
@@ -326,7 +326,7 @@ func (m *VMManager) reserveIPAddresses(cfg api.VMConfig) error {
 }
 
 // reserveIPAddress reserves a single IP address in DHCP for a network interface.
-func (m *VMManager) reserveIPAddress(vmName string, index int, net api.NetworkAttachment) error {
+func (m *VMManager) reserveIPAddress(vmName string, index int, net vbmctlapi.NetworkAttachment) error {
 	network, err := m.conn.LookupNetworkByName(net.Network)
 	if err != nil {
 		return fmt.Errorf("failed to lookup network %s: %w", net.Network, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Update vbmctlapi package name to fix lint error coming from the 'revive' linter: ''var-naming: avoid meaningless package names''
This PR reverts https://github.com/metal3-io/baremetal-operator/pull/3052
