### PR TITLE
🌱 E2E: Verify Ironic TLS and basic-auth

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -1142,6 +1142,10 @@ func WaitForIronicReady(ctx context.Context, input WaitForIronicInput) {
 	}, input.Intervals...).Should(Succeed())
 
 	Logf("Ironic %q is Ready", input.Name)
+
+	if input.SecurityConfig != nil {
+		VerifyIronicSecurityConfig(ctx, *input.SecurityConfig)
+	}
 }
 
 // WaitForIronicInput bundles the parameters for WaitForIronicReady.
@@ -1150,6 +1154,9 @@ type WaitForIronicInput struct {
 	Name      string
 	Namespace string
 	Intervals []interface{} // e.g. []interface{}{time.Minute * 15, time.Second * 5}
+	// SecurityConfig is optional. When non-nil, TLS and basic-auth security
+	// configuration of the Ironic API endpoint will also be verified.
+	SecurityConfig *IronicSecurityConfig
 }
 
 // ConfigureProvisioningNetwork adds the provisioning IP with /24 netmask to the kind cluster node.

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"context"
 	"flag"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -167,6 +168,12 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 			Name:      "ironic",
 			Namespace: bmoIronicNamespace,
 			Intervals: e2eConfig.GetIntervals("ironic", "wait-deployment"),
+			SecurityConfig: &IronicSecurityConfig{
+				Host:          net.JoinHostPort(e2eConfig.GetVariable("IRONIC_PROVISIONING_IP"), e2eConfig.GetVariable("IRONIC_PROVISIONING_PORT")),
+				Username:      e2eConfig.GetVariable("IRONIC_USERNAME"),
+				Password:      e2eConfig.GetVariable("IRONIC_PASSWORD"),
+				ClientTimeout: e2eConfig.GetDurationVariable("IRONIC_CLIENT_TIMEOUT"),
+			},
 		})
 	}
 

--- a/test/e2e/ironic_helpers.go
+++ b/test/e2e/ironic_helpers.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/httpbasic"
@@ -77,6 +78,95 @@ func WaitForIronicNodeProvisionState(ctx context.Context, input WaitForIronicNod
 		g.Expect(slices.Contains(input.States, currentState)).To(BeTrue(),
 			"Ironic node %s is in state %s, expected one of %v", input.NodeName, currentState, input.States)
 	}, intervals...).Should(Succeed())
+}
+
+// IronicSecurityConfig holds the parameters needed to verify Ironic TLS and basic-auth security.
+type IronicSecurityConfig struct {
+	// Host is the Ironic API host in "host:port" form.
+	Host string
+	// Username is the Ironic basic-auth username.
+	Username string
+	// Password is the Ironic basic-auth password.
+	Password string
+	// ClientTimeout is the HTTP client timeout used during verification requests.
+	ClientTimeout time.Duration
+}
+
+// VerifyIronicSecurityConfig verifies that the Ironic API endpoint is protected by TLS
+// and basic authentication. It checks that:
+//   - The server presents a TLS certificate
+//   - Unauthenticated requests are rejected with HTTP 401
+//   - Requests with incorrect credentials are rejected with HTTP 401
+//   - Requests with correct credentials succeed with HTTP 200
+func VerifyIronicSecurityConfig(ctx context.Context, config IronicSecurityConfig) {
+	ironicEndpoint := fmt.Sprintf("https://%s/v1", config.Host)
+	username := config.Username
+	password := config.Password
+
+	Logf("Verifying Ironic TLS and basic-auth configuration at %s", ironicEndpoint)
+
+	// Verify TLS: connect directly and confirm the server completes a handshake
+	// and presents a certificate. InsecureSkipVerify is required because Ironic
+	// uses a self-signed certificate in the test environment.
+	tlsDialer := &tls.Dialer{
+		Config: &tls.Config{
+			InsecureSkipVerify: true, // #nosec G402 Self-signed certificates in the test environment
+		},
+	}
+	rawConn, err := tlsDialer.DialContext(ctx, "tcp", config.Host)
+	Expect(err).NotTo(HaveOccurred(), "Ironic should accept TLS connections at %s", config.Host)
+	//nolint:forcetypeassert
+	tlsConn := rawConn.(*tls.Conn)
+	state := tlsConn.ConnectionState()
+	_ = rawConn.Close()
+	Expect(state.HandshakeComplete).To(BeTrue(), "TLS handshake with Ironic should be complete")
+	Expect(state.PeerCertificates).NotTo(BeEmpty(), "Ironic server should present a TLS certificate")
+	Logf("Ironic TLS certificate subject: %s", state.PeerCertificates[0].Subject)
+
+	// Create client for the basic-auth HTTP checks.
+	httpClient := &http.Client{
+		Timeout: config.ClientTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, // #nosec G402 Self-signed certificates in the test environment
+			},
+		},
+	}
+
+	// Use /v1/nodes for the auth checks: /v1 is intentionally public (version
+	// discovery), while /v1/nodes is a protected resource that requires auth.
+	nodesEndpoint := fmt.Sprintf("https://%s/v1/nodes", config.Host)
+
+	// No credentials: expect HTTP 401.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, nodesEndpoint, http.NoBody)
+	Expect(err).NotTo(HaveOccurred())
+	resp, err := httpClient.Do(req)
+	Expect(err).NotTo(HaveOccurred(), "Ironic should be reachable at %s", nodesEndpoint)
+	_ = resp.Body.Close()
+	Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized),
+		"Ironic should return HTTP 401 when accessed without credentials")
+
+	// Wrong credentials: expect HTTP 401.
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, nodesEndpoint, http.NoBody)
+	Expect(err).NotTo(HaveOccurred())
+	req.SetBasicAuth("wrong-user", "wrong-password")
+	resp, err = httpClient.Do(req)
+	Expect(err).NotTo(HaveOccurred())
+	_ = resp.Body.Close()
+	Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized),
+		"Ironic should return HTTP 401 when accessed with wrong credentials")
+
+	// Correct credentials: expect HTTP 200.
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, nodesEndpoint, http.NoBody)
+	Expect(err).NotTo(HaveOccurred())
+	req.SetBasicAuth(username, password)
+	resp, err = httpClient.Do(req)
+	Expect(err).NotTo(HaveOccurred())
+	_ = resp.Body.Close()
+	Expect(resp.StatusCode).To(Equal(http.StatusOK),
+		"Ironic should return HTTP 200 when accessed with correct credentials")
+
+	Logf("Ironic TLS and basic-auth verification passed")
 }
 
 // RedfishResetBios resets BIOS in sushy-tools (or similar implementation).

--- a/test/e2e/upgrade_bmo_test.go
+++ b/test/e2e/upgrade_bmo_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"net"
 	"path/filepath"
 	"strings"
 
@@ -57,11 +58,21 @@ func RunBMOUpgradeTest(ctx context.Context, input *BMOUpgradeSpec, upgradeCluste
 			LogPath:             filepath.Join(testCaseArtifactFolder, "logs"),
 		})
 		Expect(err).NotTo(HaveOccurred())
+		upgradeIronicIP := e2eConfig.GetVariable("IRONIC_PROVISIONING_IP")
+		if e2eConfig.HasVariable("UPGRADE_IRONIC_PROVISIONING_IP") {
+			upgradeIronicIP = e2eConfig.GetVariable("UPGRADE_IRONIC_PROVISIONING_IP")
+		}
 		WaitForIronicReady(ctx, WaitForIronicInput{
 			Client:    upgradeClusterProxy.GetClient(),
 			Name:      "ironic",
 			Namespace: bmoIronicNamespace,
 			Intervals: e2eConfig.GetIntervals("ironic", "wait-deployment"),
+			SecurityConfig: &IronicSecurityConfig{
+				Host:          net.JoinHostPort(upgradeIronicIP, e2eConfig.GetVariable("IRONIC_PROVISIONING_PORT")),
+				Username:      e2eConfig.GetVariable("IRONIC_USERNAME"),
+				Password:      e2eConfig.GetVariable("IRONIC_PASSWORD"),
+				ClientTimeout: e2eConfig.GetDurationVariable("IRONIC_CLIENT_TIMEOUT"),
+			},
 		})
 	}
 

--- a/test/e2e/upgrade_ironic_test.go
+++ b/test/e2e/upgrade_ironic_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"net"
 	"path/filepath"
 	"strings"
 
@@ -57,11 +58,21 @@ func RunIronicUpgradeTest(ctx context.Context, input *IronicUpgradeSpec, upgrade
 			LogPath:             filepath.Join(testCaseArtifactFolder, "logs"),
 		})
 		Expect(err).NotTo(HaveOccurred())
+		upgradeIronicIP := e2eConfig.GetVariable("IRONIC_PROVISIONING_IP")
+		if e2eConfig.HasVariable("UPGRADE_IRONIC_PROVISIONING_IP") {
+			upgradeIronicIP = e2eConfig.GetVariable("UPGRADE_IRONIC_PROVISIONING_IP")
+		}
 		WaitForIronicReady(ctx, WaitForIronicInput{
 			Client:    upgradeClusterProxy.GetClient(),
 			Name:      "ironic",
 			Namespace: bmoIronicNamespace,
 			Intervals: e2eConfig.GetIntervals("ironic", "wait-deployment"),
+			SecurityConfig: &IronicSecurityConfig{
+				Host:          net.JoinHostPort(upgradeIronicIP, e2eConfig.GetVariable("IRONIC_PROVISIONING_PORT")),
+				Username:      e2eConfig.GetVariable("IRONIC_USERNAME"),
+				Password:      e2eConfig.GetVariable("IRONIC_PASSWORD"),
+				ClientTimeout: e2eConfig.GetDurationVariable("IRONIC_CLIENT_TIMEOUT"),
+			},
 		})
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Make sure that basic-auth is enabled and using the expected credentials. Check that TLS is used. This does not yet verify the expected certificate is used.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
