### PR TITLE
:bug: Do not check power failure when not applicable

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -2224,6 +2224,7 @@ func setConditionsProgressing(host *metal3api.BareMetalHost, progressingReason s
 }
 
 func computeConditions(ctx context.Context, host *metal3api.BareMetalHost, prov provisioner.Provisioner) {
+	var powerFailureCheck = true
 	switch host.Status.Provisioning.State {
 	case metal3api.StateNone, metal3api.StateUnmanaged:
 		setConditionFalse(host, metal3api.ManageableCondition, metal3api.NotManagedReason)
@@ -2231,6 +2232,7 @@ func computeConditions(ctx context.Context, host *metal3api.BareMetalHost, prov 
 		setConditionFalse(host, metal3api.ProvisionedCondition, metal3api.NotProvisionedReason)
 		setConditionFalse(host, metal3api.ReadyCondition, metal3api.NotProvisionedReason)
 		setConditionFalse(host, metal3api.ProgressingCondition, metal3api.NotProgressingReason)
+		powerFailureCheck = false
 	case metal3api.StateRegistering:
 		if host.Status.OperationalStatus == metal3api.OperationalStatusError {
 			setConditionFalse(host, metal3api.ManageableCondition, metal3api.RegistrationFailedReason)
@@ -2241,6 +2243,7 @@ func computeConditions(ctx context.Context, host *metal3api.BareMetalHost, prov 
 		setConditionFalse(host, metal3api.ProvisionedCondition, metal3api.NotProvisionedReason)
 		setConditionFalse(host, metal3api.ReadyCondition, metal3api.NotProvisionedReason)
 		setConditionTrue(host, metal3api.ProgressingCondition, metal3api.RegisteringReason)
+		powerFailureCheck = false
 	case metal3api.StatePreparing:
 		setConditionsProgressing(host, metal3api.PreparingReason)
 	case metal3api.StateReady, metal3api.StateAvailable:
@@ -2265,6 +2268,7 @@ func computeConditions(ctx context.Context, host *metal3api.BareMetalHost, prov 
 	case metal3api.StatePoweringOffBeforeDelete:
 		setConditionsProgressing(host, metal3api.PoweringOffBeforeDeleteReason)
 	case metal3api.StateDeleting:
+		powerFailureCheck = false
 		setConditionsProgressing(host, metal3api.DeletingReason)
 	}
 	switch host.Status.OperationalStatus {
@@ -2273,11 +2277,12 @@ func computeConditions(ctx context.Context, host *metal3api.BareMetalHost, prov 
 	case metal3api.OperationalStatusServicing:
 		setConditionFalse(host, metal3api.ReadyCondition, metal3api.ServicingReason)
 	case metal3api.OperationalStatusDetached:
+		powerFailureCheck = false
 		setConditionFalse(host, metal3api.ReadyCondition, metal3api.DetachedReason)
 		setConditionFalse(host, metal3api.ProgressingCondition, metal3api.DetachedReason)
 	default:
 	}
-	if prov != nil && prov.HasPowerFailure(ctx) {
+	if powerFailureCheck && prov != nil && prov.HasPowerFailure(ctx) {
 		setConditionFalse(host, metal3api.ManageableCondition, metal3api.PowerFailureReason)
 	}
 }

--- a/internal/controller/metal3.io/baremetalhost_controller_test.go
+++ b/internal/controller/metal3.io/baremetalhost_controller_test.go
@@ -11,6 +11,7 @@ import (
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/fixture"
 	"github.com/metal3-io/baremetal-operator/pkg/secretutils"
 	promutil "github.com/prometheus/client_golang/prometheus/testutil"
@@ -3179,6 +3180,9 @@ func bmhWithStatus(operStatus metal3api.OperationalStatus, provStatus metal3api.
 	}
 }
 func TestComputeConditions(t *testing.T) {
+	fix := fixture.Fixture{PowerFailed: true}
+	provisionerWithPowerFailure, err := fix.NewProvisioner(t.Context(), provisioner.HostData{}, nil)
+	require.NoError(t, err)
 	testCases := []struct {
 		Scenario      string
 		BareMetalHost *metal3api.BareMetalHost
@@ -3187,6 +3191,7 @@ func TestComputeConditions(t *testing.T) {
 		isProvisioned bool
 		isProgressing bool
 		isReady       bool
+		provisioner   provisioner.Provisioner
 	}{
 		{
 			Scenario:      "before registration",
@@ -3228,10 +3233,23 @@ func TestComputeConditions(t *testing.T) {
 			isManageable:  true,
 			isProvisioned: true,
 		},
+		{
+			Scenario:      "power failure in provisioned state",
+			BareMetalHost: bmhWithStatus(metal3api.OperationalStatusError, metal3api.StateProvisioned),
+			isProvisioned: true,
+			provisioner:   provisionerWithPowerFailure,
+		},
+		{
+			Scenario:      "power failure in deleting state",
+			BareMetalHost: bmhWithStatus(metal3api.OperationalStatusOK, metal3api.StateDeleting),
+			isManageable:  true,
+			isProgressing: true,
+			provisioner:   provisionerWithPowerFailure,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Scenario, func(t *testing.T) {
-			computeConditions(t.Context(), tc.BareMetalHost, nil)
+			computeConditions(t.Context(), tc.BareMetalHost, tc.provisioner)
 			if tc.isManageable {
 				assert.True(t, conditions.IsTrue(tc.BareMetalHost, metal3api.ManageableCondition))
 			} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
During conditions computation, power failure were checked in all states which lead to errors in registering/deleting states and for detached hosts. This commit removes the check in these conditions.

Fixes: #3067
