### PR TITLE
:seedling: Add BMC emulator container management support to vbmctl

### DIFF
--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -114,10 +114,7 @@ IP_ADDRESS="192.168.222.1"
 
 if [[ "${BMO_E2E_EMULATOR}" == "vbmc" ]]; then
   # Start VBMC
-  docker start vbmc || docker run --name vbmc --network host -d \
-    -v /var/run/libvirt/libvirt-sock:/var/run/libvirt/libvirt-sock \
-    -v /var/run/libvirt/libvirt-sock-ro:/var/run/libvirt/libvirt-sock-ro \
-    quay.io/metal3-io/vbmc
+  ./bin/vbmctl create bmc-emulator --emulator-type "vbmc" --image "quay.io/metal3-io/vbmc"
 
   readarray -t BMCS < <(yq e -o=j -I=0 '.[]' "${E2E_BMCS_CONF_FILE}")
   for bmc in "${BMCS[@]}"; do
@@ -131,12 +128,7 @@ elif [[ "${BMO_E2E_EMULATOR}" == "sushy-tools" ]]; then
   # Sushy-tools variables
   SUSHY_EMULATOR_FILE="${REPO_ROOT}"/test/e2e/sushy-tools/sushy-emulator.conf
   # Start sushy-tools
-  docker start sushy-tools || docker run --name sushy-tools -d --network host \
-    -v "${SUSHY_EMULATOR_FILE}":/etc/sushy/sushy-emulator.conf:Z \
-    -v /var/run/libvirt:/var/run/libvirt:Z \
-    -e SUSHY_EMULATOR_CONFIG=/etc/sushy/sushy-emulator.conf \
-    quay.io/metal3-io/sushy-tools:latest sushy-emulator
-
+  ./bin/vbmctl create bmc-emulator --emulator-type "sushy-tools" --image "quay.io/metal3-io/sushy-tools:latest" --config-file "${SUSHY_EMULATOR_FILE}"
 else
   echo "FATAL: Invalid e2e emulator specified: ${BMO_E2E_EMULATOR}"
   exit 1

--- a/hack/clean-e2e.sh
+++ b/hack/clean-e2e.sh
@@ -3,9 +3,9 @@
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${REPO_ROOT}" || exit 1
 
-docker rm -f vbmc
+docker rm -f vbmctl-vbmc
 docker rm -f vbmctl-image-server-e2e
-docker rm -f sushy-tools
+docker rm -f vbmctl-sushy-tools
 
 "${REPO_ROOT}/tools/bmh_test/clean_local_bmh_test_setup.sh" "^bmo-e2e-"
 

--- a/test/vbmctl/README.md
+++ b/test/vbmctl/README.md
@@ -18,7 +18,7 @@ This tool is under active development.
 | `vbmctl status` | ✅ Implemented (basic) |
 | Configurable volumes |  ✅ Implemented |
 | Network management | ⚠️ Partially implemented (only libvirt networks) |
-| BMC emulator support | ❌ TODO |
+| BMC emulator support | ✅ Implemented (basic) |
 | Image server | ✅ Implemented (basic) |
 | State management (persistent state) | ❌ TODO |
 
@@ -31,6 +31,7 @@ This tool is under active development.
 - **Library Support**: Can be imported as a Go module for programmatic use
 - **Libvirt network management**: create and delete libvirt networks
 - **Image Server Management**: Create, delete, list image server
+- **BMC Emulator Management**: Create, delete, and check status of BMC emulator servers
 
 ## Build Tags
 
@@ -82,6 +83,9 @@ vbmctl create bml
 # a name is specified, vbmctl will automatically add the prefix `vbmctl-`.
 vbmctl create image-server
 
+# Create a BMC emulator with default settings.
+vbmctl create bmc-emulator
+
 # Check status
 vbmctl status
 
@@ -96,6 +100,9 @@ vbmctl delete network
 
 # Delete the image server
 vbmctl delete image-server
+
+# Delete the bmc emulator instance
+vbmctl delete bmc-emulator
 
 # Show help
 vbmctl --help
@@ -168,6 +175,10 @@ spec:
   imageServer:
     dataDir: "/tmp"
     port: 80
+  bmcEmulator:
+    type: "sushy-tools"
+    configFile: "vbmc-emulator-file"
+    image: "bmc-emulator:latest"
 ```
 
 The `spec.vms` section defines the VMs that will be created when you run `vbmctl
@@ -253,6 +264,16 @@ func main() {
         ContainerDataDir: "/usr/share/nginx/html",
         Port:          8080,
         ContainerPort: 80,
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Create a BMC emulator
+    err = containers.CreateBMCEmulatorInstance(ctx, &api.BMCEmulatorConfig{
+        Image:         "my-bmc-emulator:latest",
+        Type:          "sushy-tools",
+        ConfigFile:    "/path/to/config/file",
     })
     if err != nil {
         log.Fatal(err)

--- a/test/vbmctl/cmd/vbmctl/main.go
+++ b/test/vbmctl/cmd/vbmctl/main.go
@@ -45,9 +45,10 @@ for testing and development purposes. It currently provides functionality for:
   - Creating and managing libvirt networks
   - Image server for provisioning
   - Reserving IP addresses for VMs via DHCP on existing libvirt networks
+  - BMC emulator support (sushy-tools, vbmc)
 
 Planned features (not yet implemented):
-  - BMC emulator support (sushy-tools, vbmc)
+  - Support multiple named environments
 
 vbmctl is designed to be as simple to use as 'kind' for creating
 test environments for the Bare Metal Operator (BMO) and CAPM3.`,
@@ -88,6 +89,7 @@ func newCreateCmd() *cobra.Command {
 	cmd.AddCommand(newCreateBMLCmd())
 	cmd.AddCommand(newCreateNetworkCmd())
 	cmd.AddCommand(newCreateImageServerCmd())
+	cmd.AddCommand(newCreateBMCEmulatorCmd())
 	return cmd
 }
 
@@ -209,8 +211,12 @@ Example configuration:
       port: 8080
       containerPort: 8080
       dataDir: "/var/lib/vbmctl/images"
-      containerDataDir: "/usr/share/nginx/html",
-      containerName: "vbmctl-image-server"`,
+      containerDataDir: "/usr/share/nginx/html"
+      containerName: "vbmctl-image-server"
+    bmcEmulator:
+      type: "sushy-tools"
+      configFile: "vbmc-emulator-file"
+      image: "bmc-emulator:latest"`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx, cancel := contextWithSignal()
 			defer cancel()
@@ -232,6 +238,16 @@ Example configuration:
 			} else {
 				//nolint:forbidigo // CLI output is intentional
 				fmt.Println("No image server configuration found in the config file.")
+			}
+
+			if cfg.Spec.BMCEmulator != nil {
+				err = containers.CreateBMCEmulatorInstance(ctx, cfg.Spec.BMCEmulator)
+				if err != nil {
+					return err
+				}
+			} else {
+				//nolint:forbidigo // CLI output is intentional
+				fmt.Println("No BMC emulator configuration found in the config file.")
 			}
 
 			conn, err := libvirtgo.NewConnect(cfg.Spec.Libvirt.URI)
@@ -420,6 +436,80 @@ func newCreateImageServerCmd() *cobra.Command {
 	return cmd
 }
 
+func newCreateBMCEmulatorCmd() *cobra.Command {
+	var (
+		emulatorType string
+		image        string
+		configFile   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "bmc-emulator",
+		Short: "Create a BMC emulator instance",
+		Long:  "Create a BMC emulator instance to be used for testing.",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			ctx, cancel := contextWithSignal()
+			defer cancel()
+
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+
+			// Resolve effective BMC emulator config: config file values as base,
+			// command-line flags take precedence over both.
+			effective := &vbmctlapi.BMCEmulatorConfig{}
+			if cfg.Spec.BMCEmulator != nil {
+				effective = cfg.Spec.BMCEmulator
+			}
+
+			// Resolve type: flag > config > default.
+			if emulatorType == "" {
+				if effective.Type != "" {
+					emulatorType = effective.Type
+				} else {
+					emulatorType = config.DefaultBMCEmulatorType
+				}
+			}
+
+			// Resolve image: flag > config > correct default for the resolved type.
+			if image == "" {
+				if effective.Image != "" {
+					image = effective.Image
+				} else if emulatorType == config.BMCEmulatorTypeSushyTools {
+					image = config.DefaultBMCEmulatorSushyToolsImage
+				} else {
+					image = config.DefaultBMCEmulatorVBMCImage
+				}
+			}
+
+			// Resolve config file: flag > config > default.
+			if configFile == "" {
+				if effective.ConfigFile != "" {
+					configFile = effective.ConfigFile
+				} else {
+					// Note that the config file is only applicable for sushy-tools,
+					// but we'll set it regardless of the type since it's not harmful
+					// for vbmc and simplifies the logic.
+					configFile = config.DefaultBMCEmulatorSushyToolsConfigFile
+				}
+			}
+
+			return containers.CreateBMCEmulatorInstance(ctx, &vbmctlapi.BMCEmulatorConfig{
+				Type:       emulatorType,
+				Image:      image,
+				ConfigFile: configFile,
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&emulatorType, "emulator-type", "", "type of the BMC emulator (vbmc or sushy-tools, default is "+config.DefaultBMCEmulatorType+" if not set in config file)")
+	cmd.Flags().StringVar(&image, "image", "", "container image to use for the BMC emulator (default is "+config.DefaultBMCEmulatorVBMCImage+" or "+config.DefaultBMCEmulatorSushyToolsImage+" if not set in config file)")
+	cmd.Flags().StringVar(&configFile, "config-file", "", "configuration file to use for the BMC emulator in case of sushy-tools (default is "+config.DefaultBMCEmulatorSushyToolsConfigFile+" if not set in config file)")
+
+	return cmd
+}
+
 func newDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
@@ -431,6 +521,7 @@ func newDeleteCmd() *cobra.Command {
 	cmd.AddCommand(newDeleteBMLCmd())
 	cmd.AddCommand(newDeleteNetworkCmd())
 	cmd.AddCommand(newDeleteImageServerCmd())
+	cmd.AddCommand(newDeleteBMCEmulatorCmd())
 	return cmd
 }
 
@@ -565,6 +656,18 @@ func newDeleteBMLCmd() *cobra.Command {
 				fmt.Println("No image server configuration found in the config file.")
 			}
 
+			if cfg.Spec.BMCEmulator != nil {
+				err := containers.DeleteBMCEmulatorInstance(ctx, cfg.Spec.BMCEmulator.Type)
+				// don't fail the whole command if BMC emulator deletion fails, just log the error
+				if err != nil {
+					//nolint:forbidigo // CLI output is intentional
+					fmt.Printf("%v\n", err)
+				}
+			} else {
+				//nolint:forbidigo // CLI output is intentional
+				fmt.Println("No BMC emulator configuration found in the config file.")
+			}
+
 			return nil
 		},
 	}
@@ -646,8 +749,43 @@ func newDeleteImageServerCmd() *cobra.Command {
 	return cmd
 }
 
+func newDeleteBMCEmulatorCmd() *cobra.Command {
+	var emulatorType string
+
+	cmd := &cobra.Command{
+		Use:   "bmc-emulator",
+		Short: "Delete the BMC emulator instance",
+		Long:  "Delete the BMC emulator instance used for provisioning.",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			ctx, cancel := contextWithSignal()
+			defer cancel()
+
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+
+			// command-line flag takes precedence over config file value
+			if emulatorType == "" {
+				if cfg.Spec.BMCEmulator != nil {
+					emulatorType = cfg.Spec.BMCEmulator.Type
+				} else {
+					emulatorType = config.DefaultBMCEmulatorType
+				}
+			}
+
+			return containers.DeleteBMCEmulatorInstance(ctx, emulatorType)
+		},
+	}
+
+	cmd.Flags().StringVar(&emulatorType, "emulator-type", "", "type of the BMC emulator container to delete (default is "+config.DefaultBMCEmulatorType+" if not set in config file)")
+
+	return cmd
+}
+
 func newStatusCmd() *cobra.Command {
 	var containerName string
+	var emulatorType string
 
 	cmd := &cobra.Command{
 		Use:   "status",
@@ -695,8 +833,24 @@ func newStatusCmd() *cobra.Command {
 				return err
 			}
 
+			// command-line flag takes precedence over config file value
+			if emulatorType == "" {
+				if cfg.Spec.BMCEmulator != nil {
+					emulatorType = cfg.Spec.BMCEmulator.Type
+				} else {
+					emulatorType = config.DefaultBMCEmulatorType
+				}
+			}
+			// check if the bmc emulator is present
+			emulatorInfo, err := containers.GetBMCEmulatorInfo(ctx, emulatorType)
+			if err != nil {
+				return err
+			}
+
 			//nolint:forbidigo // CLI output is intentional
 			fmt.Printf("Image Server container: %s\n", containerInfo)
+			//nolint:forbidigo // CLI output is intentional
+			fmt.Printf("BMC Emulator container: %s\n", emulatorInfo)
 			//nolint:forbidigo // CLI output is intentional
 			fmt.Println("Virtual Machines:")
 			//nolint:forbidigo // CLI output is intentional
@@ -712,6 +866,7 @@ func newStatusCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&containerName, "name", "", "name of the image server container (default is "+config.DefaultImageServerContainerName+" if not set in config file)")
+	cmd.Flags().StringVar(&emulatorType, "emulator-type", "", "type of the BMC emulator container to check for (default is "+config.DefaultBMCEmulatorType+" if not set in config file)")
 
 	return cmd
 }
@@ -791,6 +946,14 @@ func newConfigViewCmd() *cobra.Command {
 					cfg.Spec.ImageServer.ContainerPort,
 					cfg.Spec.ImageServer.DataDir,
 					cfg.Spec.ImageServer.ContainerName)
+			}
+
+			if cfg.Spec.BMCEmulator != nil {
+				//nolint:forbidigo // CLI output is intentional
+				fmt.Printf("BMC Emulator:\n  Emulator Type: %s\n  Config File: %s\n  Image: %s\n",
+					cfg.Spec.BMCEmulator.Type,
+					cfg.Spec.BMCEmulator.ConfigFile,
+					cfg.Spec.BMCEmulator.Image)
 			}
 
 			return nil

--- a/test/vbmctl/pkg/api/types.go
+++ b/test/vbmctl/pkg/api/types.go
@@ -50,6 +50,41 @@ type ImageServerConfig struct {
 	ContainerName string `json:"containerName" yaml:"containerName"`
 }
 
+// VolumeMount represents a single host-to-container volume binding.
+type VolumeMount struct {
+	// HostPath is the path on the host to mount.
+	HostPath string
+
+	// BindSpec is the container-side bind specification, e.g.
+	// "/container/path" or "/container/path:Z".
+	BindSpec string
+}
+
+// BMCEmulatorConfig represents the configuration for the BMC emulator.
+type BMCEmulatorConfig struct {
+	// BMC Emulator type
+	Type string `json:"type" yaml:"type"`
+
+	// ConfigFile is the path to the sushy-tools config file and is only
+	// applicable/required when Type is "sushy-tools".
+	ConfigFile string `json:"configFile" yaml:"configFile"`
+
+	// Image is the container image to use for the BMC emulator.
+	Image string `json:"image" yaml:"image"`
+
+	// Cmd is an internal runtime command for the BMC emulator container.
+	Cmd []string `json:"-" yaml:"-"`
+
+	// Env contains internal runtime environment variables for the emulator container.
+	Env map[string]string `json:"-" yaml:"-"`
+
+	// ContainerName is an internal runtime container name for the BMC emulator.
+	ContainerName string `json:"-" yaml:"-"`
+
+	// VolumeMounts is an internal runtime list of host-to-container volume bindings.
+	VolumeMounts []VolumeMount `json:"-" yaml:"-"`
+}
+
 // NetworkAttachment represents a network interface attached to a VM.
 type NetworkAttachment struct {
 	// Network is the name of the libvirt network to attach to.

--- a/test/vbmctl/pkg/config/config.go
+++ b/test/vbmctl/pkg/config/config.go
@@ -71,6 +71,27 @@ const (
 
 	// DefaultImageServerContainerName is the default container name for the image server.
 	DefaultImageServerContainerName = "vbmctl-image-server"
+
+	// DefaultBMCEmulatorType is the default BMC emulator type.
+	DefaultBMCEmulatorType = BMCEmulatorTypeVBMC
+
+	// DefaultBMCEmulatorSushyToolsConfigFile is the default BMC emulator config file (used for sushy-tools).
+	DefaultBMCEmulatorSushyToolsConfigFile = "sushy-emulator.conf"
+
+	// DefaultBMCEmulatorVBMCImage is the default container image for the VBMC BMC emulator.
+	DefaultBMCEmulatorVBMCImage = "quay.io/metal3-io/vbmc"
+
+	// DefaultBMCEmulatorSushyToolsImage is the default container image for the sushy-tools BMC emulator.
+	DefaultBMCEmulatorSushyToolsImage = "quay.io/metal3-io/sushy-tools:latest"
+)
+
+// BMC emulator types.
+const (
+	// BMC emulator type: vbmc.
+	BMCEmulatorTypeVBMC = "vbmc"
+
+	// BMC emulator type: sushy-tools.
+	BMCEmulatorTypeSushyTools = "sushy-tools"
 )
 
 // Config is the top-level configuration for vbmctl.
@@ -101,6 +122,9 @@ type Spec struct {
 
 	// ImageServer contains configuration for the image server.
 	ImageServer *vbmctlapi.ImageServerConfig `json:"imageServer,omitempty" yaml:"imageServer,omitempty"`
+
+	// BMCEmulator contains configuration for the BMC emulator.
+	BMCEmulator *vbmctlapi.BMCEmulatorConfig `json:"bmcEmulator,omitempty" yaml:"bmcEmulator,omitempty"`
 }
 
 // LibvirtConfig contains libvirt connection settings.
@@ -253,6 +277,22 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	// Validate BMC emulator config
+	if c.Spec.BMCEmulator != nil {
+		if c.Spec.BMCEmulator.Type == "" {
+			return errors.New("BMC emulator type is required")
+		}
+		if c.Spec.BMCEmulator.Type != BMCEmulatorTypeVBMC && c.Spec.BMCEmulator.Type != BMCEmulatorTypeSushyTools {
+			return fmt.Errorf("unsupported BMC emulator type: %s", c.Spec.BMCEmulator.Type)
+		}
+		if c.Spec.BMCEmulator.Image == "" {
+			return errors.New("BMC emulator container image is required")
+		}
+		if c.Spec.BMCEmulator.Type == BMCEmulatorTypeSushyTools && c.Spec.BMCEmulator.ConfigFile == "" {
+			return fmt.Errorf("BMC emulator config file is required for %s type", BMCEmulatorTypeSushyTools)
+		}
+	}
+
 	return nil
 }
 
@@ -295,6 +335,26 @@ func (c *Config) ApplyDefaults() {
 		}
 		if c.Spec.ImageServer.ContainerName == "" {
 			c.Spec.ImageServer.ContainerName = DefaultImageServerContainerName
+		}
+	}
+
+	// Apply BMC emulator defaults
+	if c.Spec.BMCEmulator != nil {
+		if c.Spec.BMCEmulator.Type == "" {
+			c.Spec.BMCEmulator.Type = DefaultBMCEmulatorType
+		}
+		if c.Spec.BMCEmulator.Image == "" {
+			switch c.Spec.BMCEmulator.Type {
+			case BMCEmulatorTypeVBMC:
+				c.Spec.BMCEmulator.Image = DefaultBMCEmulatorVBMCImage
+			case BMCEmulatorTypeSushyTools:
+				c.Spec.BMCEmulator.Image = DefaultBMCEmulatorSushyToolsImage
+			default:
+				// If the type is unrecognized, we won't set a default image.
+			}
+		}
+		if c.Spec.BMCEmulator.Type == BMCEmulatorTypeSushyTools && c.Spec.BMCEmulator.ConfigFile == "" {
+			c.Spec.BMCEmulator.ConfigFile = DefaultBMCEmulatorSushyToolsConfigFile
 		}
 	}
 }

--- a/test/vbmctl/pkg/config/config_test.go
+++ b/test/vbmctl/pkg/config/config_test.go
@@ -49,6 +49,10 @@ spec:
     dataDir: "/var/lib/vbmctl/images-test"
     containerDataDir: "/usr/share/nginx/html"
     containerName: "vbmctl-image-server-test"
+  bmcEmulator:
+    type: "sushy-tools"
+    configFile: "vbmc-emulator-file"
+    image: "test/bmc-emulator:latest"
 `)
 
 	cfg, err := Parse(yamlData)
@@ -103,6 +107,22 @@ spec:
 	if cfg.Spec.ImageServer.ContainerName != "vbmctl-image-server-test" {
 		t.Errorf("expected image server container name 'vbmctl-image-server-test', got %s", cfg.Spec.ImageServer.ContainerName)
 	}
+
+	if cfg.Spec.BMCEmulator == nil {
+		t.Fatal("expected BMC emulator config, got nil")
+	}
+
+	if cfg.Spec.BMCEmulator.Type != "sushy-tools" {
+		t.Errorf("expected BMC emulator type 'sushy-tools', got %s", cfg.Spec.BMCEmulator.Type)
+	}
+
+	if cfg.Spec.BMCEmulator.ConfigFile != "vbmc-emulator-file" {
+		t.Errorf("expected BMC emulator config file 'vbmc-emulator-file', got %s", cfg.Spec.BMCEmulator.ConfigFile)
+	}
+
+	if cfg.Spec.BMCEmulator.Image != "test/bmc-emulator:latest" {
+		t.Errorf("expected BMC emulator image 'test/bmc-emulator:latest', got %s", cfg.Spec.BMCEmulator.Image)
+	}
 }
 
 func TestLoadAndSave(t *testing.T) {
@@ -121,6 +141,11 @@ func TestLoadAndSave(t *testing.T) {
 		DataDir:          "/var/lib/vbmctl/images-test",
 		ContainerDataDir: "/usr/share/nginx/html",
 		ContainerName:    "vbmctl-image-server",
+	}
+	cfg.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
+		Type:       BMCEmulatorTypeSushyTools,
+		ConfigFile: "vbmc-emulator-file",
+		Image:      "test/bmc-emulator:latest",
 	}
 
 	// Save it
@@ -173,6 +198,22 @@ func TestLoadAndSave(t *testing.T) {
 
 	if loadedCfg.Spec.ImageServer.ContainerPort != 8081 {
 		t.Errorf("expected image server container port %d, got %d", 8081, loadedCfg.Spec.ImageServer.ContainerPort)
+	}
+
+	if loadedCfg.Spec.BMCEmulator == nil {
+		t.Fatal("expected BMC emulator config, got nil")
+	}
+
+	if loadedCfg.Spec.BMCEmulator.Type != BMCEmulatorTypeSushyTools {
+		t.Errorf("expected BMC emulator type '%s', got %s", BMCEmulatorTypeSushyTools, loadedCfg.Spec.BMCEmulator.Type)
+	}
+
+	if loadedCfg.Spec.BMCEmulator.ConfigFile != "vbmc-emulator-file" {
+		t.Errorf("expected BMC emulator config file 'vbmc-emulator-file', got %s", loadedCfg.Spec.BMCEmulator.ConfigFile)
+	}
+
+	if loadedCfg.Spec.BMCEmulator.Image != "test/bmc-emulator:latest" {
+		t.Errorf("expected BMC emulator image 'test/bmc-emulator:latest', got %s", loadedCfg.Spec.BMCEmulator.Image)
 	}
 }
 
@@ -329,6 +370,58 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "valid BMC emulator config (sushy-tools)",
+			modify: func(c *Config) {
+				c.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
+					Type:       BMCEmulatorTypeSushyTools,
+					ConfigFile: "vbmc-emulator-file",
+					Image:      "test/bmc-emulator:latest",
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid BMC emulator config (vbmc)",
+			modify: func(c *Config) {
+				c.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
+					Type:  BMCEmulatorTypeVBMC,
+					Image: "test/bmc-emulator:latest",
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid BMC emulator config - missing type",
+			modify: func(c *Config) {
+				c.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
+					ConfigFile: "vbmc-emulator-file",
+					Image:      "test/bmc-emulator:latest",
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid BMC emulator config - missing config file",
+			modify: func(c *Config) {
+				c.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
+					Type:  BMCEmulatorTypeSushyTools,
+					Image: "test/bmc-emulator:latest",
+				}
+			},
+			wantErr: true,
+		},
+
+		{
+			name: "invalid BMC emulator config - missing image",
+			modify: func(c *Config) {
+				c.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
+					Type:       BMCEmulatorTypeVBMC,
+					ConfigFile: "vbmc-emulator-file",
+				}
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -345,6 +438,7 @@ func TestValidate(t *testing.T) {
 
 func TestApplyDefaults(t *testing.T) {
 	cfg := &Config{}
+	cfg.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{}
 	cfg.ApplyDefaults()
 
 	if cfg.Spec.Libvirt.URI != DefaultLibvirtURI {
@@ -353,6 +447,43 @@ func TestApplyDefaults(t *testing.T) {
 
 	if cfg.Spec.Pool.Name != DefaultPoolName {
 		t.Errorf("expected Pool Name %s, got %s", DefaultPoolName, cfg.Spec.Pool.Name)
+	}
+
+	if cfg.Spec.BMCEmulator.Type != DefaultBMCEmulatorType {
+		t.Errorf("expected BMC Emulator Type %s, got %s", DefaultBMCEmulatorType, cfg.Spec.BMCEmulator.Type)
+	}
+
+	// If type is unknown, image default should not be applied
+	unknownCfg := &Config{}
+	unknownCfg.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
+		Type: "unknown-type",
+	}
+	unknownCfg.ApplyDefaults()
+	if unknownCfg.Spec.BMCEmulator.Image != "" {
+		t.Errorf("expected BMC Emulator Image <empty>, got %s", unknownCfg.Spec.BMCEmulator.Image)
+	}
+
+	// If type is vbmc, vbmc image default should be applied
+	vbmcCfg := &Config{}
+	vbmcCfg.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
+		Type: BMCEmulatorTypeVBMC,
+	}
+	vbmcCfg.ApplyDefaults()
+	if vbmcCfg.Spec.BMCEmulator.Image != DefaultBMCEmulatorVBMCImage {
+		t.Errorf("expected BMC Emulator Image %s, got %s", DefaultBMCEmulatorVBMCImage, vbmcCfg.Spec.BMCEmulator.Image)
+	}
+
+	// Config file default is only applied for sushy-tools type. Also verify that the image default for sushy-tools is applied.
+	sushyCfg := &Config{}
+	sushyCfg.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
+		Type: BMCEmulatorTypeSushyTools,
+	}
+	sushyCfg.ApplyDefaults()
+	if sushyCfg.Spec.BMCEmulator.ConfigFile != DefaultBMCEmulatorSushyToolsConfigFile {
+		t.Errorf("expected BMC Emulator Config File %s, got %s", DefaultBMCEmulatorSushyToolsConfigFile, sushyCfg.Spec.BMCEmulator.ConfigFile)
+	}
+	if sushyCfg.Spec.BMCEmulator.Image != DefaultBMCEmulatorSushyToolsImage {
+		t.Errorf("expected BMC Emulator Image %s, got %s", DefaultBMCEmulatorSushyToolsImage, sushyCfg.Spec.BMCEmulator.Image)
 	}
 }
 

--- a/test/vbmctl/pkg/containers/bmc_emulator.go
+++ b/test/vbmctl/pkg/containers/bmc_emulator.go
@@ -1,0 +1,153 @@
+//go:build vbmctl
+// +build vbmctl
+
+package containers
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
+	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/config"
+	container "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
+)
+
+// volumeMountsToBinds converts a slice of VolumeMount to Docker bind strings in the form "hostPath:bindSpec".
+func volumeMountsToBinds(mounts []vbmctlapi.VolumeMount) []string {
+	if len(mounts) == 0 {
+		return nil
+	}
+	binds := make([]string, 0, len(mounts))
+	for _, m := range mounts {
+		binds = append(binds, fmt.Sprintf("%s:%s", m.HostPath, m.BindSpec))
+	}
+	return binds
+}
+
+// envMapToSlice converts a map of environment variables to a slice in the form "KEY=VALUE".
+func envMapToSlice(envMap map[string]string) []string {
+	if len(envMap) == 0 {
+		return nil
+	}
+	envSlice := make([]string, 0, len(envMap))
+	for key, value := range envMap {
+		envSlice = append(envSlice, fmt.Sprintf("%s=%s", key, value))
+	}
+	return envSlice
+}
+
+func createEmulatorInstance(ctx context.Context, cfg *vbmctlapi.BMCEmulatorConfig) error {
+	// Create the container
+	opts := client.ContainerCreateOptions{
+		Config: &container.Config{
+			Image: cfg.Image,
+			Env:   envMapToSlice(cfg.Env),
+			Cmd:   cfg.Cmd,
+		},
+		HostConfig: &container.HostConfig{
+			NetworkMode: "host",
+			Binds:       volumeMountsToBinds(cfg.VolumeMounts),
+		},
+		NetworkingConfig: nil,
+		Platform:         nil,
+		Name:             cfg.ContainerName,
+	}
+
+	err := CreateRunningContainer(ctx, "BMC emulator", &opts)
+	if err != nil {
+		return fmt.Errorf("failed to create BMC emulator container: %w", err)
+	}
+
+	return nil
+}
+
+func deleteEmulatorInstance(ctx context.Context, containerName string) error {
+	return DeleteContainer(ctx, "BMC emulator", containerName)
+}
+
+func createVBMCEmulatorInstance(ctx context.Context, cfg *vbmctlapi.BMCEmulatorConfig) error {
+	// Fill in configuration
+	cfg.ContainerName = ensureVbmctlPrefix(config.BMCEmulatorTypeVBMC)
+	cfg.VolumeMounts = []vbmctlapi.VolumeMount{
+		{HostPath: "/var/run/libvirt/libvirt-sock", BindSpec: "/var/run/libvirt/libvirt-sock"},
+		{HostPath: "/var/run/libvirt/libvirt-sock-ro", BindSpec: "/var/run/libvirt/libvirt-sock-ro"},
+	}
+	cfg.Env = map[string]string{}
+	cfg.Cmd = nil
+
+	return createEmulatorInstance(ctx, cfg)
+}
+
+func deleteVBMCEmulatorInstance(ctx context.Context) error {
+	return deleteEmulatorInstance(ctx, ensureVbmctlPrefix(config.BMCEmulatorTypeVBMC))
+}
+
+func getVBMCEmulatorInfo(ctx context.Context) (info string, err error) {
+	return GetContainerInfo(ctx, ensureVbmctlPrefix(config.BMCEmulatorTypeVBMC))
+}
+
+func createSushyToolsEmulatorInstance(ctx context.Context, cfg *vbmctlapi.BMCEmulatorConfig) error {
+	// Validate that the config file exists and is a file
+	info, err := os.Stat(cfg.ConfigFile)
+	if err != nil {
+		return fmt.Errorf("failed to access sushy-tools config file %q: %w", cfg.ConfigFile, err)
+	} else if info.IsDir() {
+		return fmt.Errorf("sushy-tools config file %q is a directory", cfg.ConfigFile)
+	}
+
+	// Fill in configuration
+	cfg.ContainerName = ensureVbmctlPrefix(config.BMCEmulatorTypeSushyTools)
+	cfg.VolumeMounts = []vbmctlapi.VolumeMount{
+		{HostPath: cfg.ConfigFile, BindSpec: "/etc/sushy/sushy-emulator.conf:Z"},
+		{HostPath: "/var/run/libvirt", BindSpec: "/var/run/libvirt:Z"},
+	}
+	cfg.Env = map[string]string{
+		"SUSHY_EMULATOR_CONFIG": "/etc/sushy/sushy-emulator.conf",
+	}
+	cfg.Cmd = []string{"sushy-emulator"}
+
+	return createEmulatorInstance(ctx, cfg)
+}
+
+func deleteSushyToolsEmulatorInstance(ctx context.Context) error {
+	return deleteEmulatorInstance(ctx, ensureVbmctlPrefix(config.BMCEmulatorTypeSushyTools))
+}
+
+func getSushyToolsEmulatorInfo(ctx context.Context) (info string, err error) {
+	return GetContainerInfo(ctx, ensureVbmctlPrefix(config.BMCEmulatorTypeSushyTools))
+}
+
+func CreateBMCEmulatorInstance(ctx context.Context, cfg *vbmctlapi.BMCEmulatorConfig) error {
+	switch cfg.Type {
+	case config.BMCEmulatorTypeVBMC:
+		return createVBMCEmulatorInstance(ctx, cfg)
+	case config.BMCEmulatorTypeSushyTools:
+		return createSushyToolsEmulatorInstance(ctx, cfg)
+	default:
+		return fmt.Errorf("unsupported BMC emulator type: %s", cfg.Type)
+	}
+}
+
+func DeleteBMCEmulatorInstance(ctx context.Context, emulatorType string) error {
+	switch emulatorType {
+	case config.BMCEmulatorTypeVBMC:
+		return deleteVBMCEmulatorInstance(ctx)
+	case config.BMCEmulatorTypeSushyTools:
+		return deleteSushyToolsEmulatorInstance(ctx)
+	default:
+		return fmt.Errorf("unsupported BMC emulator type: %s", emulatorType)
+	}
+}
+
+func GetBMCEmulatorInfo(ctx context.Context, emulatorType string) (info string, err error) {
+	switch emulatorType {
+	case config.BMCEmulatorTypeVBMC:
+		return getVBMCEmulatorInfo(ctx)
+	case config.BMCEmulatorTypeSushyTools:
+		return getSushyToolsEmulatorInfo(ctx)
+	default:
+		return "", fmt.Errorf("unsupported BMC emulator type: %s", emulatorType)
+	}
+}

--- a/test/vbmctl/pkg/containers/doc.go
+++ b/test/vbmctl/pkg/containers/doc.go
@@ -49,6 +49,28 @@
 //	    ContainerPort:     80,
 //	})
 //
+// # BMC Emulator Management
+//
+// A BMC emulator container can be provisioned using
+// CreateBMCEmulatorInstance:
+//
+// For the "vbmc" type, only the Image field is required.
+//
+//	err := containers.CreateBMCEmulatorInstance(ctx, &api.BMCEmulatorConfig{
+//	    Type:          "vbmc",
+//	    Image:         "my-vbmc:latest",
+//	})
+//
+// For the "sushy-tools" type, ConfigFile must point to a configuration file
+// that already exists on the host. That file will be bind-mounted into the
+// container.
+//
+//	err := containers.CreateBMCEmulatorInstance(ctx, &api.BMCEmulatorConfig{
+//	    Type:          "sushy-tools",
+//	    Image:         "my-sushy-tools:latest",
+//	    ConfigFile:    "/path/to/existing/config/file",
+//	})
+//
 // # Error Handling
 //
 // All operations return standard Go errors that can be inspected for specific

--- a/tools/bmh_test/vm2vbmc.sh
+++ b/tools/bmh_test/vm2vbmc.sh
@@ -7,6 +7,6 @@ VBMC_PORT="${2:?}"
 VBMC_ADDRESS="${3:-"::"}"
 
 # Add the BareMetalHost VM to VBMC
-docker exec vbmc vbmc add "${NAME}" --port "${VBMC_PORT}" --address "${VBMC_ADDRESS}" --libvirt-uri "qemu:///system"
-docker exec vbmc vbmc start "${NAME}"
-docker exec vbmc vbmc list
+docker exec vbmctl-vbmc vbmc add "${NAME}" --port "${VBMC_PORT}" --address "${VBMC_ADDRESS}" --libvirt-uri "qemu:///system"
+docker exec vbmctl-vbmc vbmc start "${NAME}"
+docker exec vbmctl-vbmc vbmc list


### PR DESCRIPTION
Add BMCEmulatorConfig API type and container lifecycle management for BMC emulator containers (vbmc and sushy-tools).

- Add BMCEmulatorConfig API fields
- Add defaults and validation in vbmctl config
- Implement container creation helper with env conversion and volume mounts
- Update package docs to include BMC emulator usage

Adds commands `create bmc-emulator` and `delete bmc-emulator` to manage BMC emulator instances. Management via `create/delete bml` command also included.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Part of #2751
