### PR TITLE
✨ Migrate to go-plugin system for provisioners

### DIFF
--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -1,0 +1,45 @@
+name: Out-of-tree plugin compatibility test
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+    branches:
+    - 'main'
+    - 'release-*'
+    paths:
+    - 'Dockerfile.plugin-test'
+    - 'Makefile'
+    - 'cmd/plugin-load-test/**'
+    - 'hack/plugin-test/**'
+    - 'pkg/provisioner/**'
+    - 'go.mod'
+    - 'go.sum'
+    - 'apis/go.mod'
+    - 'apis/go.sum'
+    - 'pkg/hardwareutils/go.mod'
+    - 'pkg/hardwareutils/go.sum'
+    - '.github/workflows/plugin-test.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  plugin-test:
+    name: Plugin compat ${{ matrix.arch }}
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch:
+        - amd64
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      with:
+        persist-credentials: false
+
+    - name: Build plugin-test image
+      run: ARCH=${{ matrix.arch }} make docker-build-plugin-test
+      env:
+        IMG_NAME: baremetal-operator
+        IMG_TAG: pr-test

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -21,6 +21,8 @@ jobs:
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: ${{ steps.vars.outputs.go_version }}
+    - name: Build provisioner plugins
+      run: make ironic-plugin demo-plugin
     - name: Run unit tests
       run: make -e unit-cover
       env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,50 @@
 # Support FROM override
 ARG BUILD_IMAGE=docker.io/golang:1.25.11@sha256:dd7d32e19b28621cd982082397fc0510d396805b717d5e77466aa2dd692340de
-ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
+ARG BASE_IMAGE=gcr.io/distroless/base-debian13:nonroot@sha256:a557d784ac275c287d2bdf3172f47bece8d2a0ef3c0fdefb712e95084a04a562
 
-# Build the manager binary
-FROM $BUILD_IMAGE AS builder
+# Shared SDK stage: pinned Go toolchain, modules, and checked-out tree.
+# Downstream builder stages copy from here so we pay the `go mod download`
+# cost once. Third parties can also build custom provisioner plugins against
+# this image to guarantee toolchain and module-version parity with BMO.
+FROM $BUILD_IMAGE AS sdk
 
 WORKDIR /workspace
 
-# Bring in the go dependencies before anything else so we can take
-# advantage of caching these layers in future builds.
 COPY go.mod go.sum ./
 COPY apis/go.mod apis/go.sum apis/
 COPY hack/tools/go.mod hack/tools/go.sum hack/tools/
 COPY pkg/hardwareutils/go.mod pkg/hardwareutils/go.sum pkg/hardwareutils/
 RUN go mod download
-ARG LDFLAGS=-s -w -extldflags=-static
 
 COPY . .
-ARG ARCH=amd64
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} GO111MODULE=on go build -a -ldflags "${LDFLAGS}" -o baremetal-operator main.go
 
-# Copy the controller-manager into a thin image
-# BMO has a dependency preventing us to use the static one,
-# using the base one instead
+ENV CGO_ENABLED=1
+ENV GO111MODULE=on
+
+# Build the manager binary
+FROM sdk AS builder
+ARG ARCH=amd64
+ARG LDFLAGS=-s -w
+RUN GOOS=linux GOARCH=${ARCH} \
+    go build -a -ldflags "${LDFLAGS}" -o baremetal-operator main.go
+
+# Build the ironic provisioner plugin
+FROM sdk AS ironic-plugin-builder
+ARG ARCH=amd64
+ARG LDFLAGS=-s -w
+RUN GOOS=linux GOARCH=${ARCH} \
+    go build -buildmode=plugin -ldflags "${LDFLAGS}" \
+    -o ironic-provisioner.so ./pkg/provisioner/ironic/plugin/
+
+# Build the demo provisioner plugin
+FROM sdk AS demo-plugin-builder
+ARG ARCH=amd64
+ARG LDFLAGS=-s -w
+RUN GOOS=linux GOARCH=${ARCH} \
+    go build -buildmode=plugin -ldflags "${LDFLAGS}" \
+    -o demo-provisioner.so ./pkg/provisioner/demo/plugin/
+
+# Runtime image. Uses distroless/base (not static) because Go plugins need glibc.
 FROM $BASE_IMAGE
 
 # image.version is set during image build by automation
@@ -36,5 +58,7 @@ LABEL org.opencontainers.image.vendor="Metal3-io"
 
 WORKDIR /
 COPY --from=builder /workspace/baremetal-operator .
+COPY --from=ironic-plugin-builder /workspace/ironic-provisioner.so /plugins/ironic-provisioner.so
+COPY --from=demo-plugin-builder /workspace/demo-provisioner.so /plugins/demo-provisioner.so
 USER nonroot:nonroot
 ENTRYPOINT ["/baremetal-operator"]

--- a/Dockerfile.plugin-test
+++ b/Dockerfile.plugin-test
@@ -1,0 +1,65 @@
+# Dockerfile.plugin-test
+#
+# Emulates an out-of-tree provisioner plugin author flow and verifies the
+# resulting .so still loads into a freshly built BMO binary. The build fails
+# if the plugin cannot be opened or its exported symbols cannot be invoked.
+#
+# Stages:
+#   bmo-builder        builds the BMO binary and the plugin-load-test tool
+#   plugin-author      fresh git repo with its own go.mod, builds demo .so
+#                      against BMO via replace directives (the closest
+#                      reproduction of an external author depending on BMO)
+#   plugin-load-tester runs plugin-load-test against the .so, build fails on
+#                      any error
+ARG BUILD_IMAGE=docker.io/golang:1.25.11@sha256:dd7d32e19b28621cd982082397fc0510d396805b717d5e77466aa2dd692340de
+
+FROM $BUILD_IMAGE AS bmo-builder
+WORKDIR /bmo
+COPY go.mod go.sum ./
+COPY apis/go.mod apis/go.sum apis/
+COPY hack/tools/go.mod hack/tools/go.sum hack/tools/
+COPY pkg/hardwareutils/go.mod pkg/hardwareutils/go.sum pkg/hardwareutils/
+RUN go mod download
+COPY . .
+ENV CGO_ENABLED=1
+ENV GO111MODULE=on
+ARG ARCH=amd64
+ARG LDFLAGS=-s -w
+RUN GOOS=linux GOARCH=${ARCH} \
+    go build -a -ldflags "${LDFLAGS}" -o /out/baremetal-operator main.go && \
+    GOOS=linux GOARCH=${ARCH} \
+    go build -a -ldflags "${LDFLAGS}" -o /out/plugin-load-test ./cmd/plugin-load-test
+
+FROM $BUILD_IMAGE AS plugin-author
+ARG ARCH=amd64
+ARG LDFLAGS=-s -w
+ENV CGO_ENABLED=1
+ENV GO111MODULE=on
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+# Bring in the BMO source so the replace directives below resolve to it. A
+# real consumer would `go get github.com/metal3-io/baremetal-operator@vX.Y.Z`
+# instead of carrying the source.
+COPY . /bmo
+WORKDIR /plugin
+RUN git init -q . && \
+    git config user.email "test@example.com" && \
+    git config user.name "plugin-author"
+RUN cp /bmo/pkg/provisioner/demo/plugin/main.go ./main.go
+# Rewrite GetHealth in /bmo's demo provisioner to use go.starlark.net,
+# proving the plugin can pull in deps outside BMO's go.mod.
+RUN cd /bmo && go run -tags patcher ./hack/plugin-test/patcher ./pkg/provisioner/demo/demo.go
+RUN go mod init github.com/example/demo-provisioner-plugin && \
+    go mod edit -replace github.com/metal3-io/baremetal-operator=/bmo && \
+    go mod edit -replace github.com/metal3-io/baremetal-operator/apis=/bmo/apis && \
+    go mod edit -replace github.com/metal3-io/baremetal-operator/pkg/hardwareutils=/bmo/pkg/hardwareutils && \
+    go mod tidy && \
+    git add -A && git commit -q -m "demo plugin with starlark"
+RUN GOOS=linux GOARCH=${ARCH} \
+    go build -buildmode=plugin -ldflags "${LDFLAGS}" \
+    -o /out/demo-provisioner.so .
+
+FROM $BUILD_IMAGE AS plugin-load-tester
+COPY --from=bmo-builder /out/baremetal-operator /usr/local/bin/baremetal-operator
+COPY --from=bmo-builder /out/plugin-load-test /usr/local/bin/plugin-load-test
+COPY --from=plugin-author /out/demo-provisioner.so /plugins/demo-provisioner.so
+RUN /usr/local/bin/plugin-load-test /plugins/demo-provisioner.so demo healthy

--- a/Makefile
+++ b/Makefile
@@ -198,20 +198,20 @@ manifest-lint: ## Run manifest validation
 build: generate manifests manager tools build-e2e ## Build everything
 
 .PHONY: manager
-manager: generate lint ## Build manager binary
+manager: generate lint ironic-plugin demo-plugin ## Build manager binary and bundled provisioner plugins
 	go build -ldflags $(LDFLAGS) -o bin/$(OPERATOR_NAME) main.go
 
 .PHONY: run
-run: generate lint manifests ## Run against the configured Kubernetes cluster in ~/.kube/config
-	go run -ldflags $(LDFLAGS) ./main.go -namespace=$(RUN_NAMESPACE) -dev -webhook-port=0 $(RUN_FLAGS)
+run: generate lint manifests ironic-plugin ## Run against the configured Kubernetes cluster in ~/.kube/config
+	PROVISIONER_PLUGIN_DIR=$(BIN_DIR) go run -ldflags $(LDFLAGS) ./main.go -namespace=$(RUN_NAMESPACE) -dev -provisioner=ironic -webhook-port=0 $(RUN_FLAGS)
 
 .PHONY: demo
-demo: generate lint manifests ## Run in demo mode
-	go run -ldflags $(LDFLAGS) ./main.go -namespace=$(RUN_NAMESPACE) -dev -demo-mode -webhook-port=0 $(RUN_FLAGS)
+demo: generate lint manifests demo-plugin ## Run in demo mode
+	PROVISIONER_PLUGIN_DIR=$(BIN_DIR) go run -ldflags $(LDFLAGS) ./main.go -namespace=$(RUN_NAMESPACE) -dev -provisioner=demo -webhook-port=0 $(RUN_FLAGS)
 
 .PHONY: run-test-mode
 run-test-mode: generate lint manifests ## Run against the configured Kubernetes cluster in ~/.kube/config
-	go run -ldflags $(LDFLAGS) ./main.go -namespace=$(RUN_NAMESPACE) -dev -test-mode -webhook-port=0 $(RUN_FLAGS)
+	go run -ldflags $(LDFLAGS) ./main.go -namespace=$(RUN_NAMESPACE) -dev -provisioner=fixture -webhook-port=0 $(RUN_FLAGS)
 
 .PHONY: install
 install: $(KUSTOMIZE) manifests ## Install CRDs into a cluster
@@ -320,6 +320,47 @@ docker-debug: generate manifests ## Build the docker image with debug info
 	--build-arg https_proxy=$(https_proxy) \
 	--build-arg LDFLAGS="-extldflags=-static" \
 	. -t ${IMG}-$(ARCH):${IMG_TAG}
+
+## --------------------------------------
+## Plugin / SDK Targets
+## --------------------------------------
+
+IRONIC_PLUGIN_DIR = pkg/provisioner/ironic/plugin
+IRONIC_PLUGIN_SO = bin/ironic-provisioner.so
+DEMO_PLUGIN_DIR = pkg/provisioner/demo/plugin
+DEMO_PLUGIN_SO = bin/demo-provisioner.so
+
+.PHONY: ironic-plugin
+ironic-plugin: ## Build the ironic provisioner plugin .so locally
+	CGO_ENABLED=1 go build -buildmode=plugin -ldflags $(LDFLAGS) -o $(IRONIC_PLUGIN_SO) ./$(IRONIC_PLUGIN_DIR)/
+
+.PHONY: demo-plugin
+demo-plugin: ## Build the demo provisioner plugin .so locally
+	CGO_ENABLED=1 go build -buildmode=plugin -ldflags $(LDFLAGS) -o $(DEMO_PLUGIN_SO) ./$(DEMO_PLUGIN_DIR)/
+
+.PHONY: docker-build-sdk
+docker-build-sdk: ## Build the BMO SDK image for authoring custom provisioner plugins
+	$(CONTAINER_RUNTIME) build --platform=linux/$(ARCH) \
+	--build-arg ARCH=$(ARCH) \
+	--build-arg http_proxy=$(http_proxy) \
+	--build-arg https_proxy=$(https_proxy) \
+	--target sdk \
+	. -t ${IMG}-sdk-$(ARCH):${IMG_TAG}
+
+.PHONY: docker-build-plugin-test
+docker-build-plugin-test: ## Build the out-of-tree plugin compatibility test image
+	$(CONTAINER_RUNTIME) build --platform=linux/$(ARCH) \
+	--build-arg ARCH=$(ARCH) \
+	--build-arg http_proxy=$(http_proxy) \
+	--build-arg https_proxy=$(https_proxy) \
+	-f Dockerfile.plugin-test \
+	. -t ${IMG}-plugin-test-$(ARCH):${IMG_TAG}
+
+.PHONY: docker-build-sdk-all
+docker-build-sdk-all: $(addprefix docker-build-sdk-,$(ALL_ARCH)) ## Build the SDK image for all architectures
+
+docker-build-sdk-%:
+	$(MAKE) ARCH=$* docker-build-sdk
 
 ## --------------------------------------
 ## Docker — All ARCH

--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,7 @@ docker-debug: generate manifests ## Build the docker image with debug info
 	--build-arg ARCH=$(ARCH) \
 	--build-arg http_proxy=$(http_proxy) \
 	--build-arg https_proxy=$(https_proxy) \
-	--build-arg LDFLAGS="-extldflags=-static" \
+	--build-arg LDFLAGS="" \
 	. -t ${IMG}-$(ARCH):${IMG_TAG}
 
 ## --------------------------------------

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ components, see the [Metal³ docs](https://github.com/metal3-io/metal3-docs).
 - [Setup Development Environment](docs/dev-setup.md)
 - [Configuration](docs/configuration.md)
 - [Testing](docs/testing.md)
+- [Provisioner plugins](docs/plugin-provisioners.md)
 
 ## Integration tests
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -74,6 +74,7 @@ WORKDIR /
 COPY --from=tilt-helper /start.sh .
 COPY --from=tilt-helper /restart.sh .
 COPY manager .
+COPY ironic-provisioner.so /plugins/ironic-provisioner.so
 """
 
 # Configures a provider by doing the following:
@@ -97,9 +98,11 @@ def enable_provider(name):
 
     # Set up a local_resource build of the provider's manager binary. The provider is expected to have a main.go in
     # manager_build_path or the main.go must be provided via go_main option. The binary is written to .tiltbuild/manager.
+    # CGO and dynamic linking are required for the manager to load provisioner plugins.
     local_resource(
         name + "_manager",
-        cmd = "cd " + context + ';mkdir -p .tiltbuild;CGO_ENABLED=0 go build -ldflags \'-extldflags "-static"\' -o .tiltbuild/manager ' + go_main,
+        cmd = "cd " + context + ";mkdir -p .tiltbuild;CGO_ENABLED=1 go build -o .tiltbuild/manager " + go_main +
+            " && CGO_ENABLED=1 go build -buildmode=plugin -o .tiltbuild/ironic-provisioner.so ./pkg/provisioner/ironic/plugin/",
         deps = live_reload_deps,
     )
 
@@ -126,9 +129,10 @@ def enable_provider(name):
         dockerfile_contents = dockerfile_contents,
         target = "tilt",
         entrypoint = entrypoint,
-        only = "manager",
+        only = ["manager", "ironic-provisioner.so"],
         live_update = [
             sync(context + "/.tiltbuild/manager", "/manager"),
+            sync(context + "/.tiltbuild/ironic-provisioner.so", "/plugins/ironic-provisioner.so"),
             run("sh /restart.sh"),
         ],
     )

--- a/cmd/plugin-load-test/main.go
+++ b/cmd/plugin-load-test/main.go
@@ -1,0 +1,94 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// plugin-load-test opens a provisioner plugin .so, calls each exported entry
+// point including a NewProvisioner + GetHealth round trip, and exits
+// non-zero on any failure. Used to verify that an out-of-tree plugin build
+// remains compatible with the host's plugin contract.
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
+)
+
+const (
+	minArgs       = 3
+	maxArgs       = 4
+	usageExitCode = 2
+)
+
+func main() {
+	log.SetFlags(0)
+
+	if len(os.Args) < minArgs || len(os.Args) > maxArgs {
+		log.Println("usage: plugin-load-test <plugin-path> <expected-name> [<gethealth-contains>]")
+		os.Exit(usageExitCode)
+	}
+
+	pluginPath, expectedName := os.Args[1], os.Args[2]
+	var healthContains string
+	if len(os.Args) == maxArgs {
+		healthContains = os.Args[3]
+	}
+
+	p, err := provisioner.Open(pluginPath, expectedName)
+	if err != nil {
+		log.Fatalf("Open: %v", err)
+	}
+	log.Printf("Open OK          name=%s path=%s", p.Name(), p.Path())
+
+	reqs, err := p.HostConfigure(provisioner.HostConfigureInput{Logger: logr.Discard()})
+	if err != nil {
+		log.Fatalf("HostConfigure: %v", err)
+	}
+
+	log.Printf("HostConfigure OK addToScheme=%v cacheByObject=%d",
+		reqs.AddToScheme != nil, len(reqs.CacheByObject))
+
+	factory, err := p.NewFactory(provisioner.PluginConfig{Logger: logr.Discard()})
+	if err != nil {
+		log.Fatalf("NewFactory: %v", err)
+	}
+	if factory == nil {
+		log.Fatal("NewFactory returned nil factory")
+	}
+
+	log.Println("NewFactory OK")
+
+	ctx := context.Background()
+
+	prov, err := factory.NewProvisioner(ctx, provisioner.HostData{}, func(_, _ string) {})
+	if err != nil {
+		log.Fatalf("NewProvisioner: %v", err)
+	}
+	if prov == nil {
+		log.Fatal("NewProvisioner returned nil")
+	}
+
+	health := prov.GetHealth(ctx)
+	log.Printf("GetHealth OK     output=%q", health)
+
+	if healthContains != "" && !strings.Contains(health, healthContains) {
+		log.Fatalf("GetHealth output %q does not contain %q", health, healthContains)
+	}
+
+	log.Println("plugin-load-test PASSED")
+}

--- a/config/overlays/fixture/kustomization.yaml
+++ b/config/overlays/fixture/kustomization.yaml
@@ -7,10 +7,10 @@ resources:
 
 patches:
 - patch: |
-    # Enable test mode (fixture provider instead of ironic)
+    # Use the fixture provisioner (compiled into the manager) instead of ironic
     - op: add
       path: /spec/template/spec/containers/0/args/-
-      value: --test-mode
+      value: --provisioner=fixture
     # Don't try to pull again the pre-loaded image
     - op: replace
       path: /spec/template/spec/containers/0/imagePullPolicy

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,6 +4,10 @@ Configuration Settings
 The operator supports several configuration options for controlling
 its interaction with Ironic.
 
+The provisioner itself is loaded at runtime from a plugin; see
+[Provisioner plugins](plugin-provisioners.md) for selecting and
+authoring plugins.
+
 `DEPLOY_RAMDISK_URL` -- The URL for the ramdisk of the image
 containing the Ironic agent.
 

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,5 +1,24 @@
 # Setup Development Environment
 
+## Toolchain prerequisites
+
+BMO ships its provisioners as Go plugins (`.so` files), so building the
+manager and the bundled plugins locally requires:
+
+- A C compiler (`gcc` on Debian/Ubuntu, `cc` on Fedora/Arch). `make manager`
+  builds the ironic and demo plugins via `go build -buildmode=plugin`, which
+  needs `CGO_ENABLED=1` and a working C toolchain.
+- The Go version printed by `make go-version`. Plugins must be built with
+  the same Go toolchain as the host binary, so version mismatches surface
+  as "plugin was built with a different version of package …" errors at
+  load time.
+
+`make run` and `make demo` build the relevant plugin into `bin/` and run the
+manager with `PROVISIONER_PLUGIN_DIR=$PWD/bin`. `make run-test-mode` runs the
+manager with `-provisioner=fixture`, which skips plugin loading entirely
+because the fixture provisioner is compiled into the manager binary — this
+is the easiest way to iterate without installing a C toolchain.
+
 ## With minikube
 
 1. Install and launch minikube
@@ -62,8 +81,8 @@
 
 In environments where Ironic is not available, and the only real need
 is to be able to have some test data, use the test fixture provisioner
-instead of the real Ironic provisioner by passing `-test-mode` to the
-operator when launching it.
+instead of the real Ironic provisioner by passing `-provisioner=fixture`
+to the operator when launching it.
 
 ```bash
 make run-test-mode

--- a/docs/plugin-provisioners.md
+++ b/docs/plugin-provisioners.md
@@ -1,0 +1,162 @@
+# Provisioner plugins
+
+BMO loads its provisioner at runtime from a Go plugin `.so`. The manager binary
+is decoupled from provisioner-specific dependencies (e.g. the Ironic client).
+
+## Migrating from previous releases
+
+This release replaces the compile-time provisioner selection with a runtime
+plugin. If you are upgrading from an earlier BMO version, a few flags have
+changed:
+
+| Old                          | New                                          |
+|------------------------------|----------------------------------------------|
+| `-demo-mode`                 | `-provisioner=demo`                          |
+| `-test-mode`                 | `-provisioner=fixture`                       |
+| `-ironic-name=<name>` flag   | `IRONIC_NAME=<name>` env var                 |
+| `-ironic-namespace=<ns>` flag| `IRONIC_NAMESPACE=<ns>` env var              |
+
+## What ships in the BMO image
+
+The container image bakes two plugins under `/plugins/`:
+
+| Path                                 | Provisioner      |
+|--------------------------------------|------------------|
+| `/plugins/ironic-provisioner.so`     | ironic (default) |
+| `/plugins/demo-provisioner.so`       | demo             |
+
+The `fixture` provisioner is compiled into the manager and selected with
+`-provisioner=fixture` for tests and offline runs. No plugin `.so` is loaded
+in that mode.
+
+## Selecting a plugin
+
+Plugins are selected by name with the `-provisioner=<name>` flag. The manager
+resolves the name to a `.so` under the plugin directory:
+
+```text
+-provisioner=<name>   # default: ironic
+```
+
+The flag value must match `^[a-z0-9][a-z0-9-]*$` (lowercase letters, digits,
+and hyphens) so it can't escape the plugin directory through the file path.
+
+Resolves to `${PROVISIONER_PLUGIN_DIR}/<name>-provisioner.so`. The
+`PROVISIONER_PLUGIN_DIR` environment variable defaults to `/plugins` (matching
+the image layout) and can be overridden to point at any directory holding
+`.so` files that follow the `<name>-provisioner.so` naming convention. For
+example, with `PROVISIONER_PLUGIN_DIR=/opt/bmo/plugins -provisioner=foobar`,
+the manager loads `/opt/bmo/plugins/foobar-provisioner.so`.
+
+The plugin must self-report a name (via its `PluginName()` symbol) that
+matches the `<name>` portion of the file. A `foo-provisioner.so` whose
+`PluginName()` returns `"bar"` is rejected at load time.
+
+## Writing a custom plugin
+
+A plugin is `package main` exporting these symbols:
+
+```go
+func PluginName() string
+func NewProvisionerFactory(provisioner.PluginConfig) (provisioner.Factory, error)
+// Optional, see the next section:
+func HostConfigure(provisioner.HostConfigureInput) (provisioner.HostRequirements, error)
+```
+
+See [the demo plugin](../pkg/provisioner/demo/plugin/main.go) for a minimal
+reference, and [the ironic plugin](../pkg/provisioner/ironic/plugin/main.go)
+for one that uses `HostConfigure`.
+
+Build (output filename must follow the `<name>-provisioner.so` convention so
+the manager can resolve `-provisioner=<name>`):
+
+```sh
+CGO_ENABLED=1 go build -buildmode=plugin -o foobar-provisioner.so ./path/to/plugin
+```
+
+## Plugin configuration
+
+The host passes initialization data through `provisioner.PluginConfig`:
+
+- `Logger` — a `logr.Logger` named after the plugin.
+- `Features` — a slice of host capabilities (e.g. `FeaturePreprovisioningImage`)
+   the plugin can probe with `config.HasFeature(...)`.
+- `K8sClient` and `APIReader` — the manager's controller-runtime client and
+   uncached reader, populated only after the manager has been built. Don't
+   call into them from `init()`.
+
+Plugins read their own external config (env vars, files, etc.) directly. The
+host stays generic.
+
+## Host-side requirements (optional `HostConfigure`)
+
+If the plugin needs the host to register a CRD scheme or scope its cache to a
+namespaced resource, it can export a third symbol that runs **before** the
+manager is built:
+
+```go
+func HostConfigure(input provisioner.HostConfigureInput) (provisioner.HostRequirements, error)
+```
+
+`HostRequirements` carries:
+
+- `AddToScheme func(*runtime.Scheme) error` — added to the host's scheme.
+- `CacheByObject map[client.Object]cache.ByObject` — merged into the
+   manager's `cache.Options`.
+
+Plugins that don't need either omit the symbol; the host then proceeds with
+zero requirements. The ironic plugin uses `HostConfigure` to register
+`ironicv1alpha1` and (when `IRONIC_NAME`/`IRONIC_NAMESPACE` are set) to
+namespace-scope the Ironic CR informer.
+
+## Process-wide globals and init() side effects
+
+A Go plugin loads into the *same process* as the host, so the plugin and host
+share every process-wide global: scheme registries, prometheus default
+registerers, klog/logr global loggers, signal handlers, and so on. Two
+consequences for plugin authors:
+
+- Any `init()` function in a package the plugin imports runs at
+  `plugin.Open` time, before the manager exists. Don't dial the Kubernetes
+  API or otherwise touch the cluster from `init()`.
+- If your plugin imports a controller-runtime package that registers types
+  into a global `scheme.Scheme` other than the one the host wires up in its
+  own `main.init()`, the host's manager won't see those types. Register
+  schemes via the `PluginConfig` plumbing or expose your own helper that the
+  host calls explicitly.
+
+## Toolchain lock
+
+Plugins must be built with the **same Go toolchain and same build flags** as
+the BMO binary they load into, and every module shared with the host (directly
+or transitively, including stdlib) must resolve to the **exact same version**.
+Deps unique to the plugin can be added freely because they don't participate
+in the version check. Mismatches produce:
+
+```text
+plugin was built with a different version of package <pkg>
+```
+
+For an in-tree plugin you get this for free, since the root `go.mod` is shared.
+
+For an out-of-tree plugin maintained in its own repo:
+
+- Pin BMO in the plugin's `go.mod` at the release you target. Go's module
+  resolution will then pick versions of shared deps (`k8s.io/*`,
+  `controller-runtime`, `go-logr`, etc.) compatible with BMO's closure:
+
+  ```sh
+  go get github.com/metal3-io/baremetal-operator@vX.Y.Z
+  go mod tidy
+  ```
+
+- Build with the same Go toolchain (see `go-version` target in BMO's
+  Makefile):
+
+  ```sh
+  CGO_ENABLED=1 go build -buildmode=plugin -o foobar-provisioner.so ./plugin
+  ```
+
+- If `plugin.Open` reports a mismatch on a specific package, align it in
+  your `go.mod` (`replace` or `go get <pkg>@<ver>`) to the version used by
+  the BMO release, then rebuild.

--- a/docs/plugin-provisioners.md
+++ b/docs/plugin-provisioners.md
@@ -84,6 +84,8 @@ The host passes initialization data through `provisioner.PluginConfig`:
 - `K8sClient` and `APIReader` — the manager's controller-runtime client and
    uncached reader, populated only after the manager has been built. Don't
    call into them from `init()`.
+- `ProvisionerNamespace` — host-resolved default namespace for the
+   provisioner (`POD_NAMESPACE`, falling back to the watch namespace).
 
 Plugins read their own external config (env vars, files, etc.) directly. The
 host stays generic.
@@ -98,7 +100,8 @@ manager is built:
 func HostConfigure(input provisioner.HostConfigureInput) (provisioner.HostRequirements, error)
 ```
 
-`HostRequirements` carries:
+`HostConfigureInput` carries `Logger`, `Features`, and `ProvisionerNamespace`,
+like `PluginConfig`. `HostRequirements` carries:
 
 - `AddToScheme func(*runtime.Scheme) error` — added to the host's scheme.
 - `CacheByObject map[client.Object]cache.ByObject` — merged into the
@@ -106,8 +109,9 @@ func HostConfigure(input provisioner.HostConfigureInput) (provisioner.HostRequir
 
 Plugins that don't need either omit the symbol; the host then proceeds with
 zero requirements. The ironic plugin uses `HostConfigure` to register
-`ironicv1alpha1` and (when `IRONIC_NAME`/`IRONIC_NAMESPACE` are set) to
-namespace-scope the Ironic CR informer.
+`ironicv1alpha1` and (when `IRONIC_NAME` is set and a namespace resolves from
+`IRONIC_NAMESPACE` or the host default) to namespace-scope the Ironic CR
+informer.
 
 ## Process-wide globals and init() side effects
 

--- a/hack/plugin-test/patcher/main.go
+++ b/hack/plugin-test/patcher/main.go
@@ -34,7 +34,7 @@ import (
 
 const newBodySrc = `package demo
 
-func _() {
+func _() string {
 	thread := &starlark.Thread{Name: "health"}
 	val, err := starlark.Eval(thread, "health.star", ` + "`\"healthy\"`" + `, nil)
 	if err != nil {

--- a/hack/plugin-test/patcher/main.go
+++ b/hack/plugin-test/patcher/main.go
@@ -1,0 +1,150 @@
+//go:build patcher
+
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Patches pkg/provisioner/demo/demo.go to import go.starlark.net/starlark
+// and rewrite (*demoProvisioner).GetHealth so it evaluates a tiny Starlark
+// expression. Used by Dockerfile.plugin-test to verify that an out-of-tree
+// plugin can pull in deps outside BMO's go.mod and still build and work.
+//
+// Behind the `patcher` build tag so `go build ./...` skips it.
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"os"
+)
+
+const newBodySrc = `package demo
+
+func _() {
+	thread := &starlark.Thread{Name: "health"}
+	val, err := starlark.Eval(thread, "health.star", ` + "`\"healthy\"`" + `, nil)
+	if err != nil {
+		return ""
+	}
+	return val.String()
+}
+`
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: patcher <demo.go path>")
+		os.Exit(2)
+	}
+
+	path := os.Args[1]
+	fset := token.NewFileSet()
+
+	file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+	if err != nil {
+		die("parse %s: %v", path, err)
+	}
+
+	if !addImport(file, "go.starlark.net/starlark") {
+		die("no import block in %s", path)
+	}
+
+	bodyFile, err := parser.ParseFile(fset, "body.go", newBodySrc, 0)
+	if err != nil {
+		die("parse new body: %v", err)
+	}
+
+	newBody := bodyFile.Decls[0].(*ast.FuncDecl).Body
+
+	if !replaceMethodBody(file, "demoProvisioner", "GetHealth", newBody) {
+		die("did not find (*demoProvisioner).GetHealth in %s", path)
+	}
+
+	out, err := os.Create(path)
+	if err != nil {
+		die("open %s: %v", path, err)
+	}
+	defer out.Close()
+
+	if err := format.Node(out, fset, file); err != nil {
+		die("format: %v", err)
+	}
+}
+
+func addImport(file *ast.File, path string) bool {
+	quoted := fmt.Sprintf("%q", path)
+
+	for _, decl := range file.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.IMPORT {
+			continue
+		}
+
+		for _, spec := range gd.Specs {
+			if is, ok := spec.(*ast.ImportSpec); ok && is.Path.Value == quoted {
+				return true
+			}
+		}
+
+		gd.Specs = append(gd.Specs, &ast.ImportSpec{
+			Path: &ast.BasicLit{Kind: token.STRING, Value: quoted},
+		})
+
+		gd.Lparen = gd.Specs[0].Pos()
+
+		return true
+	}
+
+	return false
+}
+
+func replaceMethodBody(file *ast.File, recvType, methodName string, body *ast.BlockStmt) bool {
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != methodName {
+			continue
+		}
+
+		if !isPointerReceiver(fn.Recv, recvType) {
+			continue
+		}
+
+		fn.Body = body
+
+		return true
+	}
+
+	return false
+}
+
+func isPointerReceiver(recv *ast.FieldList, name string) bool {
+	if recv == nil || len(recv.List) == 0 {
+		return false
+	}
+
+	star, ok := recv.List[0].Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+
+	id, ok := star.X.(*ast.Ident)
+	return ok && id.Name == name
+}
+
+func die(format string, a ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", a...)
+	os.Exit(1)
+}

--- a/main.go
+++ b/main.go
@@ -222,6 +222,9 @@ func main() {
 		hostFeatures = append(hostFeatures, provisioner.FeaturePreprovisioningImage)
 	}
 
+	// Default namespace for the provisioner, overridable by the plugin.
+	provisionerNamespace := cmp.Or(os.Getenv("POD_NAMESPACE"), watchNamespace)
+
 	// Open the plugin before any K8s I/O so a bad path fails fast.
 	var provisionerPlugin *provisioner.Plugin
 	var pluginRequirements provisioner.HostRequirements
@@ -244,8 +247,9 @@ func main() {
 			"name", provisionerPlugin.Name(), "path", provisionerPlugin.Path())
 
 		pluginRequirements, err = provisionerPlugin.HostConfigure(provisioner.HostConfigureInput{
-			Logger:   setupLog,
-			Features: hostFeatures,
+			Logger:               setupLog,
+			Features:             hostFeatures,
+			ProvisionerNamespace: provisionerNamespace,
 		})
 		if err != nil {
 			setupLog.Error(err, "plugin HostConfigure failed",
@@ -362,10 +366,11 @@ func main() {
 	} else {
 		provLog := zap.New(zap.UseFlagOptions(&logOpts)).WithName("provisioner")
 		provisionerFactory, err = provisionerPlugin.NewFactory(provisioner.PluginConfig{
-			Logger:    provLog,
-			Features:  hostFeatures,
-			K8sClient: mgr.GetClient(),
-			APIReader: mgr.GetAPIReader(),
+			Logger:               provLog,
+			Features:             hostFeatures,
+			K8sClient:            mgr.GetClient(),
+			APIReader:            mgr.GetAPIReader(),
+			ProvisionerNamespace: provisionerNamespace,
 		})
 		if err != nil {
 			setupLog.Error(err, "cannot initialize provisioner plugin", "path", provisionerPlugin.Path())

--- a/main.go
+++ b/main.go
@@ -16,10 +16,13 @@ limitations under the License.
 package main
 
 import (
+	"cmp"
 	"crypto/tls"
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -30,12 +33,9 @@ import (
 	webhooks "github.com/metal3-io/baremetal-operator/internal/webhooks/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/imageprovider"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
-	"github.com/metal3-io/baremetal-operator/pkg/provisioner/demo"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/fixture"
-	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic"
 	"github.com/metal3-io/baremetal-operator/pkg/secretutils"
 	"github.com/metal3-io/baremetal-operator/pkg/version"
-	ironicv1alpha1 "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
 	"go.uber.org/zap/zapcore"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -43,7 +43,6 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -73,11 +72,22 @@ var (
 
 const leaderElectionID = "baremetal-operator"
 
+const (
+	defaultProvisionerName      = "ironic"
+	defaultProvisionerPluginDir = "/plugins"
+	provisionerPluginSuffix     = "-provisioner.so"
+	// provisionerNameFixture is compiled in, so selecting it skips plugin loading.
+	provisionerNameFixture = "fixture"
+)
+
+// provisionerNameRE rejects flag values that would let filepath.Join escape
+// the plugin directory.
+var provisionerNameRE = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 
 	_ = metal3api.AddToScheme(scheme)
-	_ = ironicv1alpha1.AddToScheme(scheme)
 }
 
 func printVersion() {
@@ -136,8 +146,7 @@ func main() {
 	var enableLeaderElection bool
 	var preprovImgEnable bool
 	var devLogging bool
-	var runInTestMode bool
-	var runInDemoMode bool
+	var provisionerName string
 	var webhookPort int
 	var restConfigQPS float64
 	var restConfigBurst int
@@ -159,9 +168,11 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&preprovImgEnable, "build-preprov-image", false, "enable integration with the PreprovisioningImage API")
 	flag.BoolVar(&devLogging, "dev", false, "enable developer logging")
-	flag.BoolVar(&runInTestMode, "test-mode", false, "disable ironic communication")
-	flag.BoolVar(&runInDemoMode, "demo-mode", false,
-		"use the demo provisioner to set host states")
+	flag.StringVar(&provisionerName, "provisioner", defaultProvisionerName,
+		"Name of the provisioner plugin to load. Resolves to "+
+			"$PROVISIONER_PLUGIN_DIR/<name>"+provisionerPluginSuffix+
+			" (default dir "+defaultProvisionerPluginDir+"). "+
+			"Use "+provisionerNameFixture+" for the compiled-in fixture provisioner.")
 	flag.StringVar(&healthAddr, "health-addr", ":9440",
 		"The address the health endpoint binds to.")
 	flag.IntVar(&webhookPort, "webhook-port", 9443, //nolint:mnd
@@ -206,6 +217,50 @@ func main() {
 
 	printVersion()
 
+	var hostFeatures []provisioner.HostFeature
+	if preprovImgEnable {
+		hostFeatures = append(hostFeatures, provisioner.FeaturePreprovisioningImage)
+	}
+
+	// Open the plugin before any K8s I/O so a bad path fails fast.
+	var provisionerPlugin *provisioner.Plugin
+	var pluginRequirements provisioner.HostRequirements
+	if provisionerName != provisionerNameFixture {
+		if !provisionerNameRE.MatchString(provisionerName) {
+			setupLog.Error(fmt.Errorf("invalid provisioner name %q", provisionerName),
+				"provisioner name must match "+provisionerNameRE.String())
+			os.Exit(1)
+		}
+		pluginDir := cmp.Or(os.Getenv("PROVISIONER_PLUGIN_DIR"), defaultProvisionerPluginDir)
+		pluginPath := filepath.Join(pluginDir, provisionerName+provisionerPluginSuffix)
+		p, err := provisioner.Open(pluginPath, provisionerName)
+		if err != nil {
+			setupLog.Error(err, "cannot load provisioner plugin",
+				"name", provisionerName, "dir", pluginDir, "path", pluginPath)
+			os.Exit(1)
+		}
+		provisionerPlugin = p
+		setupLog.Info("loaded provisioner plugin",
+			"name", provisionerPlugin.Name(), "path", provisionerPlugin.Path())
+
+		pluginRequirements, err = provisionerPlugin.HostConfigure(provisioner.HostConfigureInput{
+			Logger:   setupLog,
+			Features: hostFeatures,
+		})
+		if err != nil {
+			setupLog.Error(err, "plugin HostConfigure failed",
+				"name", provisionerPlugin.Name(), "path", provisionerPlugin.Path())
+			os.Exit(1)
+		}
+		if pluginRequirements.AddToScheme != nil {
+			if err := pluginRequirements.AddToScheme(scheme); err != nil {
+				setupLog.Error(err, "plugin AddToScheme failed",
+					"name", provisionerPlugin.Name())
+				os.Exit(1)
+			}
+		}
+	}
+
 	enableWebhook := webhookPort != 0
 
 	leaderElectionNamespace := os.Getenv("POD_NAMESPACE")
@@ -236,24 +291,6 @@ func main() {
 		setupLog.Info("Manager set up with cluster scope")
 	}
 
-	// Setup cache options
-	var byObject map[client.Object]cache.ByObject
-
-	ironicName := os.Getenv("IRONIC_NAME")
-	ironicNamespace := os.Getenv("IRONIC_NAMESPACE")
-	if ironicNamespace == "" {
-		ironicNamespace = leaderElectionNamespace
-	}
-	if ironicName != "" && ironicNamespace != "" {
-		byObject = map[client.Object]cache.ByObject{
-			&ironicv1alpha1.Ironic{}: {
-				Namespaces: map[string]cache.Config{
-					ironicNamespace: {},
-				},
-			},
-		}
-	}
-
 	ctrlOpts := ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -272,7 +309,7 @@ func main() {
 		LeaderElectionReleaseOnCancel: true,
 		HealthProbeBindAddress:        healthAddr,
 		Cache: cache.Options{
-			ByObject:          secretutils.AddSecretSelector(byObject),
+			ByObject:          secretutils.AddSecretSelector(pluginRequirements.CacheByObject),
 			DefaultNamespaces: watchNamespaces,
 		},
 	}
@@ -319,23 +356,19 @@ func main() {
 	}
 
 	var provisionerFactory provisioner.Factory
-	if runInTestMode {
-		ctrl.Log.Info("using test provisioner")
+	if provisionerName == provisionerNameFixture {
+		ctrl.Log.Info("using fixture provisioner")
 		provisionerFactory = &fixture.Fixture{}
-	} else if runInDemoMode {
-		ctrl.Log.Info("using demo provisioner")
-		provisionerFactory = &demo.Demo{}
 	} else {
 		provLog := zap.New(zap.UseFlagOptions(&logOpts)).WithName("provisioner")
-		// Check if we should use Ironic CR integration
-		if ironicName != "" && ironicNamespace != "" {
-			provisionerFactory, err = ironic.NewProvisionerFactoryWithClient(provLog, preprovImgEnable,
-				mgr.GetClient(), mgr.GetAPIReader(), ironicName, ironicNamespace)
-		} else {
-			provisionerFactory, err = ironic.NewProvisionerFactory(provLog, preprovImgEnable)
-		}
+		provisionerFactory, err = provisionerPlugin.NewFactory(provisioner.PluginConfig{
+			Logger:    provLog,
+			Features:  hostFeatures,
+			K8sClient: mgr.GetClient(),
+			APIReader: mgr.GetAPIReader(),
+		})
 		if err != nil {
-			setupLog.Error(err, "cannot start ironic provisioner")
+			setupLog.Error(err, "cannot initialize provisioner plugin", "path", provisionerPlugin.Path())
 			os.Exit(1)
 		}
 	}

--- a/pkg/provisioner/demo/plugin/main.go
+++ b/pkg/provisioner/demo/plugin/main.go
@@ -1,0 +1,31 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner/demo"
+)
+
+// PluginName is advertised to the host via plugin.Lookup.
+func PluginName() string { return "demo" }
+
+// NewProvisionerFactory is the exported symbol BMO looks up in the plugin,
+// resolved at runtime via plugin.Lookup so static analysis cannot see the
+// reference.
+func NewProvisionerFactory(_ provisioner.PluginConfig) (provisioner.Factory, error) {
+	return &demo.Demo{}, nil
+}

--- a/pkg/provisioner/ironic/plugin/main.go
+++ b/pkg/provisioner/ironic/plugin/main.go
@@ -31,23 +31,22 @@ const pluginName = "ironic"
 const (
 	envIronicName      = "IRONIC_NAME"
 	envIronicNamespace = "IRONIC_NAMESPACE"
-	envPodNamespace    = "POD_NAMESPACE"
 )
 
 // PluginName is advertised to the host via plugin.Lookup.
 func PluginName() string { return pluginName }
 
 // HostConfigure registers the Ironic CRD scheme and scopes the cache to the
-// Ironic CR namespace. IRONIC_NAMESPACE falls back to POD_NAMESPACE.
+// Ironic CR namespace.
 //
 //nolint:unparam // signature dictated by the plugin contract
-func HostConfigure(_ provisioner.HostConfigureInput) (provisioner.HostRequirements, error) {
+func HostConfigure(input provisioner.HostConfigureInput) (provisioner.HostRequirements, error) {
 	reqs := provisioner.HostRequirements{
 		AddToScheme: ironicv1alpha1.AddToScheme,
 	}
 
 	ironicName := os.Getenv(envIronicName)
-	ironicNamespace := cmp.Or(os.Getenv(envIronicNamespace), os.Getenv(envPodNamespace))
+	ironicNamespace := cmp.Or(os.Getenv(envIronicNamespace), input.ProvisionerNamespace)
 	if ironicName != "" && ironicNamespace != "" {
 		reqs.CacheByObject = map[client.Object]cache.ByObject{
 			&ironicv1alpha1.Ironic{}: {
@@ -67,7 +66,7 @@ func NewProvisionerFactory(config provisioner.PluginConfig) (provisioner.Factory
 	havePreprovImgBuilder := config.HasFeature(provisioner.FeaturePreprovisioningImage)
 
 	ironicName := os.Getenv(envIronicName)
-	ironicNamespace := cmp.Or(os.Getenv(envIronicNamespace), os.Getenv(envPodNamespace))
+	ironicNamespace := cmp.Or(os.Getenv(envIronicNamespace), config.ProvisionerNamespace)
 
 	if config.K8sClient != nil && ironicName != "" && ironicNamespace != "" {
 		return ironic.NewProvisionerFactoryWithClient(

--- a/pkg/provisioner/ironic/plugin/main.go
+++ b/pkg/provisioner/ironic/plugin/main.go
@@ -1,0 +1,81 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"cmp"
+	"os"
+
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic"
+	ironicv1alpha1 "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const pluginName = "ironic"
+
+const (
+	envIronicName      = "IRONIC_NAME"
+	envIronicNamespace = "IRONIC_NAMESPACE"
+	envPodNamespace    = "POD_NAMESPACE"
+)
+
+// PluginName is advertised to the host via plugin.Lookup.
+func PluginName() string { return pluginName }
+
+// HostConfigure registers the Ironic CRD scheme and scopes the cache to the
+// Ironic CR namespace. IRONIC_NAMESPACE falls back to POD_NAMESPACE.
+//
+//nolint:unparam // signature dictated by the plugin contract
+func HostConfigure(_ provisioner.HostConfigureInput) (provisioner.HostRequirements, error) {
+	reqs := provisioner.HostRequirements{
+		AddToScheme: ironicv1alpha1.AddToScheme,
+	}
+
+	ironicName := os.Getenv(envIronicName)
+	ironicNamespace := cmp.Or(os.Getenv(envIronicNamespace), os.Getenv(envPodNamespace))
+	if ironicName != "" && ironicNamespace != "" {
+		reqs.CacheByObject = map[client.Object]cache.ByObject{
+			&ironicv1alpha1.Ironic{}: {
+				Namespaces: map[string]cache.Config{ironicNamespace: {}},
+			},
+		}
+	}
+
+	return reqs, nil
+}
+
+// NewProvisionerFactory is the exported symbol BMO looks up in the plugin,
+// resolved at runtime via plugin.Lookup so static analysis cannot see the
+// reference.
+func NewProvisionerFactory(config provisioner.PluginConfig) (provisioner.Factory, error) {
+	logger := config.Logger.WithName(pluginName)
+	havePreprovImgBuilder := config.HasFeature(provisioner.FeaturePreprovisioningImage)
+
+	ironicName := os.Getenv(envIronicName)
+	ironicNamespace := cmp.Or(os.Getenv(envIronicNamespace), os.Getenv(envPodNamespace))
+
+	if config.K8sClient != nil && ironicName != "" && ironicNamespace != "" {
+		return ironic.NewProvisionerFactoryWithClient(
+			logger, havePreprovImgBuilder,
+			config.K8sClient, config.APIReader,
+			ironicName, ironicNamespace,
+		)
+	}
+
+	return ironic.NewProvisionerFactory(logger, havePreprovImgBuilder)
+}

--- a/pkg/provisioner/plugin.go
+++ b/pkg/provisioner/plugin.go
@@ -43,6 +43,8 @@ type PluginConfig struct {
 	Features  []HostFeature
 	K8sClient client.Client
 	APIReader client.Reader
+	// ProvisionerNamespace is the host-resolved default namespace for the provisioner.
+	ProvisionerNamespace string
 }
 
 // HasFeature reports whether the host enabled the given feature.
@@ -54,6 +56,8 @@ func (c PluginConfig) HasFeature(f HostFeature) bool {
 type HostConfigureInput struct {
 	Logger   logr.Logger
 	Features []HostFeature
+	// ProvisionerNamespace is the host-resolved default namespace for the provisioner.
+	ProvisionerNamespace string
 }
 
 // HostRequirements is returned by HostConfigure with all fields optional.

--- a/pkg/provisioner/plugin.go
+++ b/pkg/provisioner/plugin.go
@@ -1,0 +1,142 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioner
+
+import (
+	"fmt"
+	"plugin"
+	"slices"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// HostFeature identifies an optional capability the host binary has enabled,
+// passed to plugins via PluginConfig so they can adapt without duplicating
+// the host's flag plumbing.
+type HostFeature string
+
+const (
+	// FeaturePreprovisioningImage indicates that a PreprovisioningImage
+	// controller is running in the host manager.
+	FeaturePreprovisioningImage HostFeature = "PreprovisioningImage"
+)
+
+// PluginConfig carries initialization parameters from the host binary to a provisioner plugin.
+type PluginConfig struct {
+	Logger    logr.Logger
+	Features  []HostFeature
+	K8sClient client.Client
+	APIReader client.Reader
+}
+
+// HasFeature reports whether the host enabled the given feature.
+func (c PluginConfig) HasFeature(f HostFeature) bool {
+	return slices.Contains(c.Features, f)
+}
+
+// HostConfigureInput is passed to HostConfigure before the manager is built.
+type HostConfigureInput struct {
+	Logger   logr.Logger
+	Features []HostFeature
+}
+
+// HostRequirements is returned by HostConfigure with all fields optional.
+type HostRequirements struct {
+	AddToScheme   func(*runtime.Scheme) error
+	CacheByObject map[client.Object]cache.ByObject
+}
+
+// Plugin is a loaded provisioner plugin, Open does no K8s I/O.
+type Plugin struct {
+	path          string
+	name          string
+	factory       func(PluginConfig) (Factory, error)
+	hostConfigure func(HostConfigureInput) (HostRequirements, error)
+}
+
+// Path returns the .so path.
+func (p *Plugin) Path() string { return p.path }
+
+// Name returns the plugin's self-reported name.
+func (p *Plugin) Name() string { return p.name }
+
+// NewFactory invokes the plugin's NewProvisionerFactory.
+func (p *Plugin) NewFactory(config PluginConfig) (Factory, error) {
+	return p.factory(config)
+}
+
+// HostConfigure invokes the optional HostConfigure symbol, yielding zero
+// HostRequirements when the plugin omits it.
+func (p *Plugin) HostConfigure(input HostConfigureInput) (HostRequirements, error) {
+	if p.hostConfigure == nil {
+		return HostRequirements{}, nil
+	}
+
+	return p.hostConfigure(input)
+}
+
+// Open loads the plugin at path and rejects a PluginName mismatch.
+func Open(path, expectedName string) (*Plugin, error) {
+	p, err := plugin.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open plugin %s: %w", path, err)
+	}
+
+	nameSym, err := p.Lookup("PluginName")
+	if err != nil {
+		return nil, fmt.Errorf("plugin %s does not export PluginName: %w", path, err)
+	}
+
+	nameFunc, ok := nameSym.(func() string)
+	if !ok {
+		return nil, fmt.Errorf("plugin %s: PluginName has wrong signature (want func() string)", path)
+	}
+
+	name := nameFunc()
+	if expectedName != "" && name != expectedName {
+		return nil, fmt.Errorf("plugin %s: PluginName() returned %q, expected %q", path, name, expectedName)
+	}
+
+	factorySym, err := p.Lookup("NewProvisionerFactory")
+	if err != nil {
+		return nil, fmt.Errorf("plugin %s does not export NewProvisionerFactory: %w", path, err)
+	}
+
+	factoryFunc, ok := factorySym.(func(PluginConfig) (Factory, error))
+	if !ok {
+		return nil, fmt.Errorf("plugin %s: NewProvisionerFactory has wrong signature (want func(PluginConfig) (Factory, error))", path)
+	}
+
+	loaded := &Plugin{path: path, name: name, factory: factoryFunc}
+
+	// HostConfigure is optional, only a wrong signature is an error.
+	var hostConfigureSym plugin.Symbol
+
+	hostConfigureSym, err = p.Lookup("HostConfigure")
+	if err == nil {
+		hostConfigureFunc, ok := hostConfigureSym.(func(HostConfigureInput) (HostRequirements, error))
+		if !ok {
+			return nil, fmt.Errorf("plugin %s: HostConfigure has wrong signature (want func(HostConfigureInput) (HostRequirements, error))", path)
+		}
+
+		loaded.hostConfigure = hostConfigureFunc
+	}
+
+	return loaded, nil
+}

--- a/pkg/provisioner/plugin_test.go
+++ b/pkg/provisioner/plugin_test.go
@@ -1,0 +1,152 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioner_test
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
+)
+
+func TestPluginConfigHasFeature(t *testing.T) {
+	cfg := provisioner.PluginConfig{
+		Features: []provisioner.HostFeature{provisioner.FeaturePreprovisioningImage},
+	}
+
+	if !cfg.HasFeature(provisioner.FeaturePreprovisioningImage) {
+		t.Errorf("expected HasFeature(PreprovisioningImage) = true")
+	}
+	if cfg.HasFeature(provisioner.HostFeature("Other")) {
+		t.Errorf("expected HasFeature(Other) = false")
+	}
+
+	empty := provisioner.PluginConfig{}
+	if empty.HasFeature(provisioner.FeaturePreprovisioningImage) {
+		t.Errorf("empty config should not report any feature")
+	}
+}
+
+func TestOpenMissingFile(t *testing.T) {
+	skipIfPluginsUnsupported(t)
+	_, err := provisioner.Open(filepath.Join(t.TempDir(), "nonexistent.so"), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error opening missing plugin, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "failed to open plugin") {
+		t.Errorf("error should mention 'failed to open plugin', got: %v", err)
+	}
+}
+
+// Subtests share one build because Go's plugin loader rejects loading the
+// same plugin (by package path) from two different file paths in one process.
+func TestOpenDemoPlugin(t *testing.T) {
+	skipIfPluginsUnsupported(t)
+	soPath := buildPlugin(t, "./demo/plugin", "demo-provisioner.so")
+
+	t.Run("success", func(t *testing.T) {
+		p, err := provisioner.Open(soPath, "demo")
+		if err != nil {
+			t.Fatalf("Open returned unexpected error: %v", err)
+		}
+
+		if p.Name() != "demo" {
+			t.Errorf("Name() = %q, want %q", p.Name(), "demo")
+		}
+		if p.Path() != soPath {
+			t.Errorf("Path() = %q, want %q", p.Path(), soPath)
+		}
+
+		factory, err := p.NewFactory(provisioner.PluginConfig{})
+		if err != nil {
+			t.Fatalf("NewFactory returned unexpected error: %v", err)
+		}
+		if factory == nil {
+			t.Fatal("NewFactory returned nil factory")
+		}
+	})
+
+	t.Run("name mismatch", func(t *testing.T) {
+		_, err := provisioner.Open(soPath, "not-demo")
+		if err == nil {
+			t.Fatal("expected name mismatch error, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "PluginName()") || !strings.Contains(err.Error(), "not-demo") {
+			t.Errorf("error should mention PluginName() and the expected name, got: %v", err)
+		}
+	})
+
+	t.Run("host configure absent", func(t *testing.T) {
+		p, err := provisioner.Open(soPath, "demo")
+		if err != nil {
+			t.Fatalf("Open returned unexpected error: %v", err)
+		}
+
+		reqs, err := p.HostConfigure(provisioner.HostConfigureInput{})
+		if err != nil {
+			t.Fatalf("HostConfigure returned unexpected error: %v", err)
+		}
+
+		if reqs.AddToScheme != nil || reqs.CacheByObject != nil {
+			t.Errorf("expected zero HostRequirements when plugin omits HostConfigure, got %+v", reqs)
+		}
+	})
+}
+
+func skipIfPluginsUnsupported(t *testing.T) {
+	t.Helper()
+	switch runtime.GOOS {
+	case "linux", "darwin", "freebsd":
+	default:
+		t.Skipf("plugins not supported on %s", runtime.GOOS)
+	}
+	// -cover instruments the test binary but not the plugin, so plugin.Open
+	// fails the package-version check.
+	if testing.CoverMode() != "" {
+		t.Skip("plugin load tests are incompatible with -cover instrumentation")
+	}
+}
+
+func buildPlugin(t *testing.T, pkgPath, outName string) string {
+	t.Helper()
+	soPath := filepath.Join(t.TempDir(), outName)
+
+	cmd := exec.Command("go", "build", "-buildmode=plugin", "-o", soPath, pkgPath)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=1")
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		// Missing C toolchain is an environment issue, not a code regression.
+		var execErr *exec.Error
+		if errors.As(err, &execErr) {
+			t.Skipf("go build unavailable: %v", err)
+		}
+
+		if strings.Contains(string(out), "C compiler") || strings.Contains(string(out), "cgo:") {
+			t.Skipf("C toolchain unavailable for plugin build:\n%s", out)
+		}
+		t.Fatalf("failed to build plugin %s: %v\n%s", pkgPath, err, out)
+	}
+
+	return soPath
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Migrate provisioners to go-plugin system for out-of-tree runtime BYO custom provisioner registration.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
