### PR TITLE
:bug: Remove unused RBAC permissions from controller ClusterRole

### DIFF
--- a/config/base/rbac/role.yaml
+++ b/config/base/rbac/role.yaml
@@ -10,17 +10,13 @@ rules:
   - events
   verbs:
   - create
-  - get
-  - list
   - patch
   - update
-  - watch
 - apiGroups:
   - ""
   resources:
   - secrets
   verbs:
-  - delete
   - get
   - list
   - update

--- a/config/overlays/e2e/roles-rolebindings/roles-rolebindings.yaml
+++ b/config/overlays/e2e/roles-rolebindings/roles-rolebindings.yaml
@@ -9,17 +9,13 @@ rules:
   - events
   verbs:
   - create
-  - get
-  - list
   - patch
   - update
-  - watch
 - apiGroups:
   - ""
   resources:
   - secrets
   verbs:
-  - delete
   - get
   - list
   - update

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -2406,17 +2406,13 @@ rules:
   - events
   verbs:
   - create
-  - get
-  - list
   - patch
   - update
-  - watch
 - apiGroups:
   - ""
   resources:
   - secrets
   verbs:
-  - delete
   - get
   - list
   - update

--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -90,8 +90,8 @@ func (info *reconcileInfo) publishEvent(reason, message string) {
 // +kubebuilder:rbac:groups=metal3.io,resources=preprovisioningimages,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal3.io,resources=hardwaredata,verbs=get;list;watch;create;delete;patch;update
 // +kubebuilder:rbac:groups=metal3.io,resources=hardware/finalizers,verbs=update
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update;delete
-// +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;update;patch
 
 // Allow for managing hostfirmwaresettings, firmwareschema, bmceventsubscriptions and hostfirmwarecomponents
 // +kubebuilder:rbac:groups=metal3.io,resources=hostfirmwaresettings,verbs=get;list;watch;create;update;patch


### PR DESCRIPTION
Remove unused verbs from kubebuilder RBAC markers to enforce least privilege:
- secrets: remove delete (we're consuming secrets, not removing them)
- events: remove get/list/watch (not setup via runtime)

Namespaces were not in release-0.12, dropped that part.

Manual cherry-pick of PR #3113
