### PR TITLE
:bug: Skip webhook for metadata-only BMH updates via matchConditions

### DIFF
--- a/config/base/webhook/kustomization.yaml
+++ b/config/base/webhook/kustomization.yaml
@@ -4,5 +4,8 @@ resources:
 - manifests.yaml
 - service_patch.yaml
 
+patches:
+- path: matchconditions_patch.yaml
+
 configurations:
 - kustomizeconfig.yaml

--- a/config/base/webhook/matchconditions_patch.yaml
+++ b/config/base/webhook/matchconditions_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- name: baremetalhost.metal3.io
+  matchConditions:
+  - name: "spec-or-annotations-changed"
+    expression: >-
+      request.operation == 'CREATE' ||
+      object.spec != oldObject.spec ||
+      object.metadata.?annotations.orValue({}) != oldObject.metadata.?annotations.orValue({})

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -3264,6 +3264,10 @@ webhooks:
       namespace: baremetal-operator-system
       path: /validate-metal3-io-v1alpha1-baremetalhost
   failurePolicy: Fail
+  matchConditions:
+  - expression: request.operation == 'CREATE' || object.spec != oldObject.spec ||
+      object.metadata.?annotations.orValue({}) != oldObject.metadata.?annotations.orValue({})
+    name: spec-or-annotations-changed
   name: baremetalhost.metal3.io
   rules:
   - apiGroups:


### PR DESCRIPTION
During cluster bootstrap, BMO's validating webhook endpoint may not be ready when the controller tries to add finalizers to BareMetalHost resources. This causes repeated "no endpoints available" or "context deadline exceeded" errors for up to several minutes.

Since the webhook only validates .spec and .metadata.annotations, it fires unnecessarily on metadata-only updates like finalizer additions. Add a CEL matchConditions filter to the ValidatingWebhookConfiguration so the API server skips the webhook call entirely when neither spec nor annotations changed. This is implemented as a kustomize patch to survive controller-gen regeneration of manifests.yaml.

