### PR TITLE
🌱 Use hard reboot in firmware settings test

### DIFF
--- a/test/e2e/firmware_settings_test.go
+++ b/test/e2e/firmware_settings_test.go
@@ -373,7 +373,10 @@ var _ = Describe("Host Firmware Settings", Label("required", "firmware"), func()
 			Name:      bmhName,
 			Namespace: namespace.Name,
 		}, &bmh)).To(Succeed())
-		AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, metal3api.RebootAnnotationPrefix, ptr.To(""))
+		// Use hard reboot to avoid wasting time on soft power off.
+		// CirrOS may not reliably handle ACPI shutdown events, causing Ironic to
+		// wait up to 180s before falling back to hard power off anyway.
+		AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, metal3api.RebootAnnotationPrefix, ptr.To(`{"mode": "hard"}`))
 
 		By("Waiting for the BMH to enter servicing")
 		WaitForBmhInOperationalStatus(ctx, WaitForBmhInOperationalStatusInput{


### PR DESCRIPTION
**What this PR does / why we need it**:

The test is currently flaky, probably due to unreliable soft power off and timeout before falling back to hard. The test does not rely on soft power off so we can just go with hard to avoid issues and wasting time.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #3286

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
