### PR TITLE
:bug: Correct webhook admissionReview version

### DIFF
--- a/config/base/webhook/manifests.yaml
+++ b/config/base/webhook/manifests.yaml
@@ -6,7 +6,6 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
-  - v1beta
   clientConfig:
     service:
       name: webhook-service
@@ -27,7 +26,6 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta
   clientConfig:
     service:
       name: webhook-service
@@ -48,7 +46,6 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -3257,7 +3257,6 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
-  - v1beta
   clientConfig:
     service:
       name: baremetal-operator-webhook-service
@@ -3278,7 +3277,6 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta
   clientConfig:
     service:
       name: baremetal-operator-webhook-service
@@ -3299,7 +3297,6 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: baremetal-operator-webhook-service

--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_webhook.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_webhook.go
@@ -37,7 +37,7 @@ func (webhook *BareMetalHost) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:verbs=create;update,path=/validate-metal3-io-v1alpha1-baremetalhost,mutating=false,failurePolicy=fail,sideEffects=none,admissionReviewVersions=v1;v1beta,groups=metal3.io,resources=baremetalhosts,versions=v1alpha1,name=baremetalhost.metal3.io
+//+kubebuilder:webhook:verbs=create;update,path=/validate-metal3-io-v1alpha1-baremetalhost,mutating=false,failurePolicy=fail,sideEffects=none,admissionReviewVersions=v1,groups=metal3.io,resources=baremetalhosts,versions=v1alpha1,name=baremetalhost.metal3.io
 
 // BareMetalHost implements a validation and defaulting webhook for BareMetalHost.
 type BareMetalHost struct{}
@@ -47,6 +47,10 @@ var _ admission.Validator[*metal3api.BareMetalHost] = &BareMetalHost{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (webhook *BareMetalHost) ValidateCreate(_ context.Context, bmh *metal3api.BareMetalHost) (admission.Warnings, error) {
+	if bmh == nil {
+		baremetalhostlog.Error(errors.New("object is nil"), "validate create error")
+		return nil, nil
+	}
 	baremetalhostlog.Info("validate create", "namespace", bmh.Namespace, "name", bmh.Name)
 	return nil, kerrors.NewAggregate(webhook.validateHost(bmh))
 }

--- a/internal/webhooks/metal3.io/v1alpha1/bmceventsubscription_webhook.go
+++ b/internal/webhooks/metal3.io/v1alpha1/bmceventsubscription_webhook.go
@@ -37,7 +37,7 @@ func (webhook *BMCEventSubscription) SetupWebhookWithManager(mgr ctrl.Manager) e
 		Complete()
 }
 
-//+kubebuilder:webhook:verbs=create;update,path=/validate-metal3-io-v1alpha1-bmceventsubscription,mutating=false,failurePolicy=fail,sideEffects=none,admissionReviewVersions=v1;v1beta,groups=metal3.io,resources=bmceventsubscriptions,versions=v1alpha1,name=bmceventsubscription.metal3.io
+//+kubebuilder:webhook:verbs=create;update,path=/validate-metal3-io-v1alpha1-bmceventsubscription,mutating=false,failurePolicy=fail,sideEffects=none,admissionReviewVersions=v1,groups=metal3.io,resources=bmceventsubscriptions,versions=v1alpha1,name=bmceventsubscription.metal3.io
 
 // BMCEventSubscription implements a validation and defaulting webhook for BMCEventSubscription.
 type BMCEventSubscription struct{}

--- a/internal/webhooks/metal3.io/v1alpha1/hostclaim_webhook.go
+++ b/internal/webhooks/metal3.io/v1alpha1/hostclaim_webhook.go
@@ -36,7 +36,7 @@ func (webhook *HostClaimWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error
 		Complete()
 }
 
-//+kubebuilder:webhook:verbs=create;update,path=/validate-metal3-io-v1alpha1-hostclaim,mutating=false,failurePolicy=fail,sideEffects=none,admissionReviewVersions=v1;v1beta1,groups=metal3.io,resources=hostclaims,versions=v1alpha1,name=hostclaim.metal3.io
+//+kubebuilder:webhook:verbs=create;update,path=/validate-metal3-io-v1alpha1-hostclaim,mutating=false,failurePolicy=fail,sideEffects=none,admissionReviewVersions=v1,groups=metal3.io,resources=hostclaims,versions=v1alpha1,name=hostclaim.metal3.io
 
 type HostClaimWebhook struct{}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Limit to v1 as v1beta1 is deprecated and not served since v1.22. Do not support v1beta which does not exists.
Adds a nil check in baremetalhost webhook (ValidateCreate).

Fixes: #3266

