### PR TITLE
🐛 Fix Healthy condition staying Unknown despite Ironic reporting health status

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -240,16 +240,21 @@ func (r *BareMetalHostReconciler) Reconcile(ctx context.Context, request ctrl.Re
 		return result, err
 	}
 
+	// Always compute conditions since some (e.g. Healthy) can change
+	// based on external state from Ironic regardless of state machine
+	// transitions.
+	conditionsBefore := slices.Clone(host.GetConditions())
+	computeConditions(ctx, host, prov)
+	conditionsChanged := !reflect.DeepEqual(conditionsBefore, host.GetConditions())
+
 	// Only save status when we're told to, otherwise we
 	// introduce an infinite loop reconciling the same object over and
 	// over when there is an unrecoverable error (tracked through the
 	// error state of the host).
-	if actResult.Dirty() {
-		// Save Host
+	if actResult.Dirty() || conditionsChanged {
 		info.log.Info("saving host status",
 			"operational status", host.OperationalStatus(),
 			"provisioning state", host.Status.Provisioning.State)
-		computeConditions(ctx, host, prov)
 		err = r.saveHostStatus(ctx, host)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to save host status after %q: %w", initialState, err)
@@ -2301,7 +2306,11 @@ func computeConditions(ctx context.Context, host *metal3api.BareMetalHost, prov 
 		setConditionUnknown(host, metal3api.HealthyCondition, metal3api.UnknownHealthReason)
 		return
 	}
-	switch prov.GetHealth(ctx) {
+	switch health := prov.GetHealth(ctx); health {
+	case "":
+		if meta.FindStatusCondition(host.Status.Conditions, string(metal3api.HealthyCondition)) == nil {
+			setConditionUnknown(host, metal3api.HealthyCondition, metal3api.UnknownHealthReason)
+		}
 	case provisioner.HealthOK:
 		setConditionTrue(host, metal3api.HealthyCondition, metal3api.HealthyReason)
 	case provisioner.HealthWarning:

--- a/internal/controller/metal3.io/baremetalhost_controller_test.go
+++ b/internal/controller/metal3.io/baremetalhost_controller_test.go
@@ -3188,12 +3188,6 @@ func TestComputeHealthyCondition(t *testing.T) {
 		ExpectedReason string
 	}{
 		{
-			Scenario:       "empty health reports unknown",
-			Health:         "",
-			ExpectedStatus: metav1.ConditionUnknown,
-			ExpectedReason: metal3api.UnknownHealthReason,
-		},
-		{
 			Scenario:       "OK health",
 			Health:         provisioner.HealthOK,
 			ExpectedStatus: metav1.ConditionTrue,
@@ -3232,6 +3226,27 @@ func TestComputeHealthyCondition(t *testing.T) {
 			assert.Equal(t, tc.ExpectedReason, cond.Reason)
 		})
 	}
+}
+
+func TestComputeHealthyConditionEmptyHealth(t *testing.T) {
+	host := bmhWithStatus(metal3api.OperationalStatusOK, metal3api.StateAvailable)
+	fix := &fixture.Fixture{Health: ""}
+	prov, err := fix.NewProvisioner(t.Context(), provisioner.BuildHostData(*host, bmc.Credentials{}), nil)
+	require.NoError(t, err)
+
+	// On a fresh host with no existing condition, empty health should
+	// initialise the condition to Unknown.
+	computeConditions(t.Context(), host, prov)
+	cond := conditions.Get(host, metal3api.HealthyCondition)
+	require.NotNil(t, cond, "empty health on new host should set Unknown condition")
+	assert.Equal(t, metav1.ConditionUnknown, cond.Status)
+
+	// Set a real health value, then verify empty health preserves it.
+	setConditionTrue(host, metal3api.HealthyCondition, metal3api.HealthyReason)
+	computeConditions(t.Context(), host, prov)
+	cond = conditions.Get(host, metal3api.HealthyCondition)
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionTrue, cond.Status, "empty health should not overwrite existing condition")
 }
 
 func TestComputeConditions(t *testing.T) {
@@ -3332,7 +3347,7 @@ func TestComputeConditions(t *testing.T) {
 			}
 			cond := conditions.Get(tc.BareMetalHost, metal3api.HealthyCondition)
 			require.NotNil(t, cond, "Healthy condition should always be set")
-			assert.Equal(t, metav1.ConditionUnknown, cond.Status, "Healthy should be Unknown when health is not reported")
+			assert.Equal(t, metav1.ConditionUnknown, cond.Status, "Healthy should be Unknown when no health data is available")
 		})
 	}
 }

--- a/pkg/provisioner/ironic/clients/features.go
+++ b/pkg/provisioner/ironic/clients/features.go
@@ -45,7 +45,8 @@ func (af AvailableFeatures) Log(logger logr.Logger) {
 		"maxVersion", fmt.Sprintf("1.%d", af.MaxVersion),
 		"chosenVersion", af.ChooseMicroversion(),
 		"virtualMediaGET", af.HasVirtualMediaGetAPI(),
-		"disablePowerOff", af.HasDisablePowerOff())
+		"disablePowerOff", af.HasDisablePowerOff(),
+		"healthAPI", af.HasHealthAPI())
 }
 
 func (af AvailableFeatures) HasVirtualMediaGetAPI() bool {
@@ -56,7 +57,15 @@ func (af AvailableFeatures) HasDisablePowerOff() bool {
 	return af.MaxVersion >= 95 //nolint:mnd
 }
 
+func (af AvailableFeatures) HasHealthAPI() bool {
+	return af.MaxVersion >= 109 //nolint:mnd
+}
+
 func (af AvailableFeatures) ChooseMicroversion() string {
+	if af.HasHealthAPI() {
+		return "1.109"
+	}
+
 	if af.HasDisablePowerOff() {
 		return "1.95"
 	}

--- a/pkg/provisioner/ironic/clients/features_test.go
+++ b/pkg/provisioner/ironic/clients/features_test.go
@@ -6,7 +6,6 @@ import (
 )
 
 func TestAvailableFeatures_ChooseMicroversion(t *testing.T) {
-	microVersion := "1.95"
 	type fields struct {
 		MaxVersion int
 	}
@@ -23,18 +22,32 @@ func TestAvailableFeatures_ChooseMicroversion(t *testing.T) {
 			want: baselineVersionString,
 		},
 		{
-			name: fmt.Sprintf("MaxVersion = %d return %s", 89, microVersion),
+			name: "MaxVersion = 95 return 1.95",
 			feature: fields{
 				MaxVersion: 95,
 			},
-			want: microVersion,
+			want: "1.95",
 		},
 		{
-			name: fmt.Sprintf("MaxVersion > %d return %s", 89, microVersion),
+			name: "MaxVersion = 100 return 1.95",
 			feature: fields{
 				MaxVersion: 100,
 			},
-			want: microVersion,
+			want: "1.95",
+		},
+		{
+			name: "MaxVersion = 109 return 1.109",
+			feature: fields{
+				MaxVersion: 109,
+			},
+			want: "1.109",
+		},
+		{
+			name: "MaxVersion > 109 return 1.109",
+			feature: fields{
+				MaxVersion: 115,
+			},
+			want: "1.109",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1997,7 +1997,9 @@ func (p *ironicProvisioner) HasPowerFailure(ctx context.Context) bool {
 func (p *ironicProvisioner) GetHealth(ctx context.Context) string {
 	node, err := p.getNode(ctx)
 	if err != nil {
-		p.log.Error(err, "ignored error while checking health status")
+		if !errors.Is(err, provisioner.ErrNeedsRegistration) {
+			p.log.Error(err, "ignored error while checking health status")
+		}
 		return ""
 	}
 	return node.Health


### PR DESCRIPTION
**What this PR does / why we need it:** 

The Healthy condition on BareMetalHost never reflects the actual health status reported by Ironic. On provisioned hosts in steady state, the condition stays Unknown forever. This PR fixes four interacting bugs that prevented it from working:

Conditions not recomputed on idle reconciles. computeConditions was only called inside the actResult.Dirty() block. For steady-state provisioned hosts where nothing changes during reconciliation, conditions were never recomputed — so externally-changed health data in Ironic never propagated.

Microversion too low for health API. ChooseMicroversion() capped at 1.95, but the node health field requires microversion 1.109. With a lower microversion, Ironic omits the health field from responses entirely. Added HasHealthAPI() feature detection and bumped ChooseMicroversion() accordingly.

Empty health overwrites valid condition. An empty string from GetHealth (e.g. before node registration) fell through to the default switch case, resetting a previously valid Healthy=True to Unknown on every idle reconcile. Now empty health means "no data — leave the existing condition unchanged."

Condition changes never detected. conditionsBefore was a slice header pointing to the same backing array as host.Status.Conditions. In-place mutations by conditions.Set were visible through both references, so reflect.DeepEqual always returned true and condition-only changes never triggered a status save. Fixed by deep-copying the slice before comparison.

Also suppresses ErrNeedsRegistration log noise in GetHealth, which fires on every reconcile before the node is registered in Ironic.

Fixes https://github.com/metal3-io/baremetal-operator/issues/3132

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
