### PR TITLE
:seedling:  Fix linter issues in main

### DIFF
--- a/pkg/secretutils/secret_manager_test.go
+++ b/pkg/secretutils/secret_manager_test.go
@@ -265,9 +265,9 @@ func TestSecretManager_AcquireSecret_DeletesController(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, owner).Build()
 
-	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
+	sm := NewSecretManager(logr.Discard(), fakeClient, fakeClient)
 
-	result, err := sm.AcquireSecret(types.NamespacedName{Name: "test-secret", Namespace: "test"}, owner, false)
+	result, err := sm.AcquireSecret(t.Context(), types.NamespacedName{Name: "test-secret", Namespace: "test"}, owner, false)
 	require.NoError(t, err)
 	assert.Equal(t, "test-secret", result.Name)
 
@@ -321,9 +321,9 @@ func TestSecretManager_AcquireSecret_KeepsOtherOwners(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, owner).Build()
 
-	sm := NewSecretManager(t.Context(), logr.Discard(), fakeClient, fakeClient)
+	sm := NewSecretManager(logr.Discard(), fakeClient, fakeClient)
 
-	result, err := sm.AcquireSecret(types.NamespacedName{Name: "test-secret", Namespace: "test"}, owner, false)
+	result, err := sm.AcquireSecret(t.Context(), types.NamespacedName{Name: "test-secret", Namespace: "test"}, owner, false)
 	require.NoError(t, err)
 	assert.Equal(t, "test-secret", result.Name)
 


### PR DESCRIPTION
After #2972 landed (which was an old PR and perhaps wasnt rebased on top of the new linter) the main branch had some linter issues. This PR fixes those

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #3093 

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
