### PR TITLE
:seedling: Remove obsoleted release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,12 +121,20 @@ jobs:
         curl -fsSL "https://raw.githubusercontent.com/${{ github.repository }}/main/releasenotes/${RELEASE_TAG}.md" \
         -o "${RELEASE_TAG}.md"
     - name: Release
-      uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0 # zizmor: ignore[superfluous-actions]
-      with:
-        draft: true
-        files: out/*
-        body_path: ${{ env.RELEASE_TAG }}.md
-        tag_name: ${{ env.RELEASE_TAG }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        PRERELEASE_FLAG: ${{ contains(needs.push_release_tags.outputs.release_tag, '-') && '--prerelease' || '' }}
+      run: |
+        # NOTE: No quotes around PRERELEASE_FLAG so that it expands to either `--prerelease` or an empty string,
+        # rather than an empty argument.
+        gh release create "${RELEASE_TAG}" \
+          --draft \
+          --verify-tag \
+          ${PRERELEASE_FLAG} \
+          --title "${RELEASE_TAG}" \
+          --notes-file "${RELEASE_TAG}.md" \
+          out/*
   build_bmo:
     permissions:
       contents: read


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

We don't need the softprops/action-gh-release as the same can be done with gh cli that is part of the runners and we have tokens present. This has been flagged by zizmor earlier.

This also causes issues for dependabot, as it cannot bump the release action due zizmor's extra comment on the same line.

This also improves the release by tagging the pre-releases properly in the draft note automatically.

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
