### PR TITLE
:seedling: Set manager TLS default back to unset

### DIFF
--- a/config/base/manager.yaml
+++ b/config/base/manager.yaml
@@ -23,7 +23,6 @@ spec:
         - /baremetal-operator
         args:
         - --enable-leader-election
-        - --tls-min-version=TLS13
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -3139,7 +3139,6 @@ spec:
       containers:
       - args:
         - --enable-leader-election
-        - --tls-min-version=TLS13
         command:
         - /baremetal-operator
         env:


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->
I'm removing tls flag from manager so that the project is not forcing any selection but we rely on the actual default. 

In CAPM3 I'm adding overlays that apply the flag when e2e test are run: https://github.com/metal3-io/cluster-api-provider-metal3/pull/3187 

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
