### PR TITLE
🌱 Simplify e2e fixture test configuration

### DIFF
--- a/.github/workflows/e2e-fixture-test.yml
+++ b/.github/workflows/e2e-fixture-test.yml
@@ -24,11 +24,6 @@ jobs:
       with:
         go-version: ${{ steps.vars.outputs.go_version }}
 
-    - name: Install libvirt
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libvirt-dev
-
     - name: Build BMO e2e Docker Image
       env:
         IMG: quay.io/metal3-io/baremetal-operator
@@ -38,9 +33,7 @@ jobs:
     - name: Set Up Environment and Run BMO e2e Tests
       env:
         E2E_CONF_FILE: ${{ github.workspace }}/test/e2e/config/fixture.yaml
-        USE_EXISTING_CLUSTER: "false"
         GINKGO_NODES: 1
-        GINKGO_SKIP_LABELS: "automated-cleaning"
       run: make test-e2e
 
     - name: Upload artifacts

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,12 @@ export GOFLAGS=
 #
 # Ginkgo configuration.
 #
+# We default to fixture tests, since they are fast and require little
+# both in terms of resources and tooling.
+# Note that some tests may not make sense for fixture, so we skip them.
 GINKGO_FOCUS ?=
 GINKGO_SKIP ?=
-GINKGO_SKIP_LABELS ?=
+GINKGO_SKIP_LABELS ?= automated-cleaning
 GINKGO_NODES ?= 2
 GINKGO_TIMEOUT ?= 3h
 GINKGO_POLL_PROGRESS_AFTER ?= 60m
@@ -444,6 +447,7 @@ clean: ## Remove all temporary files, directories and tools
 	rm -rf ironic-deployment/overlays/temp
 	rm -rf config/overlays/temp
 	rm -rf $(TOOLS_BIN_DIR)
+	rm -rf tools/bin
 
 .PHONY: clean-e2e
 clean-e2e: ## Remove everything related to e2e tests

--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -35,6 +35,9 @@ echo "BMO_E2E_EMULATOR=${BMO_E2E_EMULATOR}"
 export E2E_CONF_FILE="${REPO_ROOT}/test/e2e/config/ironic.yaml"
 export E2E_BMCS_CONF_FILE="${REPO_ROOT}/test/e2e/config/bmcs-${BMC_PROTOCOL}.yaml"
 
+# make test-e2e runs the fixture tests by default and skips some tests
+# that don't make sense in that context. We need to override.
+export GINKGO_SKIP_LABELS="${GINKGO_SKIP_LABELS:-}"
 GINKGO_FOCUS="${GINKGO_FOCUS:-}"
 
 case "${GINKGO_FOCUS,,}" in


### PR DESCRIPTION
**What this PR does / why we need it**:

- Remove unnecessary libvirt installation from fixture workflow
- Set `automated-cleaning` as default skip label in Makefile for fixture tests
- Override skip labels in CI e2e script to run all tests
- Add `tools/bin` to clean target
- Document fixture test defaults in Makefile comments

The main point with this is to make the `test-e2e` target work the same as the CI fixture tests. It will currently fail on automated-cleaning, which we skip in CI since it doesn't make sense for fixture tests.
Secondary, we were missing `tools/bin` in the clean target. This make `ginkgo` and `kustomize` constantly outdated unless you manually clean up.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
