### PR TITLE
:bug: Restore delete permission on secrets

### DIFF
--- a/config/base/rbac/role.yaml
+++ b/config/base/rbac/role.yaml
@@ -23,6 +23,7 @@ rules:
   resources:
   - secrets
   verbs:
+  - delete
   - get
   - list
   - update

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -2954,6 +2954,7 @@ rules:
   resources:
   - secrets
   verbs:
+  - delete
   - get
   - list
   - update

--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -92,7 +92,7 @@ func (info *reconcileInfo) publishEvent(reason, message string) {
 // +kubebuilder:rbac:groups=metal3.io,resources=preprovisioningimages,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal3.io,resources=hardwaredata,verbs=get;list;watch;create;delete;patch;update
 // +kubebuilder:rbac:groups=metal3.io,resources=hardware/finalizers,verbs=update
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;update;patch
 
 // Allow for managing hostfirmwaresettings, firmwareschema, bmceventsubscriptions and hostfirmwarecomponents


### PR DESCRIPTION
Restore delete permission on secrets because owner reference updates are rejected by the API server without it.

Fixes: #3304

