### PR TITLE
:bug: Fix network creation error check in vbmctl

### DIFF
--- a/test/vbmctl/pkg/containers/docker.go
+++ b/test/vbmctl/pkg/containers/docker.go
@@ -135,7 +135,7 @@ func CreateNetwork(ctx context.Context, name string, opts *client.NetworkCreateO
 	defer apiClient.Close()
 
 	networkID, err := GetNetworkByName(ctx, name)
-	if !errors.Is(err, ErrNetworkNotFound) {
+	if err != nil && !errors.Is(err, ErrNetworkNotFound) {
 		return "", err
 	}
 	if networkID != "" {

--- a/test/vbmctl/pkg/containers/kindnetwork.go
+++ b/test/vbmctl/pkg/containers/kindnetwork.go
@@ -46,7 +46,7 @@ func CreateBridgeNetworks(ctx context.Context, networks []vbmctlapi.DockerBridge
 		createdID, err := CreateNetwork(ctx, net.Name, &networkOpts)
 		// Don't fail if the network exists
 		if errors.Is(err, ErrNetworkExists) {
-			log.Printf("Warning: network %s already exists, continuing.", net.Name)
+			log.Printf("Warning: Docker network %s already exists, continuing.", net.Name)
 		} else if err != nil {
 			// Clean up previously created networks
 			log.Printf("Failed to create network %s, cleaning up %d previously created Docker networks", net.Name, len(createdNetworks))


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

Fixes the error check in vbmctl when creating a network. Previously, the function would not detect the existing network correctly and it would return empty ID without any error even though it should have returned an error indicating that the network existed.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] E2E tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
