### PR TITLE
:bug: Fix HFC controller error loop on deleted resource

### DIFF
--- a/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
+++ b/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
@@ -120,7 +120,7 @@ func (r *HostFirmwareComponentsReconciler) Reconcile(ctx context.Context, req ct
 		// The HFC resource may have been deleted
 		if k8serrors.IsNotFound(err) {
 			reqLogger.Info("HostFirmwareComponents not found")
-			return ctrl.Result{Requeue: false}, err
+			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
 		return ctrl.Result{}, fmt.Errorf("could not load hostFirmwareComponents: %w", err)

--- a/internal/controller/metal3.io/hostfirmwarecomponents_test.go
+++ b/internal/controller/metal3.io/hostfirmwarecomponents_test.go
@@ -429,6 +429,35 @@ func TestStoreHostFirmwareComponents(t *testing.T) {
 	}
 }
 
+// Test that the reconciler does not return an error when the HFC resource
+// has been deleted but the BMH still exists (e.g. during namespace deletion).
+func TestHFCReconcileDeletedHFC(t *testing.T) {
+	bmh := &metal3api.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hostName,
+			Namespace: hostNamespace,
+		},
+		Status: metal3api.BareMetalHostStatus{
+			Provisioning: metal3api.ProvisionStatus{
+				State: metal3api.StateDeprovisioning,
+			},
+		},
+	}
+	// Build a client with only the BMH, no HFC
+	c := fakeclient.NewClientBuilder().WithRuntimeObjects(bmh).Build()
+
+	reconciler := &HostFirmwareComponentsReconciler{
+		Client: c,
+		Log:    ctrl.Log.WithName("test_reconciler").WithName("HostFirmwareComponents"),
+	}
+
+	request := ctrl.Request{NamespacedName: client.ObjectKey{Name: hostName, Namespace: hostNamespace}}
+	result, err := reconciler.Reconcile(t.Context(), request)
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+}
+
 // Test the function to validate the components in the Spec.
 func TestValidadeHostFirmwareComponents(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
When a HostFirmwareComponents resource is deleted while its BMH still exists, the HFC controller was returning a NotFound error, causing controller-runtime to requeue indefinitely with exponential backoff.

Return nil instead of the error since there is nothing to reconcile.
