### PR TITLE
🌱 Include vbmctl unit tests in unit workflow

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -25,3 +25,9 @@ jobs:
       run: make -e unit-cover
       env:
         TEST_FLAGS: "-v"
+    - name: Install libvirt-dev
+      run: sudo apt-get update && sudo apt-get install -y libvirt-dev
+    - name: Run vbmctl unit tests
+      run: make -e unit-vbmctl
+      env:
+        TEST_FLAGS: "-v"

--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,10 @@ build-e2e:
 build-vbmctl:
 	cd test; go build --tags=e2e,vbmctl -ldflags $(LDFLAGS) -o $(abspath $(BIN_DIR)/vbmctl) ./vbmctl/cmd/vbmctl
 
+.PHONY: unit-vbmctl
+unit-vbmctl: ## Run vbmctl unit tests
+	cd test && go test --tags=e2e,vbmctl $(GO_TEST_FLAGS) ./vbmctl/...
+
 .PHONY: build-legacy-vbmctl
 build-legacy-vbmctl:
 	cd test; go build --tags=e2e,vbmctl -ldflags $(LDFLAGS) -o $(abspath $(BIN_DIR)/vbmctl) ./vbmctl/main.go


### PR DESCRIPTION
## Summary

Adds vbmctl unit tests to the CI unit workflow so they run on every PR.

## Why this matters

vbmctl has unit tests but they were never included in CI. The build target existed (`build-vbmctl`) but there was no corresponding test target. PRs could break vbmctl without anyone noticing.

## Changes

- `Makefile`: Added `unit-vbmctl` target running `cd test && go test --tags=e2e,vbmctl ./vbmctl/...`
- `.github/workflows/unit.yml`: Added steps to install `libvirt-dev` and run `make -e unit-vbmctl`

## Testing

- Follows the existing `build-vbmctl` pattern for build tags and working directory
- libvirt-dev installed in CI since vbmctl requires it (same reason it's excluded from the regular unit target)

Fixes #3115

This contribution was developed with AI assistance (Claude Code).