### PR TITLE
:sparkles: Add container networking to vbmctl and add tests

### DIFF
--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -72,24 +72,6 @@ sudo sysctl fs.inotify.max_user_instances=8192
 # Build the container image with e2e tag (used in tests)
 IMG=quay.io/metal3-io/baremetal-operator IMG_TAG=e2e make docker
 
-
-# We need to create veth pair to connect metal3 net (defined above with vbmctl)
-# and kind docker subnet. Let us start by creating a docker network with
-# pre-defined name for bridge, so that we can configure the veth pair
-# correctly. Also assume that if kind net exists, it is created by us.
-if ! docker network list | grep kind; then
-    # These options are used by kind itself. It uses docker default mtu and
-    # generates ipv6 subnet ULA, but we can fix the ULA. Only addition to kind
-    # options is the network bridge name.
-    docker network create -d=bridge \
-        -o com.docker.network.bridge.enable_ip_masquerade=true \
-        -o com.docker.network.driver.mtu=1500 \
-        -o com.docker.network.bridge.name="kind-bridge" \
-        --ipv6 --subnet "fc00:f853:ccd:e793::/64" \
-        kind
-fi
-docker network list
-
 # Build vbmctl
 make build-vbmctl
 sudo setcap cap_net_admin+epi ./bin/vbmctl

--- a/test/e2e/config/vbmctl.yaml
+++ b/test/e2e/config/vbmctl.yaml
@@ -39,3 +39,9 @@ spec:
     link2: kind-bridge
     veth1: metalend
     veth2: kindend
+  dockerNetworks:
+  - name: "kind"
+    bridgeName: "kind-bridge"
+    subnet: "fc00:f853:ccd:e793::/64"
+    driverMtu: 1500
+    ipv6: true

--- a/test/go.mod
+++ b/test/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/vishvananda/netlink v1.3.1
 	golang.org/x/crypto v0.52.0
+	golang.org/x/sys v0.45.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.35.5
 	k8s.io/apiextensions-apiserver v0.35.5
@@ -119,7 +120,6 @@ require (
 	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.14.0 // indirect

--- a/test/vbmctl/cmd/vbmctl/main.go
+++ b/test/vbmctl/cmd/vbmctl/main.go
@@ -222,7 +222,13 @@ Example configuration:
       - link1: "metal3"
         link2: "kind-bridge"
         veth1: "metalend"
-        veth2: "kindend"`,
+        veth2: "kindend"
+    dockerNetworks:
+	  - name: "kind"
+	    bridgeName: "kind-bridge"
+	    subnet: "fc00:f853:ccd:e793::/64"
+	    driverMtu: 1500
+        ipv6: true`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx, cancel := contextWithSignal()
 			defer cancel()
@@ -272,10 +278,21 @@ Example configuration:
 				return err
 			}
 			//nolint:forbidigo // CLI output is intentional
-			fmt.Println("\nCreated networks:")
+			fmt.Println("Created networks:")
 			for _, network := range networks {
 				//nolint:forbidigo // CLI output is intentional
 				fmt.Printf("  - %s (UUID: %s)\n", network.Name, network.UUID)
+			}
+
+			networkIDs, err := containers.CreateBridgeNetworks(ctx, cfg.Spec.DockerNetworks)
+			if err != nil {
+				return err
+			}
+			//nolint:forbidigo // CLI output is intentional
+			fmt.Println("Created Docker networks:")
+			for _, id := range networkIDs {
+				//nolint:forbidigo // CLI output is intentional
+				fmt.Printf("  - ID: %s\n", id)
 			}
 
 			// Connect the specified networks
@@ -284,7 +301,7 @@ Example configuration:
 				return fmt.Errorf("failed to create veth pairs: %w", err)
 			}
 			//nolint:forbidigo // CLI output is intentional
-			fmt.Println("\nCreated veth pairs:")
+			fmt.Println("Created veth pairs:")
 			for _, pair := range cfg.Spec.VethPairs {
 				//nolint:forbidigo // CLI output is intentional
 				fmt.Printf("  - between %s and %s\n", pair.Link1, pair.Link2)
@@ -666,8 +683,10 @@ func newDeleteBMLCmd() *cobra.Command {
 			//nolint:forbidigo // CLI output is intentional
 			fmt.Printf("Deleting libvirt networks (%d networks)...\n", len(networks))
 
-			if err := networkManager.DeleteNetworks(ctx, networks); err != nil {
-				return err
+			if err = networkManager.DeleteNetworks(ctx, networks); err != nil {
+				// Don't fail whole command if network deletion fails
+				//nolint:forbidigo // CLI output is intentional
+				fmt.Printf("Warning: failed to delete network: %v\n", err)
 			}
 
 			//nolint:forbidigo // CLI output is intentional
@@ -675,6 +694,19 @@ func newDeleteBMLCmd() *cobra.Command {
 			for _, name := range networks {
 				//nolint:forbidigo // CLI output is intentional
 				fmt.Printf("  - %s\n", name)
+			}
+
+			err = containers.DeleteBridgeNetworks(ctx, cfg.Spec.DockerNetworks)
+			if err != nil {
+				// Don't fail whole command if network deletion fails
+				//nolint:forbidigo // CLI output is intentional
+				fmt.Printf("Warning: failed to delete Docker network: %v\n", err)
+			}
+			//nolint:forbidigo // CLI output is intentional
+			fmt.Println("Deleted Docker networks:")
+			for _, net := range cfg.Spec.DockerNetworks {
+				//nolint:forbidigo // CLI output is intentional
+				fmt.Printf("  - name: %s\n", net.Name)
 			}
 
 			if cfg.Spec.ImageServer != nil {

--- a/test/vbmctl/pkg/api/types.go
+++ b/test/vbmctl/pkg/api/types.go
@@ -2,6 +2,8 @@
 // bare metal environments.
 package vbmctlapi
 
+import "k8s.io/utils/ptr"
+
 // VMConfig represents the configuration for a virtual machine.
 type VMConfig struct {
 	// Name is the name of the virtual machine.
@@ -101,12 +103,12 @@ type NetworkAttachment struct {
 // Network represents libvirt network.
 type NetworkConfig struct {
 	// Name is the name of the libvirt network.
-	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	Name string `json:"name" yaml:"name"`
 
 	// Bridge is the name of the bridge interface for the network.
 	Bridge string `json:"bridge,omitempty" yaml:"bridge,omitempty"`
 
-	// Address is the address of the bridge interface.
+	// Address is the address of the bridge interface. Address is expected to be IPv4.
 	Address string `json:"address,omitempty" yaml:"address,omitempty"`
 
 	// Netmask is the netmask for the network.
@@ -198,6 +200,26 @@ type Pool struct {
 	Available uint64 `json:"available,omitempty" yaml:"available,omitempty"`
 }
 
+type DockerBridgeNetwork struct {
+	// Name is the name of the docker network
+	Name string `json:"name" yaml:"name"`
+
+	// BridgeName is the name for the network bridge that is to be created
+	BridgeName string `json:"bridgeName" yaml:"bridgeName"`
+
+	// IPv4 is a boolean for enabling IPv4, true by default
+	IPv4 *bool `json:"ipv4,omitempty" yaml:"ipv4,omitempty"`
+
+	// IPv6 is a boolean for enabling IPv6, false by default
+	IPv6 *bool `json:"ipv6,omitempty" yaml:"ipv6,omitempty"`
+
+	// Subnet is the subnet to be used
+	Subnet string `json:"subnet" yaml:"subnet"`
+
+	// DriverMtu is the maximum transmission unit for the network
+	DriverMtu uint64 `json:"driverMtu,omitempty" yaml:"driverMtu,omitempty"`
+}
+
 // Defaults returns a copy of VMConfig with default values applied.
 func (c VMConfig) Defaults() VMConfig {
 	cfg := c
@@ -222,9 +244,6 @@ func (c VolumeConfig) Defaults() VolumeConfig {
 // Defaults returns a copy of NetworkConfig with default values applied.
 func (c NetworkConfig) Defaults() NetworkConfig {
 	cfg := c
-	if cfg.Name == "" {
-		cfg.Name = "baremetal-e2e"
-	}
 	if cfg.Bridge == "" {
 		cfg.Bridge = "metal3"
 	}
@@ -233,6 +252,17 @@ func (c NetworkConfig) Defaults() NetworkConfig {
 	}
 	if cfg.Netmask == "" {
 		cfg.Netmask = "255.255.255.0"
+	}
+	return cfg
+}
+
+func (c DockerBridgeNetwork) Defaults() DockerBridgeNetwork {
+	cfg := c
+	if cfg.IPv4 == nil {
+		cfg.IPv4 = ptr.To(true)
+	}
+	if cfg.IPv6 == nil {
+		cfg.IPv6 = ptr.To(false)
 	}
 	return cfg
 }

--- a/test/vbmctl/pkg/config/config.go
+++ b/test/vbmctl/pkg/config/config.go
@@ -4,10 +4,13 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
 
 	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
+	"golang.org/x/sys/unix"
 	"gopkg.in/yaml.v2"
 )
 
@@ -117,7 +120,7 @@ type Spec struct {
 	// VMs is a list of VM configurations to create.
 	VMs []vbmctlapi.VMConfig `json:"vms,omitempty" yaml:"vms,omitempty"`
 
-	// Networks is a list of network configurations to create.
+	// Networks is a list of libvirt network configurations to create.
 	Networks []vbmctlapi.NetworkConfig `json:"networks,omitempty" yaml:"networks,omitempty"`
 
 	// ImageServer contains configuration for the image server.
@@ -128,6 +131,9 @@ type Spec struct {
 
 	// VethPairs is a list of interfaces that should be connected with a veth-pair.
 	VethPairs []vbmctlapi.VethPair `json:"vethPairs,omitempty" yaml:"vethPairs,omitempty"`
+
+	// DockerNetworks is a list of docker network that should be present
+	DockerNetworks []vbmctlapi.DockerBridgeNetwork `json:"dockerNetworks,omitempty" yaml:"dockerNetworks,omitempty"`
 }
 
 // LibvirtConfig contains libvirt connection settings.
@@ -296,6 +302,65 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	// Validate libvirt network config
+	for _, network := range c.Spec.Networks {
+		if network.Name == "" {
+			return errors.New("name is required for libvirt network")
+		}
+
+		if network.Bridge != "" {
+			if len(network.Bridge) > unix.IFNAMSIZ-1 {
+				return fmt.Errorf("too long bridgename for libvirt network %s", network.Name)
+			}
+		}
+
+		if network.Address != "" {
+			addr, err := netip.ParseAddr(network.Address)
+			if err != nil {
+				return fmt.Errorf("malformed libvirt network address: %w", err)
+			}
+			if !addr.Is4() {
+				return fmt.Errorf("libvirt network address must be an IPv4 address: %s", network.Address)
+			}
+		}
+
+		if network.Netmask != "" {
+			ip := net.ParseIP(network.Netmask)
+			if ip == nil {
+				return fmt.Errorf("malformed libvirt netmask: %s", ip)
+			}
+			m := net.IPMask(ip.To4())
+			ones, zeros := m.Size()
+			if ones == 0 && zeros == 0 {
+				return fmt.Errorf("malformed libvirt netmask: %s", ip)
+			}
+		}
+	}
+
+	// Validate Docker network configs
+	for _, network := range c.Spec.DockerNetworks {
+		if network.Name == "" {
+			return errors.New("name is required for Docker network")
+		}
+
+		if network.BridgeName == "" {
+			return errors.New("BridgeName is required for Docker network")
+		}
+		if len(network.BridgeName) > unix.IFNAMSIZ-1 {
+			return fmt.Errorf("too long bridgename for Docker network %s", network.Name)
+		}
+
+		if network.Subnet == "" {
+			return errors.New("subnet is required for Docker network")
+		}
+		if network.Subnet != "" {
+			_, _, err := net.ParseCIDR(network.Subnet)
+			if err != nil {
+				return errors.New("malformed docker subnet")
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -358,6 +423,18 @@ func (c *Config) ApplyDefaults() {
 		}
 		if c.Spec.BMCEmulator.Type == BMCEmulatorTypeSushyTools && c.Spec.BMCEmulator.ConfigFile == "" {
 			c.Spec.BMCEmulator.ConfigFile = DefaultBMCEmulatorSushyToolsConfigFile
+		}
+	}
+
+	if len(c.Spec.Networks) > 0 {
+		for i, net := range c.Spec.Networks {
+			c.Spec.Networks[i] = net.Defaults()
+		}
+	}
+
+	if len(c.Spec.DockerNetworks) > 0 {
+		for i, net := range c.Spec.DockerNetworks {
+			c.Spec.DockerNetworks[i] = net.Defaults()
 		}
 	}
 }

--- a/test/vbmctl/pkg/config/config_test.go
+++ b/test/vbmctl/pkg/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
+	"k8s.io/utils/ptr"
 )
 
 func TestDefault(t *testing.T) {
@@ -53,6 +54,22 @@ spec:
     type: "sushy-tools"
     configFile: "vbmc-emulator-file"
     image: "test/bmc-emulator:latest"
+  networks:
+  - name: "baremetal-e2e"
+    bridge: "metal3"
+    address: "192.168.222.1"
+    netmask: "255.255.255.0"
+  vethPairs:
+  - link1: "metal3"
+    link2: "kind-bridge"
+    veth1: "metalend"
+    veth2: "kindend"
+  dockerNetworks:
+  - name: "kind"
+    bridgeName: "kind-bridge"
+    subnet: "fc00:f853:ccd:e793::/64"
+    driverMtu: 1500
+    ipv6: true
 `)
 
 	cfg, err := Parse(yamlData)
@@ -123,6 +140,73 @@ spec:
 	if cfg.Spec.BMCEmulator.Image != "test/bmc-emulator:latest" {
 		t.Errorf("expected BMC emulator image 'test/bmc-emulator:latest', got %s", cfg.Spec.BMCEmulator.Image)
 	}
+
+	// Libvirt network tests
+	if len(cfg.Spec.Networks) != 1 {
+		t.Fatalf("expected 1 libvirt network config, got %d", len(cfg.Spec.Networks))
+	}
+
+	if cfg.Spec.Networks[0].Name != "baremetal-e2e" {
+		t.Errorf("expected libvirt network name 'baremetal-e2e', got %s", cfg.Spec.Networks[0].Name)
+	}
+
+	if cfg.Spec.Networks[0].Bridge != "metal3" {
+		t.Errorf("expected libvirt network bridge 'metal3', got %s", cfg.Spec.Networks[0].Bridge)
+	}
+
+	if cfg.Spec.Networks[0].Address != "192.168.222.1" {
+		t.Errorf("expected libvirt network address '192.168.222.1', got %s", cfg.Spec.Networks[0].Address)
+	}
+
+	if cfg.Spec.Networks[0].Netmask != "255.255.255.0" {
+		t.Errorf("expected libvirt network netmask '255.255.255.0', got %s", cfg.Spec.Networks[0].Netmask)
+	}
+
+	// vethPairs tests
+	if len(cfg.Spec.VethPairs) != 1 {
+		t.Fatalf("expected 1 veth pair config, got %d", len(cfg.Spec.VethPairs))
+	}
+
+	if cfg.Spec.VethPairs[0].Link1 != "metal3" {
+		t.Errorf("expected veth pair link1 'metal3', got %s", cfg.Spec.VethPairs[0].Link1)
+	}
+
+	if cfg.Spec.VethPairs[0].Link2 != "kind-bridge" {
+		t.Errorf("expected veth pair link2 'kind-bridge', got %s", cfg.Spec.VethPairs[0].Link2)
+	}
+
+	if cfg.Spec.VethPairs[0].Veth1 != "metalend" {
+		t.Errorf("expected veth pair veth1 'metalend', got %s", cfg.Spec.VethPairs[0].Veth1)
+	}
+
+	if cfg.Spec.VethPairs[0].Veth2 != "kindend" {
+		t.Errorf("expected veth pair veth2 'kindend', got %s", cfg.Spec.VethPairs[0].Veth2)
+	}
+
+	// DockerNetworks tests
+	if len(cfg.Spec.DockerNetworks) != 1 {
+		t.Fatalf("expected 1 docker network config, got %d", len(cfg.Spec.DockerNetworks))
+	}
+
+	if cfg.Spec.DockerNetworks[0].Name != "kind" {
+		t.Errorf("expected docker network name 'kind', got %s", cfg.Spec.DockerNetworks[0].Name)
+	}
+
+	if cfg.Spec.DockerNetworks[0].BridgeName != "kind-bridge" {
+		t.Errorf("expected docker network bridge name 'kind-bridge', got %s", cfg.Spec.DockerNetworks[0].BridgeName)
+	}
+
+	if cfg.Spec.DockerNetworks[0].Subnet != "fc00:f853:ccd:e793::/64" {
+		t.Errorf("expected docker network subnet 'fc00:f853:ccd:e793::/64', got %s", cfg.Spec.DockerNetworks[0].Subnet)
+	}
+
+	if cfg.Spec.DockerNetworks[0].DriverMtu != 1500 {
+		t.Errorf("expected docker network driver MTU '1500', got %d", cfg.Spec.DockerNetworks[0].DriverMtu)
+	}
+
+	if *cfg.Spec.DockerNetworks[0].IPv6 != true {
+		t.Errorf("expected docker network ipv6 'true', got %v", cfg.Spec.DockerNetworks[0].IPv6)
+	}
 }
 
 func TestLoadAndSave(t *testing.T) {
@@ -147,6 +231,13 @@ func TestLoadAndSave(t *testing.T) {
 		ConfigFile: "vbmc-emulator-file",
 		Image:      "test/bmc-emulator:latest",
 	}
+	cfg.Spec.DockerNetworks = []vbmctlapi.DockerBridgeNetwork{{
+		Name:       "kind",
+		BridgeName: "kind-bridge",
+		Subnet:     "fc00:f853:ccd:e793::/64",
+		DriverMtu:  1500,
+		IPv6:       ptr.To(true),
+	}}
 
 	// Save it
 	if err := cfg.Save(configPath); err != nil {
@@ -214,6 +305,31 @@ func TestLoadAndSave(t *testing.T) {
 
 	if loadedCfg.Spec.BMCEmulator.Image != "test/bmc-emulator:latest" {
 		t.Errorf("expected BMC emulator image 'test/bmc-emulator:latest', got %s", loadedCfg.Spec.BMCEmulator.Image)
+	}
+
+	// DockerNetworks tests
+	if len(loadedCfg.Spec.DockerNetworks) != 1 {
+		t.Fatalf("expected 1 docker network config, got %d", len(cfg.Spec.DockerNetworks))
+	}
+
+	if loadedCfg.Spec.DockerNetworks[0].Name != "kind" {
+		t.Errorf("expected docker network name 'kind', got %s", cfg.Spec.DockerNetworks[0].Name)
+	}
+
+	if loadedCfg.Spec.DockerNetworks[0].BridgeName != "kind-bridge" {
+		t.Errorf("expected docker network bridge name 'kind-bridge', got %s", cfg.Spec.DockerNetworks[0].BridgeName)
+	}
+
+	if loadedCfg.Spec.DockerNetworks[0].Subnet != "fc00:f853:ccd:e793::/64" {
+		t.Errorf("expected docker network subnet 'fc00:f853:ccd:e793::/64', got %s", cfg.Spec.DockerNetworks[0].Subnet)
+	}
+
+	if loadedCfg.Spec.DockerNetworks[0].DriverMtu != 1500 {
+		t.Errorf("expected docker network driver MTU '1500', got %d", cfg.Spec.DockerNetworks[0].DriverMtu)
+	}
+
+	if *loadedCfg.Spec.DockerNetworks[0].IPv6 != true {
+		t.Errorf("expected docker network ipv6 'true', got %v", cfg.Spec.DockerNetworks[0].IPv6)
 	}
 }
 
@@ -422,6 +538,82 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+
+		{
+			name: "valid libvirt network config",
+			modify: func(c *Config) {
+				c.Spec.Networks = []vbmctlapi.NetworkConfig{{
+					Name:    "baremetal-e2e",
+					Bridge:  "metal3",
+					Address: "192.168.222.1",
+					Netmask: "255.255.255.0",
+				}}
+			},
+			wantErr: false,
+		},
+
+		{
+			name: "invalid libvirt network config - malformed address",
+			modify: func(c *Config) {
+				c.Spec.Networks = []vbmctlapi.NetworkConfig{{
+					Address: "What is your favourite pair of socks?",
+				}}
+			},
+			wantErr: true,
+		},
+
+		{
+			name: "invalid libvirt network config - malformed netmask",
+			modify: func(c *Config) {
+				c.Spec.Networks = []vbmctlapi.NetworkConfig{{
+					Netmask: "tsubadubaduu",
+				}}
+			},
+			wantErr: true,
+		},
+
+		{
+			name: "invalid libvirt network config - too long bridge name",
+			modify: func(c *Config) {
+				c.Spec.Networks = []vbmctlapi.NetworkConfig{{
+					Bridge: "RÄYY RÄKÄ TÄKÄ TÖYY",
+				}}
+			},
+			wantErr: true,
+		},
+
+		{
+			name: "valid DockerNetwork config",
+			modify: func(c *Config) {
+				c.Spec.DockerNetworks = []vbmctlapi.DockerBridgeNetwork{{
+					Name:       "kind",
+					BridgeName: "kind-bridge",
+					Subnet:     "fc00:f853:ccd:e793::/64",
+					DriverMtu:  1500,
+				}}
+			},
+			wantErr: false,
+		},
+
+		{
+			name: "invalid DockerNetwork config - too long bridge name",
+			modify: func(c *Config) {
+				c.Spec.DockerNetworks = []vbmctlapi.DockerBridgeNetwork{{
+					BridgeName: "What is the speed of smell?",
+				}}
+			},
+			wantErr: true,
+		},
+
+		{
+			name: "invalid DockerNetwork config - malformed subnet",
+			modify: func(c *Config) {
+				c.Spec.DockerNetworks = []vbmctlapi.DockerBridgeNetwork{{
+					Subnet: "Like seriously, we know the speed of light and sound, but what is the speed of smell?",
+				}}
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -439,6 +631,7 @@ func TestValidate(t *testing.T) {
 func TestApplyDefaults(t *testing.T) {
 	cfg := &Config{}
 	cfg.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{}
+	cfg.Spec.DockerNetworks = []vbmctlapi.DockerBridgeNetwork{{}}
 	cfg.ApplyDefaults()
 
 	if cfg.Spec.Libvirt.URI != DefaultLibvirtURI {
@@ -453,7 +646,19 @@ func TestApplyDefaults(t *testing.T) {
 		t.Errorf("expected BMC Emulator Type %s, got %s", DefaultBMCEmulatorType, cfg.Spec.BMCEmulator.Type)
 	}
 
-	// If type is unknown, image default should not be applied
+	if *cfg.Spec.DockerNetworks[0].IPv6 {
+		t.Error("expected IPv6 to be disabled in Docker network")
+	}
+
+	if !*cfg.Spec.DockerNetworks[0].IPv4 {
+		t.Error("expected IPv4 to enabled in Docker network")
+	}
+
+	if cfg.Spec.DockerNetworks[0].DriverMtu != 0 {
+		t.Errorf("expected Docker network driver MTU to be 0, got %d", cfg.Spec.DockerNetworks[0].DriverMtu)
+	}
+
+	// If BMCEmulator type is unknown, image default should not be applied
 	unknownCfg := &Config{}
 	unknownCfg.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
 		Type: "unknown-type",
@@ -463,7 +668,7 @@ func TestApplyDefaults(t *testing.T) {
 		t.Errorf("expected BMC Emulator Image <empty>, got %s", unknownCfg.Spec.BMCEmulator.Image)
 	}
 
-	// If type is vbmc, vbmc image default should be applied
+	// If BMCEmulator type is vbmc, vbmc image default should be applied
 	vbmcCfg := &Config{}
 	vbmcCfg.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
 		Type: BMCEmulatorTypeVBMC,
@@ -473,7 +678,7 @@ func TestApplyDefaults(t *testing.T) {
 		t.Errorf("expected BMC Emulator Image %s, got %s", DefaultBMCEmulatorVBMCImage, vbmcCfg.Spec.BMCEmulator.Image)
 	}
 
-	// Config file default is only applied for sushy-tools type. Also verify that the image default for sushy-tools is applied.
+	// BMCEmulator Config file default is only applied for sushy-tools type. Also verify that the image default for sushy-tools is applied.
 	sushyCfg := &Config{}
 	sushyCfg.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
 		Type: BMCEmulatorTypeSushyTools,

--- a/test/vbmctl/pkg/containers/doc.go
+++ b/test/vbmctl/pkg/containers/doc.go
@@ -71,6 +71,53 @@
 //	    ConfigFile:    "/path/to/existing/config/file",
 //	})
 //
+// # Container network management
+//
+// Networks can be created using CreateNetwork.
+//
+//	networkOpts := client.NetworkCreateOptions{
+//		Driver:     "bridge",
+//		EnableIPv4: net.IPv4,
+//		EnableIPv6: net.IPv6,
+//		Options: map[string]string{
+//			"com.docker.network.bridge.name": "my-bridge",
+//		},
+//	}
+//
+// createdNetworkID, err := CreateNetwork(ctx, "my-net", &networkOpts)
+//
+// The function checks if the network exists already, and creates it if it does
+// not.
+//
+// Networks can be deleted with DeleteNetwork.
+//
+// err = DeleteNetwork(ctx, networkID, &client.NetworkRemoveOptions{})
+//
+// Currently NetworkRemoveOptions don't contain anything, it is just a
+// placeholder for possible future options.
+//
+// # Bridge network management
+//
+// Bridge network (for Kind) can be created using
+//
+//	networkIDs, err := containers.CreateBridgeNetworks(ctx, []api.DockerBridgeNetwork{{
+//	 	Name: "kind",
+//	 	BridgeName: "kind-bridge",
+//	 	IPv4: ptr.To(true),
+//	 	IPv6: ptr.To(false),
+//	 	Subnet: "fc00:f853:ccd:e793::/64",
+//	 	DriverMtu: 1500,
+//	}})
+//
+// # Bridge network can be deleted using
+//
+//	err = containers.DeleteBridgeNetworks(ctx, []api.DockerBridgeNetwork{{
+//		 	Name: "kind",
+//		}})
+//
+// The deletion uses only the name to look for the network, so the rest can be
+// omitted.
+//
 // # Error Handling
 //
 // All operations return standard Go errors that can be inspected for specific

--- a/test/vbmctl/pkg/containers/docker.go
+++ b/test/vbmctl/pkg/containers/docker.go
@@ -5,13 +5,18 @@ package containers
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/config"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 )
+
+var ErrNetworkExists = errors.New("cannot create network, it already exists")
+var ErrNetworkNotFound = errors.New("given network was not found")
 
 func ensureVbmctlPrefix(name string) string {
 	if !strings.HasPrefix(name, "vbmctl-") {
@@ -117,4 +122,72 @@ func GetContainerInfo(ctx context.Context, containerName string) (info string, e
 		containerInfo = fmt.Sprintf("'%s' (id: %s)", status, containerID[:12])
 	}
 	return fmt.Sprintf("%s %s", containerName, containerInfo), nil
+}
+
+// CreateNetwork creates a new Docker network with the given name and options.
+// If the network already exists, the network ID will be returned with error
+// ErrNetworkExists.
+func CreateNetwork(ctx context.Context, name string, opts *client.NetworkCreateOptions) (string, error) {
+	apiClient, err := client.New(client.FromEnv, client.WithUserAgent("vbmctl/"+config.Version))
+	if err != nil {
+		return "", err
+	}
+	defer apiClient.Close()
+
+	networkID, err := GetNetworkByName(ctx, name)
+	if !errors.Is(err, ErrNetworkNotFound) {
+		return "", err
+	}
+	if networkID != "" {
+		return networkID, ErrNetworkExists
+	}
+
+	createdNet, err := apiClient.NetworkCreate(ctx, name, *opts)
+	if err != nil {
+		return "", fmt.Errorf("failed to create network %s: %w", name, err)
+	}
+	return createdNet.ID, nil
+}
+
+// GetNetworkByName finds the network with given name. If multiple networks
+// is found, the first match will be returned.
+func GetNetworkByName(ctx context.Context, networkName string) (string, error) {
+	apiClient, err := client.New(client.FromEnv, client.WithUserAgent("vbmctl/"+config.Version))
+	if err != nil {
+		return "", err
+	}
+	defer apiClient.Close()
+
+	filters := client.Filters{}
+	filters.Add("name", networkName)
+	networks, err := apiClient.NetworkList(ctx, client.NetworkListOptions{
+		Filters: filters,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to look for Docker network with name %s: %w", networkName, err)
+	}
+	if len(networks.Items) == 0 {
+		return "", ErrNetworkNotFound
+	}
+	if len(networks.Items) > 1 {
+		log.Printf("Warning: found %d networks with name %s", len(networks.Items), networkName)
+	}
+	return networks.Items[0].Network.ID, nil
+}
+
+// DeleteNetwork deletes network with given ID. An error is returned if the network
+// could not be deleted.
+func DeleteNetwork(ctx context.Context, networkID string, opts *client.NetworkRemoveOptions) error {
+	apiClient, err := client.New(client.FromEnv, client.WithUserAgent("vbmctl/"+config.Version))
+	if err != nil {
+		return err
+	}
+	defer apiClient.Close()
+
+	_, err = apiClient.NetworkRemove(ctx, networkID, *opts)
+	if err != nil {
+		return fmt.Errorf("failed to remove Docker network %s: %w", networkID, err)
+	}
+
+	return nil
 }

--- a/test/vbmctl/pkg/containers/kindnetwork.go
+++ b/test/vbmctl/pkg/containers/kindnetwork.go
@@ -1,0 +1,88 @@
+//go:build vbmctl
+// +build vbmctl
+
+package containers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/netip"
+	"strconv"
+
+	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
+)
+
+// CreateBridgeNetworks takes the network definitions and creates Docker bridge
+// networks with the given configuration. No error is returned if the networks
+// exist. If an error is encountered, all the created networks are removed.
+func CreateBridgeNetworks(ctx context.Context, networks []vbmctlapi.DockerBridgeNetwork) ([]string, error) {
+	createdNetworks := make([]string, 0, len(networks))
+	for _, cfg := range networks {
+		net := cfg.Defaults()
+		subnetPrefix, err := netip.ParsePrefix(net.Subnet)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse subnet for Docker network %s: %w", net.Name, err)
+		}
+		networkOpts := client.NetworkCreateOptions{
+			Driver:     "bridge",
+			EnableIPv4: net.IPv4,
+			EnableIPv6: net.IPv6,
+			Options: map[string]string{
+				"com.docker.network.driver.mtu":  strconv.FormatUint(net.DriverMtu, 10),
+				"com.docker.network.bridge.name": net.BridgeName,
+			},
+			IPAM: &network.IPAM{
+				Config: []network.IPAMConfig{
+					{
+						Subnet: subnetPrefix,
+					},
+				},
+			},
+		}
+		createdID, err := CreateNetwork(ctx, net.Name, &networkOpts)
+		// Don't fail if the network exists
+		if errors.Is(err, ErrNetworkExists) {
+			log.Printf("Warning: network %s already exists, continuing.", net.Name)
+		} else if err != nil {
+			// Clean up previously created networks
+			log.Printf("Failed to create network %s, cleaning up %d previously created Docker networks", net.Name, len(createdNetworks))
+			for _, netID := range createdNetworks {
+				delErr := DeleteNetwork(ctx, netID, &client.NetworkRemoveOptions{})
+				if delErr != nil {
+					log.Printf("Warning: failed to clean up Docker network: %v", delErr)
+				}
+			}
+			return nil, fmt.Errorf("failed to create network: %w", err)
+		} else {
+			// Add network to the created list only if it really was created.
+			// In case of cleanup procedure, this avoids cleaning up existing
+			// networks.
+			createdNetworks = append(createdNetworks, createdID)
+		}
+	}
+	return createdNetworks, nil
+}
+
+// DeleteBridgeNetworks deletes the networks with given configurations.
+// The networks are deleted by their name, so other fields in the networks
+// are ignored.
+func DeleteBridgeNetworks(ctx context.Context, networks []vbmctlapi.DockerBridgeNetwork) error {
+	var latestErr error
+	for _, net := range networks {
+		networkID, err := GetNetworkByName(ctx, net.Name)
+		if err != nil {
+			log.Printf("Warning: failed to delete Docker network %s, could not get network ID", net.Name)
+			continue
+		}
+		err = DeleteNetwork(ctx, networkID, &client.NetworkRemoveOptions{})
+		if err != nil {
+			latestErr = fmt.Errorf("failed to remove docker network: %w", err)
+		}
+	}
+
+	return latestErr
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

This PR adds docker network management to vbmctl tool.

In addition, it adds tests and validation for libvirt networks and veth pairs.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #3062

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] E2E tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
