### PR TITLE
🐛 Fix HostFirmwareSettings blocking servicing abort due to stale ObservedGeneration

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -1542,6 +1542,51 @@ func (r *BareMetalHostReconciler) actionDeprovisioning(ctx context.Context, prov
 	return actionComplete{}
 }
 
+// hostFirmwareSpecsExist reports whether firmware servicing specs are still present
+// on the host or related HFS/HFC objects. Used by the ServicingError recovery fast-path
+// before calling getHostFirmwareSettings/Components, which block on generation mismatch.
+// Only NotFound errors from Get are treated as absent resources; other errors are returned.
+func (r *BareMetalHostReconciler) hostFirmwareSpecsExist(
+	ctx context.Context,
+	info *reconcileInfo,
+	liveFirmwareSettingsAllowed, liveFirmwareUpdatesAllowed bool,
+) (bool, error) {
+	specsExist := false
+
+	if liveFirmwareSettingsAllowed {
+		if !reflect.DeepEqual(info.host.Status.Provisioning.Firmware, info.host.Spec.Firmware) &&
+			info.host.Spec.Firmware != nil {
+			specsExist = true
+		}
+
+		if !specsExist {
+			hfsCheck := &metal3api.HostFirmwareSettings{}
+			err := r.Get(ctx, info.request.NamespacedName, hfsCheck)
+			if err != nil {
+				if !k8serrors.IsNotFound(err) {
+					return false, fmt.Errorf("could not load host firmware settings: %w", err)
+				}
+			} else if len(hfsCheck.Spec.Settings) > 0 {
+				specsExist = true
+			}
+		}
+	}
+
+	if liveFirmwareUpdatesAllowed {
+		hfcCheck := &metal3api.HostFirmwareComponents{}
+		err := r.Get(ctx, info.request.NamespacedName, hfcCheck)
+		if err != nil {
+			if !k8serrors.IsNotFound(err) {
+				return false, fmt.Errorf("could not load host firmware components: %w", err)
+			}
+		} else if len(hfcCheck.Spec.Updates) > 0 {
+			specsExist = true
+		}
+	}
+
+	return specsExist, nil
+}
+
 func (r *BareMetalHostReconciler) doServiceIfNeeded(ctx context.Context, prov provisioner.Provisioner, info *reconcileInfo, hup *metal3api.HostUpdatePolicy) (result actionResult) {
 	info.log.V(VerbosityLevelTrace).Info("doServiceIfNeeded started")
 	servicingData := provisioner.ServicingData{}
@@ -1564,19 +1609,11 @@ func (r *BareMetalHostReconciler) doServiceIfNeeded(ctx context.Context, prov pr
 	// cleared before calling getHostFirmwareSettings/Components. Those
 	// functions fail on generation mismatch (sub-controller hasn't reconciled
 	// yet), which would block the abort/recovery path indefinitely.
-	if info.host.Status.ErrorType == metal3api.ServicingError {
-		specsExist := false
-		if liveFirmwareSettingsAllowed {
-			hfsCheck := &metal3api.HostFirmwareSettings{}
-			if err := r.Get(ctx, info.request.NamespacedName, hfsCheck); err == nil && len(hfsCheck.Spec.Settings) > 0 {
-				specsExist = true
-			}
-		}
-		if liveFirmwareUpdatesAllowed && !specsExist {
-			hfcCheck := &metal3api.HostFirmwareComponents{}
-			if err := r.Get(ctx, info.request.NamespacedName, hfcCheck); err == nil && len(hfcCheck.Spec.Updates) > 0 {
-				specsExist = true
-			}
+	if info.host.Status.ErrorType == metal3api.ServicingError &&
+		(liveFirmwareSettingsAllowed || liveFirmwareUpdatesAllowed) {
+		specsExist, err := r.hostFirmwareSpecsExist(ctx, info, liveFirmwareSettingsAllowed, liveFirmwareUpdatesAllowed)
+		if err != nil {
+			return actionError{fmt.Errorf("could not determine if firmware specs exist: %w", err)}
 		}
 		if !specsExist {
 			info.log.Info("specs cleared while in servicing error state, attempting abort")
@@ -1591,7 +1628,9 @@ func (r *BareMetalHostReconciler) doServiceIfNeeded(ctx context.Context, prov pr
 				return actionContinue{provResult.RequeueAfter}
 			}
 			info.log.Info("successfully recovered from servicing error")
-			clearErrorWithStatus(info.host, metal3api.OperationalStatusOK)
+			if clearErrorWithStatus(info.host, metal3api.OperationalStatusOK) {
+				return actionUpdate{}
+			}
 			return actionComplete{}
 		}
 	}
@@ -2716,6 +2755,7 @@ func (r *BareMetalHostReconciler) SetupWithManager(mgr ctrl.Manager, preprovImgE
 	// Watch HFC/HFS for spec changes (generation bumps) so that the BMH
 	// controller reconciles promptly when a user clears firmware specs,
 	// rather than waiting for error-state exponential backoff to expire.
+	// HFS and HFC use the same name and namespace as their BareMetalHost.
 	firmwareEventHandler := handler.EnqueueRequestsFromMapFunc(
 		func(_ context.Context, obj client.Object) []ctrl.Request {
 			return []ctrl.Request{{NamespacedName: client.ObjectKey{

--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -48,6 +48,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -1559,6 +1560,42 @@ func (r *BareMetalHostReconciler) doServiceIfNeeded(ctx context.Context, prov pr
 		liveFirmwareUpdatesAllowed = (hup.Spec.FirmwareUpdates == metal3api.HostUpdatePolicyOnReboot)
 	}
 
+	// Fast-path: when recovering from a servicing error, check if specs are
+	// cleared before calling getHostFirmwareSettings/Components. Those
+	// functions fail on generation mismatch (sub-controller hasn't reconciled
+	// yet), which would block the abort/recovery path indefinitely.
+	if info.host.Status.ErrorType == metal3api.ServicingError {
+		specsExist := false
+		if liveFirmwareSettingsAllowed {
+			hfsCheck := &metal3api.HostFirmwareSettings{}
+			if err := r.Get(ctx, info.request.NamespacedName, hfsCheck); err == nil && len(hfsCheck.Spec.Settings) > 0 {
+				specsExist = true
+			}
+		}
+		if liveFirmwareUpdatesAllowed && !specsExist {
+			hfcCheck := &metal3api.HostFirmwareComponents{}
+			if err := r.Get(ctx, info.request.NamespacedName, hfcCheck); err == nil && len(hfcCheck.Spec.Updates) > 0 {
+				specsExist = true
+			}
+		}
+		if !specsExist {
+			info.log.Info("specs cleared while in servicing error state, attempting abort")
+			provResult, _, err := prov.Service(ctx, servicingData, false, false)
+			if err != nil {
+				return actionError{fmt.Errorf("failed to abort servicing: %w", err)}
+			}
+			if provResult.ErrorMessage != "" {
+				return actionError{fmt.Errorf("failed to abort servicing: %s", provResult.ErrorMessage)}
+			}
+			if provResult.Dirty {
+				return actionContinue{provResult.RequeueAfter}
+			}
+			info.log.Info("successfully recovered from servicing error")
+			clearErrorWithStatus(info.host, metal3api.OperationalStatusOK)
+			return actionComplete{}
+		}
+	}
+
 	if liveFirmwareSettingsAllowed {
 		// handling pre-HFS FirmwareSettings here
 		if !reflect.DeepEqual(info.host.Status.Provisioning.Firmware, info.host.Spec.Firmware) {
@@ -2675,6 +2712,22 @@ func (r *BareMetalHostReconciler) SetupWithManager(mgr ctrl.Manager, preprovImgE
 		// need to pass MatchEveryOwner
 		controller.Owns(&metal3api.PreprovisioningImage{})
 	}
+
+	// Watch HFC/HFS for spec changes (generation bumps) so that the BMH
+	// controller reconciles promptly when a user clears firmware specs,
+	// rather than waiting for error-state exponential backoff to expire.
+	firmwareEventHandler := handler.EnqueueRequestsFromMapFunc(
+		func(_ context.Context, obj client.Object) []ctrl.Request {
+			return []ctrl.Request{{NamespacedName: client.ObjectKey{
+				Name:      obj.GetName(),
+				Namespace: obj.GetNamespace(),
+			}}}
+		},
+	)
+	controller.Watches(&metal3api.HostFirmwareSettings{}, firmwareEventHandler,
+		builder.WithPredicates(predicate.GenerationChangedPredicate{}))
+	controller.Watches(&metal3api.HostFirmwareComponents{}, firmwareEventHandler,
+		builder.WithPredicates(predicate.GenerationChangedPredicate{}))
 
 	return controller.Complete(r)
 }

--- a/internal/controller/metal3.io/baremetalhost_controller_test.go
+++ b/internal/controller/metal3.io/baremetalhost_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"testing"
@@ -3236,6 +3237,107 @@ func TestHostFirmwareSettings(t *testing.T) {
 			assert.Equal(t, tc.Dirty, dirty, "dirty flag did not match")
 		})
 	}
+}
+
+func TestHostFirmwareSpecsExist(t *testing.T) {
+	var trueVal = true
+	var falseVal = false
+
+	host := newDefaultHost(t)
+	info := makeReconcileInfo(host)
+	info.request = newRequest(host)
+
+	t.Run("legacy firmware spec pending", func(t *testing.T) {
+		hostWithFW := host.DeepCopy()
+		hostWithFW.Status.Provisioning.Firmware = &metal3api.FirmwareConfig{
+			VirtualizationEnabled: &falseVal,
+		}
+		hostWithFW.Spec.Firmware = &metal3api.FirmwareConfig{
+			VirtualizationEnabled: &trueVal,
+		}
+		fwInfo := makeReconcileInfo(hostWithFW)
+		fwInfo.request = newRequest(hostWithFW)
+		r := newTestReconciler(t, hostWithFW)
+
+		exists, err := r.hostFirmwareSpecsExist(t.Context(), fwInfo, true, false)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("HFS with settings", func(t *testing.T) {
+		hfs := newHostFirmwareSettings(host, nil)
+		r := newTestReconciler(t, host, hfs)
+
+		exists, err := r.hostFirmwareSpecsExist(t.Context(), info, true, false)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("HFS not found and no legacy spec", func(t *testing.T) {
+		r := newTestReconciler(t, host)
+
+		exists, err := r.hostFirmwareSpecsExist(t.Context(), info, true, false)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("HFS empty settings", func(t *testing.T) {
+		hfs := newHostFirmwareSettings(host, nil)
+		hfs.Spec.Settings = nil
+		r := newTestReconciler(t, host, hfs)
+
+		exists, err := r.hostFirmwareSpecsExist(t.Context(), info, true, false)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("HFC with updates", func(t *testing.T) {
+		hfc := &metal3api.HostFirmwareComponents{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      host.Name,
+				Namespace: host.Namespace,
+			},
+			Spec: metal3api.HostFirmwareComponentsSpec{
+				Updates: []metal3api.FirmwareUpdate{
+					{Component: "bmc", URL: "http://example.com/bmc"},
+				},
+			},
+		}
+		r := newTestReconciler(t, host, hfc)
+
+		exists, err := r.hostFirmwareSpecsExist(t.Context(), info, false, true)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("neither HFS nor HFC when both paths enabled", func(t *testing.T) {
+		r := newTestReconciler(t, host)
+
+		exists, err := r.hostFirmwareSpecsExist(t.Context(), info, true, true)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("Get error is propagated", func(t *testing.T) {
+		r := newTestReconciler(t, host)
+		r.Client = &getErrorClient{Client: r.Client, err: errors.New("apiserver unavailable")}
+
+		_, err := r.hostFirmwareSpecsExist(t.Context(), info, true, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "could not load host firmware settings")
+	})
+}
+
+type getErrorClient struct {
+	client.Client
+	err error
+}
+
+func (c *getErrorClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if c.err != nil {
+		return c.err
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
 }
 
 func TestBMHTransitionToPreparing(t *testing.T) {

--- a/internal/controller/metal3.io/hostfirmwaresettings_controller.go
+++ b/internal/controller/metal3.io/hostfirmwaresettings_controller.go
@@ -247,7 +247,7 @@ func (r *HostFirmwareSettingsReconciler) updateStatus(ctx context.Context, info 
 	generation := info.hfs.GetGeneration()
 
 	if specMismatch {
-		if setCondition(generation, &newStatus, info, metal3api.FirmwareSettingsChangeDetected, metav1.ConditionTrue, reason, "") {
+		if setCondition(generation, &newStatus, metal3api.FirmwareSettingsChangeDetected, metav1.ConditionTrue, reason, "") {
 			dirty = true
 		}
 
@@ -255,7 +255,7 @@ func (r *HostFirmwareSettingsReconciler) updateStatus(ctx context.Context, info 
 		// Eventually this will be handled by a webhook
 		errors := r.validateHostFirmwareSettings(info, &newStatus, schema)
 		if len(errors) == 0 {
-			if setCondition(generation, &newStatus, info, metal3api.FirmwareSettingsValid, metav1.ConditionTrue, reason, "") {
+			if setCondition(generation, &newStatus, metal3api.FirmwareSettingsValid, metav1.ConditionTrue, reason, "") {
 				dirty = true
 			}
 		} else {
@@ -266,15 +266,15 @@ func (r *HostFirmwareSettingsReconciler) updateStatus(ctx context.Context, info 
 				}
 			}
 			reason = reasonConfigurationError
-			if setCondition(generation, &newStatus, info, metal3api.FirmwareSettingsValid, metav1.ConditionFalse, reason, "Invalid BIOS setting") {
+			if setCondition(generation, &newStatus, metal3api.FirmwareSettingsValid, metav1.ConditionFalse, reason, "Invalid BIOS setting") {
 				dirty = true
 			}
 		}
 	} else {
-		if setCondition(generation, &newStatus, info, metal3api.FirmwareSettingsValid, metav1.ConditionTrue, reason, "") {
+		if setCondition(generation, &newStatus, metal3api.FirmwareSettingsValid, metav1.ConditionTrue, reason, "") {
 			dirty = true
 		}
-		if setCondition(generation, &newStatus, info, metal3api.FirmwareSettingsChangeDetected, metav1.ConditionFalse, reason, "") {
+		if setCondition(generation, &newStatus, metal3api.FirmwareSettingsChangeDetected, metav1.ConditionFalse, reason, "") {
 			dirty = true
 		}
 	}
@@ -434,7 +434,7 @@ func (r *HostFirmwareSettingsReconciler) publishEvent(ctx context.Context, reque
 	}
 }
 
-func setCondition(generation int64, status *metal3api.HostFirmwareSettingsStatus, info *rInfo,
+func setCondition(generation int64, status *metal3api.HostFirmwareSettingsStatus,
 	cond metal3api.SettingsConditionType, newStatus metav1.ConditionStatus,
 	reason conditionReason, message string) bool {
 	newCondition := metav1.Condition{
@@ -444,13 +444,8 @@ func setCondition(generation int64, status *metal3api.HostFirmwareSettingsStatus
 		Reason:             string(reason),
 		Message:            message,
 	}
-	meta.SetStatusCondition(&status.Conditions, newCondition)
 
-	currCond := meta.FindStatusCondition(info.hfs.Status.Conditions, string(cond))
-	if currCond == nil || currCond.Status != newStatus {
-		return true
-	}
-	return false
+	return meta.SetStatusCondition(&status.Conditions, newCondition)
 }
 
 // Generate a name based on the schema key and values which should be the same for similar hardware.

--- a/internal/controller/metal3.io/hostfirmwaresettings_test.go
+++ b/internal/controller/metal3.io/hostfirmwaresettings_test.go
@@ -540,6 +540,32 @@ func TestStoreHostFirmwareSettings(t *testing.T) {
 	}
 }
 
+func TestSetConditionObservedGeneration(t *testing.T) {
+	status := &metal3api.HostFirmwareSettingsStatus{}
+
+	changed := setCondition(1, status,
+		metal3api.FirmwareSettingsValid, metav1.ConditionTrue,
+		reasonSuccess, "")
+	assert.True(t, changed, "first call should report a change")
+
+	cond := status.Conditions[0]
+	assert.Equal(t, int64(1), cond.ObservedGeneration)
+
+	changed = setCondition(1, status,
+		metal3api.FirmwareSettingsValid, metav1.ConditionTrue,
+		reasonSuccess, "")
+	assert.False(t, changed, "same generation and status should not report a change")
+
+	// This is the scenario that was broken: generation bumps but status
+	// stays the same. The old code compared only Status and missed the
+	// ObservedGeneration difference, returning false.
+	changed = setCondition(2, status,
+		metal3api.FirmwareSettingsValid, metav1.ConditionTrue,
+		reasonSuccess, "")
+	assert.True(t, changed, "generation change alone must report a change")
+	assert.Equal(t, int64(2), status.Conditions[0].ObservedGeneration)
+}
+
 // Test the function to validate hostFirmwareSettings.
 func TestValidateHostFirmwareSettings(t *testing.T) {
 	testCases := []struct {

--- a/test/e2e/firmware_settings_test.go
+++ b/test/e2e/firmware_settings_test.go
@@ -573,6 +573,157 @@ var _ = Describe("Host Firmware Settings", Label("required", "firmware"), func()
 		Expect(hfs.Status.Conditions).To(ContainCondition(string(metal3api.FirmwareSettingsChangeDetected), metav1.ConditionFalse))
 	})
 
+	It("should abort servicing when HostFirmwareSettings spec is cleared during servicing", func() {
+		bmhName := specName + "-servicing-abort"
+		secretName := bmhName + "-bmc"
+
+		By("Creating a secret with BMH credentials")
+		bmcCredentialsData := map[string]string{
+			"username": bmc.User,
+			"password": bmc.Password,
+		}
+		secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+		toCleanup = append(toCleanup, secret)
+
+		By("Creating a BMH with inspection and cleaning disabled")
+		bmh := metal3api.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			},
+			Spec: metal3api.BareMetalHostSpec{
+				Online: true,
+				BMC: metal3api.BMCDetails{
+					Address:                        bmc.Address,
+					CredentialsName:                secretName,
+					DisableCertificateVerification: bmc.DisableCertificateVerification,
+				},
+				BootMode:              metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
+				BootMACAddress:        bmc.BootMacAddress,
+				AutomatedCleaningMode: metal3api.CleaningModeDisabled,
+				InspectionMode:        metal3api.InspectionModeDisabled,
+			},
+		}
+		Expect(clusterProxy.GetClient().Create(ctx, &bmh)).To(Succeed())
+		toCleanup = append(toCleanup, &bmh)
+
+		By("Waiting for the BMH to become available")
+		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.StateAvailable,
+		}, e2eConfig.GetIntervals(specName, "wait-available")...)
+
+		By("Provisioning the BMH")
+		Expect(PatchBMHForProvisioning(ctx, PatchBMHForProvisioningInput{
+			client:    clusterProxy.GetClient(),
+			bmh:       &bmh,
+			bmc:       bmc,
+			e2eConfig: e2eConfig,
+			namespace: namespace.Name,
+		})).To(Succeed())
+
+		By("Waiting for the BMH to be provisioned")
+		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.StateProvisioned,
+		}, e2eConfig.GetIntervals(specName, "wait-provisioned")...)
+
+		By("Creating a HostUpdatePolicy to allow firmware changes on reboot")
+		hup := &metal3api.HostUpdatePolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			},
+			Spec: metal3api.HostUpdatePolicySpec{
+				FirmwareSettings: metal3api.HostUpdatePolicyOnReboot,
+			},
+		}
+		Expect(clusterProxy.GetClient().Create(ctx, hup)).To(Succeed())
+
+		By("Updating HostFirmwareSettings with a new value")
+		hfs := &metal3api.HostFirmwareSettings{}
+		Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+			Name:      bmhName,
+			Namespace: namespace.Name,
+		}, hfs)).To(Succeed())
+
+		helper, err := patch.NewHelper(hfs, clusterProxy.GetClient())
+		Expect(err).NotTo(HaveOccurred())
+		hfs.Spec.Settings = metal3api.DesiredSettingsMap{
+			hfsTestKey2: intstr.FromString(hfsTestNewValue2),
+		}
+		Expect(helper.Patch(ctx, hfs)).To(Succeed())
+
+		By("Verifying the conditions on firmware setting")
+		Eventually(func(g Gomega) {
+			g.Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			}, hfs)).To(Succeed())
+			g.Expect(hfs.Status.Conditions).To(ContainCondition(string(metal3api.FirmwareSettingsValid), metav1.ConditionTrue))
+			g.Expect(hfs.Status.Conditions).To(ContainCondition(string(metal3api.FirmwareSettingsChangeDetected), metav1.ConditionTrue))
+		}, e2eConfig.GetIntervals(specName, "wait-reconcile")...).Should(Succeed())
+
+		By("Triggering a reboot via annotation")
+		Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+			Name:      bmhName,
+			Namespace: namespace.Name,
+		}, &bmh)).To(Succeed())
+		// Use hard reboot to avoid wasting time on soft power off.
+		AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, metal3api.RebootAnnotationPrefix, ptr.To(`{"mode": "hard"}`))
+
+		By("Waiting for the BMH to enter servicing")
+		WaitForBmhInOperationalStatus(ctx, WaitForBmhInOperationalStatusInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.OperationalStatusServicing,
+			UndesiredStates: []metal3api.OperationalStatus{
+				metal3api.OperationalStatusError,
+			},
+		}, e2eConfig.GetIntervals(specName, "wait-servicing")...)
+
+		By("Clearing HostFirmwareSettings spec to abort servicing")
+		Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+			Name:      bmhName,
+			Namespace: namespace.Name,
+		}, hfs)).To(Succeed())
+		helper, err = patch.NewHelper(hfs, clusterProxy.GetClient())
+		Expect(err).NotTo(HaveOccurred())
+		// spec.settings is required by CRD validation; use empty map, not nil.
+		hfs.Spec.Settings = metal3api.DesiredSettingsMap{}
+		Expect(helper.Patch(ctx, hfs)).To(Succeed())
+
+		By("Waiting for servicing to abort and the BMH to return to OK")
+		WaitForBmhInOperationalStatus(ctx, WaitForBmhInOperationalStatusInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.OperationalStatusOK,
+			UndesiredStates: []metal3api.OperationalStatus{
+				metal3api.OperationalStatusError,
+				metal3api.OperationalStatusServicing,
+			},
+		}, e2eConfig.GetIntervals(specName, "wait-firmware-settings")...)
+
+		By("Verifying the host is not stuck in ServicingError")
+		Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+			Name:      bmhName,
+			Namespace: namespace.Name,
+		}, &bmh)).To(Succeed())
+		Expect(bmh.Status.ErrorType).To(BeEmpty())
+
+		By("Deleting the BMH")
+		Expect(clusterProxy.GetClient().Delete(ctx, &bmh)).To(Succeed())
+
+		By("Waiting for the BMH to be deleted")
+		WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
+			Client:    clusterProxy.GetClient(),
+			BmhName:   bmhName,
+			Namespace: namespace.Name,
+		}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
+	})
+
 	AfterEach(func() {
 		CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
 		DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))

--- a/test/e2e/firmware_settings_test.go
+++ b/test/e2e/firmware_settings_test.go
@@ -702,7 +702,6 @@ var _ = Describe("Host Firmware Settings", Label("required", "firmware"), func()
 			State:  metal3api.OperationalStatusOK,
 			UndesiredStates: []metal3api.OperationalStatus{
 				metal3api.OperationalStatusError,
-				metal3api.OperationalStatusServicing,
 			},
 		}, e2eConfig.GetIntervals(specName, "wait-firmware-settings")...)
 
@@ -712,16 +711,6 @@ var _ = Describe("Host Firmware Settings", Label("required", "firmware"), func()
 			Namespace: namespace.Name,
 		}, &bmh)).To(Succeed())
 		Expect(bmh.Status.ErrorType).To(BeEmpty())
-
-		By("Deleting the BMH")
-		Expect(clusterProxy.GetClient().Delete(ctx, &bmh)).To(Succeed())
-
-		By("Waiting for the BMH to be deleted")
-		WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
-			Client:    clusterProxy.GetClient(),
-			BmhName:   bmhName,
-			Namespace: namespace.Name,
-		}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

The HostFirmwareSettings (HFS) controller has a bug in its setCondition function that prevents ObservedGeneration from being updated when only the generation changes but the condition status (True/False/Unknown) stays the same. This causes the BMH controller's generation-based consistency check in getHostFirmwareSettings to fail permanently with:

`hostFirmwareSettings not ready yet: generation 9 != observed generation 7`

This blocks the servicing-abort recovery path (#3000): when a user clears the HFS spec to abort a failed servicing operation, the host gets stuck in ServicingError because the BMH controller cannot get past the stale generation check.

Root cause: The HFS setCondition compared only the condition Status field against the old info.hfs.Status.Conditions to decide whether a status update was needed. When ObservedGeneration changed but Status did not, the update was silently skipped. The equivalent function in HostFirmwareComponents (setUpdatesCondition) does not have this bug -- it correctly returns the result of meta.SetStatusCondition, which compares all fields including ObservedGeneration.

Fix (two parts):

HFS controller: Replace the manual dirty-check logic in setCondition with the return value of meta.SetStatusCondition, matching the HFC controller's correct pattern. Remove the now-unused info parameter.

BMH controller: Add a fast-path in the servicing error recovery flow that checks HFS/HFC specs directly (via lightweight r.Get() calls that don't validate generation) before calling the generation-sensitive getHostFirmwareSettings/getHostFirmwareComponents. If specs are already cleared, abort immediately without waiting for the sub-controllers to reconcile. Also add watches on HFS/HFC generation changes so the BMH controller reconciles promptly on spec changes rather than waiting for error-state exponential backoff.

Fixes #3143

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
