### PR TITLE
🌱 e2e: reset BIOS settings in sushy-tools before HFS tests

### DIFF
--- a/test/e2e/firmware_settings_test.go
+++ b/test/e2e/firmware_settings_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 // These example keys and values are hardcoded in sushy-tools.
-// Warning: be careful when updating or reusing any keys: updated values will be persisted in the emulator between tests!
 const (
 	hfsTestKey1       = "ProcTurboMode"
 	hfsTestOrigValue1 = "Enabled"
@@ -46,6 +45,9 @@ var _ = Describe("Host Firmware Settings", Label("required", "firmware"), func()
 		if !e2eConfig.GetBoolVariable("DEPLOY_IRONIC") || !strings.Contains(bmc.Address, "redfish") {
 			Skip("HFS tests require a real Ironic and a host with Redfish")
 		}
+
+		// Ensure that tests don't conflict with each other
+		RedfishResetBios(ctx, bmc)
 
 		toCleanup = nil
 		namespace, cancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{

--- a/test/e2e/ironic_helpers.go
+++ b/test/e2e/ironic_helpers.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"slices"
+	"strings"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/httpbasic"
@@ -74,4 +76,20 @@ func WaitForIronicNodeProvisionState(ctx context.Context, input WaitForIronicNod
 		g.Expect(slices.Contains(input.States, currentState)).To(BeTrue(),
 			"Ironic node %s is in state %s, expected one of %v", input.NodeName, currentState, input.States)
 	}, intervals...).Should(Succeed())
+}
+
+// RedfishResetBios resets BIOS in sushy-tools (or similar implementation).
+func RedfishResetBios(ctx context.Context, bmc BMC) {
+	address, err := url.Parse(bmc.Address)
+	Expect(err).NotTo(HaveOccurred())
+	if schemeParts := strings.Split(address.Scheme, "+"); len(schemeParts) > 1 {
+		address.Scheme = schemeParts[1]
+	}
+	endpoint := address.String() + "/BIOS/Actions/Bios.ResetBios"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, http.NoBody)
+	Expect(err).NotTo(HaveOccurred())
+	resp, err := http.DefaultClient.Do(req)
+	Expect(err).NotTo(HaveOccurred())
+	defer resp.Body.Close()
+	Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 }


### PR DESCRIPTION
This ensures that the tests don't conflict with each other.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
