### PR TITLE
:seedling: Bump golangci-lint to v2.5.0 in workflow

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -36,5 +36,5 @@ jobs:
     - name: golangci-lint-${{matrix.working-directory}}
       uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
       with:
-        version: v2.1.6
+        version: v2.5.0
         working-directory: ${{matrix.working-directory}}


### PR DESCRIPTION
It was bumped in Makefile but workflow was missing

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
