### PR TITLE
:seedling: Add libvirt network creation and deletion to vbmctl

### DIFF
--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -67,15 +67,15 @@ sudo sysctl fs.inotify.max_user_instances=8192
 # Build the container image with e2e tag (used in tests)
 IMG=quay.io/metal3-io/baremetal-operator IMG_TAG=e2e make docker
 
-if ! sudo virsh net-list --all | grep baremetal-e2e; then
-    virsh -c qemu:///system net-define "${REPO_ROOT}/hack/e2e/net.xml"
-    virsh -c qemu:///system net-start baremetal-e2e
-fi
+# Build vbmctl
+make build-vbmctl
+# Create VMs to act as BMHs in the tests and the libvirt network
+./bin/vbmctl -c "${REPO_ROOT}/test/e2e/config/vbmctl.yaml" create bml
 
-# We need to create veth pair to connect metal3 net (defined above) and kind
-# docker subnet. Let us start by creating a docker network with pre-defined
-# name for bridge, so that we can configure the veth pair correctly.
-# Also assume that if kind net exists, it is created by us.
+# We need to create veth pair to connect metal3 net (defined above with vbmctl)
+# and kind docker subnet. Let us start by creating a docker network with
+# pre-defined name for bridge, so that we can configure the veth pair
+# correctly. Also assume that if kind net exists, it is created by us.
 if ! docker network list | grep kind; then
     # These options are used by kind itself. It uses docker default mtu and
     # generates ipv6 subnet ULA, but we can fix the ULA. Only addition to kind
@@ -109,11 +109,6 @@ sudo iptables -L FORWARD -n -v
 # This IP is defined by the network we created above. It is sushy-tools / image
 # server endpoint, not ironic.
 IP_ADDRESS="192.168.222.1"
-
-# Build vbmctl
-make build-vbmctl
-# Create VMs to act as BMHs in the tests.
-./bin/vbmctl -c "${REPO_ROOT}/test/e2e/config/vbmctl.yaml" create bml
 
 if [[ "${BMO_E2E_EMULATOR}" == "vbmc" ]]; then
   # Start VBMC

--- a/test/e2e/config/vbmctl.yaml
+++ b/test/e2e/config/vbmctl.yaml
@@ -15,7 +15,7 @@ spec:
       size: 20
     - name: "2"
       size: 20
-    networks:
+    networkAttachments:
     - network: baremetal-e2e
       macAddress: "00:60:2f:31:81:01"
   - name: bmo-e2e-1
@@ -26,6 +26,11 @@ spec:
       size: 20
     - name: "2"
       size: 20
-    networks:
+    networkAttachments:
     - network: baremetal-e2e
       macAddress: "00:60:2f:31:81:02"
+  networks:
+  - name: baremetal-e2e
+    bridge: metal3
+    address: 192.168.222.1
+    netmask: 255.255.255.0

--- a/test/vbmctl/README.md
+++ b/test/vbmctl/README.md
@@ -17,7 +17,7 @@ This tool is under active development.
 | `vbmctl create bml` / `vbmctl delete bml` | ✅ Implemented |
 | `vbmctl status` | ✅ Implemented (basic) |
 | Configurable volumes | ❌ TODO (hard-coded to two per VM) |
-| Network management | ❌ TODO (uses existing libvirt networks) |
+| Network management | ⚠️ Partially implemented (only libvirt networks) |
 | BMC emulator support | ❌ TODO |
 | Image server | ❌ TODO |
 | State management (persistent state) | ❌ TODO |
@@ -29,6 +29,7 @@ This tool is under active development.
 - **DHCP Reservation**: Reserve IP addresses for VMs via DHCP on existing
    libvirt networks
 - **Library Support**: Can be imported as a Go module for programmatic use
+- **Libvirt network management**: create and delete libvirt networks
 
 ## Build Tags
 
@@ -60,6 +61,9 @@ vbmctl config view
 # Create a single virtual machine
 vbmctl create vm --name test-vm --memory 4096 --vcpus 2
 
+# Create network with default values (default name: baremetal-e2e)
+vbmctl create network
+
 # Create VM with custom options
 vbmctl create vm \
   --name bmo-e2e-0 \
@@ -70,7 +74,7 @@ vbmctl create vm \
   --mac-address 00:60:2f:31:81:01 \
   --ip-address 192.168.222.100
 
-# Create a bare metal lab (all VMs defined in spec.vms of the config file)
+# Create a bare metal lab (all VMs and networks defined in spec.vms of the config file)
 vbmctl create bml
 
 # Check status
@@ -81,6 +85,9 @@ vbmctl delete vm test-vm
 
 # Delete the bare metal lab (all VMs defined in spec.vms of the config file)
 vbmctl delete bml
+
+# Create network with default values
+vbmctl delete network
 
 # Show help
 vbmctl --help
@@ -141,10 +148,15 @@ spec:
       size: 20
     - name: "data"
       size: 10
-    networks:
+    networkAttachments:
     - network: "baremetal-e2e"
       macAddress: "00:60:2f:31:81:02"
       ipAddress: "192.168.222.101"
+  networks:
+  - name: baremetal-e2e
+    bridge: metal3
+    address: 192.168.222.1
+    netmask: 255.255.255.0
 ```
 
 The `spec.vms` section defines the VMs that will be created when you run `vbmctl
@@ -176,6 +188,23 @@ func main() {
     }
     defer conn.Close()
 
+    // Create network manager
+    networkManager, err := libvirt.NewNetworkManager(conn)
+    if err != nil {
+        return fmt.Errorf("failed to create Network manager: %w", err)
+    }
+
+    // Create a network
+    network, err := networkManager.CreateNetwork(ctx, vbmctlapi.NetworkConfig{
+        Name:    "baremetal-e2e",
+        Bridge:  "metal3",
+        Address: "192.168.222.1",
+        Netmask: "255.255.255.0",
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
     // Create VM manager
     vmManager, err := libvirt.NewVMManager(conn, libvirt.VMManagerOptions{
         PoolName: "baremetal-e2e",
@@ -195,7 +224,7 @@ func main() {
         },
         Networks: []api.NetworkAttachment{
             {
-                Network:    "baremetal-e2e",
+                Network:    "baremetal-e2e", // refers to network created above
                 MACAddress: "00:60:2f:31:81:01",
             },
         },

--- a/test/vbmctl/cmd/vbmctl/main.go
+++ b/test/vbmctl/cmd/vbmctl/main.go
@@ -44,10 +44,10 @@ func newRootCmd() *cobra.Command {
 for testing and development purposes. It currently provides functionality for:
 
   - Creating and managing virtual machines using libvirt
+  - Creating and managing libvirt networks
   - Reserving IP addresses for VMs via DHCP on existing libvirt networks
 
 Planned features (not yet implemented):
-  - Network management (create/delete libvirt networks)
   - BMC emulator support (sushy-tools, vbmc)
   - Image server for provisioning
 
@@ -88,6 +88,7 @@ func newCreateCmd() *cobra.Command {
 
 	cmd.AddCommand(newCreateVMCmd())
 	cmd.AddCommand(newCreateBMLCmd())
+	cmd.AddCommand(newCreateNetworkCmd())
 	return cmd
 }
 
@@ -185,8 +186,9 @@ func newCreateBMLCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bml",
 		Short: "Create a bare metal lab from configuration file",
-		Long: `Create a bare metal lab (bml) with all VMs defined in the spec.vms section
-of the configuration file.
+		Long: `Create a bare metal lab (bml) with all VMs and networks defined in the spec.vms
+and spec.networks sections of the configuration file. Note that network block can
+be omitted and VMs can be connected to existing networks as well.
 
 Example configuration:
   spec:
@@ -197,9 +199,12 @@ Example configuration:
         volumes:
           - name: "root"
             size: 20
-        networks:
+        networkAttachments:
           - network: "baremetal-e2e"
-            macAddress: "00:60:2f:31:81:01"`,
+            macAddress: "00:60:2f:31:81:01"
+	networks:
+      - name: "baremetal-e2e"
+	  - bridge: "metal3"`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx, cancel := contextWithSignal()
 			defer cancel()
@@ -218,6 +223,22 @@ Example configuration:
 				return fmt.Errorf("failed to connect to libvirt: %w", err)
 			}
 			defer func() { _, _ = conn.Close() }()
+
+			// Create networks before VMs
+			networkManager, err := libvirt.NewNetworkManager(conn)
+			if err != nil {
+				return fmt.Errorf("failed to create Network manager: %w", err)
+			}
+			networks, err := networkManager.CreateNetworks(ctx, cfg.Spec.Networks)
+			if err != nil {
+				return err
+			}
+			//nolint:forbidigo // CLI output is intentional
+			fmt.Println("\nCreated networks:")
+			for _, network := range networks {
+				//nolint:forbidigo // CLI output is intentional
+				fmt.Printf("  - %s (UUID: %s)\n", network.Name, network.UUID)
+			}
 
 			vmManager, err := libvirt.NewVMManager(conn, libvirt.VMManagerOptions{
 				PoolName: cfg.Spec.Pool.Name,
@@ -249,6 +270,63 @@ Example configuration:
 	return cmd
 }
 
+func newCreateNetworkCmd() *cobra.Command {
+	var (
+		name    string
+		bridge  string
+		address string
+		netmask string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "network",
+		Short: "Create a network",
+		Long:  "Create a new network with the specified configuration.",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			ctx, cancel := contextWithSignal()
+			defer cancel()
+
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+
+			conn, err := libvirtgo.NewConnect(cfg.Spec.Libvirt.URI)
+			if err != nil {
+				return fmt.Errorf("failed to connect to libvirt: %w", err)
+			}
+			defer func() { _, _ = conn.Close() }()
+
+			networkManager, err := libvirt.NewNetworkManager(conn)
+			if err != nil {
+				return fmt.Errorf("failed to create Network manager: %w", err)
+			}
+
+			networkCfg := vbmctlapi.NetworkConfig{
+				Name:    name,
+				Bridge:  bridge,
+				Address: address,
+				Netmask: netmask,
+			}
+
+			network, err := networkManager.CreateNetwork(ctx, networkCfg)
+			if err != nil {
+				return err
+			}
+			//nolint:forbidigo // CLI output is intentional
+			fmt.Printf("Created network: %s (UUID: %s)\n", network.Name, network.UUID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", config.DefaultNetworkName, "name of the network")
+	cmd.Flags().StringVar(&bridge, "bridge", config.DefaultNetworkBridge, "name of the bridge interface")
+	cmd.Flags().StringVar(&address, "address", config.DefaultNetworkAddress, "address of bridge")
+	cmd.Flags().StringVar(&netmask, "netmask", config.DefaultNetworkNetmask, "netmask for network")
+
+	return cmd
+}
+
 func newDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
@@ -258,6 +336,7 @@ func newDeleteCmd() *cobra.Command {
 
 	cmd.AddCommand(newDeleteVMCmd())
 	cmd.AddCommand(newDeleteBMLCmd())
+	cmd.AddCommand(newDeleteNetworkCmd())
 	return cmd
 }
 
@@ -344,8 +423,8 @@ func newDeleteBMLCmd() *cobra.Command {
 
 			//nolint:forbidigo // CLI output is intentional
 			fmt.Printf("Deleting bare metal lab (%d VMs)...\n", len(names))
-
-			if err := vmManager.DeleteAll(ctx, names, true); err != nil {
+			err = vmManager.DeleteAll(ctx, names, true)
+			if err != nil {
 				return err
 			}
 
@@ -356,6 +435,70 @@ func newDeleteBMLCmd() *cobra.Command {
 				fmt.Printf("  - %s\n", name)
 			}
 
+			networkManager, err := libvirt.NewNetworkManager(conn)
+			if err != nil {
+				return fmt.Errorf("failed to create Network manager: %w", err)
+			}
+
+			networks := make([]string, len(cfg.Spec.Networks))
+			for i, network := range cfg.Spec.Networks {
+				networks[i] = network.Name
+			}
+
+			//nolint:forbidigo // CLI output is intentional
+			fmt.Printf("Deleting networks (%d networks)...\n", len(networks))
+
+			if err := networkManager.DeleteNetworks(ctx, networks); err != nil {
+				return err
+			}
+
+			//nolint:forbidigo // CLI output is intentional
+			fmt.Println("Deleted networks:")
+			for _, name := range networks {
+				//nolint:forbidigo // CLI output is intentional
+				fmt.Printf("  - %s\n", name)
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func newDeleteNetworkCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "network [name]",
+		Short: "Delete a network",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			ctx, cancel := contextWithSignal()
+			defer cancel()
+
+			name := args[0]
+
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+
+			conn, err := libvirtgo.NewConnect(cfg.Spec.Libvirt.URI)
+			if err != nil {
+				return fmt.Errorf("failed to connect to libvirt: %w", err)
+			}
+			defer func() { _, _ = conn.Close() }()
+
+			networkManager, err := libvirt.NewNetworkManager(conn)
+			if err != nil {
+				return fmt.Errorf("failed to create Network manager: %w", err)
+			}
+
+			if err := networkManager.DeleteNetwork(ctx, name); err != nil {
+				return fmt.Errorf("failed to delete network: %w", err)
+			}
+
+			//nolint:forbidigo // CLI output is intentional
+			fmt.Printf("Deleted network %s\n", name)
 			return nil
 		},
 	}

--- a/test/vbmctl/pkg/api/types.go
+++ b/test/vbmctl/pkg/api/types.go
@@ -17,7 +17,7 @@ type VMConfig struct {
 	Volumes []VolumeConfig `json:"volumes,omitempty" yaml:"volumes,omitempty"`
 
 	// Networks is a list of networks to attach to the VM.
-	Networks []NetworkAttachment `json:"networks,omitempty" yaml:"networks,omitempty"`
+	Networks []NetworkAttachment `json:"networkAttachments,omitempty" yaml:"networkAttachments,omitempty"`
 }
 
 // VolumeConfig represents the configuration for a storage volume.
@@ -40,6 +40,21 @@ type NetworkAttachment struct {
 
 	// IPAddress is an optional static IP address to reserve via DHCP.
 	IPAddress string `json:"ipAddress,omitempty" yaml:"ipAddress,omitempty"`
+}
+
+// Network represents libvirt network.
+type NetworkConfig struct {
+	// Name is the name of the libvirt network.
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	// Bridge is the name of the bridge interface for the network.
+	Bridge string `json:"bridge,omitempty" yaml:"bridge,omitempty"`
+
+	// Address is the address of the bridge interface.
+	Address string `json:"address,omitempty" yaml:"address,omitempty"`
+
+	// Netmask is the netmask for the network.
+	Netmask string `json:"netmask,omitempty" yaml:"netmask,omitempty"`
 }
 
 // PoolConfig represents the configuration for a storage pool.
@@ -130,6 +145,24 @@ func (c VolumeConfig) Defaults() VolumeConfig {
 	cfg := c
 	if cfg.Size == 0 {
 		cfg.Size = 20 // 20GB default
+	}
+	return cfg
+}
+
+// Defaults returns a copy of NetworkConfig with default values applied.
+func (c NetworkConfig) Defaults() NetworkConfig {
+	cfg := c
+	if cfg.Name == "" {
+		cfg.Name = "baremetal-e2e"
+	}
+	if cfg.Bridge == "" {
+		cfg.Bridge = "metal3"
+	}
+	if cfg.Address == "" {
+		cfg.Address = "192.168.222.1"
+	}
+	if cfg.Netmask == "" {
+		cfg.Netmask = "255.255.255.0"
 	}
 	return cfg
 }

--- a/test/vbmctl/pkg/config/config.go
+++ b/test/vbmctl/pkg/config/config.go
@@ -36,6 +36,15 @@ const (
 	// DefaultVolumeSize is the default volume size in GB.
 	DefaultVolumeSize = 20
 
+	// DefaultNetworkBridge is the default network interface name.
+	DefaultNetworkBridge = "metal3"
+
+	// DefaultNetworkAddress is the default address for the bridge interface.
+	DefaultNetworkAddress = "192.168.222.1"
+
+	// DefaultNetworkNetmask is the default netmask for the network.
+	DefaultNetworkNetmask = "255.255.255.0"
+
 	// dirPermissions is the default permission for directories.
 	dirPermissions = 0750
 
@@ -65,6 +74,8 @@ type Spec struct {
 
 	// VMs is a list of VM configurations to create.
 	VMs []vbmctlapi.VMConfig `json:"vms,omitempty" yaml:"vms,omitempty"`
+
+	Networks []vbmctlapi.NetworkConfig `json:"networks,omitempty" yaml:"networks,omitempty"`
 }
 
 // LibvirtConfig contains libvirt connection settings.

--- a/test/vbmctl/pkg/libvirt/network.go
+++ b/test/vbmctl/pkg/libvirt/network.go
@@ -1,0 +1,129 @@
+//go:build vbmctl
+// +build vbmctl
+
+package libvirt
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
+	"libvirt.org/go/libvirt"
+)
+
+type NetworkManager struct {
+	conn     *libvirt.Connect
+	renderer *TemplateRenderer
+}
+
+type Network struct {
+	Name   string
+	Bridge string
+	UUID   string
+}
+
+func NewNetworkManager(conn *libvirt.Connect) (*NetworkManager, error) {
+	renderer, err := NewTemplateRenderer()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create template renderer: %w", err)
+	}
+	return &NetworkManager{
+		conn:     conn,
+		renderer: renderer,
+	}, nil
+}
+
+func (m *NetworkManager) CreateNetwork(_ context.Context, cfg vbmctlapi.NetworkConfig) (*Network, error) {
+	// Render network XML
+	networkXML, err := m.renderer.RenderNetwork(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to render VM template: %w", err)
+	}
+
+	// Check if network exists, define a new if it does not
+	network, err := m.conn.LookupNetworkByName(cfg.Name)
+	defer func() { _ = network.Free() }()
+	if err == nil {
+		log.Printf("network %s already exists, continuing with existing network", cfg.Name)
+	} else {
+		network, err = m.conn.NetworkDefineXML(networkXML)
+		if err != nil {
+			return nil, fmt.Errorf("failed to define network from XML: %w", err)
+		}
+		// Start the network
+		err = network.Create()
+		if err != nil {
+			return nil, fmt.Errorf("failed to start defined network %s: %w", cfg.Name, err)
+		}
+		err = network.SetAutostart(true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set autostart for network %s: %w", cfg.Name, err)
+		}
+	}
+
+	// Get network information
+	name, err := network.GetName()
+	if err != nil {
+		return nil, fmt.Errorf("no name defined for network: %w", err)
+	}
+	bridge, err := network.GetBridgeName()
+	if err != nil {
+		return nil, fmt.Errorf("no bridge name defined for network: %w", err)
+	}
+	uuid, err := network.GetUUIDString()
+	if err != nil {
+		return nil, fmt.Errorf("could not get UUID for network: %w", err)
+	}
+
+	return &Network{
+		Name:   name,
+		Bridge: bridge,
+		UUID:   uuid,
+	}, nil
+}
+
+func (m *NetworkManager) CreateNetworks(ctx context.Context, configs []vbmctlapi.NetworkConfig) ([]*Network, error) {
+	networks := make([]*Network, 0, len(configs))
+	for _, cfg := range configs {
+		network, err := m.CreateNetwork(ctx, cfg)
+		if err != nil {
+			// Clean up previously created networks
+			log.Printf("Failed to create network %s, cleaning up %d previously created network(s)\n", cfg.Name, len(networks))
+			for _, created := range networks {
+				if delErr := m.DeleteNetwork(ctx, created.Name); delErr != nil {
+					log.Printf("Warning: failed to clean up network %s: %v\n", created.Name, delErr)
+				}
+			}
+			return nil, fmt.Errorf("failed to create network %s: %w", network.Name, err)
+		}
+		networks = append(networks, network)
+	}
+	return networks, nil
+}
+
+func (m *NetworkManager) DeleteNetwork(_ context.Context, name string) error {
+	network, err := m.conn.LookupNetworkByName(name)
+	defer func() { _ = network.Free() }()
+	if err != nil {
+		return fmt.Errorf("failed to lookup network %s: %w", name, err)
+	}
+	if err := network.Destroy(); err != nil {
+		return fmt.Errorf("failed to destroy network %s: %w", name, err)
+	}
+	if err := network.Undefine(); err != nil {
+		return fmt.Errorf("failed to undefine network %s (was it transient?): %w", name, err)
+	}
+	return nil
+}
+
+func (m *NetworkManager) DeleteNetworks(ctx context.Context, names []string) error {
+	var lastErr error
+	for _, name := range names {
+		if err := m.DeleteNetwork(ctx, name); err != nil {
+			log.Printf("Error deleting network %s: %v\n", name, err)
+			lastErr = err
+		}
+	}
+	return lastErr
+}

--- a/test/vbmctl/pkg/libvirt/templates.go
+++ b/test/vbmctl/pkg/libvirt/templates.go
@@ -96,6 +96,12 @@ func (r *TemplateRenderer) RenderVolume(cfg vbmctlapi.VolumeConfig) (string, err
 	return r.render("volume.xml.tpl", cfg)
 }
 
+// RenderNetwork renders the network XML template with the given data.
+func (r *TemplateRenderer) RenderNetwork(cfg vbmctlapi.NetworkConfig) (string, error) {
+	cfg = cfg.Defaults()
+	return r.render("network.xml.tpl", cfg)
+}
+
 // RenderDHCPHost renders XML for a DHCP host entry.
 func (r *TemplateRenderer) RenderDHCPHost(net vbmctlapi.NetworkAttachment, hostName string) (string, error) {
 	data := struct {

--- a/test/vbmctl/pkg/libvirt/templates/network.xml.tpl
+++ b/test/vbmctl/pkg/libvirt/templates/network.xml.tpl
@@ -1,0 +1,10 @@
+<network>
+  <name>{{ .Name }}</name>
+  <forward mode='nat'>
+    <nat>
+      <port start='1024' end='65535'/>
+    </nat>
+  </forward>
+  <bridge name='{{ .Bridge }}'/>
+  <ip address='{{ .Address }}' netmask='{{ .Netmask}}'/>
+</network>


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

Adds network creation/deletion to vbmctl:

- New command to create/delete networks
- Edit bml creation/deletion commands to create/delete networks defined in config
- Renames existing `networks` block in config to `networkAttachments`
- Adds new block `networks` to config to define libvirt networks
- Removes libvirt network creation from `hack/ci-e2e.sh` and uses the vbmctl tool instead

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Part of #3062

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] E2E tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
