### PR TITLE
[release-0.6] Backport CVE-2025-29781: validate BMCEventSubscription HostName/Endpoint URLs

### DIFF
--- a/apis/metal3.io/v1alpha1/bmceventsubscription_validation.go
+++ b/apis/metal3.io/v1alpha1/bmceventsubscription_validation.go
@@ -29,6 +29,12 @@ func (s *BMCEventSubscription) validateSubscription() []error {
 		errs = append(errs, errors.New("hostName cannot be empty"))
 	}
 
+	if s.Spec.HTTPHeadersRef != nil {
+		if s.Spec.HTTPHeadersRef.Namespace != s.Namespace {
+			errs = append(errs, errors.New("httpHeadersRef secret must be in the same namespace as the BMCEventSubscription"))
+		}
+	}
+
 	if s.Spec.Destination == "" {
 		errs = append(errs, errors.New("destination cannot be empty"))
 	} else {

--- a/apis/metal3.io/v1alpha1/bmceventsubscription_validation_test.go
+++ b/apis/metal3.io/v1alpha1/bmceventsubscription_validation_test.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -68,6 +69,28 @@ func TestBMCEventSubscriptionValidateCreate(t *testing.T) {
 			},
 			oldS:      nil,
 			wantedErr: "hostname-only destination must have a trailing slash",
+		},
+		{
+			name: "httpHeadersRef valid",
+			newS: &BMCEventSubscription{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: BMCEventSubscriptionSpec{HostName: "worker-01", Destination: "http://localhost/abc/abc.php",
+					HTTPHeadersRef: &corev1.SecretReference{Namespace: om.Namespace, Name: "headers"}},
+			},
+			oldS:      nil,
+			wantedErr: "",
+		},
+		{
+			name: "httpHeadersRef in different namespace",
+			newS: &BMCEventSubscription{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: BMCEventSubscriptionSpec{HostName: "worker-01", Destination: "http://localhost/abc/abc.php",
+					HTTPHeadersRef: &corev1.SecretReference{Namespace: "different", Name: "headers"}},
+			},
+			oldS:      nil,
+			wantedErr: "httpHeadersRef secret must be in the same namespace as the BMCEventSubscription",
 		},
 	}
 

--- a/controllers/metal3.io/bmceventsubscription_controller.go
+++ b/controllers/metal3.io/bmceventsubscription_controller.go
@@ -241,6 +241,10 @@ func (r *BMCEventSubscriptionReconciler) getHTTPHeaders(ctx context.Context, sub
 		return headers, nil
 	}
 
+	if subscription.Spec.HTTPHeadersRef.Namespace != subscription.Namespace {
+		return headers, errors.New("httpHeadersRef secret must be in the same namespace as the BMCEventSubscription")
+	}
+
 	secret := &corev1.Secret{}
 	secretKey := types.NamespacedName{
 		Name:      subscription.Spec.HTTPHeadersRef.Name,

--- a/controllers/metal3.io/bmceventsubscription_controller_test.go
+++ b/controllers/metal3.io/bmceventsubscription_controller_test.go
@@ -140,3 +140,84 @@ func TestBMCGetProvisioner(t *testing.T) {
 		})
 	}
 }
+
+func TestGetHTTPHeaders(t *testing.T) {
+	// NOTE: This subscription references the defaultSecretName for http headers.
+	// The secret is automatically created by newBMCTestReconciler.
+	host := newDefaultHost(t)
+	subscription := newDefaultSubscription(t)
+	r := newBMCTestReconciler(subscription, host)
+
+	for _, tc := range []struct {
+		Scenario      string
+		Subscription  *metal3api.BMCEventSubscription
+		Secret        *corev1.Secret
+		ExpectedError bool
+	}{
+		{
+			Scenario:     "Secret exists and has some content",
+			Subscription: subscription,
+			// Already created by newBMCTestReconciler.
+			Secret:        nil,
+			ExpectedError: false,
+		},
+		{
+			Scenario: "Secret does not exist",
+			Subscription: &metal3api.BMCEventSubscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-subscription",
+					Namespace: namespace,
+				},
+				Spec: metal3api.BMCEventSubscriptionSpec{
+					HostName: host.Name,
+					HTTPHeadersRef: &corev1.SecretReference{
+						Name:      "non-existent-secret",
+						Namespace: namespace,
+					},
+				},
+			},
+			Secret:        nil,
+			ExpectedError: true,
+		},
+		{
+			Scenario: "Secret in wrong namespace",
+			Subscription: &metal3api.BMCEventSubscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-subscription",
+					Namespace: namespace,
+				},
+				Spec: metal3api.BMCEventSubscriptionSpec{
+					HostName: host.Name,
+					HTTPHeadersRef: &corev1.SecretReference{
+						Name:      "test",
+						Namespace: "separate-namespace",
+					},
+				},
+			},
+			Secret:        nil,
+			ExpectedError: true,
+		},
+	} {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			if tc.Secret != nil {
+				err := r.Create(context.Background(), tc.Secret)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			headers, err := r.getHTTPHeaders(context.Background(), *tc.Subscription)
+			if tc.ExpectedError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tc.ExpectedError {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+				}
+				if len(headers) == 0 {
+					t.Error("Expected headers but got none")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Backport of upstream merge for CVE-2025-29781 to `release-0.6`.

- Upstream merge commit: [19f8443b1f](https://github.com/metal3-io/baremetal-operator/commit/19f8443b1fe182f76dd81b43122e8dd102f8b94c)
- Cherry-picked with `git cherry-pick -x -m 1` (mainline parent), preserving original author.

Apply was clean against the current tip of the target branch. Three-way merge resolved automatically.

<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #