### PR TITLE
ci: include vbmctl unit tests in unit workflow

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -21,7 +21,13 @@ jobs:
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version: ${{ steps.vars.outputs.go_version }}
+    - name: Install libvirt-dev
+      run: sudo apt-get update && sudo apt-get install -y libvirt-dev
     - name: Run unit tests
       run: make -e unit-cover
+      env:
+        TEST_FLAGS: "-v"
+    - name: Run vbmctl unit tests
+      run: make -e unit-vbmctl
       env:
         TEST_FLAGS: "-v"

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,10 @@ unit-cover: ## Run unit tests with code coverage
 	cd pkg/hardwareutils/ && go test -coverprofile=$(COVER_PROFILE) $(GO_TEST_FLAGS) ./...
 	cd pkg/hardwareutils/ && go tool cover -func=$(COVER_PROFILE)
 
+.PHONY: unit-vbmctl
+unit-vbmctl: ## Run vbmctl unit tests
+	go test -coverprofile=$(COVER_PROFILE) $(GO_TEST_FLAGS) --tags=vbmctl ./test/vbmctl/...
+
 .PHONY: unit-verbose
 unit-verbose: ## Run unit tests with verbose output
 	TEST_FLAGS=-v make unit


### PR DESCRIPTION
This PR includes `vbmctl` unit tests in the unit test workflow, as requested in #3115.

Changes:
1. Added `unit-vbmctl` target to the `Makefile` to run unit tests for `vbmctl` with the `vbmctl` tag.
2. Updated `.github/workflows/unit.yml` to install `libvirt-dev` and run the newly added `unit-vbmctl` target.

Fixes #3115