### PR TITLE
:seedling: Add e2e tests for forced detachment

### DIFF
--- a/config/overlays/e2e/force-detach/kustomization.yaml
+++ b/config/overlays/e2e/force-detach/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../roles-rolebindings
+- namespace.yaml
+
+namespace: force-detach

--- a/config/overlays/e2e/force-detach/namespace.yaml
+++ b/config/overlays/e2e/force-detach/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: force-detach

--- a/config/overlays/e2e/kustomization.yaml
+++ b/config/overlays/e2e/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - ./external-inspection
 - ./externally-provisioned
 - ./firmware-settings
+- ./force-detach
 - ./inspection
 - ./live-iso-ops
 - ./provisioning-ops

--- a/config/overlays/e2e/namespaced-manager-patch.yaml
+++ b/config/overlays/e2e/namespaced-manager-patch.yaml
@@ -9,5 +9,5 @@ spec:
       containers:
       - env:
         - name: WATCH_NAMESPACE
-          value: basic-ops,external-inspection,externally-provisioned,firmware-settings,inspection,live-iso-ops,provisioning-ops,re-inspection,automated-cleaning,upgrade-bmo,upgrade-ironic
+          value: basic-ops,external-inspection,externally-provisioned,firmware-settings,inspection,live-iso-ops,provisioning-ops,re-inspection,automated-cleaning,upgrade-bmo,upgrade-ironic,force-detach
         name: manager

--- a/test/e2e/config/fixture.yaml
+++ b/test/e2e/config/fixture.yaml
@@ -34,6 +34,7 @@ variables:
   IMAGE_CHECKSUM: "c8fc807773e5354afe61636071771906"
   CERT_MANAGER_VERSION: "v1.19.2"
   SSH_CHECK_PROVISIONED: "false"
+  FORCE_DETACH_WAIT_PROVISIONING: "false"
   FETCH_IRONIC_NODES: "false"
   IRONIC_PROVISIONING_IP: "192.168.222.2"
   # Boot mode can be legacy, UEFI or UEFISecureBoot
@@ -60,6 +61,7 @@ intervals:
   default/wait-bmh-deleted: [ "60s", "1s" ]
   default/wait-deleted: [ "5s", "10ms" ]
   default/wait-detached: [ "1s", "10ms" ]
+  default/wait-force-detached: [ "2s", "10ms" ]
   default/wait-secret-deletion: [ "5s", "10ms" ]
   default/wait-power-state: [ "5s", "10ms" ]
   default/wait-externally-provisioned: [ "1m", "10ms" ]

--- a/test/e2e/config/fixture.yaml
+++ b/test/e2e/config/fixture.yaml
@@ -34,7 +34,6 @@ variables:
   IMAGE_CHECKSUM: "c8fc807773e5354afe61636071771906"
   CERT_MANAGER_VERSION: "v1.19.2"
   SSH_CHECK_PROVISIONED: "false"
-  FORCE_DETACH_WAIT_PROVISIONING: "false"
   FETCH_IRONIC_NODES: "false"
   IRONIC_PROVISIONING_IP: "192.168.222.2"
   # Boot mode can be legacy, UEFI or UEFISecureBoot
@@ -61,7 +60,6 @@ intervals:
   default/wait-bmh-deleted: [ "60s", "1s" ]
   default/wait-deleted: [ "5s", "10ms" ]
   default/wait-detached: [ "1s", "10ms" ]
-  default/wait-force-detached: [ "2s", "10ms" ]
   default/wait-secret-deletion: [ "5s", "10ms" ]
   default/wait-power-state: [ "5s", "10ms" ]
   default/wait-externally-provisioned: [ "1m", "10ms" ]

--- a/test/e2e/config/ironic.yaml
+++ b/test/e2e/config/ironic.yaml
@@ -54,12 +54,12 @@ variables:
   SSH_PORT: "22"
   SSH_PRIV_KEY: "./images/ssh_testkey"
   SSH_PUB_KEY: "./images/ssh_testkey.pub"
-  FORCE_DETACH_WAIT_PROVISIONING: "true"
   FETCH_IRONIC_NODES: "true"
   IRONIC_USERNAME: "changeme"
   IRONIC_PASSWORD: "changeme"
   IRONIC_PROVISIONING_IP: "192.168.222.2"
   IRONIC_PROVISIONING_PORT: "6385"
+  IRONIC_CLIENT_TIMEOUT: "15s"
   # Boot mode can be legacy, UEFI or UEFISecureBoot
   BOOT_MODE: "UEFI"
 
@@ -82,8 +82,7 @@ intervals:
   default/wait-deleted: [ "20s", "10ms" ]
   default/wait-bmh-deleted: [ "6m", "10s" ]
   default/wait-detached: [ "20s", "10ms" ]
-  # NOTE(dtantsur) since provisionRequeueDelay is 10s, 20s may not be enough for forced detachment on real Ironic.
-  default/wait-force-detached: [ "40s", "1s" ]
+  force-detach/wait-ironic-state: [ "2m", "2s" ]
   default/wait-secret-deletion: [ "1m", "1s" ]
   default/wait-connect-ssh: [ "2m", "10s" ]
   default/wait-externally-provisioned: [ "1m", "10ms" ]

--- a/test/e2e/config/ironic.yaml
+++ b/test/e2e/config/ironic.yaml
@@ -54,6 +54,7 @@ variables:
   SSH_PORT: "22"
   SSH_PRIV_KEY: "./images/ssh_testkey"
   SSH_PUB_KEY: "./images/ssh_testkey.pub"
+  FORCE_DETACH_WAIT_PROVISIONING: "true"
   FETCH_IRONIC_NODES: "true"
   IRONIC_USERNAME: "changeme"
   IRONIC_PASSWORD: "changeme"
@@ -81,6 +82,8 @@ intervals:
   default/wait-deleted: [ "20s", "10ms" ]
   default/wait-bmh-deleted: [ "6m", "10s" ]
   default/wait-detached: [ "20s", "10ms" ]
+  # NOTE(dtantsur) since provisionRequeueDelay is 10s, 20s may not be enough for forced detachment on real Ironic.
+  default/wait-force-detached: [ "40s", "1s" ]
   default/wait-secret-deletion: [ "1m", "1s" ]
   default/wait-connect-ssh: [ "2m", "10s" ]
   default/wait-externally-provisioned: [ "1m", "10ms" ]

--- a/test/e2e/e2e_config.go
+++ b/test/e2e/e2e_config.go
@@ -248,3 +248,10 @@ func (c *Config) GetBoolVariable(varName string) bool {
 	}
 	return true
 }
+
+// GetDurationVariable returns a variable from environment variables or from the e2e config file as Duration.
+func (c *Config) GetDurationVariable(varName string) time.Duration {
+	converted, err := time.ParseDuration(c.GetVariable(varName))
+	Expect(err).NotTo(HaveOccurred())
+	return converted
+}

--- a/test/e2e/forced_detachment_test.go
+++ b/test/e2e/forced_detachment_test.go
@@ -28,6 +28,11 @@ var _ = Describe("Start provisioning, force detachment, delete and recreate, pro
 		)
 
 		BeforeEach(func() {
+			// NOTE(dtantsur): these tests are racy on fixtures
+			if !e2eConfig.GetBoolVariable("DEPLOY_IRONIC") {
+				Skip("Tests on forced detachment rely on using Ironic and processes that take non-zero time")
+			}
+
 			namespace, cancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
 				Creator:             clusterProxy.GetClient(),
 				ClientSet:           clusterProxy.GetClientSet(),
@@ -35,6 +40,99 @@ var _ = Describe("Start provisioning, force detachment, delete and recreate, pro
 				LogFolder:           artifactFolder,
 				IgnoreAlreadyExists: true,
 			})
+		})
+
+		It("starts inspection, forces detachment, removes the host", func() {
+			bmhName := specName + "-inspect"
+			secretName := bmhName + "-bmc-creds"
+
+			By("Creating a secret with BMH credentials")
+			bmcCredentialsData := map[string]string{
+				"username": bmc.User,
+				"password": bmc.Password,
+			}
+			CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+
+			By("Creating a BMH")
+			bmh := metal3api.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      bmhName,
+					Namespace: namespace.Name,
+				},
+				Spec: metal3api.BareMetalHostSpec{
+					Online: true,
+					BMC: metal3api.BMCDetails{
+						Address:                        bmc.Address,
+						CredentialsName:                secretName,
+						DisableCertificateVerification: bmc.DisableCertificateVerification,
+					},
+					BootMode:       metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
+					BootMACAddress: bmc.BootMacAddress,
+				},
+			}
+			err := clusterProxy.GetClient().Create(ctx, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the BMH to be in inspecting state")
+			WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+				Client: clusterProxy.GetClient(),
+				Bmh:    bmh,
+				State:  metal3api.StateInspecting,
+			}, e2eConfig.GetIntervals(specName, "wait-inspecting")...)
+
+			if e2eConfig.GetBoolVariable("DEPLOY_IRONIC") {
+				By("Waiting for the Ironic node to start inspection")
+				ironicClient := CreateIronicClient(e2eConfig)
+				ironicNodeName := IronicNodeName(namespace.Name, bmhName)
+				WaitForIronicNodeProvisionState(ctx, WaitForIronicNodeProvisionStateInput{
+					Client:   ironicClient,
+					NodeName: ironicNodeName,
+					States:   []nodes.ProvisionState{nodes.InspectWait},
+				}, e2eConfig.GetIntervals(specName, "wait-ironic-state")...)
+			}
+
+			By("Retrieving the latest BMH object")
+			err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmh.Name,
+				Namespace: bmh.Namespace,
+			}, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Adding the detached annotation")
+			AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, metal3api.DetachedAnnotation, forceTrue)
+
+			By("Waiting for the BMH to be detached")
+			WaitForBmhInOperationalStatus(ctx, WaitForBmhInOperationalStatusInput{
+				Client: clusterProxy.GetClient(),
+				Bmh:    bmh,
+				State:  metal3api.OperationalStatusDetached,
+				UndesiredStates: []metal3api.OperationalStatus{
+					metal3api.OperationalStatusError,
+				},
+			}, e2eConfig.GetIntervals(specName, "wait-detached")...)
+
+			By("Retrieving and checking the latest BMH object")
+			err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmh.Name,
+				Namespace: bmh.Namespace,
+			}, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bmh.Status.Provisioning.State).To(Equal(metal3api.StateInspecting))
+
+			By("Deleting the BMH")
+			err = clusterProxy.GetClient().Delete(ctx, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the BMH to be deleted")
+			WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
+				Client:    clusterProxy.GetClient(),
+				BmhName:   bmh.Name,
+				Namespace: bmh.Namespace,
+				UndesiredStates: []metal3api.ProvisioningState{
+					metal3api.StateDeprovisioning,
+					metal3api.StatePoweringOffBeforeDelete,
+				},
+			}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
 		})
 
 		It("starts provisioning, forces detachment, removes the host", func() {
@@ -150,10 +248,6 @@ var _ = Describe("Start provisioning, force detachment, delete and recreate, pro
 		})
 
 		It("starts provisioning, forces detachment, re-attaches and finishes provisioning", func() {
-			if !e2eConfig.GetBoolVariable("DEPLOY_IRONIC") {
-				Skip("Test on provisioning after detachment relies on provisioning taking non-zero time")
-			}
-
 			bmhName := specName + "-finish"
 			secretName := specName + "-bmc-creds"
 

--- a/test/e2e/forced_detachment_test.go
+++ b/test/e2e/forced_detachment_test.go
@@ -1,0 +1,314 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"path"
+	"time"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cluster-api/test/framework"
+)
+
+var _ = Describe("Start provisioning, force detachment, delete and recreate, provision, detach again and delete", Label("required", "provision", "detach", "force-detach"),
+	func() {
+		var (
+			specName      = "force-detach"
+			namespace     *corev1.Namespace
+			cancelWatches context.CancelFunc
+			forceTrue     = ptr.To("{\"force\": true}")
+		)
+
+		BeforeEach(func() {
+			namespace, cancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
+				Creator:             clusterProxy.GetClient(),
+				ClientSet:           clusterProxy.GetClientSet(),
+				Name:                specName,
+				LogFolder:           artifactFolder,
+				IgnoreAlreadyExists: true,
+			})
+		})
+
+		It("starts provisioning, forces detachment, removes the host", func() {
+			bmhName := specName + "-remove"
+			secretName := bmhName + "-bmc-creds"
+
+			By("Creating a secret with BMH credentials")
+			bmcCredentialsData := map[string]string{
+				"username": bmc.User,
+				"password": bmc.Password,
+			}
+			CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+
+			By("Creating a BMH with inspection and cleaning disabled")
+			bmh := metal3api.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      bmhName,
+					Namespace: namespace.Name,
+				},
+				Spec: metal3api.BareMetalHostSpec{
+					Online: true,
+					BMC: metal3api.BMCDetails{
+						Address:                        bmc.Address,
+						CredentialsName:                secretName,
+						DisableCertificateVerification: bmc.DisableCertificateVerification,
+					},
+					BootMode:              metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
+					BootMACAddress:        bmc.BootMacAddress,
+					AutomatedCleaningMode: metal3api.CleaningModeDisabled,
+					InspectionMode:        metal3api.InspectionModeDisabled,
+				},
+			}
+			err := clusterProxy.GetClient().Create(ctx, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the BMH to become available")
+			WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+				Client: clusterProxy.GetClient(),
+				Bmh:    bmh,
+				State:  metal3api.StateAvailable,
+			}, e2eConfig.GetIntervals(specName, "wait-available")...)
+
+			By("Patching the BMH to test provisioning")
+			err = PatchBMHForProvisioning(ctx, PatchBMHForProvisioningInput{
+				client:    clusterProxy.GetClient(),
+				bmh:       &bmh,
+				bmc:       bmc,
+				e2eConfig: e2eConfig,
+				namespace: namespace.Name,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the BMH to be in provisioning state")
+			WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+				Client: clusterProxy.GetClient(),
+				Bmh:    bmh,
+				State:  metal3api.StateProvisioning,
+			}, e2eConfig.GetIntervals(specName, "wait-provisioning")...)
+
+			if e2eConfig.GetVariable("FORCE_DETACH_WAIT_PROVISIONING") == "true" {
+				By("Waiting for the status in Ironic to catch up")
+				// NOTE(dtantsur): tests have no access to the state of the Ironic Node object.
+				// Wait a bit more to make sure it has actually transitioned away from "available".
+				// FIXME: this won't be needed when substates are added to the BMH API.
+				time.Sleep(2 * time.Second)
+			}
+
+			By("Retrieving the latest BMH object")
+			err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmh.Name,
+				Namespace: bmh.Namespace,
+			}, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Adding the detached annotation")
+			AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, metal3api.DetachedAnnotation, forceTrue)
+
+			By("Waiting for the BMH to be detached")
+			WaitForBmhInOperationalStatus(ctx, WaitForBmhInOperationalStatusInput{
+				Client: clusterProxy.GetClient(),
+				Bmh:    bmh,
+				State:  metal3api.OperationalStatusDetached,
+				UndesiredStates: []metal3api.OperationalStatus{
+					metal3api.OperationalStatusError,
+				},
+			}, e2eConfig.GetIntervals(specName, "wait-force-detached")...)
+
+			By("Retrieving and checking the latest BMH object")
+			err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmh.Name,
+				Namespace: bmh.Namespace,
+			}, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bmh.Status.Provisioning.State).To(Equal(metal3api.StateProvisioning))
+
+			By("Deleting the BMH")
+			err = clusterProxy.GetClient().Delete(ctx, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the BMH to be deleted")
+			WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
+				Client:    clusterProxy.GetClient(),
+				BmhName:   bmh.Name,
+				Namespace: bmh.Namespace,
+				UndesiredStates: []metal3api.ProvisioningState{
+					metal3api.StateDeprovisioning,
+					metal3api.StatePoweringOffBeforeDelete,
+				},
+			}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
+		})
+
+		It("starts provisioning, forces detachment, re-attaches and finishes provisioning", func() {
+			if e2eConfig.GetVariable("FORCE_DETACH_WAIT_PROVISIONING") == "false" {
+				Skip("Test on provisioning after detachment relies on provisioning taking non-zero time")
+			}
+
+			bmhName := specName + "-finish"
+			secretName := specName + "-bmc-creds"
+
+			By("Creating a secret with BMH credentials")
+			bmcCredentialsData := map[string]string{
+				"username": bmc.User,
+				"password": bmc.Password,
+			}
+			CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+
+			By("Creating a BMH with inspection and cleaning disabled")
+			bmh := metal3api.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      bmhName,
+					Namespace: namespace.Name,
+				},
+				Spec: metal3api.BareMetalHostSpec{
+					Online: true,
+					BMC: metal3api.BMCDetails{
+						Address:                        bmc.Address,
+						CredentialsName:                secretName,
+						DisableCertificateVerification: bmc.DisableCertificateVerification,
+					},
+					BootMode:              metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
+					BootMACAddress:        bmc.BootMacAddress,
+					AutomatedCleaningMode: metal3api.CleaningModeDisabled,
+					InspectionMode:        metal3api.InspectionModeDisabled,
+				},
+			}
+			err := clusterProxy.GetClient().Create(ctx, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the BMH to become available")
+			WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+				Client: clusterProxy.GetClient(),
+				Bmh:    bmh,
+				State:  metal3api.StateAvailable,
+			}, e2eConfig.GetIntervals(specName, "wait-available")...)
+
+			By("Patching the BMH to test provisioning")
+			var userDataSecret *corev1.SecretReference
+			if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
+				userDataSecretName := "user-data"
+				sshPubKeyPath := e2eConfig.GetVariable("SSH_PUB_KEY")
+				createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
+				userDataSecret = &corev1.SecretReference{
+					Name:      userDataSecretName,
+					Namespace: namespace.Name,
+				}
+			}
+			err = PatchBMHForProvisioning(ctx, PatchBMHForProvisioningInput{
+				client:         clusterProxy.GetClient(),
+				bmh:            &bmh,
+				bmc:            bmc,
+				e2eConfig:      e2eConfig,
+				namespace:      namespace.Name,
+				userDataSecret: userDataSecret,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the BMH to be in provisioning state")
+			WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+				Client: clusterProxy.GetClient(),
+				Bmh:    bmh,
+				State:  metal3api.StateProvisioning,
+			}, e2eConfig.GetIntervals(specName, "wait-provisioning")...)
+
+			By("Waiting for the status in Ironic to catch up")
+			// NOTE(dtantsur): tests have no access to the state of the Ironic Node object.
+			// Wait a bit more to make sure it has actually transitioned away from "available".
+			// FIXME: this won't be needed when substates are added to the BMH API.
+			time.Sleep(2 * time.Second)
+
+			By("Retrieving the latest BMH object")
+			err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmh.Name,
+				Namespace: bmh.Namespace,
+			}, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Adding the detached annotation")
+			AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, metal3api.DetachedAnnotation, forceTrue)
+
+			By("Waiting for the BMH to be detached")
+			WaitForBmhInOperationalStatus(ctx, WaitForBmhInOperationalStatusInput{
+				Client: clusterProxy.GetClient(),
+				Bmh:    bmh,
+				State:  metal3api.OperationalStatusDetached,
+				UndesiredStates: []metal3api.OperationalStatus{
+					metal3api.OperationalStatusError,
+				},
+			}, e2eConfig.GetIntervals(specName, "wait-force-detached")...)
+
+			By("Retrieving and checking the latest BMH object")
+			err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmh.Name,
+				Namespace: bmh.Namespace,
+			}, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bmh.Status.Provisioning.State).To(Equal(metal3api.StateProvisioning))
+
+			By("Removing the detached annotation")
+			AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, metal3api.DetachedAnnotation, nil)
+
+			By("Waiting for the BMH to become provisioned")
+			WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+				Client: clusterProxy.GetClient(),
+				Bmh:    bmh,
+				State:  metal3api.StateProvisioned,
+			}, e2eConfig.GetIntervals(specName, "wait-provisioned")...)
+
+			// The ssh check is not possible in all situations (e.g. fixture) so it can be skipped
+			if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
+				By("Verifying the node booting from disk")
+				PerformSSHBootCheck(e2eConfig, "disk", bmc.IPAddress)
+			} else {
+				Logf("WARNING: Skipping SSH check since SSH_CHECK_PROVISIONED != true")
+			}
+
+			By("Retrieving the latest BMH object")
+			err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmh.Name,
+				Namespace: bmh.Namespace,
+			}, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Adding the detached annotation")
+			// Making sure that forced detachment works in the normal case too
+			AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, metal3api.DetachedAnnotation, forceTrue)
+
+			By("Waiting for the BMH to be detached")
+			WaitForBmhInOperationalStatus(ctx, WaitForBmhInOperationalStatusInput{
+				Client: clusterProxy.GetClient(),
+				Bmh:    bmh,
+				State:  metal3api.OperationalStatusDetached,
+				UndesiredStates: []metal3api.OperationalStatus{
+					metal3api.OperationalStatusError,
+				},
+			}, e2eConfig.GetIntervals(specName, "wait-detached")...)
+
+			By("Delete BMH")
+			err = clusterProxy.GetClient().Delete(ctx, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the BMH to be deleted")
+			WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
+				Client:    clusterProxy.GetClient(),
+				BmhName:   bmh.Name,
+				Namespace: bmh.Namespace,
+			}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
+		})
+
+		AfterEach(func() {
+			CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
+			DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
+			if !skipCleanup {
+				isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")
+				Cleanup(ctx, clusterProxy, namespace, cancelWatches, isNamespaced, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
+			}
+		})
+	})

--- a/test/e2e/forced_detachment_test.go
+++ b/test/e2e/forced_detachment_test.go
@@ -6,8 +6,8 @@ package e2e
 import (
 	"context"
 	"path"
-	"time"
 
+	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -94,12 +94,15 @@ var _ = Describe("Start provisioning, force detachment, delete and recreate, pro
 				State:  metal3api.StateProvisioning,
 			}, e2eConfig.GetIntervals(specName, "wait-provisioning")...)
 
-			if e2eConfig.GetVariable("FORCE_DETACH_WAIT_PROVISIONING") == "true" {
-				By("Waiting for the status in Ironic to catch up")
-				// NOTE(dtantsur): tests have no access to the state of the Ironic Node object.
-				// Wait a bit more to make sure it has actually transitioned away from "available".
-				// FIXME: this won't be needed when substates are added to the BMH API.
-				time.Sleep(2 * time.Second)
+			if e2eConfig.GetBoolVariable("DEPLOY_IRONIC") {
+				By("Waiting for the Ironic node to start deploying")
+				ironicClient := CreateIronicClient(e2eConfig)
+				ironicNodeName := IronicNodeName(namespace.Name, bmhName)
+				WaitForIronicNodeProvisionState(ctx, WaitForIronicNodeProvisionStateInput{
+					Client:   ironicClient,
+					NodeName: ironicNodeName,
+					States:   []nodes.ProvisionState{nodes.DeployWait},
+				}, e2eConfig.GetIntervals(specName, "wait-ironic-state")...)
 			}
 
 			By("Retrieving the latest BMH object")
@@ -120,7 +123,7 @@ var _ = Describe("Start provisioning, force detachment, delete and recreate, pro
 				UndesiredStates: []metal3api.OperationalStatus{
 					metal3api.OperationalStatusError,
 				},
-			}, e2eConfig.GetIntervals(specName, "wait-force-detached")...)
+			}, e2eConfig.GetIntervals(specName, "wait-detached")...)
 
 			By("Retrieving and checking the latest BMH object")
 			err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{
@@ -147,7 +150,7 @@ var _ = Describe("Start provisioning, force detachment, delete and recreate, pro
 		})
 
 		It("starts provisioning, forces detachment, re-attaches and finishes provisioning", func() {
-			if e2eConfig.GetVariable("FORCE_DETACH_WAIT_PROVISIONING") == "false" {
+			if !e2eConfig.GetBoolVariable("DEPLOY_IRONIC") {
 				Skip("Test on provisioning after detachment relies on provisioning taking non-zero time")
 			}
 
@@ -218,11 +221,14 @@ var _ = Describe("Start provisioning, force detachment, delete and recreate, pro
 				State:  metal3api.StateProvisioning,
 			}, e2eConfig.GetIntervals(specName, "wait-provisioning")...)
 
-			By("Waiting for the status in Ironic to catch up")
-			// NOTE(dtantsur): tests have no access to the state of the Ironic Node object.
-			// Wait a bit more to make sure it has actually transitioned away from "available".
-			// FIXME: this won't be needed when substates are added to the BMH API.
-			time.Sleep(2 * time.Second)
+			By("Waiting for the Ironic node to start deploying")
+			ironicClient := CreateIronicClient(e2eConfig)
+			ironicNodeName := IronicNodeName(namespace.Name, bmhName)
+			WaitForIronicNodeProvisionState(ctx, WaitForIronicNodeProvisionStateInput{
+				Client:   ironicClient,
+				NodeName: ironicNodeName,
+				States:   []nodes.ProvisionState{nodes.DeployWait},
+			}, e2eConfig.GetIntervals(specName, "wait-ironic-state")...)
 
 			By("Retrieving the latest BMH object")
 			err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{
@@ -242,7 +248,7 @@ var _ = Describe("Start provisioning, force detachment, delete and recreate, pro
 				UndesiredStates: []metal3api.OperationalStatus{
 					metal3api.OperationalStatusError,
 				},
-			}, e2eConfig.GetIntervals(specName, "wait-force-detached")...)
+			}, e2eConfig.GetIntervals(specName, "wait-detached")...)
 
 			By("Retrieving and checking the latest BMH object")
 			err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{

--- a/test/e2e/ironic_helpers.go
+++ b/test/e2e/ironic_helpers.go
@@ -1,0 +1,77 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"slices"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/httpbasic"
+	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
+	. "github.com/onsi/gomega"
+)
+
+// CreateIronicClient creates a Gophercloud client for accessing the Ironic API.
+// Only valid when DEPLOY_IRONIC is true. Requires IRONIC_USERNAME, IRONIC_PASSWORD,
+// IRONIC_PROVISIONING_IP, IRONIC_PROVISIONING_PORT, and IRONIC_CLIENT_TIMEOUT in the config.
+func CreateIronicClient(e2eConfig *Config) *gophercloud.ServiceClient {
+	ironicIP := e2eConfig.GetVariable("IRONIC_PROVISIONING_IP")
+	ironicPort := e2eConfig.GetVariable("IRONIC_PROVISIONING_PORT")
+	ironicEndpoint := fmt.Sprintf("https://%s/v1", net.JoinHostPort(ironicIP, ironicPort))
+
+	username := e2eConfig.GetVariable("IRONIC_USERNAME")
+	password := e2eConfig.GetVariable("IRONIC_PASSWORD")
+
+	client, err := httpbasic.NewBareMetalHTTPBasic(httpbasic.EndpointOpts{
+		IronicEndpoint:     ironicEndpoint,
+		IronicUser:         username,
+		IronicUserPassword: password,
+	})
+	Expect(err).NotTo(HaveOccurred(), "Failed to create Ironic client")
+
+	client.Microversion = "1.89"
+
+	client.HTTPClient = http.Client{
+		Timeout: e2eConfig.GetDurationVariable("IRONIC_CLIENT_TIMEOUT"),
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, // #nosec G402 Self-signed certificates in the test environment
+			},
+		},
+	}
+
+	return client
+}
+
+// IronicNodeName returns the Ironic node name corresponding to a BMH.
+func IronicNodeName(namespace, bmhName string) string {
+	return namespace + "~" + bmhName
+}
+
+// WaitForIronicNodeProvisionStateInput is the input for WaitForIronicNodeProvisionState.
+type WaitForIronicNodeProvisionStateInput struct {
+	Client   *gophercloud.ServiceClient
+	NodeName string
+	States   []nodes.ProvisionState
+}
+
+// WaitForIronicNodeProvisionState polls the Ironic API until the node's provision
+// state matches one of the specified target states.
+func WaitForIronicNodeProvisionState(ctx context.Context, input WaitForIronicNodeProvisionStateInput, intervals ...interface{}) {
+	Logf("Waiting for Ironic node %s to reach one of %v", input.NodeName, input.States)
+
+	Eventually(func(g Gomega) {
+		ironicNode, err := nodes.Get(ctx, input.Client, input.NodeName).Extract()
+		g.Expect(err).NotTo(HaveOccurred(), "Failed to get Ironic node %s", input.NodeName)
+
+		currentState := nodes.ProvisionState(ironicNode.ProvisionState)
+		g.Expect(slices.Contains(input.States, currentState)).To(BeTrue(),
+			"Ironic node %s is in state %s, expected one of %v", input.NodeName, currentState, input.States)
+	}, intervals...).Should(Succeed())
+}

--- a/test/go.mod
+++ b/test/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/cert-manager/cert-manager v1.20.2
+	github.com/gophercloud/gophercloud/v2 v2.12.0
 	github.com/metal3-io/baremetal-operator/apis v0.5.1
 	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.5.1
 	github.com/metal3-io/ironic-standalone-operator/api v0.9.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -123,6 +123,8 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaU
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gophercloud/gophercloud/v2 v2.12.0 h1:Gxmc/Bog1UDKkxTcQW7MSPTDviJXpLeEgVeN5KrxoCo=
+github.com/gophercloud/gophercloud/v2 v2.12.0/go.mod h1:H7TTOxbLy8RIaHSNhI2GCrWIzw4Xpw8Xn2mBhCUT5kA=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=


### PR DESCRIPTION
This change adds tests for three aspects of forced detachment:
1. Detaching during inspection, deleting the host afterwards
2. Detaching during provisioning, deleting the host afterwards
3. Detaching during provisioning, re-attaching and continuing

To be able to run the verification at the right moment, the test
accesses Ironic directly and checks its internal state. A new helper
is introduced for that.

Follow-up to https://github.com/metal3-io/baremetal-operator/pull/2955
Assisted-By: Claude Code (commercial license)