### PR TITLE
🌱 Return error msg in case of failure to read preprovisioningNetworkData

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -872,7 +872,7 @@ func (r *BareMetalHostReconciler) registerHost(ctx context.Context, prov provisi
 	}
 	preprovisioningNetworkData, err := hostConf.PreprovisioningNetworkData(ctx)
 	if err != nil {
-		return recordActionFailure(info, metal3api.RegistrationError, "failed to read preprovisioningNetworkData")
+		return recordActionFailure(info, metal3api.RegistrationError, fmt.Sprintf("failed to read preprovisioningNetworkData: %v", err))
 	}
 
 	provResult, provID, err := prov.Register(


### PR DESCRIPTION
**What this PR does / why we need it**:
Return error msg in case of failure to read preprovisioningNetworkData 

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
