### PR TITLE
:book: remove duplicate "the" in e2e README

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -157,5 +157,5 @@ both redfish and ipmi protocols in CI.
 
 - Bare Metal Operator upgrade: Check that an older version of the Bare Metal
   Operator works by creating a BareMetalHost with external inspection. Then
-  upgrade the Bare Metal Operator and check the the BareMetalHost can be
+  upgrade the Bare Metal Operator and check the BareMetalHost can be
   provisioned with the upgraded version.


### PR DESCRIPTION
## Summary

`test/e2e/README.md:160` had "check the the BareMetalHost can be" - removes the duplicate "the".