### PR TITLE
🐛 Reject non-empty checksum for OCI images

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -1103,8 +1103,10 @@ func (image *Image) GetChecksum() (checksum, checksumType string, err error) {
 		return "", "", nil
 	}
 
-	// Checksum is not required for OCI images as they have embedded checksums
-	if image.IsOCI() && image.Checksum == "" {
+	if image.IsOCI() {
+		if image.Checksum != "" {
+			return "", "", errors.New("checksum must be empty for OCI images")
+		}
 		return "", "", nil
 	}
 

--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -1098,15 +1098,14 @@ func (image *Image) GetChecksum() (checksum, checksumType string, err error) {
 		return "", "", errors.New("image is not provided")
 	}
 
-	if image.DiskFormat != nil && *image.DiskFormat == "live-iso" {
-		// Checksum is not required for live-iso
+	if image.IsOCI() {
+		if image.Checksum != "" {
+			return "", "", errors.New("spec.image.checksum must be empty for OCI images (oci:// images have embedded checksums)")
+		}
 		return "", "", nil
 	}
 
-	if image.IsOCI() {
-		if image.Checksum != "" {
-			return "", "", errors.New("checksum must be empty for OCI images")
-		}
+	if image.DiskFormat != nil && *image.DiskFormat == "live-iso" {
 		return "", "", nil
 	}
 

--- a/apis/metal3.io/v1alpha1/baremetalhost_types_test.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types_test.go
@@ -496,6 +496,24 @@ func TestGetImageChecksum(t *testing.T) {
 			ExpectedType: "",
 		},
 		{
+			Scenario: "OCI image with live-iso format and checksum",
+			Host: BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myhost",
+					Namespace: "myns",
+				},
+				Spec: BareMetalHostSpec{
+					Image: &Image{
+						URL:        "oci://example.com/image:latest",
+						Checksum:   "sha256hash",
+						DiskFormat: ptr.To("live-iso"),
+					},
+				},
+			},
+			Expected:     false,
+			ExpectedType: "",
+		},
+		{
 			Scenario: "live-iso without checksum",
 			Host: BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{

--- a/apis/metal3.io/v1alpha1/baremetalhost_types_test.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types_test.go
@@ -492,7 +492,7 @@ func TestGetImageChecksum(t *testing.T) {
 					},
 				},
 			},
-			Expected:     true,
+			Expected:     false,
 			ExpectedType: "",
 		},
 		{


### PR DESCRIPTION
## Summary
- `GetChecksum()` made checksums optional for OCI images but never rejected a non-empty checksum
- This causes the webhook to accept invalid configurations where both `oci://` scheme and a checksum are provided, leading to confusing provisioning failures
- Now returns an error when checksum is set for OCI images

## Test plan
- [x] Unit tests updated (`TestGetImageChecksum` "OCI image with checksum" case)
- [x] Verify `make test` passes
- [ ] Verify BareMetalHost with `oci://` image URL and non-empty checksum is rejected
- [ ] Verify BareMetalHost with `oci://` image URL and empty checksum is accepted

Assisted by: Claude Opus 4.6