### PR TITLE
🐛 Fix return values of the HFC controller in case of provisioner errors

### DIFF
--- a/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
+++ b/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
@@ -156,10 +156,10 @@ func (r *HostFirmwareComponentsReconciler) Reconcile(ctx context.Context, req ct
 
 	if err != nil {
 		if errors.Is(err, provisioner.ErrFirmwareUpdateUnsupported) {
-			return ctrl.Result{Requeue: false}, err
+			return ctrl.Result{}, nil
 		}
 		reqLogger.Info("provisioner returns error", "Error", err.Error(), "RequeueAfter", provisionerRetryDelay)
-		return ctrl.Result{Requeue: true, RequeueAfter: provisionerRetryDelay}, err
+		return ctrl.Result{Requeue: true, RequeueAfter: provisionerRetryDelay}, nil
 	}
 
 	if err = r.updateHostFirmware(ctx, info, components); err != nil {


### PR DESCRIPTION
Returning an error and a Result is pointless: the error takes priority
(as explained by the warning in the log). Instead of the expected
behavior, we get an expontential backoff.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
