### PR TITLE
🐛 Include image URL and checksum in provisioning error message

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1282,7 +1282,8 @@ func (p *ironicProvisioner) Provision(ctx context.Context, data provisioner.Prov
 				return retryAfterDelay(0)
 			}
 			p.log.Info("found error", "msg", ironicNode.LastError)
-			return operationFailed("Image provisioning failed: " + ironicNode.LastError)
+			checksum, _, _ := data.Image.GetChecksum()
+			return operationFailed(fmt.Sprintf("Image provisioning failed (url: %s, checksum: %s): %s", data.Image.URL, checksum, ironicNode.LastError))
 		}
 		p.log.Info("recovering from previous failure")
 		if provResult, err = p.setUpForProvisioning(ctx, ironicNode, data); err != nil || provResult.Dirty || provResult.ErrorMessage != "" {

--- a/pkg/provisioner/ironic/provision_test.go
+++ b/pkg/provisioner/ironic/provision_test.go
@@ -66,7 +66,7 @@ func TestProvision(t *testing.T) {
 			}),
 			expectedRequestAfter: 0,
 			expectedDirty:        false,
-			expectedErrorMessage: "Image provisioning failed: no work today",
+			expectedErrorMessage: "Image provisioning failed (url: http://test-image, checksum: abcd): no work today",
 		},
 		{
 			name: "cleanFail state",


### PR DESCRIPTION
**What this PR does / why we need it**:

When image provisioning fails (`DeployFail` state), the error message now includes the image URL and checksum. Previously, the message only contained Ironic's last error, making it difficult for operators to identify which image was being deployed when the failure occurred.

**Before:**
```
Image provisioning failed: <ironic error>
```

**After:**
```
Image provisioning failed (url: http://example.com/image, checksum: abc123): <ironic error>
```

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
