### PR TITLE
:seedling: Add image server management commands to vbmctl

### DIFF
--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -167,9 +167,7 @@ if [[ ! -f "${IMAGE_DIR}/${IPA_FILE}" ]]; then
 fi
 
 ## Start the image server
-docker start image-server-e2e || docker run --name image-server-e2e -d \
-  -p 80:8080 \
-  -v "${IMAGE_DIR}:/usr/share/nginx/html" nginxinc/nginx-unprivileged
+./bin/vbmctl create image-server --host-port 80 --image-dir "${IMAGE_DIR}" --name "vbmctl-image-server-e2e"
 
 # Generate ssh key pair for verifying provisioned BMHs
 if [[ ! -f "${IMAGE_DIR}/ssh_testkey" ]]; then

--- a/hack/clean-e2e.sh
+++ b/hack/clean-e2e.sh
@@ -4,7 +4,7 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${REPO_ROOT}" || exit 1
 
 docker rm -f vbmc
-docker rm -f image-server-e2e
+docker rm -f vbmctl-image-server-e2e
 docker rm -f sushy-tools
 
 "${REPO_ROOT}/tools/bmh_test/clean_local_bmh_test_setup.sh" "^bmo-e2e-"

--- a/test/go.mod
+++ b/test/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/metal3-io/baremetal-operator/apis v0.5.1
 	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.5.1
 	github.com/metal3-io/ironic-standalone-operator/api v0.8.1
+	github.com/moby/moby/api v1.54.1
+	github.com/moby/moby/client v0.4.0
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/spf13/cobra v1.10.2
@@ -76,8 +78,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
-	github.com/moby/moby/api v1.54.1 // indirect
-	github.com/moby/moby/client v0.4.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect

--- a/test/vbmctl/README.md
+++ b/test/vbmctl/README.md
@@ -16,10 +16,10 @@ This tool is under active development.
 | VM management (create/delete/list) | ✅ Implemented |
 | `vbmctl create bml` / `vbmctl delete bml` | ✅ Implemented |
 | `vbmctl status` | ✅ Implemented (basic) |
-| Configurable volumes | ❌ TODO (hard-coded to two per VM) |
+| Configurable volumes |  ✅ Implemented |
 | Network management | ⚠️ Partially implemented (only libvirt networks) |
 | BMC emulator support | ❌ TODO |
-| Image server | ❌ TODO |
+| Image server | ✅ Implemented (basic) |
 | State management (persistent state) | ❌ TODO |
 
 ## Features
@@ -30,6 +30,7 @@ This tool is under active development.
    libvirt networks
 - **Library Support**: Can be imported as a Go module for programmatic use
 - **Libvirt network management**: create and delete libvirt networks
+- **Image Server Management**: Create, delete, list image server
 
 ## Build Tags
 
@@ -77,6 +78,10 @@ vbmctl create vm \
 # Create a bare metal lab (all VMs and networks defined in spec.vms of the config file)
 vbmctl create bml
 
+# Create an image server with default settings. Please note that if
+# a name is specified, vbmctl will automatically add the prefix `vbmctl-`.
+vbmctl create image-server
+
 # Check status
 vbmctl status
 
@@ -88,6 +93,9 @@ vbmctl delete bml
 
 # Create network with default values
 vbmctl delete network
+
+# Delete the image server
+vbmctl delete image-server
 
 # Show help
 vbmctl --help
@@ -157,6 +165,9 @@ spec:
     bridge: metal3
     address: 192.168.222.1
     netmask: 255.255.255.0
+  imageServer:
+    dataDir: "/tmp"
+    port: 80
 ```
 
 The `spec.vms` section defines the VMs that will be created when you run `vbmctl
@@ -175,6 +186,7 @@ import (
 
     "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
     "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/libvirt"
+    "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/containers"
     libvirtgo "libvirt.org/go/libvirt"
 )
 
@@ -228,6 +240,19 @@ func main() {
                 MACAddress: "00:60:2f:31:81:01",
             },
         },
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Create an Image Server
+    err = containers.CreateImageServerInstance(ctx, &api.ImageServerConfig{
+        Image:         "nginx:latest",
+        ContainerName: "image-server",
+        DataDir:       "/var/lib/vbmctl/images",
+        ContainerDataDir: "/usr/share/nginx/html",
+        Port:          8080,
+        ContainerPort: 80,
     })
     if err != nil {
         log.Fatal(err)

--- a/test/vbmctl/cmd/vbmctl/main.go
+++ b/test/vbmctl/cmd/vbmctl/main.go
@@ -15,15 +15,13 @@ import (
 
 	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
 	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/config"
+	containers "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/containers"
 	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/libvirt"
 	"github.com/spf13/cobra"
 	libvirtgo "libvirt.org/go/libvirt"
 )
 
 var (
-	// Version is set at build time.
-	Version = "dev"
-
 	// Global flags.
 	cfgFile     string
 	libvirtURI  string
@@ -45,11 +43,11 @@ for testing and development purposes. It currently provides functionality for:
 
   - Creating and managing virtual machines using libvirt
   - Creating and managing libvirt networks
+  - Image server for provisioning
   - Reserving IP addresses for VMs via DHCP on existing libvirt networks
 
 Planned features (not yet implemented):
   - BMC emulator support (sushy-tools, vbmc)
-  - Image server for provisioning
 
 vbmctl is designed to be as simple to use as 'kind' for creating
 test environments for the Bare Metal Operator (BMO) and CAPM3.`,
@@ -57,7 +55,7 @@ test environments for the Bare Metal Operator (BMO) and CAPM3.`,
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 			if showVersion {
 				//nolint:forbidigo // CLI output is intentional
-				fmt.Printf("vbmctl version %s\n", Version)
+				fmt.Printf("vbmctl version %s\n", config.Version)
 				os.Exit(0)
 			}
 			return nil
@@ -89,6 +87,7 @@ func newCreateCmd() *cobra.Command {
 	cmd.AddCommand(newCreateVMCmd())
 	cmd.AddCommand(newCreateBMLCmd())
 	cmd.AddCommand(newCreateNetworkCmd())
+	cmd.AddCommand(newCreateImageServerCmd())
 	return cmd
 }
 
@@ -204,7 +203,14 @@ Example configuration:
             macAddress: "00:60:2f:31:81:01"
 	networks:
       - name: "baremetal-e2e"
-	  - bridge: "metal3"`,
+	  - bridge: "metal3"
+    imageServer:
+      image: "nginxinc/nginx-unprivileged"
+      port: 8080
+      containerPort: 8080
+      dataDir: "/var/lib/vbmctl/images"
+      containerDataDir: "/usr/share/nginx/html",
+      containerName: "vbmctl-image-server"`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx, cancel := contextWithSignal()
 			defer cancel()
@@ -216,6 +222,16 @@ Example configuration:
 
 			if len(cfg.Spec.VMs) == 0 {
 				return errors.New("no VMs defined in configuration (spec.vms is empty)")
+			}
+
+			if cfg.Spec.ImageServer != nil {
+				err = containers.CreateImageServerInstance(ctx, cfg.Spec.ImageServer)
+				if err != nil {
+					return err
+				}
+			} else {
+				//nolint:forbidigo // CLI output is intentional
+				fmt.Println("No image server configuration found in the config file.")
 			}
 
 			conn, err := libvirtgo.NewConnect(cfg.Spec.Libvirt.URI)
@@ -327,6 +343,83 @@ func newCreateNetworkCmd() *cobra.Command {
 	return cmd
 }
 
+func newCreateImageServerCmd() *cobra.Command {
+	var (
+		containerName               string
+		image                       string
+		imageServerPort             uint16
+		imageServerContainerPort    uint16
+		imageServerDataDir          string
+		imageServerContainerDataDir string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "image-server",
+		Short: "Create an image server instance",
+		Long:  "Create an image server instance to be used for provisioning.",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			ctx, cancel := contextWithSignal()
+			defer cancel()
+
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+
+			// Resolve effective image server config: config file values, falling back to defaults.
+			// Command-line flags take precedence over both.
+			effective := &vbmctlapi.ImageServerConfig{
+				Image:            config.DefaultImageServerImage,
+				Port:             config.DefaultImageServerPort,
+				ContainerPort:    config.DefaultImageServerContainerPort,
+				DataDir:          config.DefaultImageServerDataDir,
+				ContainerDataDir: config.DefaultContainerDataDir,
+				ContainerName:    config.DefaultImageServerContainerName,
+			}
+			if cfg.Spec.ImageServer != nil {
+				effective = cfg.Spec.ImageServer
+			}
+
+			if image == "" {
+				image = effective.Image
+			}
+			if imageServerPort == 0 {
+				imageServerPort = effective.Port
+			}
+			if imageServerContainerPort == 0 {
+				imageServerContainerPort = effective.ContainerPort
+			}
+			if imageServerDataDir == "" {
+				imageServerDataDir = effective.DataDir
+			}
+			if imageServerContainerDataDir == "" {
+				imageServerContainerDataDir = effective.ContainerDataDir
+			}
+			if containerName == "" {
+				containerName = effective.ContainerName
+			}
+
+			return containers.CreateImageServerInstance(ctx, &vbmctlapi.ImageServerConfig{
+				Image:            image,
+				Port:             imageServerPort,
+				ContainerPort:    imageServerContainerPort,
+				DataDir:          imageServerDataDir,
+				ContainerDataDir: imageServerContainerDataDir,
+				ContainerName:    containerName,
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&containerName, "name", "", "name of the image server container (default is "+config.DefaultImageServerContainerName+" if not set in config file)")
+	cmd.Flags().StringVar(&image, "image", "", "container image to use for the image server (default is "+config.DefaultImageServerImage+" if not set in config file)")
+	cmd.Flags().Uint16Var(&imageServerPort, "host-port", 0, "host port to bind the image server to (default is "+strconv.Itoa(int(config.DefaultImageServerPort))+" if not set in config file)")
+	cmd.Flags().Uint16Var(&imageServerContainerPort, "container-port", 0, "container port that the image server listens on (default is "+strconv.Itoa(int(config.DefaultImageServerContainerPort))+" if not set in config file)")
+	cmd.Flags().StringVar(&imageServerDataDir, "image-dir", "", "host directory to mount as a volume for the image server (default is "+config.DefaultImageServerDataDir+" if not set in config file)")
+	cmd.Flags().StringVar(&imageServerContainerDataDir, "container-dir", "", "directory inside the container to mount the data volume to (default is "+config.DefaultContainerDataDir+" if not set in config file)")
+
+	return cmd
+}
+
 func newDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
@@ -337,6 +430,7 @@ func newDeleteCmd() *cobra.Command {
 	cmd.AddCommand(newDeleteVMCmd())
 	cmd.AddCommand(newDeleteBMLCmd())
 	cmd.AddCommand(newDeleteNetworkCmd())
+	cmd.AddCommand(newDeleteImageServerCmd())
 	return cmd
 }
 
@@ -459,6 +553,18 @@ func newDeleteBMLCmd() *cobra.Command {
 				fmt.Printf("  - %s\n", name)
 			}
 
+			if cfg.Spec.ImageServer != nil {
+				err := containers.DeleteImageServerInstance(ctx, cfg.Spec.ImageServer.ContainerName)
+				// don't fail the whole command if image server deletion fails, just log the error
+				if err != nil {
+					//nolint:forbidigo // CLI output is intentional
+					fmt.Printf("%v\n", err)
+				}
+			} else {
+				//nolint:forbidigo // CLI output is intentional
+				fmt.Println("No image server configuration found in the config file.")
+			}
+
 			return nil
 		},
 	}
@@ -506,7 +612,43 @@ func newDeleteNetworkCmd() *cobra.Command {
 	return cmd
 }
 
+func newDeleteImageServerCmd() *cobra.Command {
+	var containerName string
+
+	cmd := &cobra.Command{
+		Use:   "image-server",
+		Short: "Delete the image server instance",
+		Long:  "Delete the image server instance used for provisioning.",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			ctx, cancel := contextWithSignal()
+			defer cancel()
+
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+
+			// command-line flag takes precedence over config file value
+			if containerName == "" {
+				if cfg.Spec.ImageServer != nil {
+					containerName = cfg.Spec.ImageServer.ContainerName
+				} else {
+					containerName = config.DefaultImageServerContainerName
+				}
+			}
+
+			return containers.DeleteImageServerInstance(ctx, containerName)
+		},
+	}
+
+	cmd.Flags().StringVar(&containerName, "name", "", "name of the image server container to delete (default is "+config.DefaultImageServerContainerName+" if not set in config file)")
+
+	return cmd
+}
+
 func newStatusCmd() *cobra.Command {
+	var containerName string
+
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Show status of the environment",
@@ -539,6 +681,22 @@ func newStatusCmd() *cobra.Command {
 				return fmt.Errorf("failed to list VMs: %w", err)
 			}
 
+			// command-line flag takes precedence over config file value
+			if containerName == "" {
+				if cfg.Spec.ImageServer != nil {
+					containerName = cfg.Spec.ImageServer.ContainerName
+				} else {
+					containerName = config.DefaultImageServerContainerName
+				}
+			}
+			// check if the image server is present
+			containerInfo, err := containers.GetImageServerInfo(ctx, containerName)
+			if err != nil {
+				return err
+			}
+
+			//nolint:forbidigo // CLI output is intentional
+			fmt.Printf("Image Server container: %s\n", containerInfo)
 			//nolint:forbidigo // CLI output is intentional
 			fmt.Println("Virtual Machines:")
 			//nolint:forbidigo // CLI output is intentional
@@ -552,6 +710,8 @@ func newStatusCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(&containerName, "name", "", "name of the image server container (default is "+config.DefaultImageServerContainerName+" if not set in config file)")
 
 	return cmd
 }
@@ -623,6 +783,16 @@ func newConfigViewCmd() *cobra.Command {
 				}
 			}
 
+			if cfg.Spec.ImageServer != nil {
+				//nolint:forbidigo // CLI output is intentional
+				fmt.Printf("Image Server:\n  Image: %s\n  Host Port: %d\n  Container Port: %d\n  Data Dir: %s\n  Container Name: %s\n",
+					cfg.Spec.ImageServer.Image,
+					cfg.Spec.ImageServer.Port,
+					cfg.Spec.ImageServer.ContainerPort,
+					cfg.Spec.ImageServer.DataDir,
+					cfg.Spec.ImageServer.ContainerName)
+			}
+
 			return nil
 		},
 	}
@@ -637,7 +807,7 @@ func newVersionCmd() *cobra.Command {
 		Long:  "Print the version of vbmctl.",
 		Run: func(_ *cobra.Command, _ []string) {
 			//nolint:forbidigo // CLI output is intentional
-			fmt.Printf("vbmctl version %s\n", Version)
+			fmt.Printf("vbmctl version %s\n", config.Version)
 		},
 	}
 }

--- a/test/vbmctl/pkg/api/types.go
+++ b/test/vbmctl/pkg/api/types.go
@@ -29,6 +29,27 @@ type VolumeConfig struct {
 	Size int `json:"size" yaml:"size"`
 }
 
+// ImageServerConfig represents the configuration for the image server.
+type ImageServerConfig struct {
+	// Port is the host port to bind the image server to.
+	Port uint16 `json:"port" yaml:"port"`
+
+	// ContainerPort is the container port that the image server listens on.
+	ContainerPort uint16 `json:"containerPort" yaml:"containerPort"`
+
+	// DataDir is the host directory to mount as a volume for the image server.
+	DataDir string `json:"dataDir" yaml:"dataDir"`
+
+	// ContainerDataDir is the directory inside the container to mount the data volume to.
+	ContainerDataDir string `json:"containerDataDir" yaml:"containerDataDir"`
+
+	// Image is the container image to use for the image server.
+	Image string `json:"image" yaml:"image"`
+
+	// ContainerName is the name of the container to create for the image server.
+	ContainerName string `json:"containerName" yaml:"containerName"`
+}
+
 // NetworkAttachment represents a network interface attached to a VM.
 type NetworkAttachment struct {
 	// Network is the name of the libvirt network to attach to.

--- a/test/vbmctl/pkg/config/config.go
+++ b/test/vbmctl/pkg/config/config.go
@@ -7,11 +7,14 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
+	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
 	"gopkg.in/yaml.v2"
 )
 
 const (
+	// Version is set at build time.
+	Version = "dev"
+
 	// DefaultConfigFileName is the default name for the config file.
 	DefaultConfigFileName = "vbmctl.yaml"
 
@@ -50,6 +53,24 @@ const (
 
 	// filePermissions is the default permission for config files.
 	filePermissions = 0600
+
+	// DefaultImageServerPort is the default host port for the image server.
+	DefaultImageServerPort = 8080
+
+	// DefaultImageServerContainerPort is the default container port for the image server.
+	DefaultImageServerContainerPort = 8080
+
+	// DefaultImageServerDataDir is the default data directory for the image server.
+	DefaultImageServerDataDir = "/var/lib/vbmctl/images"
+
+	// DefaultContainerDataDir is the default directory inside the container to mount the data volume to.
+	DefaultContainerDataDir = "/usr/share/nginx/html"
+
+	// DefaultImageServerImage is the default container image for the image server.
+	DefaultImageServerImage = "nginxinc/nginx-unprivileged"
+
+	// DefaultImageServerContainerName is the default container name for the image server.
+	DefaultImageServerContainerName = "vbmctl-image-server"
 )
 
 // Config is the top-level configuration for vbmctl.
@@ -75,7 +96,11 @@ type Spec struct {
 	// VMs is a list of VM configurations to create.
 	VMs []vbmctlapi.VMConfig `json:"vms,omitempty" yaml:"vms,omitempty"`
 
+	// Networks is a list of network configurations to create.
 	Networks []vbmctlapi.NetworkConfig `json:"networks,omitempty" yaml:"networks,omitempty"`
+
+	// ImageServer contains configuration for the image server.
+	ImageServer *vbmctlapi.ImageServerConfig `json:"imageServer,omitempty" yaml:"imageServer,omitempty"`
 }
 
 // LibvirtConfig contains libvirt connection settings.
@@ -206,6 +231,28 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	// Validate image server config
+	if c.Spec.ImageServer != nil {
+		if c.Spec.ImageServer.Port == 0 {
+			return errors.New("image server port is required")
+		}
+		if c.Spec.ImageServer.ContainerPort == 0 {
+			return errors.New("image server container port is required")
+		}
+		if c.Spec.ImageServer.DataDir == "" {
+			return errors.New("image server data directory is required")
+		}
+		if c.Spec.ImageServer.ContainerDataDir == "" {
+			return errors.New("image server container data directory is required")
+		}
+		if c.Spec.ImageServer.Image == "" {
+			return errors.New("image server container image is required")
+		}
+		if c.Spec.ImageServer.ContainerName == "" {
+			return errors.New("image server container name is required")
+		}
+	}
+
 	return nil
 }
 
@@ -227,6 +274,28 @@ func (c *Config) ApplyDefaults() {
 	// Apply VM defaults
 	for i := range c.Spec.VMs {
 		c.Spec.VMs[i] = c.Spec.VMs[i].Defaults()
+	}
+
+	// Apply image server defaults
+	if c.Spec.ImageServer != nil {
+		if c.Spec.ImageServer.Port == 0 {
+			c.Spec.ImageServer.Port = DefaultImageServerPort
+		}
+		if c.Spec.ImageServer.ContainerPort == 0 {
+			c.Spec.ImageServer.ContainerPort = DefaultImageServerContainerPort
+		}
+		if c.Spec.ImageServer.DataDir == "" {
+			c.Spec.ImageServer.DataDir = DefaultImageServerDataDir
+		}
+		if c.Spec.ImageServer.ContainerDataDir == "" {
+			c.Spec.ImageServer.ContainerDataDir = DefaultContainerDataDir
+		}
+		if c.Spec.ImageServer.Image == "" {
+			c.Spec.ImageServer.Image = DefaultImageServerImage
+		}
+		if c.Spec.ImageServer.ContainerName == "" {
+			c.Spec.ImageServer.ContainerName = DefaultImageServerContainerName
+		}
 	}
 }
 

--- a/test/vbmctl/pkg/config/config_test.go
+++ b/test/vbmctl/pkg/config/config_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
+	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
 )
 
 func TestDefault(t *testing.T) {
@@ -42,6 +42,13 @@ spec:
     - name: "test-vm"
       memory: 8192
       vcpus: 4
+  imageServer:
+    image: "test/image-server:latest"
+    port: 81
+    containerPort: 8081
+    dataDir: "/var/lib/vbmctl/images-test"
+    containerDataDir: "/usr/share/nginx/html"
+    containerName: "vbmctl-image-server-test"
 `)
 
 	cfg, err := Parse(yamlData)
@@ -68,6 +75,34 @@ spec:
 	if cfg.Spec.VMs[0].Memory != 8192 {
 		t.Errorf("expected VM memory 8192, got %d", cfg.Spec.VMs[0].Memory)
 	}
+
+	if cfg.Spec.ImageServer == nil {
+		t.Fatal("expected image server config, got nil")
+	}
+
+	if cfg.Spec.ImageServer.Image != "test/image-server:latest" {
+		t.Errorf("expected image server image 'test/image-server:latest', got %s", cfg.Spec.ImageServer.Image)
+	}
+
+	if cfg.Spec.ImageServer.Port != 81 {
+		t.Errorf("expected image server port 81, got %d", cfg.Spec.ImageServer.Port)
+	}
+
+	if cfg.Spec.ImageServer.ContainerPort != 8081 {
+		t.Errorf("expected image server container port 8081, got %d", cfg.Spec.ImageServer.ContainerPort)
+	}
+
+	if cfg.Spec.ImageServer.DataDir != "/var/lib/vbmctl/images-test" {
+		t.Errorf("expected image server data dir '/var/lib/vbmctl/images-test', got %s", cfg.Spec.ImageServer.DataDir)
+	}
+
+	if cfg.Spec.ImageServer.ContainerDataDir != "/usr/share/nginx/html" {
+		t.Errorf("expected image server container data dir '/usr/share/nginx/html', got %s", cfg.Spec.ImageServer.ContainerDataDir)
+	}
+
+	if cfg.Spec.ImageServer.ContainerName != "vbmctl-image-server-test" {
+		t.Errorf("expected image server container name 'vbmctl-image-server-test', got %s", cfg.Spec.ImageServer.ContainerName)
+	}
 }
 
 func TestLoadAndSave(t *testing.T) {
@@ -78,6 +113,14 @@ func TestLoadAndSave(t *testing.T) {
 	cfg := Default()
 	cfg.Spec.VMs = []vbmctlapi.VMConfig{
 		{Name: "saved-vm", Memory: 2048, VCPUs: 1},
+	}
+	cfg.Spec.ImageServer = &vbmctlapi.ImageServerConfig{
+		Image:            "test/image-server:latest",
+		Port:             81,
+		ContainerPort:    8081,
+		DataDir:          "/var/lib/vbmctl/images-test",
+		ContainerDataDir: "/usr/share/nginx/html",
+		ContainerName:    "vbmctl-image-server",
 	}
 
 	// Save it
@@ -102,6 +145,34 @@ func TestLoadAndSave(t *testing.T) {
 
 	if loadedCfg.Spec.VMs[0].Name != "saved-vm" {
 		t.Errorf("expected VM name 'saved-vm', got %s", loadedCfg.Spec.VMs[0].Name)
+	}
+
+	if loadedCfg.Spec.ImageServer == nil {
+		t.Fatal("expected image server config, got nil")
+	}
+
+	if loadedCfg.Spec.ImageServer.Image != "test/image-server:latest" {
+		t.Errorf("expected image server image 'test/image-server:latest', got %s", loadedCfg.Spec.ImageServer.Image)
+	}
+
+	if loadedCfg.Spec.ImageServer.DataDir != "/var/lib/vbmctl/images-test" {
+		t.Errorf("expected image server data dir '/var/lib/vbmctl/images-test', got %s", loadedCfg.Spec.ImageServer.DataDir)
+	}
+
+	if loadedCfg.Spec.ImageServer.ContainerDataDir != "/usr/share/nginx/html" {
+		t.Errorf("expected image server container data dir '/usr/share/nginx/html', got %s", loadedCfg.Spec.ImageServer.ContainerDataDir)
+	}
+
+	if loadedCfg.Spec.ImageServer.ContainerName != "vbmctl-image-server" {
+		t.Errorf("expected image server container name 'vbmctl-image-server', got %s", loadedCfg.Spec.ImageServer.ContainerName)
+	}
+
+	if loadedCfg.Spec.ImageServer.Port != 81 {
+		t.Errorf("expected image server port %d, got %d", 81, loadedCfg.Spec.ImageServer.Port)
+	}
+
+	if loadedCfg.Spec.ImageServer.ContainerPort != 8081 {
+		t.Errorf("expected image server container port %d, got %d", 8081, loadedCfg.Spec.ImageServer.ContainerPort)
 	}
 }
 
@@ -163,6 +234,98 @@ func TestValidate(t *testing.T) {
 			name: "VM without name",
 			modify: func(c *Config) {
 				c.Spec.VMs = []vbmctlapi.VMConfig{{Memory: 1024}}
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid image server config",
+			modify: func(c *Config) {
+				c.Spec.ImageServer = &vbmctlapi.ImageServerConfig{
+					Image:            "test/image-server:latest",
+					Port:             80,
+					ContainerPort:    8080,
+					DataDir:          "/var/lib/vbmctl/images-test",
+					ContainerDataDir: "/var/lib/vbmctl/images-test",
+					ContainerName:    "vbmctl-image-server",
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid image server config - missing port",
+			modify: func(c *Config) {
+				c.Spec.ImageServer = &vbmctlapi.ImageServerConfig{
+					Image:            "test/image-server:latest",
+					ContainerPort:    8080,
+					DataDir:          "/var/lib/vbmctl/images-test",
+					ContainerDataDir: "/var/lib/vbmctl/images-test",
+					ContainerName:    "vbmctl-image-server",
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid image server config - missing container port",
+			modify: func(c *Config) {
+				c.Spec.ImageServer = &vbmctlapi.ImageServerConfig{
+					Image:            "test/image-server:latest",
+					Port:             80,
+					DataDir:          "/var/lib/vbmctl/images-test",
+					ContainerDataDir: "/var/lib/vbmctl/images-test",
+					ContainerName:    "vbmctl-image-server",
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid image server config - missing data dir",
+			modify: func(c *Config) {
+				c.Spec.ImageServer = &vbmctlapi.ImageServerConfig{
+					Image:            "test/image-server:latest",
+					Port:             80,
+					ContainerPort:    8080,
+					ContainerDataDir: "/var/lib/vbmctl/images-test",
+					ContainerName:    "vbmctl-image-server",
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid image server config - missing container data dir",
+			modify: func(c *Config) {
+				c.Spec.ImageServer = &vbmctlapi.ImageServerConfig{
+					Image:         "test/image-server:latest",
+					Port:          80,
+					ContainerPort: 8080,
+					DataDir:       "/var/lib/vbmctl/images-test",
+					ContainerName: "vbmctl-image-server",
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid image server config - missing image",
+			modify: func(c *Config) {
+				c.Spec.ImageServer = &vbmctlapi.ImageServerConfig{
+					Port:             80,
+					ContainerPort:    8080,
+					DataDir:          "/var/lib/vbmctl/images-test",
+					ContainerDataDir: "/var/lib/vbmctl/images-test",
+					ContainerName:    "vbmctl-image-server",
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid image server config - missing container name",
+			modify: func(c *Config) {
+				c.Spec.ImageServer = &vbmctlapi.ImageServerConfig{
+					Image:            "test/image-server:latest",
+					Port:             80,
+					ContainerPort:    8080,
+					DataDir:          "/var/lib/vbmctl/images-test",
+					ContainerDataDir: "/var/lib/vbmctl/images-test",
+				}
 			},
 			wantErr: true,
 		},

--- a/test/vbmctl/pkg/containers/doc.go
+++ b/test/vbmctl/pkg/containers/doc.go
@@ -1,0 +1,57 @@
+//go:build vbmctl
+// +build vbmctl
+
+// Package containers provides a wrapper around the Docker/Moby client for
+// managing containers and image servers.
+//
+// This package is designed to be used by vbmctl for creating and managing
+// container-based services in virtual bare metal environments. It provides
+// high-level abstractions over the low-level Docker API.
+//
+// # Container Management
+//
+// Containers can be created and started using CreateRunningContainer:
+//
+//	opts := &client.ContainerCreateOptions{
+//	    Name: "bmc-emulator",
+//	    Config: &container.Config{
+//	        Image: "my-bmc:latest",
+//	        Env:   []string{"BMC_USER=admin"},
+//	    },
+//	}
+//	err := containers.CreateRunningContainer(ctx, "BMC emulator", opts)
+//
+// The function checks whether the container already exists before creating it,
+// and starts it regardless of whether it was freshly created or was previously
+// stopped.
+//
+// Containers can be removed forcefully using DeleteContainer:
+//
+//	err := containers.DeleteContainer(ctx, "BMC emulator", "bmc-emulator")
+//
+// The current status and short ID of a container can be retrieved using
+// GetContainerInfo:
+//
+//	info, err := containers.GetContainerInfo(ctx, "bmc-emulator")
+//	// info is e.g. "bmc-emulator 'running' (id: a1b2c3d4e5f6)" or "'not found'"
+//
+// # Image Server Management
+//
+// An image server container can be provisioned using
+// CreateImageServerInstance:
+//
+//	err := containers.CreateImageServerInstance(ctx, &api.ImageServerConfig{
+//	    Image:             "nginx:latest",
+//	    ContainerName:     "vbmctl-image-server",
+//	    DataDir:           "/var/lib/vbmctl/images",
+//	    ContainerDataDir:  "/data",
+//	    Port:              8080,
+//	    ContainerPort:     80,
+//	})
+//
+// # Error Handling
+//
+// All operations return standard Go errors that can be inspected for specific
+// failure modes. Callers should handle these errors according to their needs,
+// for example by checking the underlying Docker API error where appropriate.
+package containers

--- a/test/vbmctl/pkg/containers/docker.go
+++ b/test/vbmctl/pkg/containers/docker.go
@@ -1,0 +1,120 @@
+//go:build vbmctl
+// +build vbmctl
+
+package containers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/config"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
+)
+
+func ensureVbmctlPrefix(name string) string {
+	if !strings.HasPrefix(name, "vbmctl-") {
+		return "vbmctl-" + name
+	}
+	return name
+}
+
+func getContainerStatus(ctx context.Context, containerName string, apiClient *client.Client) (status container.ContainerState, uuid string, err error) {
+	// Use a name filter (anchored regex for exact match) and limit to 1
+	// to avoid fetching all containers. Returns empty strings without error if not found.
+	list, err := apiClient.ContainerList(ctx, client.ContainerListOptions{
+		All:     true,
+		Filters: make(client.Filters).Add("name", "^/"+containerName+"$"),
+		Limit:   1,
+	})
+	if err != nil || len(list.Items) == 0 {
+		return "", "", err
+	}
+
+	return list.Items[0].State, list.Items[0].ID, nil
+}
+
+func CreateRunningContainer(ctx context.Context, humanName string, opts *client.ContainerCreateOptions) error {
+	apiClient, err := client.New(client.FromEnv, client.WithUserAgent("vbmctl/"+config.Version))
+	if err != nil {
+		return err
+	}
+	defer apiClient.Close()
+
+	// need to check if the container is already running to avoid creating multiple instances
+	status, containerID, err := getContainerStatus(ctx, opts.Name, apiClient)
+	if err != nil {
+		return fmt.Errorf("failed to get status for container %q: %w", opts.Name, err)
+	}
+	if containerID != "" {
+		//nolint:forbidigo // CLI output is intentional
+		fmt.Printf("Found %s container: %s (id: %s) status: %s\n", humanName, opts.Name, containerID[:12], status)
+		if status == "running" {
+			return nil
+		}
+		// container exists but is not running, we can start it below
+	} else {
+		// Pull the image if it is not already present locally
+		if _, err := apiClient.ImageInspect(ctx, opts.Config.Image); err != nil {
+			//nolint:forbidigo // CLI output is intentional
+			fmt.Printf("Pulling image %s ...\n", opts.Config.Image)
+			rc, err := apiClient.ImagePull(ctx, opts.Config.Image, client.ImagePullOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to pull image %q for %s container: %w", opts.Config.Image, humanName, err)
+			}
+			if err := rc.Wait(ctx); err != nil {
+				return fmt.Errorf("failed to pull image %q: %w", opts.Config.Image, err)
+			}
+		}
+
+		// Create the container
+		resp, err := apiClient.ContainerCreate(ctx, *opts)
+		if err != nil {
+			return fmt.Errorf("failed to create %s container: %w", humanName, err)
+		}
+		containerID = resp.ID
+	}
+
+	if _, err := apiClient.ContainerStart(ctx, containerID, client.ContainerStartOptions{}); err != nil {
+		return fmt.Errorf("failed to start the %s container: %w", humanName, err)
+	}
+	//nolint:forbidigo // CLI output is intentional
+	fmt.Printf("Started the %s container: %s (id: %s)\n", humanName, opts.Name, containerID[:12])
+
+	return nil
+}
+
+func DeleteContainer(ctx context.Context, realName string, containerName string) error {
+	apiClient, err := client.New(client.FromEnv, client.WithUserAgent("vbmctl/"+config.Version))
+	if err != nil {
+		return err
+	}
+	defer apiClient.Close()
+
+	if _, err := apiClient.ContainerRemove(ctx, containerName, client.ContainerRemoveOptions{Force: true}); err != nil {
+		return fmt.Errorf("failed to delete %s container %q: %w", realName, containerName, err)
+	}
+	//nolint:forbidigo // CLI output is intentional
+	fmt.Printf("Deleted the %s container: %s\n", realName, containerName)
+
+	return nil
+}
+
+func GetContainerInfo(ctx context.Context, containerName string) (info string, err error) {
+	apiClient, err := client.New(client.FromEnv, client.WithUserAgent("vbmctl/"+config.Version))
+	if err != nil {
+		return "", err
+	}
+	defer apiClient.Close()
+
+	status, containerID, err := getContainerStatus(ctx, containerName, apiClient)
+	if err != nil {
+		return "", fmt.Errorf("failed to get status for container %q: %w", containerName, err)
+	}
+	containerInfo := "'not found'"
+	if containerID != "" {
+		containerInfo = fmt.Sprintf("'%s' (id: %s)", status, containerID[:12])
+	}
+	return fmt.Sprintf("%s %s", containerName, containerInfo), nil
+}

--- a/test/vbmctl/pkg/containers/imageserver.go
+++ b/test/vbmctl/pkg/containers/imageserver.go
@@ -1,0 +1,77 @@
+//go:build vbmctl
+// +build vbmctl
+
+package containers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
+	container "github.com/moby/moby/api/types/container"
+	mount "github.com/moby/moby/api/types/mount"
+	network "github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
+)
+
+func CreateImageServerInstance(ctx context.Context, cfg *vbmctlapi.ImageServerConfig) error {
+	containerPort, err := network.ParsePort(fmt.Sprintf("%d/tcp", cfg.ContainerPort))
+	if err != nil {
+		return fmt.Errorf("failed to parse container port: %w", err)
+	}
+
+	// Validate that the data directory exists and is a directory
+	info, err := os.Stat(cfg.DataDir)
+	if err != nil {
+		return fmt.Errorf("failed to access image server data directory %q: %w", cfg.DataDir, err)
+	} else if !info.IsDir() {
+		return fmt.Errorf("image server data directory %q is not a directory", cfg.DataDir)
+	}
+
+	// Create the container
+	opts := client.ContainerCreateOptions{
+		Config: &container.Config{
+			Image: cfg.Image,
+			ExposedPorts: network.PortSet{
+				containerPort: struct{}{},
+			},
+		},
+		HostConfig: &container.HostConfig{
+			Mounts: []mount.Mount{
+				{
+					Type:     mount.TypeBind,
+					Source:   cfg.DataDir,
+					Target:   cfg.ContainerDataDir,
+					ReadOnly: false,
+				},
+			},
+			PortBindings: network.PortMap{
+				containerPort: []network.PortBinding{
+					{
+						HostPort: strconv.FormatUint(uint64(cfg.Port), 10),
+					},
+				},
+			},
+		},
+		NetworkingConfig: nil,
+		Platform:         nil,
+		Name:             ensureVbmctlPrefix(cfg.ContainerName),
+	}
+
+	err = CreateRunningContainer(ctx, "image server", &opts)
+	if err != nil {
+		return fmt.Errorf("failed to create image server container: %w", err)
+	}
+
+	return nil
+}
+
+func DeleteImageServerInstance(ctx context.Context, containerName string) error {
+	return DeleteContainer(ctx, "image server", ensureVbmctlPrefix(containerName))
+}
+
+func GetImageServerInfo(ctx context.Context, containerName string) (info string, err error) {
+	return GetContainerInfo(ctx, ensureVbmctlPrefix(containerName))
+}


### PR DESCRIPTION
Add `create image-server` and `delete image-server` subcommands, plus image server status in the `status` command. Uses github.com/moby/moby to manage a container serving provisioning images.

- New `ImageServerConfig` type; optional `spec.imageServer` in config
- `create`: reuses a stopped container or creates a new one with port binding and bind-mount; errors if already running
- `delete`: force-removes the container by name
- `create bml` / `delete bml`: manage image server alongside VMs
- Config defaults, validation, and tests included
- Added a new helper pkg: containers

Do not track the configuration file `vbmctl.yaml`.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Part of #2751