### PR TITLE
:sparkles: Add webhooks to validate URLs

### DIFF
--- a/config/base/webhook/manifests.yaml
+++ b/config/base/webhook/manifests.yaml
@@ -50,6 +50,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-metal3-io-v1alpha1-dataimage
+  failurePolicy: Fail
+  name: dataimage.metal3.io
+  rules:
+  - apiGroups:
+    - metal3.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - dataimages
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-metal3-io-v1alpha1-hostclaim
   failurePolicy: Fail
   name: hostclaim.metal3.io
@@ -63,6 +83,26 @@ webhooks:
     - UPDATE
     resources:
     - hostclaims
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-metal3-io-v1alpha1-hostfirmwarecomponents
+  failurePolicy: Fail
+  name: hostfirmwarecomponents.metal3.io
+  rules:
+  - apiGroups:
+    - metal3.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - hostfirmwarecomponents
   sideEffects: None
 - admissionReviewVersions:
   - v1

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -3670,6 +3670,26 @@ webhooks:
     service:
       name: baremetal-operator-webhook-service
       namespace: baremetal-operator-system
+      path: /validate-metal3-io-v1alpha1-dataimage
+  failurePolicy: Fail
+  name: dataimage.metal3.io
+  rules:
+  - apiGroups:
+    - metal3.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - dataimages
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: baremetal-operator-webhook-service
+      namespace: baremetal-operator-system
       path: /validate-metal3-io-v1alpha1-hostclaim
   failurePolicy: Fail
   name: hostclaim.metal3.io
@@ -3683,6 +3703,26 @@ webhooks:
     - UPDATE
     resources:
     - hostclaims
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: baremetal-operator-webhook-service
+      namespace: baremetal-operator-system
+      path: /validate-metal3-io-v1alpha1-hostfirmwarecomponents
+  failurePolicy: Fail
+  name: hostfirmwarecomponents.metal3.io
+  rules:
+  - apiGroups:
+    - metal3.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - hostfirmwarecomponents
   sideEffects: None
 - admissionReviewVersions:
   - v1

--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"net/url"
 	"regexp"
 	"slices"
 	"strings"
@@ -293,7 +292,7 @@ func validateStatusAnnotation(statusAnnotation string) error {
 func validateImage(image *metal3api.Image) []error {
 	var errs []error
 
-	_, err := url.ParseRequestURI(image.URL)
+	err := validateURL(image.URL)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("image URL %s is invalid: %w", image.URL, err))
 	}

--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -580,6 +580,19 @@ func TestValidateCreate(t *testing.T) {
 			oldBMH: nil,
 		},
 		{
+			name: "validImageURLOCI",
+			newBMH: &metal3api.BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: metal3api.BareMetalHostSpec{
+					Image: &metal3api.Image{
+						URL: "oci://example.com/image:latest",
+					},
+				},
+			},
+			oldBMH: nil,
+		},
+		{
 			name: "validImageLiveISO",
 			newBMH: &metal3api.BareMetalHost{
 				TypeMeta:   tm,
@@ -607,6 +620,21 @@ func TestValidateCreate(t *testing.T) {
 			},
 			oldBMH:    nil,
 			wantedErr: "image URL test1 is invalid: parse \"test1\": invalid URI for request",
+		},
+		{
+			name: "invalidImageURLScheme",
+			newBMH: &metal3api.BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: metal3api.BareMetalHostSpec{
+					Image: &metal3api.Image{
+						URL:      "unix://example.com",
+						Checksum: "be254ebfd73e66ca91f6d91f5050aa2ee1ec4813ee65ba472f608ed340cbff09",
+					},
+				},
+			},
+			oldBMH:    nil,
+			wantedErr: "image URL unix://example.com is invalid: invalid scheme in URL, \"unix\" not allowed",
 		},
 		{
 			name: "emptyImageURL",

--- a/internal/webhooks/metal3.io/v1alpha1/common_validation.go
+++ b/internal/webhooks/metal3.io/v1alpha1/common_validation.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2025 The Metal3 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"fmt"
+	"net/url"
+	"slices"
+)
+
+// validateURL validates the given URL. The URL is assumed to come from HTTP
+// request. On success, no error is returned. Empty string also returns an error.
+func validateURL(input string) error {
+	urlObj, err := url.ParseRequestURI(input)
+	if err != nil {
+		return err
+	}
+
+	// Check the URL scheme
+	allowed := []string{"http", "https", "ftp", "gopher", "oci"}
+	if !slices.Contains(allowed, urlObj.Scheme) {
+		return fmt.Errorf("invalid scheme in URL, \"%s\" not allowed", urlObj.Scheme)
+	}
+
+	return nil
+}

--- a/internal/webhooks/metal3.io/v1alpha1/dataimage_validation.go
+++ b/internal/webhooks/metal3.io/v1alpha1/dataimage_validation.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2025 The Metal3 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"fmt"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+)
+
+// validateDataImage validates DataImage resource for creation and updating.
+func (webhook *DataImage) validateDataImage(img *metal3api.DataImage) []error {
+	var errs []error
+
+	if err := validateURL(img.Spec.URL); err != nil {
+		errs = append(errs, fmt.Errorf("URL \"%s\" is invalid: %w", img.Spec.URL, err))
+	}
+
+	return errs
+}

--- a/internal/webhooks/metal3.io/v1alpha1/dataimage_validation_test.go
+++ b/internal/webhooks/metal3.io/v1alpha1/dataimage_validation_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2025 The Metal3 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"testing"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDataImageValidateCreate(t *testing.T) {
+	tm := metav1.TypeMeta{
+		Kind:       "DataImage",
+		APIVersion: "metal3.io/v1alpha1",
+	}
+
+	om := metav1.ObjectMeta{
+		Name:      "test",
+		Namespace: "test-namespace",
+	}
+
+	tests := []struct {
+		name      string
+		newS      *metal3api.DataImage
+		oldS      *metal3api.DataImage
+		wantedErr string
+	}{
+		{
+			name:      "validURL",
+			newS:      &metal3api.DataImage{TypeMeta: tm, ObjectMeta: om, Spec: metal3api.DataImageSpec{URL: "http://localhost/abc/abc.php"}},
+			oldS:      nil,
+			wantedErr: "",
+		},
+		{
+			name:      "invalidURL",
+			newS:      &metal3api.DataImage{TypeMeta: tm, ObjectMeta: om, Spec: metal3api.DataImageSpec{URL: "abc"}},
+			oldS:      nil,
+			wantedErr: "URL \"abc\" is invalid: parse \"abc\": invalid URI for request",
+		},
+		{
+			name:      "invalidURLScheme",
+			newS:      &metal3api.DataImage{TypeMeta: tm, ObjectMeta: om, Spec: metal3api.DataImageSpec{URL: "unix://localhost/abc/abc.php"}},
+			oldS:      nil,
+			wantedErr: "URL \"unix://localhost/abc/abc.php\" is invalid: invalid scheme in URL, \"unix\" not allowed",
+		},
+		{
+			name:      "invalidURLempty",
+			newS:      &metal3api.DataImage{TypeMeta: tm, ObjectMeta: om, Spec: metal3api.DataImageSpec{URL: ""}},
+			oldS:      nil,
+			wantedErr: "URL \"\" is invalid: parse \"\": empty url",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			webhook := &DataImage{}
+			if err := webhook.validateDataImage(tt.newS); !errorArrContains(err, tt.wantedErr) {
+				t.Errorf("DataImageWebhook error = %v, wantErr %v", err, tt.wantedErr)
+			}
+		})
+	}
+}

--- a/internal/webhooks/metal3.io/v1alpha1/dataimage_webhook.go
+++ b/internal/webhooks/metal3.io/v1alpha1/dataimage_webhook.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2025 The Metal3 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// dataimagelog is for logging in this webhook.
+var dataimagelog = logf.Log.WithName("webhooks").WithName("DataImage")
+
+// SetupWebhookWithManager registers the DataImage validation and defaulting webhooks with the manager.
+func (webhook *DataImage) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr, &metal3api.DataImage{}).
+		WithValidator(webhook).
+		WithDefaulter(webhook).
+		Complete()
+}
+
+//+kubebuilder:webhook:verbs=create;update,path=/validate-metal3-io-v1alpha1-dataimage,mutating=false,failurePolicy=fail,sideEffects=none,admissionReviewVersions=v1,groups=metal3.io,resources=dataimages,versions=v1alpha1,name=dataimage.metal3.io
+
+// DataImage implements a validation and defaulting webhook for DataImage.
+type DataImage struct{}
+
+var _ admission.Defaulter[*metal3api.DataImage] = &DataImage{}
+var _ admission.Validator[*metal3api.DataImage] = &DataImage{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+func (webhook *DataImage) ValidateCreate(_ context.Context, dataimg *metal3api.DataImage) (admission.Warnings, error) {
+	if dataimg == nil {
+		dataimagelog.Error(errors.New("object is nil"), "validate create error")
+		return nil, nil
+	}
+
+	dataimagelog.Info("validate create", "namespace", dataimg.Namespace, "name", dataimg.Name)
+	return nil, kerrors.NewAggregate(webhook.validateDataImage(dataimg))
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+func (webhook *DataImage) ValidateUpdate(_ context.Context, oldImg, newImg *metal3api.DataImage) (admission.Warnings, error) {
+	if oldImg == nil {
+		dataimagelog.Error(errors.New("old object is nil"), "validate update error")
+		return nil, nil
+	}
+
+	if newImg == nil {
+		dataimagelog.Error(fmt.Errorf("new object is nil for %s/%s", oldImg.Namespace, oldImg.Name), "validate update error")
+		return nil, nil
+	}
+	dataimagelog.Info("validate update", "namespace", newImg.Namespace, "name", newImg.Name)
+
+	return nil, kerrors.NewAggregate(webhook.validateDataImage(newImg))
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
+func (webhook *DataImage) ValidateDelete(_ context.Context, _ *metal3api.DataImage) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type.
+func (webhook *DataImage) Default(_ context.Context, _ *metal3api.DataImage) error {
+	return nil
+}

--- a/internal/webhooks/metal3.io/v1alpha1/hostfirmwarecomponents_validation.go
+++ b/internal/webhooks/metal3.io/v1alpha1/hostfirmwarecomponents_validation.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2025 The Metal3 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"fmt"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+)
+
+// ValidateHostFirmwareComponents validates HostFirmwareComponents resource for creation and updating.
+func (webhook *HostFirmwareComponents) validateHostFirmwareComponents(hfc *metal3api.HostFirmwareComponents) []error {
+	var errs []error
+
+	for _, update := range hfc.Spec.Updates {
+		if err := validateURL(update.URL); err != nil {
+			errs = append(errs, fmt.Errorf("invalid URL \"%s\" in FirmwareUpdate in component \"%s\": %w", update.URL, update.Component, err))
+		}
+	}
+
+	return errs
+}

--- a/internal/webhooks/metal3.io/v1alpha1/hostfirmwarecomponents_validation_test.go
+++ b/internal/webhooks/metal3.io/v1alpha1/hostfirmwarecomponents_validation_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2025 The Metal3 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"testing"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestHostFirmwareComponentsValidateCreate(t *testing.T) {
+	tm := metav1.TypeMeta{
+		Kind:       "HostFirmwareComponents",
+		APIVersion: "metal3.io/v1alpha1",
+	}
+
+	om := metav1.ObjectMeta{
+		Name:      "test",
+		Namespace: "test-namespace",
+	}
+
+	tests := []struct {
+		name      string
+		newS      *metal3api.HostFirmwareComponents
+		oldS      *metal3api.HostFirmwareComponents
+		wantedErr string
+	}{
+		{
+			name:      "validURL",
+			newS:      &metal3api.HostFirmwareComponents{TypeMeta: tm, ObjectMeta: om, Spec: metal3api.HostFirmwareComponentsSpec{Updates: []metal3api.FirmwareUpdate{{URL: "http://example.com"}}}},
+			oldS:      nil,
+			wantedErr: "",
+		},
+		{
+			name:      "invalidURL",
+			newS:      &metal3api.HostFirmwareComponents{TypeMeta: tm, ObjectMeta: om, Spec: metal3api.HostFirmwareComponentsSpec{Updates: []metal3api.FirmwareUpdate{{URL: "abc", Component: "test1"}}}},
+			oldS:      nil,
+			wantedErr: "invalid URL \"abc\" in FirmwareUpdate in component \"test1\": parse \"abc\": invalid URI for request",
+		},
+		{
+			name:      "invalidURLScheme",
+			newS:      &metal3api.HostFirmwareComponents{TypeMeta: tm, ObjectMeta: om, Spec: metal3api.HostFirmwareComponentsSpec{Updates: []metal3api.FirmwareUpdate{{URL: "unix://example.com", Component: "test1"}}}},
+			oldS:      nil,
+			wantedErr: "invalid URL \"unix://example.com\" in FirmwareUpdate in component \"test1\": invalid scheme in URL, \"unix\" not allowed",
+		},
+		{
+			name:      "invalidURLempty",
+			newS:      &metal3api.HostFirmwareComponents{TypeMeta: tm, ObjectMeta: om, Spec: metal3api.HostFirmwareComponentsSpec{Updates: []metal3api.FirmwareUpdate{{URL: "", Component: "test1"}}}},
+			oldS:      nil,
+			wantedErr: "invalid URL \"\" in FirmwareUpdate in component \"test1\": parse \"\": empty url",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			webhook := &HostFirmwareComponents{}
+			if err := webhook.validateHostFirmwareComponents(tt.newS); !errorArrContains(err, tt.wantedErr) {
+				t.Errorf("HostFirmwareComponentsWebhook error = %v, wantErr %v", err, tt.wantedErr)
+			}
+		})
+	}
+}

--- a/internal/webhooks/metal3.io/v1alpha1/hostfirmwarecomponents_webhook.go
+++ b/internal/webhooks/metal3.io/v1alpha1/hostfirmwarecomponents_webhook.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2025 The Metal3 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// hfclog is for logging in this package.
+var hfclog = logf.Log.WithName("webhooks").WithName("HostFirmwareComponents")
+
+// SetupWebhookWithManager registers the HostFirmwareComponents validation and defaulting webhooks with the manager.
+func (webhook *HostFirmwareComponents) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr, &metal3api.HostFirmwareComponents{}).
+		WithValidator(webhook).
+		WithDefaulter(webhook).
+		Complete()
+}
+
+//+kubebuilder:webhook:verbs=create;update,path=/validate-metal3-io-v1alpha1-hostfirmwarecomponents,mutating=false,failurePolicy=fail,sideEffects=none,admissionReviewVersions=v1,groups=metal3.io,resources=hostfirmwarecomponents,versions=v1alpha1,name=hostfirmwarecomponents.metal3.io
+
+// HostFirmwareComponents implements a validation and defaulting webhook for HostFirmwareComponents.
+type HostFirmwareComponents struct{}
+
+var _ admission.Defaulter[*metal3api.HostFirmwareComponents] = &HostFirmwareComponents{}
+var _ admission.Validator[*metal3api.HostFirmwareComponents] = &HostFirmwareComponents{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type.
+func (webhook *HostFirmwareComponents) Default(_ context.Context, _ *metal3api.HostFirmwareComponents) error {
+	return nil
+}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+func (webhook *HostFirmwareComponents) ValidateCreate(_ context.Context, hfc *metal3api.HostFirmwareComponents) (admission.Warnings, error) {
+	if hfc == nil {
+		hfclog.Error(errors.New("object is nil"), "validate create error")
+		return nil, nil
+	}
+
+	hfclog.Info("validate create", "namespace", hfc.Namespace, "name", hfc.Name)
+	return nil, kerrors.NewAggregate(webhook.validateHostFirmwareComponents(hfc))
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+func (webhook *HostFirmwareComponents) ValidateUpdate(_ context.Context, oldHfc, newHfc *metal3api.HostFirmwareComponents) (admission.Warnings, error) {
+	if oldHfc == nil {
+		hfclog.Error(errors.New("old object is nil"), "validate update error")
+		return nil, nil
+	}
+	if newHfc == nil {
+		hfclog.Error(fmt.Errorf("new object is nil for %s/%s", oldHfc.Namespace, oldHfc.Name), "validate update error")
+		return nil, nil
+	}
+	hfclog.Info("validate update", "namespace", newHfc.Namespace, "name", newHfc.Name)
+	return nil, kerrors.NewAggregate(webhook.validateHostFirmwareComponents(newHfc))
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
+func (webhook *HostFirmwareComponents) ValidateDelete(_ context.Context, _ *metal3api.HostFirmwareComponents) (admission.Warnings, error) {
+	return nil, nil
+}

--- a/main.go
+++ b/main.go
@@ -157,6 +157,16 @@ func setupWebhooks(ctx context.Context, mgr ctrl.Manager) {
 		setupLog.Error(err, "unable to create webhook", "webhook", "HostNetworkAttachment")
 		os.Exit(1)
 	}
+
+	if err := (&webhooks.DataImage{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "DataImage")
+		os.Exit(1)
+	}
+
+	if err := (&webhooks.HostFirmwareComponents{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "HostFirmwareComponents")
+		os.Exit(1)
+	}
 }
 
 func main() {


### PR DESCRIPTION
- Adds new webhooks for DataImages and HostFirmwareComponents
- Validates URLs in DataImages, HostFirmwareComponents and BMHs
- Adds common function to validate URL in webhooks

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

Currently the URLs are not validated at all or very little. Adding validation reduces intentional and accidental mistakes.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] E2E tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
