### PR TITLE
:seedling: Create ironic.yaml for the e2e tests from a template file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/_test
 _artifacts
 artifacts*.tar.gz
 test/e2e/images
+test/e2e/data/ironic-standalone-operator/ironic/base/ironic.yaml
 out
 
 # Created by https://www.gitignore.io/api/go

--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -56,7 +56,7 @@ export PATH="/usr/local/go/bin:${PATH}"
 "${REPO_ROOT}/hack/e2e/ensure_yq.sh"
 
 sudo apt-get update
-sudo apt-get install -y libvirt-dev pkg-config
+sudo apt-get install -y libvirt-dev pkg-config gettext-base
 
 # Increase inotify limits to prevent "too many open files" errors.
 # Kind nodes (Docker containers running systemd) consume inotify resources heavily.
@@ -228,7 +228,10 @@ IRSO_IRONIC_AUTH_DIR="${REPO_ROOT}/test/e2e/data/ironic-standalone-operator/comp
 echo "${IRONIC_USERNAME}" > "${IRSO_IRONIC_AUTH_DIR}/ironic-username"
 echo "${IRONIC_PASSWORD}" > "${IRSO_IRONIC_AUTH_DIR}/ironic-password"
 
-sed -i "s|SSH_PUB_KEY_CONTENT|${pub_ssh_key}|" "${REPO_ROOT}"/test/e2e/data/ironic-standalone-operator/ironic/base/ironic.yaml
+# shellcheck disable=SC2016
+SSH_PUB_KEY_CONTENT="${pub_ssh_key}" envsubst '${SSH_PUB_KEY_CONTENT}' < \
+  "${REPO_ROOT}/test/e2e/data/ironic-standalone-operator/ironic/base/ironic.yaml.tmpl" > \
+  "${REPO_ROOT}/test/e2e/data/ironic-standalone-operator/ironic/base/ironic.yaml"
 
 # We need to gather artifacts/logs before exiting also if there are errors
 set +e

--- a/test/e2e/data/ironic-standalone-operator/ironic/base/ironic.yaml.tmpl
+++ b/test/e2e/data/ironic-standalone-operator/ironic/base/ironic.yaml.tmpl
@@ -18,5 +18,5 @@ spec:
     ipAddress: "192.168.222.2"
     ipAddressManager: "keepalived"
   deployRamdisk:
-    sshKey: "SSH_PUB_KEY_CONTENT"
+    sshKey: "${SSH_PUB_KEY_CONTENT}"
     extraKernelParams: "console=ttyS0"


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

Prevent changes to a tracked configuration file and instead construct the configuration file from a template file during e2e tests. Do not track the configuration file.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

