### PR TITLE
🐛 Add missing `context` to `PreprovisioningImageFormats` func

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -833,7 +833,7 @@ func (r *BareMetalHostReconciler) registerHost(ctx context.Context, prov provisi
 		dirty = true
 	}
 
-	preprovImgFormats, err := prov.PreprovisioningImageFormats()
+	preprovImgFormats, err := prov.PreprovisioningImageFormats(ctx)
 	if err != nil {
 		return actionError{err}
 	}

--- a/internal/controller/metal3.io/host_state_machine_test.go
+++ b/internal/controller/metal3.io/host_state_machine_test.go
@@ -1319,7 +1319,7 @@ func (m *mockProvisioner) Register(_ context.Context, _ provisioner.ManagementAc
 	return m.getNextResultByMethod("ValidateManagementAccess"), "", err
 }
 
-func (m *mockProvisioner) PreprovisioningImageFormats() ([]metal3api.ImageFormat, error) {
+func (m *mockProvisioner) PreprovisioningImageFormats(_ context.Context) ([]metal3api.ImageFormat, error) {
 	return nil, nil
 }
 

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -111,7 +111,7 @@ func (p *demoProvisioner) Register(_ context.Context, _ provisioner.ManagementAc
 	return
 }
 
-func (p *demoProvisioner) PreprovisioningImageFormats() ([]metal3api.ImageFormat, error) {
+func (p *demoProvisioner) PreprovisioningImageFormats(_ context.Context) ([]metal3api.ImageFormat, error) {
 	return nil, nil
 }
 

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -149,7 +149,7 @@ func (p *fixtureProvisioner) Register(_ context.Context, _ provisioner.Managemen
 	return
 }
 
-func (p *fixtureProvisioner) PreprovisioningImageFormats() ([]metal3api.ImageFormat, error) {
+func (p *fixtureProvisioner) PreprovisioningImageFormats(_ context.Context) ([]metal3api.ImageFormat, error) {
 	return nil, nil
 }
 

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -382,7 +382,7 @@ func (p *ironicProvisioner) configureNode(ctx context.Context, data provisioner.
 // PreprovisioningImageFormats returns a list of acceptable formats for a
 // pre-provisioning image to be built by a PreprovisioningImage object. The
 // list should be nil if no image build is requested.
-func (p *ironicProvisioner) PreprovisioningImageFormats() ([]metal3api.ImageFormat, error) {
+func (p *ironicProvisioner) PreprovisioningImageFormats(_ context.Context) ([]metal3api.ImageFormat, error) {
 	if !p.config.havePreprovImgBuilder {
 		return nil, nil
 	}

--- a/pkg/provisioner/ironic/register_test.go
+++ b/pkg/provisioner/ironic/register_test.go
@@ -1,6 +1,7 @@
 package ironic
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -964,7 +965,7 @@ func TestPreprovisioningImageFormats(t *testing.T) {
 			prov, _ := newProvisionerWithSettings(host, bmc.Credentials{}, nil, ironicEndpoint, auth)
 			prov.config.havePreprovImgBuilder = tc.PreprovImgEnabled
 
-			fmts, err := prov.PreprovisioningImageFormats()
+			fmts, err := prov.PreprovisioningImageFormats(context.Background())
 
 			require.NoError(t, err)
 			assert.Equal(t, tc.Expected, fmts)

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -147,7 +147,7 @@ type Provisioner interface {
 	// PreprovisioningImageFormats returns a list of acceptable formats for a
 	// pre-provisioning image to be built by a PreprovisioningImage object. The
 	// list should be nil if no image build is requested.
-	PreprovisioningImageFormats() ([]metal3api.ImageFormat, error)
+	PreprovisioningImageFormats(ctx context.Context) ([]metal3api.ImageFormat, error)
 
 	// InspectHardware updates the HardwareDetails field of the host with
 	// details of devices discovered on the hardware. It may be called


### PR DESCRIPTION
Adds missing `context` function argument to `PreprovisioningImageFormats`

This is needed for cases when custom provisioner gets implemented, against existing Provisioner interface.