### PR TITLE
:bug: Fix reconciling HFS created before BMH and add e2e tests

### DIFF
--- a/config/overlays/e2e/firmware-settings/kustomization.yaml
+++ b/config/overlays/e2e/firmware-settings/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../roles-rolebindings
+- namespace.yaml
+
+namespace: firmware-settings

--- a/config/overlays/e2e/firmware-settings/namespace.yaml
+++ b/config/overlays/e2e/firmware-settings/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: firmware-settings

--- a/config/overlays/e2e/kustomization.yaml
+++ b/config/overlays/e2e/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - ./basic-ops
 - ./external-inspection
 - ./externally-provisioned
+- ./firmware-settings
 - ./inspection
 - ./live-iso-ops
 - ./provisioning-ops

--- a/config/overlays/e2e/namespaced-manager-patch.yaml
+++ b/config/overlays/e2e/namespaced-manager-patch.yaml
@@ -9,5 +9,5 @@ spec:
       containers:
       - env:
         - name: WATCH_NAMESPACE
-          value: basic-ops,external-inspection,externally-provisioned,inspection,live-iso-ops,provisioning-ops,re-inspection,automated-cleaning,upgrade-bmo,upgrade-ironic
+          value: basic-ops,external-inspection,externally-provisioned,firmware-settings,inspection,live-iso-ops,provisioning-ops,re-inspection,automated-cleaning,upgrade-bmo,upgrade-ironic
         name: manager

--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -951,7 +951,7 @@ func (r *BareMetalHostReconciler) registerHost(ctx context.Context, prov provisi
 		} else {
 			if err = r.createHostFirmwareSettings(ctx, info); err != nil {
 				info.log.Info("failed creating hostfirmwaresettings")
-				return actionError{fmt.Errorf("failed to validate BMC access: %w", err)}
+				return actionError{fmt.Errorf("failed to create or update hostFirmwareSettings: %w", err)}
 			}
 			if supportsFirmwareComponents {
 				if err = r.createHostFirmwareComponents(ctx, info); err != nil {
@@ -2088,8 +2088,8 @@ func (r *BareMetalHostReconciler) createHostFirmwareSettings(ctx context.Context
 			hfs.Spec.Settings = make(metal3api.DesiredSettingsMap)
 
 			// Set bmh as owner, this makes sure the resource is deleted when bmh is deleted
-			if err = controllerutil.SetControllerReference(info.host, hfs, r.Scheme()); err != nil {
-				return fmt.Errorf("could not set bmh as controller: %w", err)
+			if err = controllerutil.SetOwnerReference(info.host, hfs, r.Scheme()); err != nil {
+				return fmt.Errorf("could not set bmh as owner: %w", err)
 			}
 			if err = r.Create(ctx, hfs); err != nil {
 				return fmt.Errorf("failure creating hostFirmwareSettings resource: %w", err)
@@ -2099,6 +2099,15 @@ func (r *BareMetalHostReconciler) createHostFirmwareSettings(ctx context.Context
 		} else {
 			// Error reading the object
 			return fmt.Errorf("could not load hostFirmwareSettings resource: %w", err)
+		}
+	}
+
+	if !ownerReferenceExists(info.host, hfs) {
+		if err := controllerutil.SetOwnerReference(info.host, hfs, r.Scheme()); err != nil {
+			return fmt.Errorf("could not set bmh as owner for hostFirmwareSettings: %w", err)
+		}
+		if err := r.Update(ctx, hfs); err != nil {
+			return fmt.Errorf("failure updating hostFirmwareSettings resource: %w", err)
 		}
 	}
 

--- a/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
+++ b/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
@@ -246,10 +246,22 @@ func (r *HostFirmwareComponentsReconciler) SetupWithManager(mgr ctrl.Manager, ma
 		Complete(r)
 }
 
+// updateEventHandler ensures no reconciliation happens for unimportant changes like finalizers or annotations.
 func (r *HostFirmwareComponentsReconciler) updateEventHandler(e event.UpdateEvent) bool {
-	r.Log.Info("hostfirmwarecomponents in event handler")
+	// If the update increased the resource Generation then let's process it
+	if e.ObjectNew.GetGeneration() != e.ObjectOld.GetGeneration() {
+		return true
+	}
 
-	return e.ObjectNew.GetGeneration() != e.ObjectOld.GetGeneration()
+	// NOTE(dtantsur): the only realistic case of a changed owner reference is when pre-created HFC is adopted by a BMH that was created later.
+	// In this case, it's reasonable to reconcile the resource using the information from the new BMH.
+	if !reflect.DeepEqual(e.ObjectNew.GetOwnerReferences(), e.ObjectOld.GetOwnerReferences()) {
+		r.Log.Info("processing event for changed owner reference", "namespace", e.ObjectNew.GetNamespace(), "name", e.ObjectNew.GetName())
+		return true
+	}
+
+	r.Log.V(1).Info("ignoring event that did not change generation or owners", "namespace", e.ObjectNew.GetNamespace(), "name", e.ObjectNew.GetName())
+	return false
 }
 
 func (r *HostFirmwareComponentsReconciler) validateHostFirmwareComponents(info *rhfcInfo) []error {

--- a/internal/controller/metal3.io/hostfirmwaresettings_controller.go
+++ b/internal/controller/metal3.io/hostfirmwaresettings_controller.go
@@ -371,15 +371,21 @@ func (r *HostFirmwareSettingsReconciler) SetupWithManager(mgr ctrl.Manager, maxC
 		Complete(r)
 }
 
+// updateEventHandler ensures no reconciliation happens for unimportant changes like finalizers or annotations.
 func (r *HostFirmwareSettingsReconciler) updateEventHandler(e event.UpdateEvent) bool {
-	r.Log.Info("hostfirmwaresettings in event handler")
-
 	// If the update increased the resource Generation then let's process it
 	if e.ObjectNew.GetGeneration() != e.ObjectOld.GetGeneration() {
-		r.Log.Info("returning true as generation changed from event handler")
 		return true
 	}
 
+	// NOTE(dtantsur): the only realistic case of a changed owner reference is when pre-created HFS is adopted by a BMH that was created later.
+	// In this case, it's reasonable to reconcile the resource using the information from the new BMH.
+	if !reflect.DeepEqual(e.ObjectNew.GetOwnerReferences(), e.ObjectOld.GetOwnerReferences()) {
+		r.Log.Info("processing event for changed owner reference", "namespace", e.ObjectNew.GetNamespace(), "name", e.ObjectNew.GetName())
+		return true
+	}
+
+	r.Log.V(1).Info("ignoring event that did not change generation or owners", "namespace", e.ObjectNew.GetNamespace(), "name", e.ObjectNew.GetName())
 	return false
 }
 

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -26,6 +26,7 @@ import (
 	irsov1alpha1 "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
 	"golang.org/x/crypto/ssh"
 	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/apps/v1"
@@ -996,4 +997,14 @@ func ConfigureProvisioningNetwork(ctx context.Context, clusterName string, provi
 	} else {
 		Logf("Provisioning network configured successfully")
 	}
+}
+
+// ContainCondition is a Gomega matcher for Kubernetes conditions.
+func ContainCondition(conditionType string, conditionStatus metav1.ConditionStatus) gomegatypes.GomegaMatcher {
+	return ContainElement(
+		And(
+			HaveField("Type", conditionType),
+			HaveField("Status", conditionStatus),
+		),
+	)
 }

--- a/test/e2e/config/ironic.yaml
+++ b/test/e2e/config/ironic.yaml
@@ -82,6 +82,9 @@ intervals:
   default/wait-secret-deletion: [ "1m", "1s" ]
   default/wait-connect-ssh: [ "2m", "10s" ]
   default/wait-externally-provisioned: [ "1m", "10ms" ]
+  default/wait-servicing: [ "1m", "100ms" ]
+  default/wait-firmware-settings: [ "15m", "1s" ]
+  default/wait-reconcile: [ "1s", "10ms" ]
 
 kindExtraPortMappings:
 # Expose Ironic ports so they are reachable outside of kind

--- a/test/e2e/firmware_settings_test.go
+++ b/test/e2e/firmware_settings_test.go
@@ -1,0 +1,434 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"path"
+	"strings"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/util/patch"
+)
+
+// These example keys and values are hardcoded in sushy-tools.
+// Warning: be careful when updating or reusing any keys: updated values will be persisted in the emulator between tests!
+const (
+	hfsTestKey1       = "ProcTurboMode"
+	hfsTestOrigValue1 = "Enabled"
+	hfsTestNewValue1  = "Disabled"
+	hfsTestKey2       = "QuietBoot"
+	hfsTestOrigValue2 = "true"
+	hfsTestNewValue2  = "false"
+)
+
+var _ = Describe("Host Firmware Settings", Label("required", "firmware"), func() {
+	var (
+		specName      = "firmware-settings"
+		namespace     *corev1.Namespace
+		cancelWatches context.CancelFunc
+	)
+
+	BeforeEach(func() {
+		// FIXME(dtantsur): find a more elegant way to check for this feature
+		if !e2eConfig.GetBoolVariable("DEPLOY_IRONIC") || !strings.Contains(bmc.Address, "redfish") {
+			Skip("HFS tests require a real Ironic and a host with Redfish")
+		}
+
+		namespace, cancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
+			Creator:             clusterProxy.GetClient(),
+			ClientSet:           clusterProxy.GetClientSet(),
+			Name:                specName,
+			LogFolder:           artifactFolder,
+			IgnoreAlreadyExists: true,
+		})
+	})
+
+	It("should apply firmware settings created before the host, then apply a new value for available host", func() {
+		bmhName := specName + "-before-bmh"
+		secretName := bmhName + "-bmc"
+
+		By("Creating a secret with BMH credentials")
+		bmcCredentialsData := map[string]string{
+			"username": bmc.User,
+			"password": bmc.Password,
+		}
+		CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+
+		By("Creating a HostFirmwareSettings with modified value before BMH")
+		hfs := &metal3api.HostFirmwareSettings{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			},
+			Spec: metal3api.HostFirmwareSettingsSpec{
+				Settings: metal3api.DesiredSettingsMap{
+					hfsTestKey1: intstr.FromString(hfsTestNewValue1),
+				},
+			},
+		}
+		Expect(clusterProxy.GetClient().Create(ctx, hfs)).To(Succeed())
+
+		By("Creating a BMH with inspection and cleaning disabled")
+		bmh := metal3api.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			},
+			Spec: metal3api.BareMetalHostSpec{
+				Online: true,
+				BMC: metal3api.BMCDetails{
+					Address:                        bmc.Address,
+					CredentialsName:                secretName,
+					DisableCertificateVerification: bmc.DisableCertificateVerification,
+				},
+				BootMode:              metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
+				BootMACAddress:        bmc.BootMacAddress,
+				AutomatedCleaningMode: metal3api.CleaningModeDisabled,
+				InspectionMode:        metal3api.InspectionModeDisabled,
+			},
+		}
+		Expect(clusterProxy.GetClient().Create(ctx, &bmh)).To(Succeed())
+
+		By("Waiting for the BMH to start preparing")
+		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.StatePreparing,
+		}, e2eConfig.GetIntervals(specName, "wait-available")...)
+
+		By("Waiting for the BMH to become available")
+		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.StateAvailable,
+		}, e2eConfig.GetIntervals(specName, "wait-firmware-settings")...)
+
+		By("Verifying the firmware setting was applied in HFS status")
+		Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+			Name:      bmhName,
+			Namespace: namespace.Name,
+		}, hfs)).To(Succeed())
+		Expect(hfs.Status.Settings).To(HaveKeyWithValue(hfsTestKey1, hfsTestNewValue1))
+		Expect(hfs.Status.Conditions).To(ContainCondition(string(metal3api.FirmwareSettingsValid), metav1.ConditionTrue))
+		Expect(hfs.Status.Conditions).To(ContainCondition(string(metal3api.FirmwareSettingsChangeDetected), metav1.ConditionFalse))
+
+		By("Checking firmware schema")
+		fSchema := &metal3api.FirmwareSchema{}
+		Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+			Name:      hfs.Status.FirmwareSchema.Name,
+			Namespace: hfs.Status.FirmwareSchema.Namespace,
+		}, fSchema)).To(Succeed())
+		Expect(fSchema.Spec.Schema).To(HaveKey(hfsTestKey1))
+		Expect(fSchema.Spec.Schema).To(HaveKey(hfsTestKey2))
+
+		By("Deleting the BMH to get rid of cached values")
+		Expect(clusterProxy.GetClient().Delete(ctx, &bmh)).To(Succeed())
+
+		By("Waiting for the BMH to be deleted")
+		WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
+			Client:    clusterProxy.GetClient(),
+			BmhName:   bmhName,
+			Namespace: namespace.Name,
+		}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
+
+		By("Making sure HFS was deleted too")
+		Eventually(func() bool {
+			return k8serrors.IsNotFound(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			}, hfs))
+		}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...).Should(BeTrue())
+
+		By("Creating a secret with BMH credentials again")
+		CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+
+		By("Re-creating the BMH to check that the settings were saved in the backend")
+		bmh = metal3api.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			},
+			Spec: metal3api.BareMetalHostSpec{
+				Online: true,
+				BMC: metal3api.BMCDetails{
+					Address:                        bmc.Address,
+					CredentialsName:                secretName,
+					DisableCertificateVerification: bmc.DisableCertificateVerification,
+				},
+				BootMode:              metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
+				BootMACAddress:        bmc.BootMacAddress,
+				AutomatedCleaningMode: metal3api.CleaningModeDisabled,
+				InspectionMode:        metal3api.InspectionModeDisabled,
+			},
+		}
+		Expect(clusterProxy.GetClient().Create(ctx, &bmh)).To(Succeed())
+
+		By("Waiting for the BMH to become available")
+		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.StateAvailable,
+		}, e2eConfig.GetIntervals(specName, "wait-available")...)
+
+		By("Verifying the updated firmware setting in HFS status")
+		Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+			Name:      bmhName,
+			Namespace: namespace.Name,
+		}, hfs)).To(Succeed())
+		Expect(hfs.Status.Settings).To(HaveKeyWithValue(hfsTestKey1, hfsTestNewValue1))
+		Expect(hfs.Status.Conditions).To(ContainCondition(string(metal3api.FirmwareSettingsValid), metav1.ConditionTrue))
+		Expect(hfs.Status.Conditions).To(ContainCondition(string(metal3api.FirmwareSettingsChangeDetected), metav1.ConditionFalse))
+
+		By("Updating HostFirmwareSettings with the original value")
+		helper, err := patch.NewHelper(hfs, clusterProxy.GetClient())
+		Expect(err).NotTo(HaveOccurred())
+		hfs.Spec.Settings = metal3api.DesiredSettingsMap{
+			hfsTestKey1: intstr.FromString(hfsTestOrigValue1),
+		}
+		Expect(helper.Patch(ctx, hfs)).To(Succeed())
+
+		By("Verifying the conditions on firmware setting")
+		Eventually(func(g Gomega) {
+			g.Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			}, hfs)).To(Succeed())
+			g.Expect(hfs.Status.Conditions).To(ContainCondition(string(metal3api.FirmwareSettingsValid), metav1.ConditionTrue))
+			g.Expect(hfs.Status.Conditions).To(ContainCondition(string(metal3api.FirmwareSettingsChangeDetected), metav1.ConditionTrue))
+		}, e2eConfig.GetIntervals(specName, "wait-reconcile")...).Should(Succeed())
+
+		By("Waiting for the BMH to start preparing")
+		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.StatePreparing,
+		}, e2eConfig.GetIntervals(specName, "wait-available")...)
+
+		By("Waiting for the BMH to become available")
+		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.StateAvailable,
+		}, e2eConfig.GetIntervals(specName, "wait-firmware-settings")...)
+
+		By("Verifying the firmware setting was applied in HFS status")
+		Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+			Name:      bmhName,
+			Namespace: namespace.Name,
+		}, hfs)).To(Succeed())
+		Expect(hfs.Status.Settings).To(HaveKeyWithValue(hfsTestKey1, hfsTestOrigValue1))
+		Expect(hfs.Status.Conditions).To(ContainCondition(string(metal3api.FirmwareSettingsValid), metav1.ConditionTrue))
+		Expect(hfs.Status.Conditions).To(ContainCondition(string(metal3api.FirmwareSettingsChangeDetected), metav1.ConditionFalse))
+
+		By("Deleting the BMH")
+		Expect(clusterProxy.GetClient().Delete(ctx, &bmh)).To(Succeed())
+
+		By("Waiting for the BMH to be deleted")
+		WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
+			Client:    clusterProxy.GetClient(),
+			BmhName:   bmhName,
+			Namespace: namespace.Name,
+		}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
+	})
+
+	It("should update firmware settings on a provisioned host via servicing", func() {
+		bmhName := specName + "-servicing"
+		secretName := bmhName + "-bmc"
+
+		By("Creating a secret with BMH credentials")
+		bmcCredentialsData := map[string]string{
+			"username": bmc.User,
+			"password": bmc.Password,
+		}
+		CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+
+		By("Creating a BMH with inspection and cleaning disabled")
+		bmh := metal3api.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			},
+			Spec: metal3api.BareMetalHostSpec{
+				Online: true,
+				BMC: metal3api.BMCDetails{
+					Address:                        bmc.Address,
+					CredentialsName:                secretName,
+					DisableCertificateVerification: bmc.DisableCertificateVerification,
+				},
+				BootMode:              metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
+				BootMACAddress:        bmc.BootMacAddress,
+				AutomatedCleaningMode: metal3api.CleaningModeDisabled,
+				InspectionMode:        metal3api.InspectionModeDisabled,
+			},
+		}
+		Expect(clusterProxy.GetClient().Create(ctx, &bmh)).To(Succeed())
+
+		By("Waiting for the BMH to become available")
+		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.StateAvailable,
+		}, e2eConfig.GetIntervals(specName, "wait-available")...)
+
+		By("Checking the original value of the parameter")
+		origHFS := &metal3api.HostFirmwareSettings{}
+		Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+			Name:      bmhName,
+			Namespace: namespace.Name,
+		}, origHFS)).To(Succeed())
+		Expect(origHFS.Status.Settings).To(HaveKeyWithValue(hfsTestKey2, hfsTestOrigValue2))
+
+		By("Checking firmware schema")
+		fSchema := &metal3api.FirmwareSchema{}
+		Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+			Name:      origHFS.Status.FirmwareSchema.Name,
+			Namespace: origHFS.Status.FirmwareSchema.Namespace,
+		}, fSchema)).To(Succeed())
+		Expect(fSchema.Spec.Schema).To(HaveKey(hfsTestKey1))
+		Expect(fSchema.Spec.Schema).To(HaveKey(hfsTestKey2))
+
+		By("Provisioning the BMH")
+		var userDataSecret *corev1.SecretReference
+		if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
+			userDataSecretName := "user-data"
+			sshPubKeyPath := e2eConfig.GetVariable("SSH_PUB_KEY")
+			createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
+			userDataSecret = &corev1.SecretReference{
+				Name:      userDataSecretName,
+				Namespace: namespace.Name,
+			}
+		}
+		Expect(PatchBMHForProvisioning(ctx, PatchBMHForProvisioningInput{
+			client:         clusterProxy.GetClient(),
+			bmh:            &bmh,
+			bmc:            bmc,
+			e2eConfig:      e2eConfig,
+			namespace:      namespace.Name,
+			userDataSecret: userDataSecret,
+		})).To(Succeed())
+
+		By("Waiting for the BMH to be provisioned")
+		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.StateProvisioned,
+		}, e2eConfig.GetIntervals(specName, "wait-provisioned")...)
+
+		By("Creating a HostUpdatePolicy to allow firmware changes on reboot")
+		hup := &metal3api.HostUpdatePolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			},
+			Spec: metal3api.HostUpdatePolicySpec{
+				FirmwareSettings: metal3api.HostUpdatePolicyOnReboot,
+			},
+		}
+		Expect(clusterProxy.GetClient().Create(ctx, hup)).To(Succeed())
+
+		By("Updating HostFirmwareSettings with a new value")
+		hfs := &metal3api.HostFirmwareSettings{}
+		Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+			Name:      bmhName,
+			Namespace: namespace.Name,
+		}, hfs)).To(Succeed())
+
+		helper, err := patch.NewHelper(hfs, clusterProxy.GetClient())
+		Expect(err).NotTo(HaveOccurred())
+		hfs.Spec.Settings = metal3api.DesiredSettingsMap{
+			hfsTestKey2: intstr.FromString(hfsTestNewValue2),
+		}
+		Expect(helper.Patch(ctx, hfs)).To(Succeed())
+
+		By("Verifying the conditions on firmware setting")
+		Eventually(func(g Gomega) {
+			g.Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			}, hfs)).To(Succeed())
+			g.Expect(hfs.Status.Conditions).To(ContainCondition(string(metal3api.FirmwareSettingsValid), metav1.ConditionTrue))
+			g.Expect(hfs.Status.Conditions).To(ContainCondition(string(metal3api.FirmwareSettingsChangeDetected), metav1.ConditionTrue))
+		}, e2eConfig.GetIntervals(specName, "wait-reconcile")...).Should(Succeed())
+
+		By("Triggering a reboot via annotation")
+		Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+			Name:      bmhName,
+			Namespace: namespace.Name,
+		}, &bmh)).To(Succeed())
+		AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, metal3api.RebootAnnotationPrefix, ptr.To(""))
+
+		By("Waiting for the BMH to enter servicing")
+		WaitForBmhInOperationalStatus(ctx, WaitForBmhInOperationalStatusInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.OperationalStatusServicing,
+			UndesiredStates: []metal3api.OperationalStatus{
+				metal3api.OperationalStatusError,
+			},
+		}, e2eConfig.GetIntervals(specName, "wait-servicing")...)
+
+		By("Waiting for servicing to complete")
+		WaitForBmhInOperationalStatus(ctx, WaitForBmhInOperationalStatusInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.OperationalStatusOK,
+			UndesiredStates: []metal3api.OperationalStatus{
+				metal3api.OperationalStatusError,
+			},
+		}, e2eConfig.GetIntervals(specName, "wait-firmware-settings")...)
+
+		By("Verifying the firmware setting was applied in HFS status")
+		Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+			Name:      bmhName,
+			Namespace: namespace.Name,
+		}, hfs)).To(Succeed())
+		Expect(hfs.Status.Settings).To(HaveKeyWithValue(hfsTestKey2, hfsTestNewValue2))
+		Expect(hfs.Status.Conditions).To(ContainCondition(string(metal3api.FirmwareSettingsValid), metav1.ConditionTrue))
+		Expect(hfs.Status.Conditions).To(ContainCondition(string(metal3api.FirmwareSettingsChangeDetected), metav1.ConditionFalse))
+
+		if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
+			By("Verifying the instance is still accessible via SSH")
+			PerformSSHBootCheck(e2eConfig, "disk", bmc.IPAddress)
+		} else {
+			Logf("WARNING: Skipping SSH check since SSH_CHECK_PROVISIONED != true")
+		}
+
+		By("Deleting the BMH")
+		Expect(clusterProxy.GetClient().Delete(ctx, &bmh)).To(Succeed())
+
+		By("Waiting for the BMH to be deleted")
+		WaitForBmhDeleted(ctx, WaitForBmhDeletedInput{
+			Client:    clusterProxy.GetClient(),
+			BmhName:   bmhName,
+			Namespace: namespace.Name,
+		}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...)
+
+		By("Making sure HFS was deleted too")
+		Eventually(func() bool {
+			return k8serrors.IsNotFound(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			}, hfs))
+		}, e2eConfig.GetIntervals(specName, "wait-bmh-deleted")...).Should(BeTrue())
+	})
+
+	AfterEach(func() {
+		CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
+		DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
+		if !skipCleanup {
+			isNamespaced := e2eConfig.GetBoolVariable("NAMESPACE_SCOPED")
+			Cleanup(ctx, clusterProxy, namespace, cancelWatches, isNamespaced, e2eConfig.GetIntervals("default", "wait-namespace-deleted")...)
+		}
+	})
+})


### PR DESCRIPTION
Currently, the BMH controller sets an OwnerReference on HFC objects
regardless of what created them. For HFS, on the other hand, only
controller-created objects get an OwnerReference. Not only is it
inconsistent, but it also opens a possibility of a bug: if the HFS is
reconciled before the corresponding BMH is in the controller cache,
the HFS will skip reconciliation and will never be reconciled again.

Adjust the event handler to allow reconciliations when only owner
references are changed.

Also fix the obviously wrong error message. And update log messages.

Also add e2e tests that verify HFS (with servicing too).

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
