### PR TITLE
:seedling: vbmctl: support multiple volume sizes via repeatable --volume-size flag

### DIFF
--- a/test/vbmctl/cmd/vbmctl/main.go
+++ b/test/vbmctl/cmd/vbmctl/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 
 	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
@@ -92,13 +93,13 @@ func newCreateCmd() *cobra.Command {
 
 func newCreateVMCmd() *cobra.Command {
 	var (
-		name       string
-		memory     int
-		vcpus      int
-		network    string
-		macAddress string
-		ipAddress  string
-		volumeSize int
+		name        string
+		memory      int
+		vcpus       int
+		network     string
+		macAddress  string
+		ipAddress   string
+		volumeSizes []int
 	)
 
 	cmd := &cobra.Command{
@@ -128,14 +129,22 @@ func newCreateVMCmd() *cobra.Command {
 				return fmt.Errorf("failed to create VM manager: %w", err)
 			}
 
+			if len(volumeSizes) == 0 {
+				volumeSizes = []int{config.DefaultVolumeSize}
+			}
+			volumes := make([]vbmctlapi.VolumeConfig, len(volumeSizes))
+			for i, sz := range volumeSizes {
+				volumes[i] = vbmctlapi.VolumeConfig{
+					Name: "p" + strconv.Itoa(i+1),
+					Size: sz,
+				}
+			}
+
 			vmCfg := vbmctlapi.VMConfig{
-				Name:   name,
-				Memory: memory,
-				VCPUs:  vcpus,
-				Volumes: []vbmctlapi.VolumeConfig{
-					{Name: "1", Size: volumeSize},
-					{Name: "2", Size: volumeSize},
-				},
+				Name:    name,
+				Memory:  memory,
+				VCPUs:   vcpus,
+				Volumes: volumes,
 			}
 
 			if network != "" {
@@ -165,7 +174,9 @@ func newCreateVMCmd() *cobra.Command {
 	cmd.Flags().StringVar(&network, "network", config.DefaultNetworkName, "network to attach to")
 	cmd.Flags().StringVar(&macAddress, "mac-address", "00:60:2f:31:81:01", "MAC address for the network interface")
 	cmd.Flags().StringVar(&ipAddress, "ip-address", "", "IP address to reserve (optional)")
-	cmd.Flags().IntVar(&volumeSize, "volume-size", config.DefaultVolumeSize, "volume size in GB")
+	cmd.Flags().IntSliceVar(&volumeSizes, "volume-size", nil,
+		"volume size in GB (default a single "+strconv.Itoa(config.DefaultVolumeSize)+
+			" GB volume, repeat flag to add multiple volumes or use comma-separated values)")
 
 	return cmd
 }


### PR DESCRIPTION
Replace the single --volume-size integer flag with a repeatable IntSlice flag in the `create vm` command. When no flag is given, a single volume of DefaultVolumeSize is created. When the flag is specified one or more times (or as a comma-separated list), one volume is created per entry. The `create bml` command already supports per-VM volumes via the config file's spec.vms[].volumes field, which is unchanged.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

Part of #2751 

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->
