### PR TITLE
:seedling: Bump golangci-lint to v2.5.0

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -36,5 +36,5 @@ jobs:
     - name: golangci-lint-${{matrix.working-directory}}
       uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
       with:
-        version: v2.1.6
+        version: v2.5.0
         working-directory: ${{matrix.working-directory}}

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ SKIP_RESOURCE_CLEANUP ?= false
 GINKGO_NOCOLOR ?= false
 
 GOLANGCI_LINT_BIN := golangci-lint
-GOLANGCI_LINT_VER := v2.1.6
+GOLANGCI_LINT_VER := v2.5.0
 GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN))
 GOLANGCI_LINT_PKG := github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 

--- a/cmd/make-virt-host/main.go
+++ b/cmd/make-virt-host/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
@@ -147,8 +148,10 @@ func main() {
 		log.Printf("net: %s domain: %s\n", *provisionNet, virshDomain)
 	}
 
+	ctx := context.Background()
+
 	// Figure out the MAC for the VM
-	virshOut, err := exec.Command("sudo", "virsh", "dumpxml", virshDomain).Output() // #nosec
+	virshOut, err := exec.CommandContext(ctx, "sudo", "virsh", "dumpxml", virshDomain).Output() // #nosec
 	if err != nil {
 		log.Fatalf("ERROR: Could not get details of domain %s: %s\n",
 			virshDomain, err)
@@ -186,7 +189,7 @@ func main() {
 			virshDomain, *provisionNet)
 	}
 
-	vbmcOut, err := exec.Command(
+	vbmcOut, err := exec.CommandContext(ctx,
 		"vbmc", "list", "-f", "json", "-c", "Domain name", "-c", "Port",
 	).Output()
 	if err != nil {

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -409,7 +409,7 @@ func setExternalURL(p *ironicProvisioner, driverInfo map[string]interface{}) map
 	ip := net.ParseIP(parsedURL.Hostname())
 	if ip == nil {
 		// Maybe it's a hostname?
-		ips, err := net.LookupIP(parsedURL.Hostname())
+		ips, err := net.DefaultResolver.LookupIPAddr(p.ctx, parsedURL.Hostname())
 		if err != nil {
 			p.log.Info("Failed to look up the IP address for BMC hostname", "hostname", p.bmcAddress)
 			return driverInfo
@@ -420,7 +420,7 @@ func setExternalURL(p *ironicProvisioner, driverInfo map[string]interface{}) map
 			return driverInfo
 		}
 
-		ip = ips[0]
+		ip = ips[0].IP
 	}
 
 	// In the case of IPv4, we don't have to do anything.


### PR DESCRIPTION
Also fixes linter findings

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
