### PR TITLE
:sparkles: Allow exiting the externally provisioned state

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller_test.go
+++ b/internal/controller/metal3.io/baremetalhost_controller_test.go
@@ -1581,7 +1581,56 @@ func TestExternallyProvisionedTransitions(t *testing.T) {
 		waitForProvisioningState(t, r, host, metal3api.StateExternallyProvisioned)
 	})
 
-	t.Run("externally provisioned to inspecting", func(t *testing.T) {
+	t.Run("externally provisioned to provisioned", func(t *testing.T) {
+		host := newDefaultHost(t)
+		host.Spec.Online = true
+		host.Spec.ExternallyProvisioned = true
+		host.Spec.Image = &metal3api.Image{URL: "foo", Checksum: "123"}
+		r := newTestReconciler(t, host)
+
+		waitForProvisioningState(t, r, host, metal3api.StateExternallyProvisioned)
+
+		host.Spec.ExternallyProvisioned = false
+		err := r.Update(t.Context(), host)
+		require.NoError(t, err)
+		t.Log("set externally provisioned to false")
+
+		tryReconcile(t, r, host,
+			func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
+				return host.Status.Provisioning.State == metal3api.StateProvisioned &&
+					host.Status.Provisioning.Image.URL == "foo"
+			},
+		)
+		assert.Equal(t, "foo", host.Status.Provisioning.Image.URL)
+		assert.Equal(t, "123", host.Status.Provisioning.Image.Checksum)
+		assert.Nil(t, host.Status.Provisioning.CustomDeploy)
+	})
+
+	t.Run("externally provisioned to provisioned copies customDeploy to status", func(t *testing.T) {
+		host := newDefaultHost(t)
+		host.Spec.Online = true
+		host.Spec.ExternallyProvisioned = true
+		host.Spec.CustomDeploy = &metal3api.CustomDeploy{Method: "install_everything"}
+		r := newTestReconciler(t, host)
+
+		waitForProvisioningState(t, r, host, metal3api.StateExternallyProvisioned)
+
+		host.Spec.ExternallyProvisioned = false
+		err := r.Update(t.Context(), host)
+		require.NoError(t, err)
+
+		tryReconcile(t, r, host,
+			func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
+				return host.Status.Provisioning.State == metal3api.StateProvisioned &&
+					host.Status.Provisioning.CustomDeploy != nil &&
+					host.Status.Provisioning.CustomDeploy.Method == "install_everything"
+			},
+		)
+		assert.Equal(t, "install_everything", host.Status.Provisioning.CustomDeploy.Method)
+		assert.Empty(t, host.Status.Provisioning.Image)
+	})
+
+	t.Run("externally provisioned without image deprovisions", func(t *testing.T) {
 		host := newDefaultHost(t)
 		host.Spec.Online = true
 		host.Spec.ExternallyProvisioned = true
@@ -1591,12 +1640,9 @@ func TestExternallyProvisionedTransitions(t *testing.T) {
 
 		host.Spec.ExternallyProvisioned = false
 		err := r.Update(t.Context(), host)
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Log("set externally provisioned to false")
+		require.NoError(t, err)
 
-		waitForProvisioningState(t, r, host, metal3api.StateInspecting)
+		waitForProvisioningState(t, r, host, metal3api.StateDeprovisioning)
 	})
 
 	t.Run("preparing to externally provisioned", func(t *testing.T) {

--- a/internal/controller/metal3.io/host_state_machine.go
+++ b/internal/controller/metal3.io/host_state_machine.go
@@ -433,11 +433,17 @@ func (hsm *hostStateMachine) handleExternallyProvisioned(ctx context.Context, in
 		return hsm.Reconciler.actionManageSteadyState(ctx, hsm.Provisioner, info)
 	}
 
-	if hsm.Host.NeedsHardwareInspection() {
-		hsm.NextState = metal3api.StateInspecting
-	} else {
-		hsm.NextState = metal3api.StatePreparing
+	// The host is exiting externally provisioned at this point.
+	// Set image and customDeploy in status to prevent unconditional deprovisioning.
+	if hsm.Host.Spec.Image != nil {
+		hsm.Host.Status.Provisioning.Image = *hsm.Host.Spec.Image
 	}
+	if hsm.Host.Spec.CustomDeploy != nil {
+		hsm.Host.Status.Provisioning.CustomDeploy = hsm.Host.Spec.CustomDeploy.DeepCopy()
+	}
+
+	// Move to Provisioned. If image and customDeploy are not set, deprovisioning will start on the next reconciliation.
+	hsm.NextState = metal3api.StateProvisioned
 	return actionComplete{}
 }
 

--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation.go
@@ -113,11 +113,6 @@ func (webhook *BareMetalHost) validateChanges(oldObj *metal3api.BareMetalHost, n
 		errs = append(errs, errors.New("bootMACAddress can not be changed once it is set"))
 	}
 
-	// Disallow disabling externallyProvisioned.
-	if oldObj.Spec.ExternallyProvisioned && !newObj.Spec.ExternallyProvisioned {
-		errs = append(errs, errors.New("externallyProvisioned can not be changed from true to false"))
-	}
-
 	// Only allow enabling externallyProvisioned from Available state.
 	if !oldObj.Spec.ExternallyProvisioned && newObj.Spec.ExternallyProvisioned &&
 		newObj.Status.Provisioning.State != metal3api.StateAvailable {

--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -1139,12 +1139,12 @@ func TestValidateUpdate(t *testing.T) {
 			wantedErr: "address invalid-mac: invalid MAC address",
 		},
 		{
-			name: "rejectDisablingExternallyProvisioned",
+			name: "allowDisablingExternallyProvisioned",
 			newBMH: &metal3api.BareMetalHost{
 				TypeMeta: tm, ObjectMeta: om, Spec: metal3api.BareMetalHostSpec{ExternallyProvisioned: false}},
 			oldBMH: &metal3api.BareMetalHost{
 				TypeMeta: tm, ObjectMeta: om, Spec: metal3api.BareMetalHostSpec{ExternallyProvisioned: true}},
-			wantedErr: "externallyProvisioned can not be changed from true to false",
+			wantedErr: "",
 		},
 		{
 			name: "rejectEnablingExternallyProvisionedWhenNotInAvailable",

--- a/test/e2e/externally_provisioned_test.go
+++ b/test/e2e/externally_provisioned_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Create as externally provisioned, deprovision", Label("require
 			})
 		})
 
-		It("provisions a BMH as externally provisioned, validates state immutability, then deprovisions", func() {
+		It("provisions a BMH as externally provisioned, then removes the flag to deprovision", func() {
 			secretName := "bmc-credentials-external"
 			By("Creating a secret with BMH credentials")
 			bmcCredentialsData := map[string]string{
@@ -86,7 +86,7 @@ var _ = Describe("Create as externally provisioned, deprovision", Label("require
 			Expect(bmh.Status.OperationHistory.Inspect.Start.IsZero()).To(BeTrue())
 			Expect(bmh.Status.OperationHistory.Provision.Start.IsZero()).To(BeTrue())
 
-			By("Attempting to set ExternallyProvisioned to false (should be blocked by webhook)")
+			By("Setting ExternallyProvisioned to false to trigger deprovisioning")
 			err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{
 				Name:      bmh.Name,
 				Namespace: bmh.Namespace,
@@ -96,18 +96,99 @@ var _ = Describe("Create as externally provisioned, deprovision", Label("require
 			patch := client.MergeFrom(bmh.DeepCopy())
 			bmh.Spec.ExternallyProvisioned = false
 			err = clusterProxy.GetClient().Patch(ctx, &bmh, patch)
-			Expect(err).To(HaveOccurred(), "Webhook should reject transition from true to false")
-			Expect(err.Error()).To(ContainSubstring("externallyProvisioned can not be changed from true to false"))
+			Expect(err).NotTo(HaveOccurred())
 
-			By("Verifying BMH remains in ExternallyProvisioned state")
+			By("Waiting for the BMH to reach Available state after deprovisioning")
+			WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+				Client: clusterProxy.GetClient(),
+				Bmh:    bmh,
+				State:  metal3api.StateAvailable,
+			}, e2eConfig.GetIntervals(specName, "wait-available")...)
+		})
+
+		It("provisions a BMH as externally provisioned, then removes the flag but stays provisioned", func() {
+			secretName := "bmc-credentials-stay-provisioned"
+			By("Creating a secret with BMH credentials")
+			bmcCredentialsData := map[string]string{
+				"username": bmc.User,
+				"password": bmc.Password,
+			}
+			secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+			toCleanup = append(toCleanup, secret)
+
+			By("Creating a BMH as externally provisioned with image")
+			bmh := metal3api.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      specName + "-external",
+					Namespace: namespace.Name,
+				},
+				Spec: metal3api.BareMetalHostSpec{
+					Online: true,
+					BMC: metal3api.BMCDetails{
+						Address:                        bmc.Address,
+						CredentialsName:                secretName,
+						DisableCertificateVerification: bmc.DisableCertificateVerification,
+					},
+					BootMACAddress:        bmc.BootMacAddress,
+					ExternallyProvisioned: true,
+					Image: &metal3api.Image{
+						URL:      e2eConfig.GetVariable("IMAGE_URL"),
+						Checksum: e2eConfig.GetVariable("IMAGE_CHECKSUM"),
+					},
+				},
+			}
+			err := clusterProxy.GetClient().Create(ctx, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+			toCleanup = append(toCleanup, &bmh)
+
+			By("Waiting for the BMH to become externally provisioned")
+			WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+				Client: clusterProxy.GetClient(),
+				Bmh:    bmh,
+				State:  metal3api.StateExternallyProvisioned,
+			}, e2eConfig.GetIntervals(specName, "wait-externally-provisioned")...)
+
+			By("Retrieving the latest BMH object")
 			err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{
 				Name:      bmh.Name,
 				Namespace: bmh.Namespace,
 			}, &bmh)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(bmh.Spec.ExternallyProvisioned).To(BeTrue(), "ExternallyProvisioned should still be true")
-			Expect(bmh.Status.Provisioning.State).To(Equal(metal3api.StateExternallyProvisioned))
 
+			By("Checking that the BMH was not inspected or deployed")
+			Expect(bmh.Status.OperationHistory.Inspect.Start.IsZero()).To(BeTrue())
+			Expect(bmh.Status.OperationHistory.Provision.Start.IsZero()).To(BeTrue())
+
+			By("Setting ExternallyProvisioned to false to transition to provisioned")
+			err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmh.Name,
+				Namespace: bmh.Namespace,
+			}, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+
+			patch := client.MergeFrom(bmh.DeepCopy())
+			bmh.Spec.ExternallyProvisioned = false
+			err = clusterProxy.GetClient().Patch(ctx, &bmh, patch)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the BMH to become provisioned")
+			WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+				Client: clusterProxy.GetClient(),
+				Bmh:    bmh,
+				State:  metal3api.StateExternallyProvisioned,
+				// NOTE(dtantsur): using the smaller externally-provisioned interval on purpose since a real provisioning is not expected
+			}, e2eConfig.GetIntervals(specName, "wait-externally-provisioned")...)
+
+			By("Retrieving the latest BMH object")
+			err = clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmh.Name,
+				Namespace: bmh.Namespace,
+			}, &bmh)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking that the BMH was not inspected or deployed")
+			Expect(bmh.Status.OperationHistory.Inspect.Start.IsZero()).To(BeTrue())
+			Expect(bmh.Status.OperationHistory.Provision.Start.IsZero()).To(BeTrue())
 		})
 
 		It("transitions from Available to ExternallyProvisioned", func() {


### PR DESCRIPTION
This change unblocks setting externallyProvisioned to false to allow
a host to follow the regular lifecycle.

During the transition, image and customDeploy are copied over to the
status to make sure the host does not get unconditionally deprovisioned.
Hosts without image and customDeploy will still be deprovisioned.

This is an independently written alternative to #2566 since that PR
got abandoned.

Fixes: #2465 
Generated-By: Claude Code (commercial license)
Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
