### PR TITLE
:bug: Remove unused RBAC permissions from controller ClusterRole

### DIFF
--- a/config/base/rbac/role.yaml
+++ b/config/base/rbac/role.yaml
@@ -10,25 +10,19 @@ rules:
   - events
   verbs:
   - create
-  - get
-  - list
   - patch
   - update
-  - watch
 - apiGroups:
   - ""
   resources:
   - namespaces
   verbs:
   - get
-  - list
-  - watch
 - apiGroups:
   - ""
   resources:
   - secrets
   verbs:
-  - delete
   - get
   - list
   - update

--- a/config/overlays/e2e/roles-rolebindings/roles-rolebindings.yaml
+++ b/config/overlays/e2e/roles-rolebindings/roles-rolebindings.yaml
@@ -9,17 +9,13 @@ rules:
   - events
   verbs:
   - create
-  - get
-  - list
   - patch
   - update
-  - watch
 - apiGroups:
   - ""
   resources:
   - secrets
   verbs:
-  - delete
   - get
   - list
   - update

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -2908,25 +2908,19 @@ rules:
   - events
   verbs:
   - create
-  - get
-  - list
   - patch
   - update
-  - watch
 - apiGroups:
   - ""
   resources:
   - namespaces
   verbs:
   - get
-  - list
-  - watch
 - apiGroups:
   - ""
   resources:
   - secrets
   verbs:
-  - delete
   - get
   - list
   - update

--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -90,8 +90,8 @@ func (info *reconcileInfo) publishEvent(reason, message string) {
 // +kubebuilder:rbac:groups=metal3.io,resources=preprovisioningimages,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal3.io,resources=hardwaredata,verbs=get;list;watch;create;delete;patch;update
 // +kubebuilder:rbac:groups=metal3.io,resources=hardware/finalizers,verbs=update
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update;delete
-// +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;update;patch
 
 // Allow for managing hostfirmwaresettings, firmwareschema, bmceventsubscriptions and hostfirmwarecomponents
 // +kubebuilder:rbac:groups=metal3.io,resources=hostfirmwaresettings,verbs=get;list;watch;create;update;patch

--- a/internal/controller/metal3.io/hostclaim_controller.go
+++ b/internal/controller/metal3.io/hostclaim_controller.go
@@ -35,7 +35,7 @@ type HostClaimReconciler struct {
 //+kubebuilder:rbac:groups=metal3.io,resources=hostclaims/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=metal3.io,resources=hostclaims/finalizers,verbs=update
 //+kubebuilder:rbac:groups=metal3.io,resources=hostdeploypolicies,verbs=get;list;watch
-//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get
 
 func (r *HostClaimReconciler) Reconcile(_ context.Context, _ ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil


### PR DESCRIPTION
Remove unused verbs from kubebuilder RBAC markers to enforce least privilege:
- secrets: remove delete (we're consuming secrets, not removing them)
- events: remove get/list/watch (not setup via runtime)
- namespaces: remove list/watch (we have explicit list, if we care about them)
