### PR TITLE
🌱 e2e: avoid non-string values in the HFS tests

### DIFF
--- a/test/e2e/firmware_settings_test.go
+++ b/test/e2e/firmware_settings_test.go
@@ -27,9 +27,9 @@ const (
 	hfsTestKey1       = "ProcTurboMode"
 	hfsTestOrigValue1 = "Enabled"
 	hfsTestNewValue1  = "Disabled"
-	hfsTestKey2       = "QuietBoot"
-	hfsTestOrigValue2 = "true"
-	hfsTestNewValue2  = "false"
+	hfsTestKey2       = "EmbeddedSata"
+	hfsTestOrigValue2 = "Raid"
+	hfsTestNewValue2  = "Ata"
 )
 
 var _ = Describe("Host Firmware Settings", Label("required", "firmware"), func() {


### PR DESCRIPTION
Boolean values are particularly broken (see #3261), and QuietBoot is
a Boolean. It only happened to work because sushy-tools used to turn
every value into a string.

Use a string value until we can figure out what to do.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
