### PR TITLE
:bug: Skip cleaning when host is being deleted

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -765,6 +765,10 @@ func (r *BareMetalHostReconciler) getPreprovImage(ctx context.Context, info *rec
 		}
 
 		err = r.Create(ctx, &preprovImage)
+		if k8serrors.IsForbidden(err) && info.host.Status.Provisioning.State == metal3api.StateDeprovisioning {
+			info.log.Info("skipping PreprovisioningImage creation during deprovisioning, namespace may be terminating")
+			return nil, nil //nolint:nilnil
+		}
 		return nil, err
 	}
 	if err != nil {
@@ -844,7 +848,9 @@ func (r *BareMetalHostReconciler) registerHost(ctx context.Context, prov provisi
 		}
 	case metal3api.StateDeprovisioning:
 		// PreprovisioningImage is not required for deprovisioning when cleaning is disabled
-		if info.host.Spec.AutomatedCleaningMode == metal3api.CleaningModeDisabled {
+		// or when the host is being deleted (e.g. namespace is terminating)
+		if info.host.Spec.AutomatedCleaningMode == metal3api.CleaningModeDisabled ||
+			!info.host.DeletionTimestamp.IsZero() {
 			preprovImgFormats = nil
 		}
 	default:
@@ -868,11 +874,18 @@ func (r *BareMetalHostReconciler) registerHost(ctx context.Context, prov provisi
 		return recordActionFailure(info, metal3api.RegistrationError, "failed to read preprovisioningNetworkData")
 	}
 
+	automatedCleaningMode := info.host.Spec.AutomatedCleaningMode
+	if info.host.Status.Provisioning.State == metal3api.StateDeprovisioning && !info.host.DeletionTimestamp.IsZero() {
+		// Skip cleaning when the host is being deleted (e.g. namespace is terminating),
+		// since we cannot create the required PreprovisioningImage.
+		automatedCleaningMode = metal3api.CleaningModeDisabled
+	}
+
 	provResult, provID, err := prov.Register(
 		ctx,
 		provisioner.ManagementAccessData{
 			BootMode:                   info.host.Status.Provisioning.BootMode,
-			AutomatedCleaningMode:      info.host.Spec.AutomatedCleaningMode,
+			AutomatedCleaningMode:      automatedCleaningMode,
 			State:                      info.host.Status.Provisioning.State,
 			OperationalStatus:          info.host.Status.OperationalStatus,
 			CurrentImage:               getCurrentImage(info.host),
@@ -1404,10 +1417,17 @@ func (r *BareMetalHostReconciler) actionDeprovisioning(ctx context.Context, prov
 
 	info.log.Info("deprovisioning")
 
+	automatedCleaningMode := info.host.Spec.AutomatedCleaningMode
+	if !info.host.DeletionTimestamp.IsZero() {
+		// Skip cleaning when the host is being deleted (e.g. namespace is terminating),
+		// since we cannot create the required PreprovisioningImage.
+		automatedCleaningMode = metal3api.CleaningModeDisabled
+	}
+
 	provResult, err := prov.Deprovision(
 		ctx,
 		info.host.Status.ErrorType == metal3api.ProvisioningError,
-		info.host.Spec.AutomatedCleaningMode)
+		automatedCleaningMode)
 	if err != nil {
 		return actionError{fmt.Errorf("failed to deprovision: %w", err)}
 	}

--- a/internal/controller/metal3.io/baremetalhost_controller_test.go
+++ b/internal/controller/metal3.io/baremetalhost_controller_test.go
@@ -28,6 +28,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -2691,6 +2692,80 @@ func TestGetPreprovImageBeingDeleted(t *testing.T) {
 	// because it has a DeletionTimestamp
 	imgData, err := r.getPreprovImage(t.Context(), i, acceptFormats)
 	require.NoError(t, err)
+	assert.Nil(t, imgData)
+}
+
+func TestGetPreprovImageForbiddenDuringDeprovisioning(t *testing.T) {
+	host := newDefaultHost(t)
+	host.Status.Provisioning.State = metal3api.StateDeprovisioning
+
+	c := fakeclient.NewClientBuilder().
+		WithRuntimeObjects(host).
+		WithStatusSubresource(host).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*metal3api.PreprovisioningImage); ok {
+					return k8serrors.NewForbidden(
+						metal3api.GroupVersion.WithResource("preprovisioningimages").GroupResource(),
+						host.Name,
+						fmt.Errorf("unable to create new content in namespace %s because it is being terminated", host.Namespace),
+					)
+				}
+				return client.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	bmcSecret := newBMCCredsSecret(defaultSecretName, "User", "Pass")
+	_ = c.Create(t.Context(), bmcSecret)
+
+	r := &BareMetalHostReconciler{
+		Client:             c,
+		ProvisionerFactory: &fixture.Fixture{},
+		Log:                ctrl.Log.WithName("controllers").WithName("BareMetalHost"),
+		APIReader:          c,
+	}
+	i := makeReconcileInfo(host)
+
+	imgData, err := r.getPreprovImage(t.Context(), i, []metal3api.ImageFormat{metal3api.ImageFormatISO})
+	require.NoError(t, err)
+	assert.Nil(t, imgData)
+}
+
+func TestGetPreprovImageForbiddenNotDeprovisioning(t *testing.T) {
+	host := newDefaultHost(t)
+	host.Status.Provisioning.State = metal3api.StateInspecting
+
+	c := fakeclient.NewClientBuilder().
+		WithRuntimeObjects(host).
+		WithStatusSubresource(host).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*metal3api.PreprovisioningImage); ok {
+					return k8serrors.NewForbidden(
+						metal3api.GroupVersion.WithResource("preprovisioningimages").GroupResource(),
+						host.Name,
+						fmt.Errorf("unable to create new content in namespace %s because it is being terminated", host.Namespace),
+					)
+				}
+				return client.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	bmcSecret := newBMCCredsSecret(defaultSecretName, "User", "Pass")
+	_ = c.Create(t.Context(), bmcSecret)
+
+	r := &BareMetalHostReconciler{
+		Client:             c,
+		ProvisionerFactory: &fixture.Fixture{},
+		Log:                ctrl.Log.WithName("controllers").WithName("BareMetalHost"),
+		APIReader:          c,
+	}
+	i := makeReconcileInfo(host)
+
+	// When not deprovisioning, the Forbidden error should still be returned
+	imgData, err := r.getPreprovImage(t.Context(), i, []metal3api.ImageFormat{metal3api.ImageFormatISO})
+	require.Error(t, err)
+	assert.True(t, k8serrors.IsForbidden(err))
 	assert.Nil(t, imgData)
 }
 


### PR DESCRIPTION
When a BMH is deprovisioning in a terminating namespace, the controller cannot create the `PreprovisioningImage` required for automated cleaning. This causes the BMH to get stuck in deprovisioning indefinitely.

We fix this by skipping automated cleaning when the host has a deletion timestamp, since we know the PPI cannot be created. This is applied in three places: `registerHost` (PPI format selection and Register call) and `actionDeprovisioning` (Deprovision call). A check in `getPreprovImage` also handles the Forbidden error gracefully.