### PR TITLE
🌱 Centralize BMH cleanup in AfterEach via Cleanup function

### DIFF
--- a/test/e2e/automated_cleaning_test.go
+++ b/test/e2e/automated_cleaning_test.go
@@ -14,17 +14,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Automated cleaning", Label("required", "automated-cleaning"), func() {
 	var (
 		specName      = "automated-cleaning"
-		secretName    = "bmc-credentials"
 		namespace     *corev1.Namespace
 		cancelWatches context.CancelFunc
+		toCleanup     []client.Object
 	)
 
 	BeforeEach(func() {
+		toCleanup = nil
 		namespace, cancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
 			Creator:             clusterProxy.GetClient(),
 			ClientSet:           clusterProxy.GetClientSet(),
@@ -40,7 +42,8 @@ var _ = Describe("Automated cleaning", Label("required", "automated-cleaning"), 
 			"username": bmc.User,
 			"password": bmc.Password,
 		}
-		CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+		secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, "bmc-credentials", bmcCredentialsData)
+		toCleanup = append(toCleanup, secret)
 
 		By("Creating a BMH")
 		bmh := metal3api.BareMetalHost{
@@ -66,6 +69,7 @@ var _ = Describe("Automated cleaning", Label("required", "automated-cleaning"), 
 		}
 		err := clusterProxy.GetClient().Create(ctx, &bmh)
 		Expect(err).NotTo(HaveOccurred())
+		toCleanup = append(toCleanup, &bmh)
 
 		By("Waiting for the BMH to become available")
 		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
@@ -198,23 +202,12 @@ var _ = Describe("Automated cleaning", Label("required", "automated-cleaning"), 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(output).To(ContainSubstring("file not found"), "Test file /mnt/data/test_file_vdb.txt should have been cleaned")
 
-		By("Delete BMH")
-		err = clusterProxy.GetClient().Delete(ctx, &bmh)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Waiting for the BMH to be deleted")
-		WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
-			Client:    clusterProxy.GetClient(),
-			BmhName:   bmh.Name,
-			Namespace: bmh.Namespace,
-		}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
 	})
 	AfterEach(func() {
 		CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
 		DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
 		if !skipCleanup {
-			isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")
-			Cleanup(ctx, clusterProxy, namespace, cancelWatches, isNamespaced, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
+			Cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig, toCleanup)
 		}
 	})
 })

--- a/test/e2e/basic_ops_test.go
+++ b/test/e2e/basic_ops_test.go
@@ -14,20 +14,22 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("basic", Label("required", "basic"), func() {
 	var (
 		specName      = "basic-ops"
-		secretName    = "bmc-credentials"
 		namespace     *corev1.Namespace
 		cancelWatches context.CancelFunc
+		toCleanup     []client.Object
 	)
 	const (
 		rebootAnnotation   = "reboot.metal3.io"
 		poweroffAnnotation = "reboot.metal3.io/poweroff"
 	)
 	BeforeEach(func() {
+		toCleanup = nil
 		namespace, cancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
 			Creator:             clusterProxy.GetClient(),
 			ClientSet:           clusterProxy.GetClientSet(),
@@ -43,7 +45,8 @@ var _ = Describe("basic", Label("required", "basic"), func() {
 			"username": bmc.User,
 			"password": bmc.Password,
 		}
-		CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+		secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, "bmc-credentials", bmcCredentialsData)
+		toCleanup = append(toCleanup, secret)
 
 		By("creating a BMH")
 		bmh := metal3api.BareMetalHost{
@@ -67,6 +70,7 @@ var _ = Describe("basic", Label("required", "basic"), func() {
 		}
 		err := clusterProxy.GetClient().Create(ctx, &bmh)
 		Expect(err).NotTo(HaveOccurred())
+		toCleanup = append(toCleanup, &bmh)
 
 		By("waiting for the BMH to become available")
 		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
@@ -109,24 +113,13 @@ var _ = Describe("basic", Label("required", "basic"), func() {
 			State:  PoweredOn,
 		}, e2eConfig.GetIntervals(specName, "wait-power-state")...)
 
-		By("Delete BMH")
-		err = clusterProxy.GetClient().Delete(ctx, &bmh)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Waiting for the BMH to be deleted")
-		WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
-			Client:    clusterProxy.GetClient(),
-			BmhName:   bmh.Name,
-			Namespace: bmh.Namespace,
-		}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
 	})
 
 	AfterEach(func() {
 		CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
 		DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
 		if !skipCleanup {
-			isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")
-			Cleanup(ctx, clusterProxy, namespace, cancelWatches, isNamespaced, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
+			Cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig, toCleanup)
 		}
 	})
 })

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -289,6 +289,47 @@ func DeleteBmhsInNamespace(ctx context.Context, deleter client.Client, namespace
 	Expect(err).NotTo(HaveOccurred(), "Unable to delete BMHs")
 }
 
+// CleanupBMH deletes the given BMH and waits for it to be fully removed.
+// If the BMH has no name set (i.e. it was never created), it is a no-op.
+// This function is safe to use when tests run in parallel and share a namespace,
+// because it only deletes the specific BMH that belongs to the current test.
+func CleanupBMH(ctx context.Context, cl client.Client, bmh *metal3api.BareMetalHost, intervals ...interface{}) {
+	if bmh.Name == "" {
+		return
+	}
+	Logf("Cleaning up BMH %s/%s", bmh.Namespace, bmh.Name)
+	err := cl.Delete(ctx, bmh)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		Expect(err).NotTo(HaveOccurred(), "Unable to delete BMH %s/%s", bmh.Namespace, bmh.Name)
+	}
+	WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
+		Client:    cl,
+		BmhName:   bmh.Name,
+		Namespace: bmh.Namespace,
+	}, intervals...)
+}
+
+// DeleteSecretIfExists deletes the named secret from the given namespace if it exists.
+// If the secret does not exist, this is a no-op. It is used to clean up BMC
+// credentials secrets in namespace-scoped runs where the namespace is reused
+// between test runs, to prevent CreateSecret from failing on the next run.
+func DeleteSecretIfExists(ctx context.Context, cl client.Client, namespace, name string) {
+	if name == "" {
+		return
+	}
+	secret := &corev1.Secret{}
+	err := cl.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, secret)
+	if k8serrors.IsNotFound(err) {
+		return
+	}
+	Expect(err).NotTo(HaveOccurred(), "Unable to look up secret %s/%s", namespace, name)
+	err = cl.Delete(ctx, secret)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		Expect(err).NotTo(HaveOccurred(), "Unable to delete secret %s/%s", namespace, name)
+	}
+	Logf("Deleted secret %s/%s", namespace, name)
+}
+
 // WaitForBmhDeletedInput is the input for WaitForBmhDeleted.
 type WaitForBmhDeletedInput struct {
 	Client          client.Client
@@ -338,9 +379,22 @@ func WaitForNamespaceDeleted(ctx context.Context, input WaitForNamespaceDeletedI
 	}, intervals...).Should(BeTrue())
 }
 
-func Cleanup(ctx context.Context, clusterProxy framework.ClusterProxy, namespace *corev1.Namespace, cancelWatches context.CancelFunc, isNamespaced bool, intervals ...interface{}) {
-	// Due to limitation in controller runtime watched namespaces cannot be deleted
-	if !isNamespaced {
+// Cleanup cleans up resources created by a test. It should only be called when
+// skipCleanup is false. For cluster-scoped BMO (NAMESPACE_SCOPED=false), the entire
+// namespace is deleted, which implicitly removes all resources including BMHs and
+// secrets. For namespace-scoped BMO (NAMESPACE_SCOPED=true), the namespace is shared
+// across tests and must not be deleted; instead, we delete the objects in toCleanup
+// so that subsequent runs can start clean.
+// cancelWatches stops the namespace event watcher in both cases.
+func Cleanup(ctx context.Context, clusterProxy framework.ClusterProxy, namespace *corev1.Namespace, cancelWatches context.CancelFunc, cfg *Config, toCleanup []client.Object) {
+	if namespace == nil {
+		// The test was likely skipped before the namespace was created.
+		return
+	}
+
+	if !cfg.GetBoolVariable("NAMESPACE_SCOPED") {
+		// When not namespace-scoped, we can delete the whole namespace which
+		// takes care of all remaining resources.
 		// Trigger deletion of BMHs before deleting the namespace.
 		// This way there should be no risk of BMO getting stuck trying to progress
 		// and create HardwareDetails or similar, while the namespace is terminating.
@@ -352,9 +406,23 @@ func Cleanup(ctx context.Context, clusterProxy framework.ClusterProxy, namespace
 		WaitForNamespaceDeleted(ctx, WaitForNamespaceDeletedInput{
 			Getter:    clusterProxy.GetClient(),
 			Namespace: *namespace,
-		}, intervals...)
+		}, cfg.GetIntervals("default", "wait-namespace-deleted")...)
+	} else {
+		// When namespace-scoped, the namespace is reused between tests; clean up
+		// individual resources to allow the next run to start clean.
+		for _, obj := range toCleanup {
+			if bmh, ok := obj.(*metal3api.BareMetalHost); ok {
+				CleanupBMH(ctx, clusterProxy.GetClient(), bmh, cfg.GetIntervals("default", "wait-bmh-deleted")...)
+			} else {
+				if err := clusterProxy.GetClient().Delete(ctx, obj); err != nil && !k8serrors.IsNotFound(err) {
+					Expect(err).NotTo(HaveOccurred(), "Unable to delete %T %s/%s", obj, obj.GetNamespace(), obj.GetName())
+				}
+			}
+		}
 	}
-	cancelWatches()
+	if cancelWatches != nil {
+		cancelWatches()
+	}
 }
 
 type WaitForBmhInPowerStateInput struct {
@@ -382,8 +450,8 @@ func BuildKustomizeManifest(source string) ([]byte, error) {
 	return resources.AsYaml()
 }
 
-func CreateSecret(ctx context.Context, client client.Client, secretNamespace, secretName string, data map[string]string) {
-	secret := corev1.Secret{
+func CreateSecret(ctx context.Context, cl client.Client, secretNamespace, secretName string, data map[string]string) *corev1.Secret {
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: secretNamespace,
@@ -391,7 +459,8 @@ func CreateSecret(ctx context.Context, client client.Client, secretNamespace, se
 		StringData: data,
 	}
 
-	Expect(client.Create(ctx, &secret)).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create secret '%s/%s'", secretNamespace, secretName))
+	Expect(cl.Create(ctx, secret)).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create secret '%s/%s'", secretNamespace, secretName))
+	return secret
 }
 
 func executeSSHCommand(client *ssh.Client, command string) (string, error) {

--- a/test/e2e/external_inspection_test.go
+++ b/test/e2e/external_inspection_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const hardwareDetails = `
@@ -177,8 +178,10 @@ var _ = Describe("External Inspection", Label("required", "external-inspection")
 		specName      = "external-inspection"
 		namespace     *corev1.Namespace
 		cancelWatches context.CancelFunc
+		toCleanup     []client.Object
 	)
 	BeforeEach(func() {
+		toCleanup = nil
 		namespace, cancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
 			Creator:             clusterProxy.GetClient(),
 			ClientSet:           clusterProxy.GetClientSet(),
@@ -189,12 +192,14 @@ var _ = Describe("External Inspection", Label("required", "external-inspection")
 	})
 
 	It("should skip inspection and become available when a BMH has annotations with hardware details and inspection disabled", func() {
+		secretName := "bmc-credentials-annotation"
 		By("Creating a secret with BMH credentials")
 		bmcCredentialsData := map[string]string{
 			"username": bmc.User,
 			"password": bmc.Password,
 		}
-		CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, "bmc-credentials-annotation", bmcCredentialsData)
+		secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+		toCleanup = append(toCleanup, secret)
 
 		By("creating a BMH with inspection disabled and hardware details added")
 		bmh := metal3api.BareMetalHost{
@@ -209,7 +214,7 @@ var _ = Describe("External Inspection", Label("required", "external-inspection")
 			Spec: metal3api.BareMetalHostSpec{
 				BMC: metal3api.BMCDetails{
 					Address:                        bmc.Address,
-					CredentialsName:                "bmc-credentials-annotation",
+					CredentialsName:                secretName,
 					DisableCertificateVerification: bmc.DisableCertificateVerification,
 				},
 				BootMode:       metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
@@ -218,6 +223,7 @@ var _ = Describe("External Inspection", Label("required", "external-inspection")
 		}
 		err := clusterProxy.GetClient().Create(ctx, &bmh)
 		Expect(err).NotTo(HaveOccurred())
+		toCleanup = append(toCleanup, &bmh)
 
 		By("waiting for the BMH to become available")
 		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
@@ -235,26 +241,17 @@ var _ = Describe("External Inspection", Label("required", "external-inspection")
 		hwStatusJSON, err := json.Marshal(bmh.Status.HardwareDetails)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(hwStatusJSON).To(MatchJSON(hardwareDetails))
-
-		By("Delete BMH")
-		err = clusterProxy.GetClient().Delete(ctx, &bmh)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Waiting for the BMH to be deleted")
-		WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
-			Client:    clusterProxy.GetClient(),
-			BmhName:   bmh.Name,
-			Namespace: bmh.Namespace,
-		}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
 	})
 
 	It("should skip inspection and become available when HardwareData exists and BMH has inspection disabled", func() {
+		secretName := "bmc-credentials-hardware-data"
 		By("Creating a secret with BMH credentials")
 		bmcCredentialsData := map[string]string{
 			"username": bmc.User,
 			"password": bmc.Password,
 		}
-		CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, "bmc-credentials-hardware-data", bmcCredentialsData)
+		secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+		toCleanup = append(toCleanup, secret)
 
 		By("pre-creating a hardware data")
 		hwdata := metal3api.HardwareData{
@@ -280,7 +277,7 @@ var _ = Describe("External Inspection", Label("required", "external-inspection")
 			Spec: metal3api.BareMetalHostSpec{
 				BMC: metal3api.BMCDetails{
 					Address:                        bmc.Address,
-					CredentialsName:                "bmc-credentials-hardware-data",
+					CredentialsName:                secretName,
 					DisableCertificateVerification: bmc.DisableCertificateVerification,
 				},
 				BootMode:       metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
@@ -290,6 +287,7 @@ var _ = Describe("External Inspection", Label("required", "external-inspection")
 		}
 		err = clusterProxy.GetClient().Create(ctx, &bmh)
 		Expect(err).NotTo(HaveOccurred())
+		toCleanup = append(toCleanup, &bmh)
 
 		By("waiting for the BMH to become available")
 		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
@@ -308,25 +306,13 @@ var _ = Describe("External Inspection", Label("required", "external-inspection")
 		hwStatusJSON, err := json.Marshal(bmh.Status.HardwareDetails)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(hwStatusJSON).To(MatchJSON(hardwareDetails))
-
-		By("Delete BMH")
-		err = clusterProxy.GetClient().Delete(ctx, &bmh)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Waiting for the BMH to be deleted")
-		WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
-			Client:    clusterProxy.GetClient(),
-			BmhName:   bmh.Name,
-			Namespace: bmh.Namespace,
-		}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
 	})
 
 	AfterEach(func() {
 		CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
 		DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
 		if !skipCleanup {
-			isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")
-			Cleanup(ctx, clusterProxy, namespace, cancelWatches, isNamespaced, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
+			Cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig, toCleanup)
 		}
 	})
 })

--- a/test/e2e/externally_provisioned_test.go
+++ b/test/e2e/externally_provisioned_test.go
@@ -6,13 +6,11 @@ package e2e
 import (
 	"context"
 	"path"
-	"time"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cluster-api/test/framework"
@@ -23,12 +21,13 @@ var _ = Describe("Create as externally provisioned, deprovision", Label("require
 	func() {
 		var (
 			specName      = "externally-provisioned"
-			secretName    = "bmc-credentials"
 			namespace     *corev1.Namespace
 			cancelWatches context.CancelFunc
+			toCleanup     []client.Object
 		)
 
 		BeforeEach(func() {
+			toCleanup = nil
 			namespace, cancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
 				Creator:             clusterProxy.GetClient(),
 				ClientSet:           clusterProxy.GetClientSet(),
@@ -39,13 +38,14 @@ var _ = Describe("Create as externally provisioned, deprovision", Label("require
 		})
 
 		It("provisions a BMH as externally provisioned, validates state immutability, then deprovisions", func() {
-			testSecretName := secretName + "-external"
+			secretName := "bmc-credentials-external"
 			By("Creating a secret with BMH credentials")
 			bmcCredentialsData := map[string]string{
 				"username": bmc.User,
 				"password": bmc.Password,
 			}
-			CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, testSecretName, bmcCredentialsData)
+			secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+			toCleanup = append(toCleanup, secret)
 
 			By("Creating a BMH as externally provisioned")
 			bmh := metal3api.BareMetalHost{
@@ -57,7 +57,7 @@ var _ = Describe("Create as externally provisioned, deprovision", Label("require
 					Online: true,
 					BMC: metal3api.BMCDetails{
 						Address:                        bmc.Address,
-						CredentialsName:                testSecretName,
+						CredentialsName:                secretName,
 						DisableCertificateVerification: bmc.DisableCertificateVerification,
 					},
 					BootMACAddress:        bmc.BootMacAddress,
@@ -66,6 +66,7 @@ var _ = Describe("Create as externally provisioned, deprovision", Label("require
 			}
 			err := clusterProxy.GetClient().Create(ctx, &bmh)
 			Expect(err).NotTo(HaveOccurred())
+			toCleanup = append(toCleanup, &bmh)
 
 			By("Waiting for the BMH to become externally provisioned")
 			WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
@@ -107,45 +108,17 @@ var _ = Describe("Create as externally provisioned, deprovision", Label("require
 			Expect(bmh.Spec.ExternallyProvisioned).To(BeTrue(), "ExternallyProvisioned should still be true")
 			Expect(bmh.Status.Provisioning.State).To(Equal(metal3api.StateExternallyProvisioned))
 
-			By("Deleting the BMH")
-			// Wait for 2 seconds to allow time to confirm annotation is set
-			// TODO: fix this so we do not need the sleep
-			time.Sleep(2 * time.Second)
-
-			err = clusterProxy.GetClient().Delete(ctx, &bmh)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the BMH to be deleted")
-			WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
-				Client:    clusterProxy.GetClient(),
-				BmhName:   bmh.Name,
-				Namespace: bmh.Namespace,
-				UndesiredStates: []metal3api.ProvisioningState{
-					metal3api.StateProvisioning,
-					metal3api.StateRegistering,
-					metal3api.StateDeprovisioning,
-					metal3api.StateInspecting,
-				},
-			}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
-
-			By("Waiting for the secret to be deleted")
-			Eventually(func() bool {
-				err := clusterProxy.GetClient().Get(ctx, types.NamespacedName{
-					Name:      testSecretName,
-					Namespace: namespace.Name,
-				}, &corev1.Secret{})
-				return k8serrors.IsNotFound(err)
-			}, e2eConfig.GetIntervals(specName, "wait-secret-deletion")...).Should(BeTrue())
 		})
 
 		It("transitions from Available to ExternallyProvisioned", func() {
-			testSecretName := secretName + "-available-to-ext"
+			secretName := "bmc-credentials-available-to-ext"
 			By("Creating a secret with BMH credentials")
 			bmcCredentialsData := map[string]string{
 				"username": bmc.User,
 				"password": bmc.Password,
 			}
-			CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, testSecretName, bmcCredentialsData)
+			secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+			toCleanup = append(toCleanup, secret)
 
 			By("Creating a BMH without ExternallyProvisioned to allow inspection")
 			bmh := metal3api.BareMetalHost{
@@ -156,7 +129,7 @@ var _ = Describe("Create as externally provisioned, deprovision", Label("require
 				Spec: metal3api.BareMetalHostSpec{
 					BMC: metal3api.BMCDetails{
 						Address:                        bmc.Address,
-						CredentialsName:                testSecretName,
+						CredentialsName:                secretName,
 						DisableCertificateVerification: bmc.DisableCertificateVerification,
 					},
 					BootMode:              metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
@@ -166,6 +139,7 @@ var _ = Describe("Create as externally provisioned, deprovision", Label("require
 			}
 			err := clusterProxy.GetClient().Create(ctx, &bmh)
 			Expect(err).NotTo(HaveOccurred())
+			toCleanup = append(toCleanup, &bmh)
 
 			By("waiting for the BMH to be in inspecting state")
 			WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
@@ -213,32 +187,13 @@ var _ = Describe("Create as externally provisioned, deprovision", Label("require
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bmh.Status.OperationHistory.Provision.Start.IsZero()).To(BeTrue(), "BMO provisioning should not have occurred")
 
-			By("Cleaning up the BMH")
-			err = clusterProxy.GetClient().Delete(ctx, &bmh)
-			Expect(err).NotTo(HaveOccurred())
-
-			WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
-				Client:    clusterProxy.GetClient(),
-				BmhName:   bmh.Name,
-				Namespace: bmh.Namespace,
-			}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
-
-			By("Waiting for the secret to be deleted")
-			Eventually(func() bool {
-				err := clusterProxy.GetClient().Get(ctx, types.NamespacedName{
-					Name:      testSecretName,
-					Namespace: namespace.Name,
-				}, &corev1.Secret{})
-				return k8serrors.IsNotFound(err)
-			}, e2eConfig.GetIntervals(specName, "wait-secret-deletion")...).Should(BeTrue())
 		})
 
 		AfterEach(func() {
 			CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
 			DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
 			if !skipCleanup {
-				isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")
-				Cleanup(ctx, clusterProxy, namespace, cancelWatches, isNamespaced, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
+				Cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig, toCleanup)
 			}
 		})
 	})

--- a/test/e2e/firmware_settings_test.go
+++ b/test/e2e/firmware_settings_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // These example keys and values are hardcoded in sushy-tools.
@@ -37,6 +38,7 @@ var _ = Describe("Host Firmware Settings", Label("required", "firmware"), func()
 		specName      = "firmware-settings"
 		namespace     *corev1.Namespace
 		cancelWatches context.CancelFunc
+		toCleanup     []client.Object
 	)
 
 	BeforeEach(func() {
@@ -45,6 +47,7 @@ var _ = Describe("Host Firmware Settings", Label("required", "firmware"), func()
 			Skip("HFS tests require a real Ironic and a host with Redfish")
 		}
 
+		toCleanup = nil
 		namespace, cancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
 			Creator:             clusterProxy.GetClient(),
 			ClientSet:           clusterProxy.GetClientSet(),
@@ -63,7 +66,8 @@ var _ = Describe("Host Firmware Settings", Label("required", "firmware"), func()
 			"username": bmc.User,
 			"password": bmc.Password,
 		}
-		CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+		secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+		toCleanup = append(toCleanup, secret)
 
 		By("Creating a HostFirmwareSettings with modified value before BMH")
 		hfs := &metal3api.HostFirmwareSettings{
@@ -99,6 +103,7 @@ var _ = Describe("Host Firmware Settings", Label("required", "firmware"), func()
 			},
 		}
 		Expect(clusterProxy.GetClient().Create(ctx, &bmh)).To(Succeed())
+		toCleanup = append(toCleanup, &bmh)
 
 		By("Waiting for the BMH to start preparing")
 		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
@@ -251,7 +256,8 @@ var _ = Describe("Host Firmware Settings", Label("required", "firmware"), func()
 			"username": bmc.User,
 			"password": bmc.Password,
 		}
-		CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+		secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+		toCleanup = append(toCleanup, secret)
 
 		By("Creating a BMH with inspection and cleaning disabled")
 		bmh := metal3api.BareMetalHost{
@@ -273,6 +279,7 @@ var _ = Describe("Host Firmware Settings", Label("required", "firmware"), func()
 			},
 		}
 		Expect(clusterProxy.GetClient().Create(ctx, &bmh)).To(Succeed())
+		toCleanup = append(toCleanup, &bmh)
 
 		By("Waiting for the BMH to become available")
 		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
@@ -427,8 +434,7 @@ var _ = Describe("Host Firmware Settings", Label("required", "firmware"), func()
 		CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
 		DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
 		if !skipCleanup {
-			isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")
-			Cleanup(ctx, clusterProxy, namespace, cancelWatches, isNamespaced, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
+			Cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig, toCleanup)
 		}
 	})
 })

--- a/test/e2e/forced_detachment_test.go
+++ b/test/e2e/forced_detachment_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Start provisioning, force detachment, delete and recreate, provision, detach again and delete", Label("required", "provision", "detach", "force-detach"),
@@ -25,9 +26,12 @@ var _ = Describe("Start provisioning, force detachment, delete and recreate, pro
 			namespace     *corev1.Namespace
 			cancelWatches context.CancelFunc
 			forceTrue     = ptr.To("{\"force\": true}")
+			toCleanup     []client.Object
 		)
 
 		BeforeEach(func() {
+			toCleanup = nil
+
 			// NOTE(dtantsur): these tests are racy on fixtures
 			if !e2eConfig.GetBoolVariable("DEPLOY_IRONIC") {
 				Skip("Tests on forced detachment rely on using Ironic and processes that take non-zero time")
@@ -51,7 +55,8 @@ var _ = Describe("Start provisioning, force detachment, delete and recreate, pro
 				"username": bmc.User,
 				"password": bmc.Password,
 			}
-			CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+			secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+			toCleanup = append(toCleanup, secret)
 
 			By("Creating a BMH")
 			bmh := metal3api.BareMetalHost{
@@ -144,7 +149,8 @@ var _ = Describe("Start provisioning, force detachment, delete and recreate, pro
 				"username": bmc.User,
 				"password": bmc.Password,
 			}
-			CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+			secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+			toCleanup = append(toCleanup, secret)
 
 			By("Creating a BMH with inspection and cleaning disabled")
 			bmh := metal3api.BareMetalHost{
@@ -256,7 +262,8 @@ var _ = Describe("Start provisioning, force detachment, delete and recreate, pro
 				"username": bmc.User,
 				"password": bmc.Password,
 			}
-			CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+			secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+			toCleanup = append(toCleanup, secret)
 
 			By("Creating a BMH with inspection and cleaning disabled")
 			bmh := metal3api.BareMetalHost{
@@ -407,8 +414,7 @@ var _ = Describe("Start provisioning, force detachment, delete and recreate, pro
 			CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
 			DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
 			if !skipCleanup {
-				isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")
-				Cleanup(ctx, clusterProxy, namespace, cancelWatches, isNamespaced, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
+				Cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig, toCleanup)
 			}
 		})
 	})

--- a/test/e2e/inspection_test.go
+++ b/test/e2e/inspection_test.go
@@ -16,17 +16,18 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Inspection", Label("required", "inspection"), func() {
 	var (
 		specName      = "inspection"
-		secretName    = "bmc-credentials"
 		namespace     *corev1.Namespace
 		cancelWatches context.CancelFunc
+		toCleanup     []client.Object
 	)
 	BeforeEach(func() {
-
+		toCleanup = nil
 		isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")
 
 		namespaceInput := framework.CreateNamespaceAndWatchEventsInput{
@@ -55,6 +56,7 @@ var _ = Describe("Inspection", Label("required", "inspection"), func() {
 		}
 		err := clusterProxy.GetClient().Create(ctx, &bmh)
 		Expect(err).NotTo(HaveOccurred())
+		toCleanup = append(toCleanup, &bmh)
 
 		By("waiting for the BMH to be in unmanaged state")
 		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
@@ -63,16 +65,6 @@ var _ = Describe("Inspection", Label("required", "inspection"), func() {
 			State:  metal3api.StateUnmanaged,
 		}, e2eConfig.GetIntervals(specName, "wait-unmanaged")...)
 
-		By("Delete BMH")
-		err = clusterProxy.GetClient().Delete(ctx, &bmh)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Waiting for the BMH to be deleted")
-		WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
-			Client:    clusterProxy.GetClient(),
-			BmhName:   bmh.Name,
-			Namespace: bmh.Namespace,
-		}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
 	})
 
 	It("should fail to register the BMH if the secret is missing", func() {
@@ -92,6 +84,7 @@ var _ = Describe("Inspection", Label("required", "inspection"), func() {
 		}
 		err := clusterProxy.GetClient().Create(ctx, &bmh)
 		Expect(err).NotTo(HaveOccurred())
+		toCleanup = append(toCleanup, &bmh)
 
 		By("trying to register the BMH")
 		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
@@ -106,17 +99,6 @@ var _ = Describe("Inspection", Label("required", "inspection"), func() {
 			g.Expect(clusterProxy.GetClient().Get(ctx, key, &bmh)).To(Succeed())
 			g.Expect(bmh.Status.ErrorType).To(Equal(metal3api.RegistrationError))
 		}, e2eConfig.GetIntervals(specName, "wait-registration-error")...).Should(Succeed())
-
-		By("Delete BMH")
-		err = clusterProxy.GetClient().Delete(ctx, &bmh)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Waiting for the BMH to be deleted")
-		WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
-			Client:    clusterProxy.GetClient(),
-			BmhName:   bmh.Name,
-			Namespace: bmh.Namespace,
-		}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
 	})
 
 	It("should inspect a newly created BMH", func() {
@@ -126,7 +108,8 @@ var _ = Describe("Inspection", Label("required", "inspection"), func() {
 			"username": bmc.User,
 			"password": bmc.Password,
 		}
-		CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+		secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, "bmc-credentials", bmcCredentialsData)
+		toCleanup = append(toCleanup, secret)
 
 		By("creating a BMH")
 		bmh := metal3api.BareMetalHost{
@@ -146,6 +129,7 @@ var _ = Describe("Inspection", Label("required", "inspection"), func() {
 		}
 		err := clusterProxy.GetClient().Create(ctx, &bmh)
 		Expect(err).NotTo(HaveOccurred())
+		toCleanup = append(toCleanup, &bmh)
 
 		By("waiting for the BMH to be in inspecting state")
 		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
@@ -167,25 +151,13 @@ var _ = Describe("Inspection", Label("required", "inspection"), func() {
 		} else {
 			Logf("WARNING: Skipping boot source verification since SSH_CHECK_PROVISIONED != true")
 		}
-
-		By("Delete BMH")
-		err = clusterProxy.GetClient().Delete(ctx, &bmh)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Waiting for the BMH to be deleted")
-		WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
-			Client:    clusterProxy.GetClient(),
-			BmhName:   bmh.Name,
-			Namespace: bmh.Namespace,
-		}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
 	})
 
 	AfterEach(func() {
 		CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
 		DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
 		if !skipCleanup {
-			isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")
-			Cleanup(ctx, clusterProxy, namespace, cancelWatches, isNamespaced, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
+			Cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig, toCleanup)
 		}
 	})
 })

--- a/test/e2e/live_iso_test.go
+++ b/test/e2e/live_iso_test.go
@@ -16,18 +16,21 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Live-ISO", Label("required", "live-iso"), func() {
 	var (
 		specName      = "live-iso-ops"
-		secretName    = "bmc-credentials"
 		namespace     *corev1.Namespace
 		cancelWatches context.CancelFunc
 		imageURL      string
+		toCleanup     []client.Object
 	)
 
 	BeforeEach(func() {
+		toCleanup = nil
+
 		// Check what kind of BMC we are dealing with
 		// It may be *possible* to boot a live-ISO over (i)PXE, but there are severe limitations.
 		// Therefore we skip the test if it doesn't support ISO preprovisioning images.
@@ -55,7 +58,8 @@ var _ = Describe("Live-ISO", Label("required", "live-iso"), func() {
 			"username": bmc.User,
 			"password": bmc.Password,
 		}
-		CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+		secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, "bmc-credentials", bmcCredentialsData)
+		toCleanup = append(toCleanup, secret)
 
 		By("Creating a BMH with inspection disabled and hardware details added")
 		bmh := metal3api.BareMetalHost{
@@ -71,7 +75,7 @@ var _ = Describe("Live-ISO", Label("required", "live-iso"), func() {
 				Online: true,
 				BMC: metal3api.BMCDetails{
 					Address:                        bmc.Address,
-					CredentialsName:                secretName,
+					CredentialsName:                "bmc-credentials",
 					DisableCertificateVerification: bmc.DisableCertificateVerification,
 				},
 				Image: &metal3api.Image{
@@ -85,6 +89,7 @@ var _ = Describe("Live-ISO", Label("required", "live-iso"), func() {
 		}
 		err := clusterProxy.GetClient().Create(ctx, &bmh)
 		Expect(err).NotTo(HaveOccurred())
+		toCleanup = append(toCleanup, &bmh)
 
 		By("Waiting for the BMH to be in provisioning state")
 		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
@@ -131,24 +136,13 @@ var _ = Describe("Live-ISO", Label("required", "live-iso"), func() {
 			State:  metal3api.StateAvailable,
 		}, e2eConfig.GetIntervals(specName, "wait-available")...)
 
-		By("Delete BMH")
-		err = clusterProxy.GetClient().Delete(ctx, &bmh)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Waiting for the BMH to be deleted")
-		WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
-			Client:    clusterProxy.GetClient(),
-			BmhName:   bmh.Name,
-			Namespace: bmh.Namespace,
-		}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
 	})
 
 	AfterEach(func() {
 		CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
 		DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
 		if !skipCleanup {
-			isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")
-			Cleanup(ctx, clusterProxy, namespace, cancelWatches, isNamespaced, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
+			Cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig, toCleanup)
 		}
 	})
 })

--- a/test/e2e/provisioning_and_annotation_test.go
+++ b/test/e2e/provisioning_and_annotation_test.go
@@ -17,18 +17,20 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Provision, detach, recreate from status and deprovision", Label("required", "provision", "detach", "status", "deprovision"),
 	func() {
 		var (
 			specName      = "provisioning-ops"
-			secretName    = "bmc-credentials"
 			namespace     *corev1.Namespace
 			cancelWatches context.CancelFunc
+			toCleanup     []client.Object
 		)
 
 		BeforeEach(func() {
+			toCleanup = nil
 			namespace, cancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
 				Creator:             clusterProxy.GetClient(),
 				ClientSet:           clusterProxy.GetClientSet(),
@@ -44,7 +46,8 @@ var _ = Describe("Provision, detach, recreate from status and deprovision", Labe
 				"username": bmc.User,
 				"password": bmc.Password,
 			}
-			CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+			secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, "bmc-credentials", bmcCredentialsData)
+			toCleanup = append(toCleanup, secret)
 
 			By("Creating a BMH with inspection disabled and hardware details added")
 			bmh := metal3api.BareMetalHost{
@@ -70,6 +73,7 @@ var _ = Describe("Provision, detach, recreate from status and deprovision", Labe
 			}
 			err := clusterProxy.GetClient().Create(ctx, &bmh)
 			Expect(err).NotTo(HaveOccurred())
+			toCleanup = append(toCleanup, &bmh)
 
 			By("Waiting for the BMH to become available")
 			WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
@@ -190,7 +194,7 @@ var _ = Describe("Provision, detach, recreate from status and deprovision", Labe
 				"username": bmc.User,
 				"password": bmc.Password,
 			}
-			CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+			CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, "bmc-credentials", bmcCredentialsData)
 
 			By("Recreating the BMH with the previously saved status in the status annotation")
 			bmh = metal3api.BareMetalHost{
@@ -221,6 +225,7 @@ var _ = Describe("Provision, detach, recreate from status and deprovision", Labe
 
 			err = clusterProxy.GetClient().Create(ctx, &bmh)
 			Expect(err).NotTo(HaveOccurred())
+			toCleanup = append(toCleanup, &bmh)
 
 			By("Checking that the BMH goes directly to 'provisioned' state")
 			WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
@@ -255,24 +260,13 @@ var _ = Describe("Provision, detach, recreate from status and deprovision", Labe
 				State:  metal3api.StateAvailable,
 			}, e2eConfig.GetIntervals(specName, "wait-available")...)
 
-			By("Delete BMH")
-			err = clusterProxy.GetClient().Delete(ctx, &bmh)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the BMH to be deleted")
-			WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
-				Client:    clusterProxy.GetClient(),
-				BmhName:   bmh.Name,
-				Namespace: bmh.Namespace,
-			}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
 		})
 
 		AfterEach(func() {
 			CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
 			DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
 			if !skipCleanup {
-				isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")
-				Cleanup(ctx, clusterProxy, namespace, cancelWatches, isNamespaced, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
+				Cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig, toCleanup)
 			}
 		})
 	})

--- a/test/e2e/re_inspection_test.go
+++ b/test/e2e/re_inspection_test.go
@@ -16,19 +16,22 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Re-Inspection", Label("required", "re-inspection"), func() {
 	var (
 		specName      = "re-inspection"
-		secretName    = "bmc-credentials"
 		namespace     *corev1.Namespace
 		cancelWatches context.CancelFunc
+		toCleanup     []client.Object
 	)
 	const (
 		wrongHostName = "wrongHostName"
 	)
 	BeforeEach(func() {
+		toCleanup = nil
+
 		namespace, cancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
 			Creator:             clusterProxy.GetClient(),
 			ClientSet:           clusterProxy.GetClientSet(),
@@ -44,7 +47,8 @@ var _ = Describe("Re-Inspection", Label("required", "re-inspection"), func() {
 			"username": bmc.User,
 			"password": bmc.Password,
 		}
-		CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+		secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, "bmc-credentials", bmcCredentialsData)
+		toCleanup = append(toCleanup, secret)
 
 		By("creating a BMH with inspection disabled and hardware details added with wrong HostName")
 		newHardwareDetails := strings.Replace(hardwareDetails, "localhost.localdomain", wrongHostName, 1)
@@ -69,6 +73,7 @@ var _ = Describe("Re-Inspection", Label("required", "re-inspection"), func() {
 		}
 		err := clusterProxy.GetClient().Create(ctx, &bmh)
 		Expect(err).NotTo(HaveOccurred())
+		toCleanup = append(toCleanup, &bmh)
 
 		By("waiting for the BMH to become available")
 		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
@@ -108,24 +113,13 @@ var _ = Describe("Re-Inspection", Label("required", "re-inspection"), func() {
 		// We are just checking that it changed from wrongHostName to something else.
 		Expect(bmh.Status.HardwareDetails.Hostname).To(Not(Equal(wrongHostName)))
 
-		By("Delete BMH")
-		err = clusterProxy.GetClient().Delete(ctx, &bmh)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Waiting for the BMH to be deleted")
-		WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
-			Client:    clusterProxy.GetClient(),
-			BmhName:   bmh.Name,
-			Namespace: bmh.Namespace,
-		}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
 	})
 
 	AfterEach(func() {
 		CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
 		DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
 		if !skipCleanup {
-			isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")
-			Cleanup(ctx, clusterProxy, namespace, cancelWatches, isNamespaced, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
+			Cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig, toCleanup)
 		}
 	})
 })

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -114,6 +114,8 @@ func RunUpgradeTest(ctx context.Context, input *BMOIronicUpgradeInput, upgradeCl
 		"password": bmc.Password,
 	}
 	secretName := "bmc-credentials"
+	// Delete any leftover secret from a previous run (namespace may be reused with IgnoreAlreadyExists).
+	DeleteSecretIfExists(ctx, upgradeClusterProxy.GetClient(), namespace.Name, secretName)
 	CreateSecret(ctx, upgradeClusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
 
 	By("Creating a BMH with inspection disabled and hardware details added")
@@ -318,6 +320,9 @@ var _ = Describe("Upgrade", Ordered, Label("optional", "upgrade"), func() {
 		DumpResources(ctx, e2eConfig, upgradeClusterProxy, testArtifactFolder, upgradeIronicIP)
 		if !skipCleanup {
 			if e2eConfig.GetBoolVariable("UPGRADE_USE_EXISTING_CLUSTER") {
+				if namespace == nil {
+					return
+				}
 				// Trigger deletion of BMHs before deleting the namespace.
 				// This way there should be no risk of BMO getting stuck trying to progress
 				// and create HardwareDetails or similar, while the namespace is terminating.


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove manual BMH deletion code from individual test cases and rely on
the unified Cleanup function instead.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #3195

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
