### PR TITLE
:seedling: remove unneeded vbmctl template datatypes

### DIFF
--- a/test/vbmctl/pkg/libvirt/pool.go
+++ b/test/vbmctl/pkg/libvirt/pool.go
@@ -52,10 +52,7 @@ func (m *PoolManager) EnsurePool(_ context.Context, cfg vbmctlapi.PoolConfig) (*
 	}
 
 	// Render pool XML
-	poolXML, err := m.renderer.RenderPool(PoolTemplateData{
-		PoolName: cfg.Name,
-		PoolPath: cfg.Path,
-	})
+	poolXML, err := m.renderer.RenderPool(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to render pool template: %w", err)
 	}
@@ -117,9 +114,9 @@ func (m *PoolManager) CreateVolume(_ context.Context, poolName, volumeName strin
 	}
 
 	// Render volume XML
-	volumeXML, err := m.renderer.RenderVolume(VolumeTemplateData{
-		VolumeName:         volumeName,
-		VolumeCapacityInGB: sizeGB,
+	volumeXML, err := m.renderer.RenderVolume(vbmctlapi.VolumeConfig{
+		Name: volumeName,
+		Size: sizeGB,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to render volume template: %w", err)

--- a/test/vbmctl/pkg/libvirt/templates.go
+++ b/test/vbmctl/pkg/libvirt/templates.go
@@ -37,22 +37,6 @@ func NewTemplateRenderer() (*TemplateRenderer, error) {
 	}, nil
 }
 
-// VMTemplateData contains data for rendering VM templates.
-type VMTemplateData struct {
-	Name     string
-	Memory   int // in KiB
-	VCPUs    int
-	PoolPath string
-	Networks []NetworkInterfaceData
-	Volumes  []VolumeAttachmentData
-}
-
-// NetworkInterfaceData contains data for a network interface in VM templates.
-type NetworkInterfaceData struct {
-	Network    string
-	MACAddress string
-}
-
 // VolumeAttachmentData contains data for a volume attachment in VM templates.
 type VolumeAttachmentData struct {
 	Name   string
@@ -61,42 +45,68 @@ type VolumeAttachmentData struct {
 	Bus    string // e.g., "virtio"
 }
 
-// PoolTemplateData contains data for rendering storage pool templates.
-type PoolTemplateData struct {
-	PoolName string
-	PoolPath string
-}
-
-// VolumeTemplateData contains data for rendering volume templates.
-type VolumeTemplateData struct {
-	VolumeName         string
-	VolumeCapacityInGB int
-}
-
-// DHCPHostData contains data for a DHCP host entry.
-type DHCPHostData struct {
-	MACAddress string
-	Name       string
-	IPAddress  string
-}
-
 // RenderVM renders the VM XML template with the given data.
-func (r *TemplateRenderer) RenderVM(data VMTemplateData) (string, error) {
+func (r *TemplateRenderer) RenderVM(cfg vbmctlapi.VMConfig, poolPath string) (string, error) {
+	// Apply defaults
+	cfg = cfg.Defaults()
+
+	// Convert memory from MB to KiB
+	memoryKiB := cfg.Memory * kiBPerMiB
+
+	// Check and convert volumes to attachments
+	devices := []string{"vda", "vdb", "vdc", "vdd", "vde", "vdf", "vdg", "vdh"}
+	if len(cfg.Volumes) > len(devices) {
+		return "", fmt.Errorf("configuration has %d volumes but only %d are supported", len(cfg.Volumes), len(devices))
+	}
+	volumes := make([]VolumeAttachmentData, len(cfg.Volumes))
+	for i, vol := range cfg.Volumes {
+		volumes[i] = VolumeAttachmentData{
+			Name:   vol.Name,
+			Path:   fmt.Sprintf("%s/%s-%s.qcow2", poolPath, cfg.Name, vol.Name),
+			Device: devices[i],
+			Bus:    "virtio",
+		}
+	}
+
+	data := struct {
+		Name     string
+		Memory   int // in KiB
+		VCPUs    int
+		PoolPath string
+		Networks []vbmctlapi.NetworkAttachment
+		Volumes  []VolumeAttachmentData
+	}{
+		Name:     cfg.Name,
+		Memory:   memoryKiB,
+		VCPUs:    cfg.VCPUs,
+		PoolPath: poolPath,
+		Networks: cfg.Networks,
+		Volumes:  volumes,
+	}
 	return r.render("VM.xml.tpl", data)
 }
 
 // RenderPool renders the storage pool XML template with the given data.
-func (r *TemplateRenderer) RenderPool(data PoolTemplateData) (string, error) {
-	return r.render("pool.xml.tpl", data)
+func (r *TemplateRenderer) RenderPool(cfg vbmctlapi.PoolConfig) (string, error) {
+	return r.render("pool.xml.tpl", cfg)
 }
 
 // RenderVolume renders the volume XML template with the given data.
-func (r *TemplateRenderer) RenderVolume(data VolumeTemplateData) (string, error) {
-	return r.render("volume.xml.tpl", data)
+func (r *TemplateRenderer) RenderVolume(cfg vbmctlapi.VolumeConfig) (string, error) {
+	return r.render("volume.xml.tpl", cfg)
 }
 
 // RenderDHCPHost renders XML for a DHCP host entry.
-func (r *TemplateRenderer) RenderDHCPHost(data DHCPHostData) (string, error) {
+func (r *TemplateRenderer) RenderDHCPHost(net vbmctlapi.NetworkAttachment, hostName string) (string, error) {
+	data := struct {
+		MACAddress string
+		Name       string
+		IPAddress  string
+	}{
+		MACAddress: net.MACAddress,
+		Name:       hostName,
+		IPAddress:  net.IPAddress,
+	}
 	tmpl, err := template.New("dhcp-host").Parse(
 		"<host mac='{{ .MACAddress }}' name='{{ .Name }}' ip='{{ .IPAddress }}' />",
 	)
@@ -135,64 +145,4 @@ func RenderTemplate(inputFile string, data interface{}) (string, error) {
 	}
 
 	return buf.String(), nil
-}
-
-// VMConfigToTemplateData converts a VMConfig to VMTemplateData.
-func VMConfigToTemplateData(cfg vbmctlapi.VMConfig, poolPath string) VMTemplateData {
-	// Apply defaults
-	cfg = cfg.Defaults()
-
-	// Convert memory from MB to KiB
-	memoryKiB := cfg.Memory * kiBPerMiB
-
-	// Convert networks
-	networks := make([]NetworkInterfaceData, len(cfg.Networks))
-	for i, net := range cfg.Networks {
-		networks[i] = NetworkInterfaceData{
-			Network:    net.Network,
-			MACAddress: net.MACAddress,
-		}
-	}
-
-	// Convert volumes to attachments
-	volumes := make([]VolumeAttachmentData, len(cfg.Volumes))
-	devices := []string{"vda", "vdb", "vdc", "vdd", "vde", "vdf", "vdg", "vdh"}
-	for i, vol := range cfg.Volumes {
-		device := "vda"
-		if i < len(devices) {
-			device = devices[i]
-		}
-		volumes[i] = VolumeAttachmentData{
-			Name:   vol.Name,
-			Path:   fmt.Sprintf("%s/%s-%s.qcow2", poolPath, cfg.Name, vol.Name),
-			Device: device,
-			Bus:    "virtio",
-		}
-	}
-
-	return VMTemplateData{
-		Name:     cfg.Name,
-		Memory:   memoryKiB,
-		VCPUs:    cfg.VCPUs,
-		PoolPath: poolPath,
-		Networks: networks,
-		Volumes:  volumes,
-	}
-}
-
-// PoolConfigToTemplateData converts a PoolConfig to PoolTemplateData.
-func PoolConfigToTemplateData(cfg vbmctlapi.PoolConfig) PoolTemplateData {
-	return PoolTemplateData{
-		PoolName: cfg.Name,
-		PoolPath: cfg.Path,
-	}
-}
-
-// VolumeConfigToTemplateData converts a VolumeConfig to VolumeTemplateData.
-func VolumeConfigToTemplateData(cfg vbmctlapi.VolumeConfig) VolumeTemplateData {
-	cfg = cfg.Defaults()
-	return VolumeTemplateData{
-		VolumeName:         cfg.Name,
-		VolumeCapacityInGB: cfg.Size,
-	}
 }

--- a/test/vbmctl/pkg/libvirt/templates/pool.xml.tpl
+++ b/test/vbmctl/pkg/libvirt/templates/pool.xml.tpl
@@ -1,7 +1,7 @@
 <pool type='dir'>
-  <name>{{ .PoolName }}</name>
+  <name>{{ .Name }}</name>
   <target>
-    <path>{{ .PoolPath }}</path>
+    <path>{{ .Path }}</path>
     <permissions>
       <mode>0755</mode>
       <owner>-1</owner>

--- a/test/vbmctl/pkg/libvirt/templates/volume.xml.tpl
+++ b/test/vbmctl/pkg/libvirt/templates/volume.xml.tpl
@@ -1,6 +1,6 @@
 <volume>
-  <name>{{ .VolumeName }}.qcow2</name>
-  <capacity unit="G">{{ .VolumeCapacityInGB }}</capacity>
+  <name>{{ .Name }}.qcow2</name>
+  <capacity unit="G">{{ .Size }}</capacity>
   <target>
     <format type='qcow2'/>
   </target>

--- a/test/vbmctl/pkg/libvirt/vm.go
+++ b/test/vbmctl/pkg/libvirt/vm.go
@@ -96,8 +96,7 @@ func (m *VMManager) Create(ctx context.Context, cfg vbmctlapi.VMConfig) (*vbmctl
 	}
 
 	// Render VM XML
-	templateData := VMConfigToTemplateData(cfg, m.opts.PoolPath)
-	vmXML, err := m.renderer.RenderVM(templateData)
+	vmXML, err := m.renderer.RenderVM(cfg, m.opts.PoolPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to render VM template: %w", err)
 	}
@@ -336,11 +335,7 @@ func (m *VMManager) reserveIPAddress(vmName string, index int, net vbmctlapi.Net
 	// Generate host name for DHCP entry
 	hostName := fmt.Sprintf("%s-%d", vmName, index)
 
-	dhcpXML, err := m.renderer.RenderDHCPHost(DHCPHostData{
-		MACAddress: net.MACAddress,
-		Name:       hostName,
-		IPAddress:  net.IPAddress,
-	})
+	dhcpXML, err := m.renderer.RenderDHCPHost(net, hostName)
 	if err != nil {
 		return fmt.Errorf("failed to render DHCP host entry: %w", err)
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

This PR removes explicit template data types and conversion between these types. It reduces the number of declared types and uses more the existing ones.

With volumes and pools the data from the config types was simply renamed into different struct. Moving data around without doing anything to it is little pointless exercise. Furthermore, new there is also no need for explicit conversion and hence less code that does not do anything useful.

The downside of this refactor is that now each render function takes different parameters instead of one data template. However, this is not really a downside, because the same parameters would have needed to be passed to the conversion method and to be first converted to the data template before passing the template to the render function. So instead of having multiple parameters in the conversion method, they are now directly in the rendering method.

The explicit data templates would provide clear interface for the names in templates and in the code. I don't think this really makes much difference, because the `template.go` file need to ensure that the names are correct anyway, and all the naming between templates and code is handled in the `template.go` file anyway, so no need for the template types.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] E2E tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
