### PR TITLE
🐛 Avoid calling getNode in GetFirmwareSettings

### DIFF
--- a/pkg/provisioner/ironic/bios_test.go
+++ b/pkg/provisioner/ironic/bios_test.go
@@ -22,6 +22,7 @@ func TestGetFirmwareSettings(t *testing.T) {
 
 	cases := []struct {
 		name                string
+		nodeUUID            string
 		expectedSettingsMap metal3api.SettingsMap
 		expectedSchemaMap   map[string]metal3api.SettingSchema
 		includeSchema       bool
@@ -29,7 +30,8 @@ func TestGetFirmwareSettings(t *testing.T) {
 		expectedError       string
 	}{
 		{
-			name: "no-schema",
+			name:     "no-schema",
+			nodeUUID: nodeUUID,
 			expectedSettingsMap: metal3api.SettingsMap{
 				"L2Cache":            "10x256 KB",
 				"NumCores":           "10",
@@ -41,7 +43,8 @@ func TestGetFirmwareSettings(t *testing.T) {
 			expectedError:     "",
 		},
 		{
-			name: "include-schema",
+			name:     "include-schema",
+			nodeUUID: nodeUUID,
 			expectedSettingsMap: metal3api.SettingsMap{
 				"L2Cache":            "10x256 KB",
 				"NumCores":           "10",
@@ -85,11 +88,20 @@ func TestGetFirmwareSettings(t *testing.T) {
 		},
 		{
 			name:                "error404",
+			nodeUUID:            nodeUUID,
 			expectedSettingsMap: metal3api.SettingsMap(nil),
 			expectedSchemaMap:   map[string]metal3api.SettingSchema(nil),
 			ironic:              testserver.NewIronic(t).NoBIOS(nodeUUID),
 			includeSchema:       false,
-			expectedError:       "could not get node for BIOS settings: host not registered",
+			expectedError:       "could not get BIOS settings for node .* got 404 instead.*",
+		},
+		{
+			name:                "not-registered",
+			expectedSettingsMap: metal3api.SettingsMap(nil),
+			expectedSchemaMap:   map[string]metal3api.SettingSchema(nil),
+			ironic:              testserver.NewIronic(t).NoBIOS(nodeUUID),
+			includeSchema:       false,
+			expectedError:       "could not get BIOS settings: host not registered",
 		},
 	}
 
@@ -100,7 +112,7 @@ func TestGetFirmwareSettings(t *testing.T) {
 
 			host := makeHost()
 			host.Name = "node-1"
-			host.Status.Provisioning.ID = nodeUUID
+			host.Status.Provisioning.ID = tc.nodeUUID
 
 			auth := clients.AuthConfig{Type: clients.NoAuth}
 

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -733,9 +733,8 @@ func (p *ironicProvisioner) getInstanceUpdateOpts(ironicNode *nodes.Node, data p
 
 // GetFirmwareSettings gets the BIOS settings and optional schema from the host and returns maps.
 func (p *ironicProvisioner) GetFirmwareSettings(ctx context.Context, includeSchema bool) (settings metal3api.SettingsMap, schema map[string]metal3api.SettingSchema, err error) {
-	ironicNode, err := p.getNode(ctx)
-	if err != nil {
-		return nil, nil, fmt.Errorf("could not get node for BIOS settings: %w", err)
+	if p.nodeID == "" {
+		return nil, nil, fmt.Errorf("could not get BIOS settings: %w", provisioner.ErrNeedsRegistration)
 	}
 
 	// Get the settings from Ironic via Gophercloud
@@ -743,14 +742,14 @@ func (p *ironicProvisioner) GetFirmwareSettings(ctx context.Context, includeSche
 	var biosListErr error
 	if includeSchema {
 		opts := nodes.ListBIOSSettingsOpts{Detail: true}
-		settingsList, biosListErr = nodes.ListBIOSSettings(ctx, p.client, ironicNode.UUID, opts).Extract()
+		settingsList, biosListErr = nodes.ListBIOSSettings(ctx, p.client, p.nodeID, opts).Extract()
 	} else {
-		settingsList, biosListErr = nodes.ListBIOSSettings(ctx, p.client, ironicNode.UUID, nil).Extract()
+		settingsList, biosListErr = nodes.ListBIOSSettings(ctx, p.client, p.nodeID, nil).Extract()
 	}
 	if biosListErr != nil {
-		return nil, nil, fmt.Errorf("could not get BIOS settings for node %s: %w", ironicNode.UUID, biosListErr)
+		return nil, nil, fmt.Errorf("could not get BIOS settings for node %s: %w", p.nodeID, biosListErr)
 	}
-	p.log.Info("retrieved BIOS settings for node", "node", ironicNode.UUID, "size", len(settingsList))
+	p.log.Info("retrieved BIOS settings for node", "node", p.nodeID, "size", len(settingsList))
 
 	settings = make(map[string]string)
 	schema = make(map[string]metal3api.SettingSchema)

--- a/pkg/provisioner/ironic/testserver/ironic.go
+++ b/pkg/provisioner/ironic/testserver/ironic.go
@@ -463,9 +463,13 @@ func (m *IronicMock) BIOSDetailSettings(nodeUUID string) *IronicMock {
 	return m
 }
 
-// NoBIOS configures the server so /v1/node/<node>/bios returns a 404.
+// NoBIOS configures the server so /v1/nodes/<node>/bios returns a 404.
 func (m *IronicMock) NoBIOS(nodeUUID string) *IronicMock {
-	return m.NodeError(nodeUUID, http.StatusNotFound)
+	m.ErrorResponse(v1node+nodeUUID+"/bios", http.StatusNotFound)
+	m.AddDefaultResponseJSON(v1node+nodeUUID, "", http.StatusOK, nodes.Node{
+		UUID: nodeUUID,
+	})
+	return m
 }
 
 // WithInventory configures the server with a valid response for /v1/nodes/<node>/inventory.


### PR DESCRIPTION
It's pointless since we only use node UUID, which is already known.

Fix the unit test to check what it actually claims to check.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
