### PR TITLE
feat: use failure domain label as Ironic conductor group

### DIFF
--- a/main.go
+++ b/main.go
@@ -140,6 +140,7 @@ func main() {
 	var leaseDurationSeconds string
 	var renewDeadlineSeconds string
 	var retryPeriodSeconds string
+	var useFailureDomainAsConductorGroup bool
 
 	// From CAPI point of view, BMO should be able to watch all namespaces
 	// in case of a deployment that is not multi-tenant. If the deployment
@@ -187,6 +188,8 @@ func main() {
 	flag.StringVar(&leaseDurationSeconds, "lease-duration-seconds", os.Getenv("LEASE_DURATION_SECONDS"), "Leader election duration in seconds.")
 	flag.StringVar(&renewDeadlineSeconds, "renew-deadline-seconds", os.Getenv("RENEW_DEADLINE_SECONDS"), "Leader election renew deadline duration in seconds.")
 	flag.StringVar(&retryPeriodSeconds, "retry-period-seconds", os.Getenv("RETRY_PERIOD_SECONDS"), "Leader election retry period in seconds.")
+	flag.BoolVar(&useFailureDomainAsConductorGroup, "use-failure-domain-as-conductor-group", false,
+		"Use failure domain label as Ironic conductor group")
 
 	flag.Parse()
 
@@ -324,10 +327,10 @@ func main() {
 		provLog := zap.New(zap.UseFlagOptions(&logOpts)).WithName("provisioner")
 		// Check if we should use Ironic CR integration
 		if ironicName != "" && ironicNamespace != "" {
-			provisionerFactory, err = ironic.NewProvisionerFactoryWithClient(provLog, preprovImgEnable,
+			provisionerFactory, err = ironic.NewProvisionerFactoryWithClient(provLog, preprovImgEnable, useFailureDomainAsConductorGroup,
 				mgr.GetClient(), mgr.GetAPIReader(), ironicName, ironicNamespace)
 		} else {
-			provisionerFactory, err = ironic.NewProvisionerFactory(provLog, preprovImgEnable)
+			provisionerFactory, err = ironic.NewProvisionerFactory(provLog, preprovImgEnable, useFailureDomainAsConductorGroup)
 		}
 		if err != nil {
 			setupLog.Error(err, "cannot start ironic provisioner")

--- a/pkg/provisioner/ironic/conductor_group_test.go
+++ b/pkg/provisioner/ironic/conductor_group_test.go
@@ -1,0 +1,117 @@
+package ironic
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
+	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/hostclaim"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/testserver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnrollWithConductorGroup(t *testing.T) {
+	cases := []struct {
+		name                   string
+		useFailureDomain       bool
+		labels                 map[string]string
+		expectedConductorGroup string
+	}{
+		{
+			name:             "flag enabled, label present",
+			useFailureDomain: true,
+			labels: map[string]string{
+				hostclaim.FailureDomainLabelName: "zone-1",
+			},
+			expectedConductorGroup: "zone-1",
+		},
+		{
+			name:             "flag enabled, label missing",
+			useFailureDomain: true,
+			labels:           map[string]string{},
+			expectedConductorGroup: "",
+		},
+		{
+			name:             "flag disabled, label present",
+			useFailureDomain: false,
+			labels: map[string]string{
+				hostclaim.FailureDomainLabelName: "zone-1",
+			},
+			expectedConductorGroup: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			host := makeHost()
+			host.ObjectMeta.Labels = tc.labels
+			host.Status.Provisioning.ID = ""
+
+			var createdNode *nodes.Node
+			createCallback := func(node nodes.Node) {
+				createdNode = &node
+			}
+
+			ironic := testserver.NewIronic(t).WithDrivers().CreateNodes(createCallback).NoNode(host.Namespace + nameSeparator + host.Name).NoNode(host.Name)
+			// Add response for PATCH which is called after creation
+			ironic.NodeUpdate(nodes.Node{
+				UUID:           "node-0",
+				ProvisionState: string(nodes.Verifying),
+			})
+			ironic.Start()
+			defer ironic.Stop()
+
+			auth := clients.AuthConfig{Type: clients.NoAuth}
+			prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher, ironic.Endpoint(), auth)
+			require.NoError(t, err)
+
+			prov.config.useFailureDomainAsConductorGroup = tc.useFailureDomain
+
+			_, _, err = prov.Register(t.Context(), provisioner.ManagementAccessData{}, false, false)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedConductorGroup, createdNode.ConductorGroup)
+		})
+	}
+}
+
+func TestUpdateConductorGroup(t *testing.T) {
+	host := makeHost()
+	host.ObjectMeta.Labels = map[string]string{
+		hostclaim.FailureDomainLabelName: "zone-2",
+	}
+
+	ironic := testserver.NewIronic(t).WithDrivers().Node(nodes.Node{
+		Name:           host.Namespace + nameSeparator + host.Name,
+		UUID:           host.Status.Provisioning.ID,
+		ConductorGroup: "zone-1",
+		ProvisionState: string(nodes.Verifying), // Avoid configureNode which makes extra PATCH
+	}).NodeUpdate(nodes.Node{
+		UUID:           host.Status.Provisioning.ID,
+		ProvisionState: string(nodes.Verifying),
+	})
+	ironic.Start()
+	defer ironic.Stop()
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher, ironic.Endpoint(), auth)
+	require.NoError(t, err)
+
+	prov.config.useFailureDomainAsConductorGroup = true
+
+	_, _, err = prov.Register(t.Context(), provisioner.ManagementAccessData{}, false, false)
+	require.NoError(t, err)
+
+	updates := ironic.GetLastNodeUpdateRequestFor(host.Status.Provisioning.ID)
+	found := false
+	for _, up := range updates {
+		if up.Path == "/conductor_group" {
+			assert.Equal(t, "zone-2", up.Value)
+			found = true
+		}
+	}
+	assert.True(t, found, "conductor_group update not found in any PATCH request")
+}

--- a/pkg/provisioner/ironic/factory.go
+++ b/pkg/provisioner/ironic/factory.go
@@ -38,16 +38,16 @@ type ironicProvisionerFactory struct {
 	ironicNamespace string
 }
 
-func NewProvisionerFactory(logger logr.Logger, havePreprovImgBuilder bool) (provisioner.Factory, error) {
+func NewProvisionerFactory(logger logr.Logger, havePreprovImgBuilder, useFailureDomainAsConductorGroup bool) (provisioner.Factory, error) {
 	factory := ironicProvisionerFactory{
 		log: logger.WithName("ironic"),
 	}
 
-	err := factory.init(havePreprovImgBuilder)
+	err := factory.init(havePreprovImgBuilder, useFailureDomainAsConductorGroup)
 	return factory, err
 }
 
-func NewProvisionerFactoryWithClient(logger logr.Logger, havePreprovImgBuilder bool, k8sClient client.Client, apiReader client.Reader, ironicName, ironicNamespace string) (provisioner.Factory, error) {
+func NewProvisionerFactoryWithClient(logger logr.Logger, havePreprovImgBuilder, useFailureDomainAsConductorGroup bool, k8sClient client.Client, apiReader client.Reader, ironicName, ironicNamespace string) (provisioner.Factory, error) {
 	factory := ironicProvisionerFactory{
 		log:             logger.WithName("ironic"),
 		k8sClient:       k8sClient,
@@ -56,13 +56,13 @@ func NewProvisionerFactoryWithClient(logger logr.Logger, havePreprovImgBuilder b
 		ironicNamespace: ironicNamespace,
 	}
 
-	err := factory.init(havePreprovImgBuilder)
+	err := factory.init(havePreprovImgBuilder, useFailureDomainAsConductorGroup)
 	return factory, err
 }
 
-func (f *ironicProvisionerFactory) init(havePreprovImgBuilder bool) error {
+func (f *ironicProvisionerFactory) init(havePreprovImgBuilder, useFailureDomainAsConductorGroup bool) error {
 	var err error
-	f.config, err = loadConfigFromEnv(havePreprovImgBuilder)
+	f.config, err = loadConfigFromEnv(havePreprovImgBuilder, useFailureDomainAsConductorGroup)
 	if err != nil {
 		return err
 	}
@@ -75,6 +75,7 @@ func (f *ironicProvisionerFactory) init(havePreprovImgBuilder bool) error {
 			"deployRamdiskURL", f.config.deployRamdiskURL,
 			"deployISOURL", f.config.deployISOURL,
 			"liveISOForcePersistentBootDevice", f.config.liveISOForcePersistentBootDevice,
+			"useFailureDomainAsConductorGroup", f.config.useFailureDomainAsConductorGroup,
 		)
 		// NOTE(dtantsur): the Ironic object will be loaded from the client cache on each reconciliation, so exiting here.
 		return nil
@@ -102,6 +103,7 @@ func (f *ironicProvisionerFactory) init(havePreprovImgBuilder bool) error {
 		"deployISOURL", f.config.deployISOURL,
 		"liveISOForcePersistentBootDevice", f.config.liveISOForcePersistentBootDevice,
 		"directDeployForcePersistentBootDevice", f.config.directDeployForcePersistentBootDevice,
+		"useFailureDomainAsConductorGroup", f.config.useFailureDomainAsConductorGroup,
 		"CACertFile", tlsConf.TrustedCAFile,
 		"ClientCertFile", tlsConf.ClientCertificateFile,
 		"ClientPrivKeyFile", tlsConf.ClientPrivateKeyFile,
@@ -168,9 +170,10 @@ func (f ironicProvisionerFactory) NewProvisioner(ctx context.Context, hostData p
 	return f.ironicProvisioner(ctx, hostData, publisher)
 }
 
-func loadConfigFromEnv(havePreprovImgBuilder bool) (ironicConfig, error) {
+func loadConfigFromEnv(havePreprovImgBuilder, useFailureDomainAsConductorGroup bool) (ironicConfig, error) {
 	c := ironicConfig{
-		havePreprovImgBuilder: havePreprovImgBuilder,
+		havePreprovImgBuilder:            havePreprovImgBuilder,
+		useFailureDomainAsConductorGroup: useFailureDomainAsConductorGroup,
 	}
 
 	c.deployKernelURL = os.Getenv("DEPLOY_KERNEL_URL")

--- a/pkg/provisioner/ironic/factory_test.go
+++ b/pkg/provisioner/ironic/factory_test.go
@@ -211,7 +211,7 @@ func TestLoadConfigFromEnv(t *testing.T) {
 				defer tc.env.TearDown()
 				tc.env.SetUp()
 				imgBuild := tt != ""
-				config, err := loadConfigFromEnv(imgBuild)
+				config, err := loadConfigFromEnv(imgBuild, false)
 				expectedError := tc.expectedError
 				if imgBuild {
 					expectedError = tc.expectedImgBuildError

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -71,6 +71,7 @@ type ironicConfig struct {
 	maxBusyHosts                          int
 	externalURL                           string
 	provNetDisabled                       bool
+	useFailureDomainAsConductorGroup      bool
 }
 
 // Provisioner implements the provisioning.Provisioner interface

--- a/pkg/provisioner/ironic/register.go
+++ b/pkg/provisioner/ironic/register.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/hostclaim"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
 	"sigs.k8s.io/yaml"
@@ -154,6 +155,12 @@ func (p *ironicProvisioner) Register(ctx context.Context, data provisioner.Manag
 		// The updater only updates disable_power_off if it has changed
 		updater.SetTopLevelOpt("disable_power_off", data.DisablePowerOff, ironicNode.DisablePowerOff)
 
+		if p.config.useFailureDomainAsConductorGroup {
+			if labelValue, ok := p.objectMeta.Labels[hostclaim.FailureDomainLabelName]; ok {
+				updater.SetTopLevelOpt("conductor_group", labelValue, ironicNode.ConductorGroup)
+			}
+		}
+
 		// Update cpu_arch in Properties if specified.
 		// This is important for multi-arch deployments to ensure the correct
 		// architecture-specific IPA kernel/ramdisk is used via deploy_kernel_by_arch.
@@ -268,6 +275,12 @@ func (p *ironicProvisioner) enrollNode(ctx context.Context, data provisioner.Man
 			"capabilities": buildCapabilitiesValue(nil, data.BootMode),
 			"cpu_arch":     data.CPUArchitecture,
 		},
+	}
+
+	if p.config.useFailureDomainAsConductorGroup {
+		if labelValue, ok := p.objectMeta.Labels[hostclaim.FailureDomainLabelName]; ok {
+			nodeCreateOpts.ConductorGroup = labelValue
+		}
 	}
 
 	ironicNode, err = nodes.Create(ctx, p.client, nodeCreateOpts).Extract()


### PR DESCRIPTION
Add a new operator flag --use-failure-domain-as-conductor-group. When enabled, the ironic provisioner will set the ConductorGroup on nodes to the value of the infrastructure.cluster.x-k8s.io/failure-domain label from the BareMetalHost resource.