### PR TITLE
🐛 Avoid calling getNode in GetFirmwareComponents

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -939,21 +939,24 @@ func (r *BareMetalHostReconciler) registerHost(ctx context.Context, prov provisi
 		return actionUpdate{}
 	}
 
-	// Check if the host can support firmware components before creating the resource
-	_, errGetFirmwareComponents := prov.GetFirmwareComponents(ctx)
-	supportsFirmwareComponents := !errors.Is(errGetFirmwareComponents, provisioner.ErrFirmwareUpdateUnsupported)
-
 	// Create the hostFirmwareSettings resource with same host name/namespace if it doesn't exist
 	// Create the hostFirmwareComponents resource with same host name/namespace if it doesn't exist
 	if info.host.Name != "" {
 		if !info.host.DeletionTimestamp.IsZero() {
 			info.log.Info("will not attempt to create new hostFirmwareSettings and hostFirmwareComponents in " + info.host.Namespace)
 		} else {
+			// Check if the host can support firmware components before creating the resource
+			firmwareComponents, errGetFirmwareComponents := prov.GetFirmwareComponents(ctx)
+			if errGetFirmwareComponents != nil {
+				info.log.V(1).Error(errGetFirmwareComponents, "failed to retrieve firmware components; deferring HostFirmwareComponents creation")
+				firmwareComponents = nil
+			}
+
 			if err = r.createHostFirmwareSettings(ctx, info); err != nil {
 				info.log.Info("failed creating hostfirmwaresettings")
 				return actionError{fmt.Errorf("failed to create or update hostFirmwareSettings: %w", err)}
 			}
-			if supportsFirmwareComponents {
+			if len(firmwareComponents) > 0 {
 				if err = r.createHostFirmwareComponents(ctx, info); err != nil {
 					info.log.Info("failed creating hostfirmwarecomponents")
 					return actionError{fmt.Errorf("failed creating hostFirmwareComponents: %w", err)}

--- a/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
+++ b/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 
@@ -150,9 +149,6 @@ func (r *HostFirmwareComponentsReconciler) Reconcile(ctx context.Context, req ct
 	components, err := prov.GetFirmwareComponents(ctx)
 
 	if err != nil {
-		if errors.Is(err, provisioner.ErrFirmwareUpdateUnsupported) {
-			return ctrl.Result{}, nil
-		}
 		reqLogger.Info("provisioner returns error", "Error", err.Error(), "RequeueAfter", provisionerRetryDelay)
 		return ctrl.Result{Requeue: true, RequeueAfter: provisionerRetryDelay}, nil
 	}

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -778,28 +778,23 @@ func (p *ironicProvisioner) GetFirmwareSettings(ctx context.Context, includeSche
 
 // GetFirmwareComponents gets all available firmware components for a node and return a list.
 func (p *ironicProvisioner) GetFirmwareComponents(ctx context.Context) ([]metal3api.FirmwareComponentStatus, error) {
-	ironicNode, err := p.getNode(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("could not get node to retrieve firmware components: %w", err)
+	if p.nodeID == "" {
+		return nil, fmt.Errorf("could not retrieve firmware components: %w", provisioner.ErrNeedsRegistration)
 	}
 
 	// We support bmc, bios, and multiple NICs components. Starting with 3 slots.
 	componentsInfo := make([]metal3api.FirmwareComponentStatus, 0, 3) //nolint:mnd
 
-	if ironicNode.FirmwareInterface == "no-firmware" {
-		return componentsInfo, provisioner.ErrFirmwareUpdateUnsupported
-	}
 	// Get the components from Ironic via Gophercloud
-	componentList, componentListErr := nodes.ListFirmware(ctx, p.client, ironicNode.UUID).Extract()
-
-	if componentListErr != nil {
-		return nil, fmt.Errorf("could not get firmware components for node %s: %w", ironicNode.UUID, componentListErr)
+	componentList, err := nodes.ListFirmware(ctx, p.client, p.nodeID).Extract()
+	if err != nil {
+		return nil, fmt.Errorf("could not get firmware components for node %s: %w", p.nodeID, err)
 	}
 
 	// Iterate over the list of components to extract their information and update the list.
 	for _, fwc := range componentList {
 		if fwc.Component != "bios" && fwc.Component != "bmc" && !strings.HasPrefix(fwc.Component, metal3api.NICComponentPrefix) {
-			p.log.Info("ignoring firmware component for node", "component", fwc.Component, "node", ironicNode.UUID)
+			p.log.Info("ignoring firmware component for node", "component", fwc.Component, "node", p.nodeID)
 			continue
 		}
 		component := metal3api.FirmwareComponentStatus{
@@ -815,10 +810,10 @@ func (p *ironicProvisioner) GetFirmwareComponents(ctx context.Context) ([]metal3
 			}
 		}
 		componentsInfo = append(componentsInfo, component)
-		p.log.V(1).Info("firmware component found for node", "component", fwc.Component, "node", ironicNode.UUID)
+		p.log.V(1).Info("firmware component found for node", "component", fwc.Component, "node", p.nodeID)
 	}
 
-	return componentsInfo, componentListErr
+	return componentsInfo, err
 }
 
 func (p *ironicProvisioner) setUpForProvisioning(ctx context.Context, ironicNode *nodes.Node, data provisioner.ProvisionData) (result provisioner.Result, err error) {

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -278,9 +278,6 @@ var ErrNeedsRegistration = errors.New("host not registered")
 // required.
 var ErrNeedsPreprovisioningImage = errors.New("no suitable Preprovisioning image available")
 
-// ErrFirmwareUpdateUnsupported is returned if the host can't execute firmware updates.
-var ErrFirmwareUpdateUnsupported = errors.New("host does not support Firmware Updates")
-
 // ErrNodeIsBusy is returned when the node is busy due to being reserved for another
 // task.
 var ErrNodeIsBusy = errors.New("node is busy")


### PR DESCRIPTION
The only actual purpose of the call there is to see if firmware
components are supported by the Node. Which, in turn, is needed
to determine if the HFC object needs to be created by the BMH
controller.

This commit changes the behavior slightly: now HFC is not created when
the list of components is empty. This happens both when firmware
settings are not supported and during early stages of enrollment.

Most users will only see that the HFC resource may get created slightly
later than before.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
