### PR TITLE
:sparkles: Add AutomatedCleaningPhase API field

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -575,6 +575,18 @@ type BareMetalHostSpec struct {
 	// +kubebuilder:validation:Optional
 	AutomatedCleaningMode AutomatedCleaningMode `json:"automatedCleaningMode,omitempty"`
 
+	// Defines the phase of deprovisioning where automated cleaning is
+	// performed. When set to "deprovisioning" (the default), cleaning
+	// runs on every deprovisioning including deletion. When set to
+	// "reprovisioning", cleaning is skipped when the host is being
+	// deleted, and only runs between provisionings.
+	// This field is only relevant when automatedCleaningMode is not
+	// set to "disabled".
+	// +optional
+	// +kubebuilder:default:=deprovisioning
+	// +kubebuilder:validation:Optional
+	AutomatedCleaningPhase AutomatedCleaningPhase `json:"automatedCleaningPhase,omitempty"`
+
 	// A custom deploy procedure. This is an advanced feature that allows
 	// using a custom deploy step provided by a site-specific deployment
 	// ramdisk. Most users will want to use "image" instead. Setting this
@@ -608,6 +620,21 @@ type AutomatedCleaningMode string
 const (
 	CleaningModeDisabled AutomatedCleaningMode = "disabled"
 	CleaningModeMetadata AutomatedCleaningMode = "metadata"
+)
+
+// AutomatedCleaningPhase indicates when automated cleaning should be performed.
+// +kubebuilder:validation:Enum:=deprovisioning;reprovisioning
+type AutomatedCleaningPhase string
+
+// Allowed automated cleaning phases.
+const (
+	// CleaningPhaseDeprovisioning means cleaning runs on every
+	// deprovisioning, including when the host is being deleted.
+	CleaningPhaseDeprovisioning AutomatedCleaningPhase = "deprovisioning"
+
+	// CleaningPhaseReprovisioning means cleaning runs only between
+	// provisionings. Cleaning is skipped when the host is being deleted.
+	CleaningPhaseReprovisioning AutomatedCleaningPhase = "reprovisioning"
 )
 
 // ChecksumType holds the algorithm name for the checksum
@@ -923,6 +950,20 @@ func (host *BareMetalHost) CredentialsKey() types.NamespacedName {
 		Name:      host.Spec.BMC.CredentialsName,
 		Namespace: host.ObjectMeta.Namespace,
 	}
+}
+
+// EffectiveCleaningMode returns the effective AutomatedCleaningMode,
+// taking into account AutomatedCleaningPhase and whether the host is
+// being deleted.
+func (host *BareMetalHost) EffectiveCleaningMode() AutomatedCleaningMode {
+	if host.Spec.AutomatedCleaningMode == CleaningModeDisabled {
+		return CleaningModeDisabled
+	}
+	if host.Spec.AutomatedCleaningPhase == CleaningPhaseReprovisioning &&
+		!host.DeletionTimestamp.IsZero() {
+		return CleaningModeDisabled
+	}
+	return host.Spec.AutomatedCleaningMode
 }
 
 // InspectionDisabled returns true if inspection is disabled via either

--- a/apis/metal3.io/v1alpha1/baremetalhost_types_test.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types_test.go
@@ -769,6 +769,72 @@ func TestInspectionDisabled(t *testing.T) {
 	}
 }
 
+func TestEffectiveCleaningMode(t *testing.T) {
+	now := metav1.Now()
+	for _, tc := range []struct {
+		Scenario          string
+		CleaningMode      AutomatedCleaningMode
+		CleaningPhase     AutomatedCleaningPhase
+		DeletionTimestamp *metav1.Time
+		Expected          AutomatedCleaningMode
+	}{
+		{
+			Scenario:      "default phase, not deleting",
+			CleaningMode:  CleaningModeMetadata,
+			CleaningPhase: CleaningPhaseDeprovisioning,
+			Expected:      CleaningModeMetadata,
+		},
+		{
+			Scenario:          "default phase, deleting",
+			CleaningMode:      CleaningModeMetadata,
+			CleaningPhase:     CleaningPhaseDeprovisioning,
+			DeletionTimestamp: &now,
+			Expected:          CleaningModeMetadata,
+		},
+		{
+			Scenario:      "reprovisioning phase, not deleting",
+			CleaningMode:  CleaningModeMetadata,
+			CleaningPhase: CleaningPhaseReprovisioning,
+			Expected:      CleaningModeMetadata,
+		},
+		{
+			Scenario:          "reprovisioning phase, deleting",
+			CleaningMode:      CleaningModeMetadata,
+			CleaningPhase:     CleaningPhaseReprovisioning,
+			DeletionTimestamp: &now,
+			Expected:          CleaningModeDisabled,
+		},
+		{
+			Scenario:          "cleaning disabled, deleting",
+			CleaningMode:      CleaningModeDisabled,
+			CleaningPhase:     CleaningPhaseDeprovisioning,
+			DeletionTimestamp: &now,
+			Expected:          CleaningModeDisabled,
+		},
+		{
+			Scenario:          "zero value phase, deleting",
+			CleaningMode:      CleaningModeMetadata,
+			CleaningPhase:     "",
+			DeletionTimestamp: &now,
+			Expected:          CleaningModeMetadata,
+		},
+	} {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			host := BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: tc.DeletionTimestamp,
+				},
+				Spec: BareMetalHostSpec{
+					AutomatedCleaningMode:  tc.CleaningMode,
+					AutomatedCleaningPhase: tc.CleaningPhase,
+				},
+			}
+			actual := host.EffectiveCleaningMode()
+			assert.Equal(t, tc.Expected, actual)
+		})
+	}
+}
+
 func TestIsOCI(t *testing.T) {
 	for _, tc := range []struct {
 		Scenario string

--- a/config/base/crds/bases/metal3.io_baremetalhosts.yaml
+++ b/config/base/crds/bases/metal3.io_baremetalhosts.yaml
@@ -87,6 +87,20 @@ spec:
                 - metadata
                 - disabled
                 type: string
+              automatedCleaningPhase:
+                default: deprovisioning
+                description: |-
+                  Defines the phase of deprovisioning where automated cleaning is
+                  performed. When set to "deprovisioning" (the default), cleaning
+                  runs on every deprovisioning including deletion. When set to
+                  "reprovisioning", cleaning is skipped when the host is being
+                  deleted, and only runs between provisionings.
+                  This field is only relevant when automatedCleaningMode is not
+                  set to "disabled".
+                enum:
+                - deprovisioning
+                - reprovisioning
+                type: string
               bmc:
                 description: |-
                   How do we connect to the BMC (Baseboard Management Controller) on

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -87,6 +87,20 @@ spec:
                 - metadata
                 - disabled
                 type: string
+              automatedCleaningPhase:
+                default: deprovisioning
+                description: |-
+                  Defines the phase of deprovisioning where automated cleaning is
+                  performed. When set to "deprovisioning" (the default), cleaning
+                  runs on every deprovisioning including deletion. When set to
+                  "reprovisioning", cleaning is skipped when the host is being
+                  deleted, and only runs between provisionings.
+                  This field is only relevant when automatedCleaningMode is not
+                  set to "disabled".
+                enum:
+                - deprovisioning
+                - reprovisioning
+                type: string
               bmc:
                 description: |-
                   How do we connect to the BMC (Baseboard Management Controller) on

--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -843,8 +843,7 @@ func (r *BareMetalHostReconciler) registerHost(ctx context.Context, prov provisi
 			preprovImgFormats = nil
 		}
 	case metal3api.StateDeprovisioning:
-		// PreprovisioningImage is not required for deprovisioning when cleaning is disabled
-		if info.host.Spec.AutomatedCleaningMode == metal3api.CleaningModeDisabled {
+		if info.host.EffectiveCleaningMode() == metal3api.CleaningModeDisabled {
 			preprovImgFormats = nil
 		}
 	default:
@@ -868,11 +867,16 @@ func (r *BareMetalHostReconciler) registerHost(ctx context.Context, prov provisi
 		return recordActionFailure(info, metal3api.RegistrationError, "failed to read preprovisioningNetworkData")
 	}
 
+	automatedCleaningMode := info.host.Spec.AutomatedCleaningMode
+	if info.host.Status.Provisioning.State == metal3api.StateDeprovisioning {
+		automatedCleaningMode = info.host.EffectiveCleaningMode()
+	}
+
 	provResult, provID, err := prov.Register(
 		ctx,
 		provisioner.ManagementAccessData{
 			BootMode:                   info.host.Status.Provisioning.BootMode,
-			AutomatedCleaningMode:      info.host.Spec.AutomatedCleaningMode,
+			AutomatedCleaningMode:      automatedCleaningMode,
 			State:                      info.host.Status.Provisioning.State,
 			OperationalStatus:          info.host.Status.OperationalStatus,
 			CurrentImage:               getCurrentImage(info.host),
@@ -1404,10 +1408,12 @@ func (r *BareMetalHostReconciler) actionDeprovisioning(ctx context.Context, prov
 
 	info.log.Info("deprovisioning")
 
+	automatedCleaningMode := info.host.EffectiveCleaningMode()
+
 	provResult, err := prov.Deprovision(
 		ctx,
 		info.host.Status.ErrorType == metal3api.ProvisioningError,
-		info.host.Spec.AutomatedCleaningMode)
+		automatedCleaningMode)
 	if err != nil {
 		return actionError{fmt.Errorf("failed to deprovision: %w", err)}
 	}

--- a/internal/controller/metal3.io/baremetalhost_controller_test.go
+++ b/internal/controller/metal3.io/baremetalhost_controller_test.go
@@ -2694,6 +2694,48 @@ func TestGetPreprovImageBeingDeleted(t *testing.T) {
 	assert.Nil(t, imgData)
 }
 
+func TestGetPreprovImageSkippedForReprovisioningPhase(t *testing.T) {
+	host := newDefaultHost(t)
+	host.Status.Provisioning.State = metal3api.StateDeprovisioning
+	host.Spec.AutomatedCleaningMode = metal3api.CleaningModeMetadata
+	host.Spec.AutomatedCleaningPhase = metal3api.CleaningPhaseReprovisioning
+	now := metav1.Now()
+	host.DeletionTimestamp = &now
+	host.Finalizers = []string{"baremetalhost.metal3.io"}
+
+	r := newTestReconciler(t, host)
+	i := makeReconcileInfo(host)
+
+	// With reprovisioning phase and DeletionTimestamp, EffectiveCleaningMode
+	// returns disabled, so getPreprovImage should be called with nil formats
+	// (meaning no PPI is needed). Verify that nil formats returns nil.
+	imgData, err := r.getPreprovImage(t.Context(), i, nil)
+	require.NoError(t, err)
+	assert.Nil(t, imgData)
+}
+
+func TestGetPreprovImageNotSkippedForDefaultPhase(t *testing.T) {
+	host := newDefaultHost(t)
+	host.Status.Provisioning.State = metal3api.StateDeprovisioning
+	host.Spec.AutomatedCleaningMode = metal3api.CleaningModeMetadata
+	host.Spec.AutomatedCleaningPhase = metal3api.CleaningPhaseDeprovisioning
+	now := metav1.Now()
+	host.DeletionTimestamp = &now
+	host.Finalizers = []string{"baremetalhost.metal3.io"}
+
+	r := newTestReconciler(t, host)
+	i := makeReconcileInfo(host)
+
+	// With default deprovisioning phase, even with DeletionTimestamp,
+	// EffectiveCleaningMode returns metadata, so PPI is still needed.
+	// getPreprovImage will attempt to create a PPI (no existing one),
+	// and succeed since we're using a fake client.
+	imgData, err := r.getPreprovImage(t.Context(), i, []metal3api.ImageFormat{metal3api.ImageFormatISO})
+	require.NoError(t, err)
+	// PPI was created but is not ready yet
+	assert.Nil(t, imgData)
+}
+
 func TestPreprovImageAvailable(t *testing.T) {
 	host := newDefaultHost(t)
 	r := newTestReconciler(t, host, newSecret("network_secret_1", nil))

--- a/internal/testutil/common.go
+++ b/internal/testutil/common.go
@@ -161,6 +161,11 @@ func (bb *BareMetalHostBuilder) SetCleaningMode(cmode metal3api.AutomatedCleanin
 	return bb
 }
 
+func (bb *BareMetalHostBuilder) SetCleaningPhase(phase metal3api.AutomatedCleaningPhase) *BareMetalHostBuilder {
+	bb.bmh.Spec.AutomatedCleaningPhase = phase
+	return bb
+}
+
 func (bb *BareMetalHostBuilder) SetCustomDeploy(cd string) *BareMetalHostBuilder {
 	bb.bmh.Spec.CustomDeploy = &metal3api.CustomDeploy{Method: cd}
 	return bb


### PR DESCRIPTION
Introduce a new `AutomatedCleaningPhase` field on `BareMetalHostSpec` that controls when automated cleaning is performed during deprovisioning.

The field has two values:
- "deprovisioning" (default): cleaning runs on every deprovisioning, including deletion. This preserves existing behavior.
- "reprovisioning": cleaning only runs between provisionings and is skipped when the host is being deleted (e.g. namespace terminating).

This allows users to explicitly opt out of cleaning on deletion without violating the existing API semantics of `AutomatedCleaningMode`.
