### PR TITLE
⚠️ Provisioner: drop the separate TryInit call

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -217,20 +217,12 @@ func (r *BareMetalHostReconciler) Reconcile(ctx context.Context, request ctrl.Re
 
 	prov, err := r.ProvisionerFactory.NewProvisioner(ctx, provisioner.BuildHostData(*host, *bmcCreds), info.publishEvent)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to create provisioner: %w", err)
-	}
-
-	ready, err := prov.TryInit(ctx)
-	if err != nil || !ready {
-		var msg string
-		if err == nil {
-			msg = NotReady
-		} else {
-			msg = err.Error()
+		if errors.Is(err, provisioner.ErrNotReady) {
+			provisionerNotReady.Inc()
+			reqLogger.Info("provisioner is not ready", "Error", err.Error(), "RequeueAfter", provisionerNotReadyRetryDelay)
+			return ctrl.Result{RequeueAfter: provisionerNotReadyRetryDelay}, nil
 		}
-		provisionerNotReady.Inc()
-		reqLogger.Info("provisioner is not ready", "Error", msg, "RequeueAfter", provisionerNotReadyRetryDelay)
-		return ctrl.Result{Requeue: true, RequeueAfter: provisionerNotReadyRetryDelay}, nil
+		return ctrl.Result{}, fmt.Errorf("failed to create provisioner: %w", err)
 	}
 
 	stateMachine := newHostStateMachine(host, r, prov, haveCreds)

--- a/internal/controller/metal3.io/bmceventsubscription_controller.go
+++ b/internal/controller/metal3.io/bmceventsubscription_controller.go
@@ -99,17 +99,13 @@ func (r *BMCEventSubscriptionReconciler) Reconcile(ctx context.Context, request 
 		return ctrl.Result{}, fmt.Errorf("failed add finalizer: %w", err)
 	}
 
-	prov, ready, err := r.getProvisioner(ctx, request, host)
-
-	if err != nil || !ready {
-		var msg string
-		if err == nil {
-			msg = NotReady
-		} else {
-			msg = err.Error()
+	prov, err := r.getProvisioner(ctx, request, host)
+	if err != nil {
+		if errors.Is(err, provisioner.ErrNotReady) {
+			reqLogger.Info("provisioner is not ready", "Error", err.Error(), "RequeueAfter", provisionerNotReadyRetryDelay)
+			return ctrl.Result{RequeueAfter: provisionerNotReadyRetryDelay}, nil
 		}
-		reqLogger.Info("provisioner is not ready", "Error", msg, "RequeueAfter", provisionerNotReadyRetryDelay)
-		return ctrl.Result{RequeueAfter: provisionerNotReadyRetryDelay}, nil
+		return ctrl.Result{}, fmt.Errorf("failed to create provisioner: %w", err)
 	}
 
 	if subscription.DeletionTimestamp.IsZero() {
@@ -214,27 +210,8 @@ func (r *BMCEventSubscriptionReconciler) deleteSubscription(ctx context.Context,
 	return nil
 }
 
-func (r *BMCEventSubscriptionReconciler) getProvisioner(ctx context.Context, request ctrl.Request, host *metal3api.BareMetalHost) (prov provisioner.Provisioner, ready bool, err error) {
-	reqLogger := r.Log.WithValues("bmceventsubscription", request.NamespacedName)
-
-	prov, err = r.ProvisionerFactory.NewProvisioner(ctx, provisioner.BuildHostDataNoBMC(*host), nil)
-	if err != nil {
-		return prov, ready, fmt.Errorf("failed to create provisioner: %w", err)
-	}
-
-	ready, err = prov.TryInit(ctx)
-	if err != nil || !ready {
-		var msg string
-		if err == nil {
-			msg = NotReady
-		} else {
-			msg = err.Error()
-		}
-		reqLogger.Info("provisioner is not ready", "Error", msg, "RequeueAfter", provisionerNotReadyRetryDelay)
-		return prov, ready, nil
-	}
-
-	return prov, ready, nil
+func (r *BMCEventSubscriptionReconciler) getProvisioner(ctx context.Context, _ ctrl.Request, host *metal3api.BareMetalHost) (provisioner.Provisioner, error) {
+	return r.ProvisionerFactory.NewProvisioner(ctx, provisioner.BuildHostDataNoBMC(*host), nil)
 }
 
 func (r *BMCEventSubscriptionReconciler) getHTTPHeaders(ctx context.Context, subscription metal3api.BMCEventSubscription) ([]map[string]string, error) {

--- a/internal/controller/metal3.io/bmceventsubscription_controller_test.go
+++ b/internal/controller/metal3.io/bmceventsubscription_controller_test.go
@@ -118,26 +118,23 @@ func TestBMCGetProvisioner(t *testing.T) {
 	for _, tc := range []struct {
 		Scenario string
 		Host     *metal3api.BareMetalHost
-		Expected bool
 	}{
 		{
 			Scenario: "No provisioning id is provided",
 			Host:     host,
-			Expected: true,
 		},
 		{
 			Scenario: "Provisioning id is provided",
 			Host:     HostWithProvisioningID(t, host),
-			Expected: true,
 		},
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
-			prov, actual, err := r.getProvisioner(t.Context(), request, tc.Host)
+			prov, err := r.getProvisioner(t.Context(), request, tc.Host)
 			if err != nil {
 				t.Error(err)
 			}
 			t.Log("Provisioner Details:", prov)
-			if tc.Expected && !actual {
+			if prov == nil {
 				t.Error("Expected a ready provisioner")
 			}
 		})

--- a/internal/controller/metal3.io/dataimage_controller.go
+++ b/internal/controller/metal3.io/dataimage_controller.go
@@ -184,19 +184,11 @@ func (r *DataImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Create a provisioner that can access Ironic API
 	prov, err := r.ProvisionerFactory.NewProvisioner(ctx, provisioner.BuildHostDataNoBMC(*bmh), info.publishEvent)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to create provisioner, %w", err)
-	}
-
-	ready, err := prov.TryInit(ctx)
-	if err != nil || !ready {
-		var msg string
-		if err == nil {
-			msg = "Not ready"
-		} else {
-			msg = err.Error()
+		if errors.Is(err, provisioner.ErrNotReady) {
+			reqLogger.Info("provisioner is not ready", "Error", err.Error(), "RequeueAfter", provisionerRetryDelay)
+			return ctrl.Result{RequeueAfter: provisionerRetryDelay}, nil
 		}
-		reqLogger.Info("provisioner is not ready", "Error", msg, "RequeueAfter", provisionerRetryDelay)
-		return ctrl.Result{Requeue: true, RequeueAfter: provisionerRetryDelay}, nil
+		return ctrl.Result{}, fmt.Errorf("failed to create provisioner: %w", err)
 	}
 
 	// Check if any attach/detach action is pending or failed to attach

--- a/internal/controller/metal3.io/host_state_machine_test.go
+++ b/internal/controller/metal3.io/host_state_machine_test.go
@@ -1369,10 +1369,6 @@ func (m *mockProvisioner) PowerOff(_ context.Context, _ metal3api.RebootMode, _ 
 	return m.getNextResultByMethod("PowerOff"), err
 }
 
-func (m *mockProvisioner) TryInit(context.Context) (result bool, err error) {
-	return
-}
-
 func (m *mockProvisioner) GetFirmwareSettings(_ context.Context, _ bool) (settings metal3api.SettingsMap, schema map[string]metal3api.SettingSchema, err error) {
 	return
 }

--- a/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
+++ b/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
@@ -130,19 +130,11 @@ func (r *HostFirmwareComponentsReconciler) Reconcile(ctx context.Context, req ct
 	info := &rhfcInfo{log: reqLogger, hfc: hfc, bmh: bmh}
 	prov, err := r.ProvisionerFactory.NewProvisioner(ctx, provisioner.BuildHostDataNoBMC(*bmh), info.publishEvent)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to create provisioner: %w", err)
-	}
-
-	ready, err := prov.TryInit(ctx)
-	if err != nil || !ready {
-		var msg string
-		if err == nil {
-			msg = "not ready"
-		} else {
-			msg = err.Error()
+		if errors.Is(err, provisioner.ErrNotReady) {
+			reqLogger.Info("provisioner is not ready", "Error", err.Error(), "RequeueAfter", provisionerRetryDelay)
+			return ctrl.Result{RequeueAfter: provisionerRetryDelay}, nil
 		}
-		reqLogger.Info("provisioner is not ready", "Error", msg, "RequeueAfter", provisionerRetryDelay)
-		return ctrl.Result{Requeue: true, RequeueAfter: provisionerRetryDelay}, nil
+		return ctrl.Result{}, fmt.Errorf("failed to create provisioner: %w", err)
 	}
 
 	info.log.V(1).Info("retrieving firmware components and saving to resource", "Node", bmh.Status.Provisioning.ID)

--- a/internal/controller/metal3.io/hostfirmwaresettings_controller.go
+++ b/internal/controller/metal3.io/hostfirmwaresettings_controller.go
@@ -147,19 +147,11 @@ func (r *HostFirmwareSettingsReconciler) Reconcile(ctx context.Context, req ctrl
 	// Create a provisioner that can access Ironic API
 	prov, err := r.ProvisionerFactory.NewProvisioner(ctx, provisioner.BuildHostDataNoBMC(*bmh), info.publishEvent)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to create provisioner: %w", err)
-	}
-
-	ready, err := prov.TryInit(ctx)
-	if err != nil || !ready {
-		var msg string
-		if err == nil {
-			msg = "not ready"
-		} else {
-			msg = err.Error()
+		if errors.Is(err, provisioner.ErrNotReady) {
+			reqLogger.Info("provisioner is not ready", "Error", err.Error(), "RequeueAfter", provisionerRetryDelay)
+			return ctrl.Result{RequeueAfter: provisionerRetryDelay}, nil
 		}
-		reqLogger.Info("provisioner is not ready", "Error", msg, "RequeueAfter", provisionerRetryDelay)
-		return ctrl.Result{Requeue: true, RequeueAfter: provisionerRetryDelay}, nil
+		return ctrl.Result{}, fmt.Errorf("failed to create provisioner: %w", err)
 	}
 
 	info.log.V(1).Info("retrieving firmware settings and saving to resource", "Node", bmh.Status.Provisioning.ID)

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -306,11 +306,6 @@ func (p *demoProvisioner) PowerOff(_ context.Context, _ metal3api.RebootMode, _ 
 	return result, nil
 }
 
-// TryInit always returns true for the demo provisioner.
-func (p *demoProvisioner) TryInit(_ context.Context) (result bool, err error) {
-	return true, nil
-}
-
 func (p *demoProvisioner) GetFirmwareSettings(_ context.Context, _ bool) (settings metal3api.SettingsMap, schema map[string]metal3api.SettingSchema, err error) {
 	p.log.Info("getting BIOS settings")
 	return

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -108,7 +108,15 @@ type Fixture struct {
 }
 
 // NewProvisioner returns a new Fixture Provisioner.
+// Returns provisioner.ErrNotReady if BecomeReadyCounter has not reached 0.
 func (f *Fixture) NewProvisioner(_ context.Context, hostData provisioner.HostData, publisher provisioner.EventPublisher) (provisioner.Provisioner, error) {
+	if f.BecomeReadyCounter > 0 {
+		f.BecomeReadyCounter--
+	}
+	if f.BecomeReadyCounter != 0 {
+		return nil, provisioner.ErrNotReady
+	}
+
 	p := &fixtureProvisioner{
 		provID:    hostData.ProvisionerID,
 		bmcCreds:  hostData.BMCCredentials,
@@ -391,17 +399,6 @@ func (p *fixtureProvisioner) PowerOff(_ context.Context, _ metal3api.RebootMode,
 	}
 
 	return result, nil
-}
-
-// TryInit returns the current availability status of the provisioner.
-func (p *fixtureProvisioner) TryInit(_ context.Context) (result bool, err error) {
-	p.log.Info("checking provisioner status")
-
-	if p.state.BecomeReadyCounter > 0 {
-		p.state.BecomeReadyCounter--
-	}
-
-	return p.state.BecomeReadyCounter == 0, nil
 }
 
 func (p *fixtureProvisioner) GetFirmwareSettings(_ context.Context, _ bool) (settings metal3api.SettingsMap, schema map[string]metal3api.SettingSchema, err error) {

--- a/pkg/provisioner/ironic/dependencies.go
+++ b/pkg/provisioner/ironic/dependencies.go
@@ -35,7 +35,7 @@ func (p *ironicProvisioner) checkIronicConductor(ctx context.Context) error {
 	}
 
 	driverCount := 0
-	_ = pager.EachPage(ctx, func(_ context.Context, page pagination.Page) (bool, error) {
+	err := pager.EachPage(ctx, func(_ context.Context, page pagination.Page) (bool, error) {
 		actual, driverErr := drivers.ExtractDrivers(page)
 		if driverErr != nil {
 			return false, driverErr
@@ -43,6 +43,10 @@ func (p *ironicProvisioner) checkIronicConductor(ctx context.Context) error {
 		driverCount += len(actual)
 		return true, nil
 	})
+	if err != nil {
+		p.log.Error(err, "Unexpected error from the drivers API, still initializing?")
+		return fmt.Errorf("%w: unexpected error from the drivers API", provisioner.ErrNotReady)
+	}
 
 	if driverCount == 0 {
 		return fmt.Errorf("%w: no drivers loaded in ironic", provisioner.ErrNotReady)

--- a/pkg/provisioner/ironic/dependencies.go
+++ b/pkg/provisioner/ironic/dependencies.go
@@ -2,20 +2,22 @@ package ironic
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/drivers"
 	"github.com/gophercloud/gophercloud/v2/pagination"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
 )
 
-// TryInit checks if the provisioning backend is available.
-func (p *ironicProvisioner) TryInit(ctx context.Context) (ready bool, err error) {
+func (p *ironicProvisioner) init(ctx context.Context) error {
 	p.debugLog.Info("verifying ironic provisioner dependencies")
 
+	var err error
 	p.availableFeatures, err = clients.GetAvailableFeatures(ctx, p.client)
 	if err != nil {
 		p.log.Info("error caught while checking endpoint, will retry", "endpoint", p.client.Endpoint, "error", err)
-		return false, nil
+		return fmt.Errorf("%w: cannot reach ironic endpoint", provisioner.ErrNotReady)
 	}
 
 	p.client.Microversion = p.availableFeatures.ChooseMicroversion()
@@ -24,14 +26,12 @@ func (p *ironicProvisioner) TryInit(ctx context.Context) (ready bool, err error)
 	return p.checkIronicConductor(ctx)
 }
 
-func (p *ironicProvisioner) checkIronicConductor(ctx context.Context) (ready bool, err error) {
+func (p *ironicProvisioner) checkIronicConductor(ctx context.Context) error {
 	pager := drivers.ListDrivers(p.client, drivers.ListDriversOpts{
 		Detail: false,
 	})
-	err = pager.Err
-
-	if err != nil {
-		return ready, err
+	if pager.Err != nil {
+		return pager.Err
 	}
 
 	driverCount := 0
@@ -44,8 +44,9 @@ func (p *ironicProvisioner) checkIronicConductor(ctx context.Context) (ready boo
 		return true, nil
 	})
 
-	// If we have any drivers, conductor is up.
-	ready = driverCount > 0
+	if driverCount == 0 {
+		return fmt.Errorf("%w: no drivers loaded in ironic", provisioner.ErrNotReady)
+	}
 
-	return ready, err
+	return nil
 }

--- a/pkg/provisioner/ironic/factory.go
+++ b/pkg/provisioner/ironic/factory.go
@@ -164,8 +164,18 @@ func (f ironicProvisionerFactory) ironicProvisioner(ctx context.Context, hostDat
 
 // NewProvisioner returns a new Ironic Provisioner using the global
 // configuration for finding the Ironic services.
+// Returns provisioner.ErrNotReady if Ironic is not available yet.
 func (f ironicProvisionerFactory) NewProvisioner(ctx context.Context, hostData provisioner.HostData, publisher provisioner.EventPublisher) (provisioner.Provisioner, error) {
-	return f.ironicProvisioner(ctx, hostData, publisher)
+	p, err := f.ironicProvisioner(ctx, hostData, publisher)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := p.init(ctx); err != nil {
+		return nil, err
+	}
+
+	return p, nil
 }
 
 func loadConfigFromEnv(havePreprovImgBuilder bool) (ironicConfig, error) {

--- a/pkg/provisioner/ironic/ironic_test.go
+++ b/pkg/provisioner/ironic/ironic_test.go
@@ -133,7 +133,7 @@ func TestNewNoBMCDetails(t *testing.T) {
 	host.Spec.BMC = metal3api.BMCDetails{}
 
 	factory := newTestProvisionerFactory()
-	prov, err := factory.NewProvisioner(t.Context(), provisioner.BuildHostData(host, bmc.Credentials{}), nullEventPublisher)
+	prov, err := factory.ironicProvisioner(t.Context(), provisioner.BuildHostData(host, bmc.Credentials{}), nullEventPublisher)
 	require.NoError(t, err)
 	assert.NotNil(t, prov)
 }

--- a/pkg/provisioner/ironic/ready_test.go
+++ b/pkg/provisioner/ironic/ready_test.go
@@ -29,7 +29,7 @@ func TestProvisionerIsReady(t *testing.T) {
 		},
 		{
 			name:                "NoDriversLoaded",
-			ironic:              testserver.NewIronic(t),
+			ironic:              testserver.NewIronic(t).WithNoDrivers(),
 			expectedIronicCalls: "/v1/;/v1/drivers;",
 		},
 		{

--- a/pkg/provisioner/ironic/ready_test.go
+++ b/pkg/provisioner/ironic/ready_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/testserver"
 	"github.com/stretchr/testify/assert"
@@ -64,10 +65,7 @@ func TestProvisionerIsReady(t *testing.T) {
 				t.Fatalf("could not create provisioner: %s", err)
 			}
 
-			ready, err := prov.TryInit(t.Context())
-			if err != nil {
-				t.Fatalf("could not determine ready state: %s", err)
-			}
+			err = prov.init(t.Context())
 
 			if tc.ironic != nil {
 				assert.Equal(t, tc.expectedIronicCalls, tc.ironic.Requests, "ironic calls")
@@ -75,9 +73,10 @@ func TestProvisionerIsReady(t *testing.T) {
 
 			if tc.expectedError != "" {
 				assert.Regexp(t, tc.expectedError, err, "error message")
-			} else {
+			} else if tc.expectedIsReady {
 				require.NoError(t, err)
-				assert.Equal(t, tc.expectedIsReady, ready, "ready flag")
+			} else {
+				assert.ErrorIs(t, err, provisioner.ErrNotReady)
 			}
 		})
 	}

--- a/pkg/provisioner/ironic/register_test.go
+++ b/pkg/provisioner/ironic/register_test.go
@@ -1358,7 +1358,8 @@ func TestRegisterDisablePowerOff(t *testing.T) {
 		t.Fatalf("could not create provisioner: %s", err)
 	}
 
-	prov.TryInit(t.Context())
+	prov.availableFeatures.MaxVersion = 95
+
 	result, _, err := prov.Register(t.Context(), provisioner.ManagementAccessData{DisablePowerOff: true}, false, false)
 	if err != nil {
 		t.Fatalf("error from Register: %s", err)
@@ -1371,7 +1372,7 @@ func TestRegisterDisablePowerOffNotAvail(t *testing.T) {
 	host := makeHost()
 
 	// Set up ironic server to return the node
-	ironic := testserver.NewIronic(t).WithVersion("1.87").
+	ironic := testserver.NewIronic(t).
 		Node(nodes.Node{
 			UUID: host.Status.Provisioning.ID,
 		}).NodeUpdate(nodes.Node{
@@ -1386,7 +1387,8 @@ func TestRegisterDisablePowerOffNotAvail(t *testing.T) {
 		t.Fatalf("could not create provisioner: %s", err)
 	}
 
-	prov.TryInit(t.Context())
+	prov.availableFeatures.MaxVersion = 89
+
 	result, _, err := prov.Register(t.Context(), provisioner.ManagementAccessData{DisablePowerOff: true}, false, false)
 	if err != nil {
 		t.Fatalf("error from Register: %s", err)

--- a/pkg/provisioner/ironic/testserver/ironic.go
+++ b/pkg/provisioner/ironic/testserver/ironic.go
@@ -112,6 +112,16 @@ func (m *IronicMock) WithDrivers() *IronicMock {
 	return m
 }
 
+// WithNoDrivers configures the server so /v1/drivers returns an empty list.
+func (m *IronicMock) WithNoDrivers() *IronicMock {
+	m.ResponseWithCode("/v1/drivers", `
+	{
+		"drivers": []
+	}
+	`, http.StatusOK)
+	return m
+}
+
 func (m *IronicMock) buildURL(url string, method string) string {
 	return fmt.Sprintf("%s:%s", url, method)
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -16,6 +16,10 @@ import (
 Package provisioning defines the API for talking to the provisioning backend.
 */
 
+// ErrNotReady is returned by NewProvisioner when the provisioning backend
+// is not yet available. Controllers should requeue and retry.
+var ErrNotReady = errors.New("provisioner is not ready")
+
 // EventPublisher is a function type for publishing events associated
 // with provisioning.
 type EventPublisher func(reason, message string)
@@ -208,10 +212,6 @@ type Provisioner interface {
 	// The automatedCleaningMode indicates the user's current intent regarding
 	// automated cleaning, used to determine if cleaning should be aborted during deletion.
 	PowerOff(ctx context.Context, rebootMode metal3api.RebootMode, force bool, automatedCleaningMode metal3api.AutomatedCleaningMode) (result Result, err error)
-
-	// TryInit checks if the provisioning backend is available to accept
-	// all the incoming requests and configures the available features.
-	TryInit(ctx context.Context) (ready bool, err error)
 
 	// HasCapacity checks if the backend has a free (de)provisioning slot for the current host
 	HasCapacity(ctx context.Context) (result bool, err error)


### PR DESCRIPTION
All of our production code calls TryInit right after NewProvisioner,
so there is little point for them to be separate. A new ErrNotReady
error indicates what returning ready=false used to indicate.

This simplification is needed for my follow-up changes to improve
caching of Ironic parameters between reconciliations.

Using ⚠️ to highlight the change in the Provisioner interface.

Generated-By: Claude Code (commercial)
Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
