### PR TITLE
:sparkles: Validation webhook for hostclaims

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ manifests: manifests-generate manifests-kustomize ## Generate manifests e.g. CRD
 
 .PHONY: manifests-generate
 manifests-generate: $(CONTROLLER_GEN)
-	cd apis; $(abspath $<) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:webhook:dir=../config/base/webhook/ output:crd:artifacts:config=../config/base/crds/bases
+	cd internal/webhooks; $(abspath $<) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:webhook:dir=../../config/base/webhook/ output:crd:artifacts:config=../../config/base/crds/bases
 	$< rbac:roleName=manager-role paths="./..." output:rbac:artifacts:config=config/base/rbac
 
 .PHONY: manifests-kustomize

--- a/PROJECT
+++ b/PROJECT
@@ -109,6 +109,9 @@ resources:
   kind: HostClaim
   path: github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true

--- a/config/base/webhook/manifests.yaml
+++ b/config/base/webhook/manifests.yaml
@@ -46,3 +46,24 @@ webhooks:
     resources:
     - bmceventsubscriptions
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-metal3-io-v1alpha1-hostclaim
+  failurePolicy: Fail
+  name: hostclaim.metal3.io
+  rules:
+  - apiGroups:
+    - metal3.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - hostclaims
+  sideEffects: None

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -3297,3 +3297,24 @@ webhooks:
     resources:
     - bmceventsubscriptions
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: baremetal-operator-webhook-service
+      namespace: baremetal-operator-system
+      path: /validate-metal3-io-v1alpha1-hostclaim
+  failurePolicy: Fail
+  name: hostclaim.metal3.io
+  rules:
+  - apiGroups:
+    - metal3.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - hostclaims
+  sideEffects: None

--- a/internal/webhooks/metal3.io/v1alpha1/hostclaim_validation.go
+++ b/internal/webhooks/metal3.io/v1alpha1/hostclaim_validation.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 The Metal3 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"fmt"
+	"strings"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// validateHostClaim validates a HostClaim resource.
+func (webhook *HostClaimWebhook) validateHostClaim(hostclaim *metal3api.HostClaim) []error {
+	var errs []error
+	for lblKey, lblValue := range hostclaim.Spec.HostSelector.MatchLabels {
+		for _, err := range validation.IsQualifiedName(lblKey) {
+			errs = append(errs, fmt.Errorf("%s=%s: %s", lblKey, lblValue, err))
+		}
+		for _, err := range validation.IsValidLabelValue(lblValue) {
+			errs = append(errs, fmt.Errorf("%s=%s: %s", lblKey, lblValue, err))
+		}
+	}
+	for i, hsr := range hostclaim.Spec.HostSelector.MatchExpressions {
+		for _, err := range validation.IsQualifiedName(hsr.Key) {
+			errs = append(errs, fmt.Errorf("matchExpr %d: %s", i+1, err))
+		}
+		switch hsr.Operator {
+		case selection.Equals, selection.DoubleEquals, selection.NotEquals:
+			if len(hsr.Values) != 1 {
+				errs = append(errs, fmt.Errorf(
+					"matchExpr %d: exactly one value for operator %s in match expression on label key %s",
+					i+1, hsr.Operator, hsr.Key))
+			} else {
+				for _, err := range validation.IsValidLabelValue(hsr.Values[0]) {
+					errs = append(errs, fmt.Errorf("matchExpr %d (value %q): %s", i+1, hsr.Values[0], err))
+				}
+			}
+		case selection.In, selection.NotIn:
+			if len(hsr.Values) == 0 {
+				errs = append(errs, fmt.Errorf(
+					"matchExpr %d: At least one value in list for operator %s in match expression on label key %s",
+					i+1, hsr.Operator, hsr.Key))
+			}
+			for _, v := range hsr.Values {
+				for _, err := range validation.IsValidLabelValue(v) {
+					errs = append(errs, fmt.Errorf("matchExpr %d (value %q): %s", i+1, v, err))
+				}
+			}
+		case selection.Exists, selection.DoesNotExist:
+			if len(hsr.Values) != 0 {
+				errs = append(errs, fmt.Errorf(
+					"matchExpr %d: values not authorized for operator %s in match expression on label key %s",
+					i+1, hsr.Operator, hsr.Key))
+			}
+		default:
+			errs = append(errs, fmt.Errorf(
+				"matchExpr %d: invalid operation %s in match expression on label key %s", i+1, hsr.Operator, hsr.Key))
+		}
+	}
+
+	annotationErrs := validateHostclaimAnnotations(hostclaim)
+	errs = append(errs, annotationErrs...)
+
+	if hostclaim.Spec.Image != nil {
+		imageErrs := validateImage(hostclaim.Spec.Image)
+		errs = append(errs, imageErrs...)
+	}
+
+	return errs
+}
+
+func validateHostclaimAnnotations(hostclaim *metal3api.HostClaim) []error {
+	var errs []error
+	var err error
+
+	for annotation, value := range hostclaim.Annotations {
+		switch {
+		case strings.HasPrefix(annotation, metal3api.RebootAnnotationPrefix+"/") || annotation == metal3api.RebootAnnotationPrefix:
+			err = validateRebootAnnotation(value)
+		// TODO: should we check Detached annotation.
+		default:
+			err = nil
+		}
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errs
+}

--- a/internal/webhooks/metal3.io/v1alpha1/hostclaim_validation_test.go
+++ b/internal/webhooks/metal3.io/v1alpha1/hostclaim_validation_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026 The Metal3 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"strings"
+	"testing"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func errorArrContainsPrefix(out []error, want string) bool {
+	if want == "" {
+		return len(out) == 0
+	}
+	for _, err := range out {
+		if strings.HasPrefix(err.Error(), want) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestValidateHostClaimSelectorCreate(t *testing.T) {
+	tests := []struct {
+		name      string
+		selector  *metal3api.HostSelector
+		wantedErr string
+	}{
+		{
+			name: "valid",
+			selector: &metal3api.HostSelector{
+				MatchLabels: map[string]string{"key": "value"},
+				MatchExpressions: []metal3api.HostSelectorRequirement{
+					{
+						Key:      "key",
+						Operator: "=",
+						Values:   []string{"v"},
+					},
+				},
+			},
+			wantedErr: "",
+		},
+		{
+			name: "invalid key matchLabel",
+			selector: &metal3api.HostSelector{
+				MatchLabels: map[string]string{"-key-": "value"},
+			},
+			wantedErr: "-key-=value: name part",
+		},
+		{
+			name: "invalid value matchLabel",
+			selector: &metal3api.HostSelector{
+				MatchLabels: map[string]string{"key": "-value-"},
+			},
+			wantedErr: "key=-value-: a valid label",
+		},
+		{
+			name: "invalid key matchExpr",
+			selector: &metal3api.HostSelector{
+				MatchExpressions: []metal3api.HostSelectorRequirement{
+					{
+						Key:      "-key-",
+						Operator: "=",
+						Values:   []string{"v"},
+					},
+				},
+			},
+			wantedErr: "matchExpr 1: name part ",
+		},
+		{
+			name: "bad arity = matchExpr",
+			selector: &metal3api.HostSelector{
+				MatchExpressions: []metal3api.HostSelectorRequirement{
+					{
+						Key:      "key",
+						Operator: "=",
+						Values:   []string{},
+					},
+				},
+			},
+			wantedErr: "matchExpr 1: exactly one value",
+		},
+		{
+			name: "bad value = matchExpr",
+			selector: &metal3api.HostSelector{
+				MatchExpressions: []metal3api.HostSelectorRequirement{
+					{
+						Key:      "key",
+						Operator: "=",
+						Values:   []string{"-vvv-"},
+					},
+				},
+			},
+			wantedErr: "matchExpr 1 (value \"-vvv-\"): a valid label ",
+		},
+		{
+			name: "bad arity exists matchExpr",
+			selector: &metal3api.HostSelector{
+				MatchExpressions: []metal3api.HostSelectorRequirement{
+					{
+						Key:      "key",
+						Operator: "exists",
+						Values:   []string{"vvv"},
+					},
+				},
+			},
+			wantedErr: "matchExpr 1: values not authorized",
+		},
+		{
+			name: "bad value in matchExpr",
+			selector: &metal3api.HostSelector{
+				MatchExpressions: []metal3api.HostSelectorRequirement{
+					{
+						Key:      "key",
+						Operator: "in",
+						Values:   []string{"vvv", "-bad-"},
+					},
+				},
+			},
+			wantedErr: "matchExpr 1 (value \"-bad-\"): a valid",
+		},
+		{
+			name: "bad operator",
+			selector: &metal3api.HostSelector{
+				MatchExpressions: []metal3api.HostSelectorRequirement{
+					{
+						Key:      "key",
+						Operator: "badOp",
+						Values:   []string{"vvv"},
+					},
+				},
+			},
+			wantedErr: "matchExpr 1: invalid operation badOp in",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			webhook := &HostClaimWebhook{}
+			hostclaim := &metal3api.HostClaim{
+				TypeMeta:   metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: metal3api.HostClaimSpec{
+					HostSelector: *tt.selector,
+				},
+			}
+			if err := webhook.validateHostClaim(hostclaim); !errorArrContainsPrefix(err, tt.wantedErr) {
+				t.Errorf("metal3api.HostClaimWebhook HostSelector error = %v, wantErr %v", err, tt.wantedErr)
+			}
+		})
+	}
+}
+
+func TestValidateHostClaimImageCreate(t *testing.T) {
+	tests := []struct {
+		name      string
+		image     *metal3api.Image
+		wantedErr string
+	}{
+		{
+			name: "valid image",
+			image: &metal3api.Image{
+				URL:      "https://example.com/image",
+				Checksum: "be254ebfd73e66ca91f6d91f5050aa2ee1ec4813ee65ba472f608ed340cbff09",
+			},
+		},
+		{
+			name: "invalid image",
+			image: &metal3api.Image{
+				URL:      "test1",
+				Checksum: "be254ebfd73e66ca91f6d91f5050aa2ee1ec4813ee65ba472f608ed340cbff09",
+			},
+			wantedErr: "image URL test1 is invalid: parse \"test1\": invalid URI for request",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			webhook := &HostClaimWebhook{}
+			hostclaim := &metal3api.HostClaim{
+				TypeMeta:   metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: metal3api.HostClaimSpec{
+					Image: tt.image,
+				},
+			}
+			if err := webhook.validateHostClaim(hostclaim); !errorArrContainsPrefix(err, tt.wantedErr) {
+				t.Errorf("metal3api.HostClaimWebhook Image error = %v, wantErr %v", err, tt.wantedErr)
+			}
+		})
+	}
+}

--- a/internal/webhooks/metal3.io/v1alpha1/hostclaim_webhook.go
+++ b/internal/webhooks/metal3.io/v1alpha1/hostclaim_webhook.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2026 The Metal3 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"errors"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// hostclaimlog is for logging in this webhook.
+var hostclaimlog = logf.Log.WithName("webhooks").WithName("HostClaim")
+
+func (webhook *HostClaimWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr, &metal3api.HostClaim{}).
+		WithValidator(webhook).
+		Complete()
+}
+
+//+kubebuilder:webhook:verbs=create;update,path=/validate-metal3-io-v1alpha1-hostclaim,mutating=false,failurePolicy=fail,sideEffects=none,admissionReviewVersions=v1;v1beta1,groups=metal3.io,resources=hostclaims,versions=v1alpha1,name=hostclaim.metal3.io
+
+type HostClaimWebhook struct{}
+
+var _ admission.Validator[*metal3api.HostClaim] = &HostClaimWebhook{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+func (webhook *HostClaimWebhook) ValidateCreate(_ context.Context, hc *metal3api.HostClaim) (admission.Warnings, error) {
+	if hc == nil {
+		hostclaimlog.Error(errors.New("object is nil"), "validate create error")
+		return nil, nil
+	}
+
+	hostclaimlog.Info("validate create", "name", hc.Name, "namespace", hc.Namespace)
+	return nil, kerrors.NewAggregate(webhook.validateHostClaim(hc))
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+func (webhook *HostClaimWebhook) ValidateUpdate(_ context.Context, _, newHc *metal3api.HostClaim) (admission.Warnings, error) {
+	if newHc == nil {
+		hostclaimlog.Error(errors.New("object is nil"), "validate update error")
+		return nil, nil
+	}
+	hostclaimlog.Info("validate update", "name", newHc.Name, "namespace", newHc.Namespace)
+	return nil, kerrors.NewAggregate(webhook.validateHostClaim(newHc))
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
+func (webhook *HostClaimWebhook) ValidateDelete(_ context.Context, _ *metal3api.HostClaim) (admission.Warnings, error) {
+	return nil, nil
+}

--- a/internal/webhooks/metal3.io/v1alpha1/hostclaim_webhook_test.go
+++ b/internal/webhooks/metal3.io/v1alpha1/hostclaim_webhook_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 The Metal3 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"testing"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestHostClaimCreate(t *testing.T) {
+	tests := []struct {
+		name      string
+		hostclaim *metal3api.HostClaim
+		wantedErr string
+	}{
+		{
+			name: "valid",
+			hostclaim: &metal3api.HostClaim{TypeMeta: metav1.TypeMeta{
+				Kind:       "HostClaim",
+				APIVersion: "metal3.io/v1alpha1",
+			}, ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test-namespace",
+			}, Spec: metal3api.HostClaimSpec{}},
+			wantedErr: "",
+		},
+		{
+			name: "invalid-bad-label-selector",
+			hostclaim: &metal3api.HostClaim{TypeMeta: metav1.TypeMeta{
+				Kind:       "HostClaim",
+				APIVersion: "metal3.io/v1alpha1",
+			}, ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test-namespace",
+			}, Spec: metal3api.HostClaimSpec{
+				HostSelector: metal3api.HostSelector{
+					MatchLabels: map[string]string{"-bad-key-": "v"},
+				},
+			}},
+			wantedErr: "-bad-key-=v: name part must consist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			webhook := &HostClaimWebhook{}
+			ctx := t.Context()
+			if _, err := webhook.ValidateCreate(ctx, tt.hostclaim); !errorContains(err, tt.wantedErr) {
+				t.Errorf("HostClaim.ValidateCreate() error = %v, wantErr %v", err, tt.wantedErr)
+			}
+		})
+	}
+}
+
+func TestHostClaimUpdate(t *testing.T) {
+	tests := []struct {
+		name      string
+		hostclaim *metal3api.HostClaim
+		wantedErr string
+	}{
+		{
+			name: "valid",
+			hostclaim: &metal3api.HostClaim{TypeMeta: metav1.TypeMeta{
+				Kind:       "HostClaim",
+				APIVersion: "metal3.io/v1alpha1",
+			}, ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test-namespace",
+			}, Spec: metal3api.HostClaimSpec{}},
+			wantedErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			webhook := &HostClaimWebhook{}
+			ctx := t.Context()
+			// We do not really test on oldObj as it is ignored
+			if _, err := webhook.ValidateUpdate(ctx, nil, tt.hostclaim); !errorContains(err, tt.wantedErr) {
+				t.Errorf("HostClaim.ValidateUpdate() error = %v, wantErr %v", err, tt.wantedErr)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -123,6 +123,11 @@ func setupWebhooks(mgr ctrl.Manager) {
 		setupLog.Error(err, "unable to create webhook", "webhook", "BareMetalHost")
 		os.Exit(1)
 	}
+
+	if err := (&webhooks.HostClaimWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "HostClaim")
+		os.Exit(1)
+	}
 }
 
 func main() {


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR adds a validation webhook for hostclaims.
* Checks that hostSelector requirements are valid (both keys and values constraints for matchLabels and matcExprs, also operation coherence for matchExpr).
* Checks image coherence.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
