### PR TITLE
:bug: Fix webhook state guard status checks

### DIFF
--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation.go
@@ -104,7 +104,9 @@ func (webhook *BareMetalHost) validateChanges(oldObj *metal3api.BareMetalHost, n
 
 	if oldObj.Spec.BMC.Address != "" &&
 		newObj.Spec.BMC.Address != oldObj.Spec.BMC.Address &&
+		oldObj.Status.OperationalStatus != metal3api.OperationalStatusDetached &&
 		newObj.Status.OperationalStatus != metal3api.OperationalStatusDetached &&
+		oldObj.Status.Provisioning.State != metal3api.StateRegistering &&
 		newObj.Status.Provisioning.State != metal3api.StateRegistering {
 		errs = append(errs, errors.New("BMC address can not be changed if the BMH is not in the Registering state, or if the BMH is not detached"))
 	}
@@ -115,10 +117,11 @@ func (webhook *BareMetalHost) validateChanges(oldObj *metal3api.BareMetalHost, n
 
 	// Only allow enabling externallyProvisioned from Available state.
 	if !oldObj.Spec.ExternallyProvisioned && newObj.Spec.ExternallyProvisioned &&
+		oldObj.Status.Provisioning.State != metal3api.StateAvailable &&
 		newObj.Status.Provisioning.State != metal3api.StateAvailable {
 		errs = append(errs, fmt.Errorf(
 			"externallyProvisioned can only be enabled when in Available state, currently in %s",
-			newObj.Status.Provisioning.State))
+			oldObj.Status.Provisioning.State))
 	}
 
 	return errs

--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -1080,7 +1080,10 @@ func TestValidateUpdate(t *testing.T) {
 				ObjectMeta: om,
 				Spec: metal3api.BareMetalHostSpec{
 					BMC: metal3api.BMCDetails{
-						Address: "test-address"}}},
+						Address: "test-address"}},
+				Status: metal3api.BareMetalHostStatus{
+					Provisioning: metal3api.ProvisionStatus{
+						State: metal3api.StateRegistering}}},
 			wantedErr: "",
 		},
 		{
@@ -1098,7 +1101,9 @@ func TestValidateUpdate(t *testing.T) {
 				ObjectMeta: om,
 				Spec: metal3api.BareMetalHostSpec{
 					BMC: metal3api.BMCDetails{
-						Address: "test-address"}}},
+						Address: "test-address"}},
+				Status: metal3api.BareMetalHostStatus{
+					OperationalStatus: metal3api.OperationalStatusDetached}},
 			wantedErr: "",
 		},
 		{


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

The webhook allows changing the BMC address only when the BMH is in detached or registering state. However, it reads that state from the incoming/updated BMH. So the user can simply set the status to the correct value to bypass the check. This PR changes the webhook so that it checks the status of the old object and prevents bypassing the check.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] E2E tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
