### PR TITLE
🌱 e2e: check that all namespaces are added to WATCH_NAMESPACE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ lint: $(GOLANGCI_LINT)
 	cd test; $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) ./... --timeout=10m
 	cd pkg/hardwareutils; $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) ./... --timeout=10m
 	cd hack/tools; $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) ./... --timeout=10m
+	./hack/check-e2e.sh
 
 .PHONY: lint-fix
 lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter

--- a/hack/check-e2e.sh
+++ b/hack/check-e2e.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+REPO_ROOT=$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")
+cd "${REPO_ROOT}" || exit 1
+
+WATCH_NS="$(grep -A1 WATCH_NAMESPACE config/overlays/e2e/namespaced-manager-patch.yaml | grep 'value:' | awk '{ print $2; }')"
+EXCEPTIONS=upgrade
+
+EXITCODE=0
+for spec in $(grep -E --no-filename ' *specName +:?=' test/e2e/*_test.go | grep -o '".*"' | tr -d '"'); do
+    # shellcheck disable=SC2076
+    if ! [[ ",${WATCH_NS},${EXCEPTIONS}," =~ ",${spec}," ]]; then
+        echo "ERROR: namespace ${spec} is declared in e2e test but not added to config/overlays/e2e/namespaced-manager-patch.yaml or EXCEPTIONS"
+        EXITCODE=1
+    fi
+
+    # shellcheck disable=SC2076
+    if ! [[ ",${EXCEPTIONS}," =~ ",${spec}," ]] && ! [[ -f "config/overlays/e2e/${spec}/namespace.yaml" ]]; then
+        echo "ERROR: namespace ${spec} is declared in e2e test but there is no namespace kustomization in config/overlays/e2e/"
+        EXITCODE=1
+    fi
+done
+exit ${EXITCODE}

--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -17,6 +17,8 @@ REPO_ROOT=$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")
 
 cd "${REPO_ROOT}" || exit 1
 
+"${REPO_ROOT}"/hack/check-e2e.sh
+
 BMC_PROTOCOL="${BMC_PROTOCOL:-"redfish-virtualmedia"}"
 if [[ "${BMC_PROTOCOL}" == "redfish" ]] || [[ "${BMC_PROTOCOL}" == "redfish-virtualmedia" ]]; then
   BMO_E2E_EMULATOR="sushy-tools"


### PR DESCRIPTION
It's a huge footgun that newly added tests get their hosts ignored by
default. Add a validation that will at least warn a developer.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
