### PR TITLE
:seedling: Drive e2e setup via vbmctl config template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ _artifacts
 artifacts*.tar.gz
 test/e2e/images
 test/e2e/data/ironic-standalone-operator/ironic/base/ironic.yaml
+test/e2e/config/vbmctl.yaml
 out
 
 # Created by https://www.gitignore.io/api/go

--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -21,9 +21,9 @@ cd "${REPO_ROOT}" || exit 1
 
 BMC_PROTOCOL="${BMC_PROTOCOL:-"redfish-virtualmedia"}"
 if [[ "${BMC_PROTOCOL}" == "redfish" ]] || [[ "${BMC_PROTOCOL}" == "redfish-virtualmedia" ]]; then
-  BMO_E2E_EMULATOR="sushy-tools"
+  export BMO_E2E_EMULATOR="sushy-tools"
 elif [[ "${BMC_PROTOCOL}" == "ipmi" ]]; then
-  BMO_E2E_EMULATOR="vbmc"
+  export BMO_E2E_EMULATOR="vbmc"
 else
   echo "FATAL: Invalid BMC protocol specified: ${BMC_PROTOCOL}"
   exit 1
@@ -79,28 +79,18 @@ IMG=quay.io/metal3-io/baremetal-operator IMG_TAG=e2e make docker
 # Build vbmctl
 make build-vbmctl
 sudo setcap cap_net_admin+epi ./bin/vbmctl
-# Create VMs to act as BMHs in the tests and the libvirt network
-./bin/vbmctl -c "${REPO_ROOT}/test/e2e/config/vbmctl.yaml" create bml
 
 # This IP is defined by the network we created above. It is sushy-tools / image
 # server endpoint, not ironic.
-IP_ADDRESS="192.168.222.1"
+export IP_ADDRESS="192.168.222.1"
 
+# E2E emulator configuration variables
 if [[ "${BMO_E2E_EMULATOR}" == "vbmc" ]]; then
-  # Start VBMC
-  ./bin/vbmctl create bmc-emulator --emulator-type "vbmc" --image "${VBMC_IMAGE}"
-
-  readarray -t BMCS < <(yq e -o=j -I=0 '.[]' "${E2E_BMCS_CONF_FILE}")
-  for bmc in "${BMCS[@]}"; do
-    address=$(echo "${bmc}" | jq -r '.address')
-    hostName=$(echo "${bmc}" | jq -r '.name')
-    vbmc_port="${address##*:}"
-    "${REPO_ROOT}/tools/bmh_test/vm2vbmc.sh" "${hostName}" "${vbmc_port}" "${IP_ADDRESS}"
-  done
-
+  export BMO_E2E_IMAGE="${VBMC_IMAGE}"
+  export BMO_E2E_LISTEN_PORT="0"
 elif [[ "${BMO_E2E_EMULATOR}" == "sushy-tools" ]]; then
-  # Start sushy-tools
-  ./bin/vbmctl create bmc-emulator --emulator-type "sushy-tools" --image "${SUSHY_EMULATOR_IMAGE}" --listen-address "${IP_ADDRESS}" --listen-port "${SUSHY_EMULATOR_PORT}"
+  export BMO_E2E_IMAGE="${SUSHY_EMULATOR_IMAGE}"
+  export BMO_E2E_LISTEN_PORT="${SUSHY_EMULATOR_PORT}"
 else
   echo "FATAL: Invalid e2e emulator specified: ${BMO_E2E_EMULATOR}"
   exit 1
@@ -111,7 +101,7 @@ CIRROS_VERSION="0.6.2"
 IMAGE_FILE="cirros-${CIRROS_VERSION}-x86_64-disk.img"
 export IMAGE_CHECKSUM="c8fc807773e5354afe61636071771906"
 export IMAGE_URL="http://${IP_ADDRESS}/${IMAGE_FILE}"
-IMAGE_DIR="${REPO_ROOT}/test/e2e/images"
+export IMAGE_DIR="${REPO_ROOT}/test/e2e/images"
 mkdir -p "${IMAGE_DIR}"
 
 ## Download disk images
@@ -130,8 +120,25 @@ if [[ ! -f "${IMAGE_DIR}/${IPA_FILE}" ]]; then
     wget --quiet -P "${IMAGE_DIR}/" "${IPA_BASEURI}/${IPA_FILE}"
 fi
 
-## Start the image server
-./bin/vbmctl create image-server --host-port 80 --image-dir "${IMAGE_DIR}" --name "vbmctl-image-server-e2e"
+# shellcheck disable=SC2016
+envsubst '${BMO_E2E_EMULATOR},${IP_ADDRESS},${BMO_E2E_IMAGE},${BMO_E2E_LISTEN_PORT},${IMAGE_DIR}' < \
+  "${REPO_ROOT}/test/e2e/config/vbmctl.yaml.tmpl" > \
+  "${REPO_ROOT}/test/e2e/config/vbmctl.yaml"
+
+# Create VMs to act as BMHs in the tests and the libvirt network. Create
+# also image server and E2E emulator containers.
+./bin/vbmctl -c "${REPO_ROOT}/test/e2e/config/vbmctl.yaml" create bml
+
+# Need to do some extra setup for the vbmc emulator
+if [[ "${BMO_E2E_EMULATOR}" == "vbmc" ]]; then
+  readarray -t BMCS < <(yq e -o=j -I=0 '.[]' "${E2E_BMCS_CONF_FILE}")
+  for bmc in "${BMCS[@]}"; do
+    address=$(echo "${bmc}" | jq -r '.address')
+    hostName=$(echo "${bmc}" | jq -r '.name')
+    vbmc_port="${address##*:}"
+    "${REPO_ROOT}/tools/bmh_test/vm2vbmc.sh" "${hostName}" "${vbmc_port}" "${IP_ADDRESS}"
+  done
+fi
 
 # Generate ssh key pair for verifying provisioned BMHs
 if [[ ! -f "${IMAGE_DIR}/ssh_testkey" ]]; then

--- a/test/e2e/config/vbmctl.yaml.tmpl
+++ b/test/e2e/config/vbmctl.yaml.tmpl
@@ -45,3 +45,12 @@ spec:
     subnet: "fc00:f853:ccd:e793::/64"
     driverMtu: 1500
     ipv6: true
+  bmcEmulator:
+    type: "${BMO_E2E_EMULATOR}"
+    image: "${BMO_E2E_IMAGE}"
+    listenAddress: "${IP_ADDRESS}"
+    listenPort: ${BMO_E2E_LISTEN_PORT}
+  imageServer:
+    port: 80
+    dataDir: "${IMAGE_DIR}"
+    containerName: "vbmctl-image-server-e2e"

--- a/test/vbmctl/pkg/config/config.go
+++ b/test/vbmctl/pkg/config/config.go
@@ -423,7 +423,7 @@ func (c *Config) ApplyDefaults() {
 			case BMCEmulatorTypeSushyTools:
 				c.Spec.BMCEmulator.Image = DefaultBMCEmulatorSushyToolsImage
 			default:
-				// If the type is unrecognized, we won't set a default image.
+				// If the type is unrecognized, we won't set a default image
 			}
 		}
 		if c.Spec.BMCEmulator.Type == BMCEmulatorTypeSushyTools {
@@ -434,6 +434,9 @@ func (c *Config) ApplyDefaults() {
 				c.Spec.BMCEmulator.ListenAddress = DefaultNetworkAddress
 			}
 		}
+		// Set storage pool and libvirt URI for BMC emulator to match the main config
+		c.Spec.BMCEmulator.StoragePool = c.Spec.Pool.Name
+		c.Spec.BMCEmulator.LibvirtURI = c.Spec.Libvirt.URI
 	}
 
 	if len(c.Spec.Networks) > 0 {

--- a/test/vbmctl/pkg/config/config_test.go
+++ b/test/vbmctl/pkg/config/config_test.go
@@ -751,6 +751,12 @@ func TestApplyDefaults(t *testing.T) {
 	if sushyCfg.Spec.BMCEmulator.ListenPort != DefaultBMCEmulatorSushyToolsListenPort {
 		t.Errorf("expected BMC Emulator Listen Port %d, got %d", DefaultBMCEmulatorSushyToolsListenPort, sushyCfg.Spec.BMCEmulator.ListenPort)
 	}
+	if sushyCfg.Spec.BMCEmulator.StoragePool != DefaultPoolName {
+		t.Errorf("expected BMC Emulator Storage Pool %s, got %s", DefaultPoolName, sushyCfg.Spec.BMCEmulator.StoragePool)
+	}
+	if sushyCfg.Spec.BMCEmulator.LibvirtURI != DefaultLibvirtURI {
+		t.Errorf("expected BMC Emulator Libvirt URI %s, got %s", DefaultLibvirtURI, sushyCfg.Spec.BMCEmulator.LibvirtURI)
+	}
 
 	// However, if a config file is specified for sushy-tools, the listen address and listen port defaults should not be applied.
 	sushyWithConfigFileCfg := &Config{}


### PR DESCRIPTION
Replace individual vbmctl CLI calls for image server and BMC emulator setup with envsubst-rendered vbmctl.yaml.tmpl. Export variables needed for substitution and move VM/emulator creation to after the config is generated.

Also fix ApplyDefaults to always override StoragePool and LibvirtURI in BMCEmulator config with values from the top-level spec.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

We can simplify `hack/ci-e2e.sh` to use a single `vbmctl` command to setup the test environment.
