### PR TITLE
:seedling: Add support to skip specific parts during setup

### DIFF
--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -56,16 +56,39 @@ case "${GINKGO_FOCUS,,}" in
     ;;
 esac
 
+# Set CI_E2E_SKIP_INSTALLATION/CI_E2E_SKIP_BUILDING/CI_E2E_SKIP_SETUP to "true"
+# (case-insensitive) to skip that stage when re-running this script.
+CI_E2E_SKIP_INSTALLATION="${CI_E2E_SKIP_INSTALLATION:-false}"
+CI_E2E_SKIP_BUILDING="${CI_E2E_SKIP_BUILDING:-false}"
+CI_E2E_SKIP_SETUP="${CI_E2E_SKIP_SETUP:-false}"
+
+# Ensure common requirements are installed before proceeding with the setup and tests
+ensure_requirements() {
+  "${REPO_ROOT}/hack/e2e/ensure_go.sh"
+  "${REPO_ROOT}/hack/e2e/ensure_htpasswd.sh"
+  # CAPI test framework uses kubectl in the background
+  "${REPO_ROOT}/hack/e2e/ensure_kubectl.sh"
+  "${REPO_ROOT}/hack/e2e/ensure_yq.sh"
+
+  sudo apt-get update
+  sudo apt-get install -y libvirt-dev pkg-config gettext-base curl
+}
+
+# Build binaries required for the tests
+build_binaries() {
+  # Build the container image with e2e tag (used in tests)
+  IMG=quay.io/metal3-io/baremetal-operator IMG_TAG=e2e make docker
+
+  # Build vbmctl
+  make build-vbmctl
+  sudo setcap cap_net_admin+epi ./bin/vbmctl
+}
+
 # Ensure requirements are installed
 export PATH="/usr/local/go/bin:${PATH}"
-"${REPO_ROOT}/hack/e2e/ensure_go.sh"
-"${REPO_ROOT}/hack/e2e/ensure_htpasswd.sh"
-# CAPI test framework uses kubectl in the background
-"${REPO_ROOT}/hack/e2e/ensure_kubectl.sh"
-"${REPO_ROOT}/hack/e2e/ensure_yq.sh"
-
-sudo apt-get update
-sudo apt-get install -y libvirt-dev pkg-config gettext-base curl
+if [[ "${CI_E2E_SKIP_INSTALLATION,,}" != "true" ]]; then
+  ensure_requirements
+fi
 
 # Increase inotify limits to prevent "too many open files" errors.
 # Kind nodes (Docker containers running systemd) consume inotify resources heavily.
@@ -73,12 +96,10 @@ sudo apt-get install -y libvirt-dev pkg-config gettext-base curl
 sudo sysctl fs.inotify.max_user_watches=1048576
 sudo sysctl fs.inotify.max_user_instances=8192
 
-# Build the container image with e2e tag (used in tests)
-IMG=quay.io/metal3-io/baremetal-operator IMG_TAG=e2e make docker
-
-# Build vbmctl
-make build-vbmctl
-sudo setcap cap_net_admin+epi ./bin/vbmctl
+# Build binaries required for the tests
+if [[ "${CI_E2E_SKIP_BUILDING,,}" != "true" ]]; then
+  build_binaries
+fi
 
 # This IP is defined by the network we created above. It is sushy-tools / image
 # server endpoint, not ironic.
@@ -114,14 +135,14 @@ ARTIFACTORY_ROOT=https://artifactory.nordix.org/artifactory
 
 ## Download disk images
 if [[ ! -f "${IMAGE_DIR}/${IMAGE_FILE}" ]]; then
-    if ! cache_image "${ARTIFACTORY_ROOT}/metal3/images/iso/${IMAGE_FILE}"; then
-        cache_image https://download.cirros-cloud.net/"${CIRROS_VERSION}/${IMAGE_FILE}"
-    fi
+  if ! cache_image "${ARTIFACTORY_ROOT}/metal3/images/iso/${IMAGE_FILE}"; then
+    cache_image https://download.cirros-cloud.net/"${CIRROS_VERSION}/${IMAGE_FILE}"
+  fi
 fi
 if [[ ! -f "${IMAGE_DIR}/${ISO_FILE}" ]]; then
-    if ! cache_image "${ARTIFACTORY_ROOT}/metal3/images/sysrescue/${ISO_FILE}"; then
-        wget --no-verbose -O "${IMAGE_DIR}/${ISO_FILE}" https://sourceforge.net/projects/systemrescuecd/files/sysresccd-x86/"${SYSRESCUE_VERSION}"/"${ISO_FILE}"/download
-    fi
+  if ! cache_image "${ARTIFACTORY_ROOT}/metal3/images/sysrescue/${ISO_FILE}"; then
+    wget --no-verbose -O "${IMAGE_DIR}/${ISO_FILE}" https://sourceforge.net/projects/systemrescuecd/files/sysresccd-x86/"${SYSRESCUE_VERSION}"/"${ISO_FILE}"/download
+  fi
 fi
 
 ## Download IPA (Ironic Python Agent) image
@@ -131,19 +152,21 @@ fi
 IPA_FILE="ipa-centos9-master.tar.gz"
 IPA_BASEURI="${ARTIFACTORY_ROOT}/openstack-remote/ironic-python-agent/dib/"
 if [[ ! -f "${IMAGE_DIR}/${IPA_FILE}" ]]; then
-    if ! cache_image "${IPA_BASEURI}/${IPA_FILE}"; then
-        cache_image https://tarballs.opendev.org/openstack/ironic-python-agent/dib/"${IPA_FILE}"
-    fi
+  if ! cache_image "${IPA_BASEURI}/${IPA_FILE}"; then
+    cache_image https://tarballs.opendev.org/openstack/ironic-python-agent/dib/"${IPA_FILE}"
+  fi
 fi
 
-# shellcheck disable=SC2016
-envsubst '${BMO_E2E_EMULATOR},${IP_ADDRESS},${BMO_E2E_IMAGE},${BMO_E2E_LISTEN_PORT},${IMAGE_DIR}' < \
-  "${REPO_ROOT}/test/e2e/config/vbmctl.yaml.tmpl" > \
-  "${REPO_ROOT}/test/e2e/config/vbmctl.yaml"
+if [[ "${CI_E2E_SKIP_SETUP,,}" != "true" ]]; then
+  # shellcheck disable=SC2016
+  envsubst '${BMO_E2E_EMULATOR},${IP_ADDRESS},${BMO_E2E_IMAGE},${BMO_E2E_LISTEN_PORT},${IMAGE_DIR}' < \
+    "${REPO_ROOT}/test/e2e/config/vbmctl.yaml.tmpl" > \
+    "${REPO_ROOT}/test/e2e/config/vbmctl.yaml"
 
-# Create VMs to act as BMHs in the tests and the libvirt network. Create
-# also image server and E2E emulator containers.
-./bin/vbmctl -c "${REPO_ROOT}/test/e2e/config/vbmctl.yaml" create bml
+  # Create VMs to act as BMHs in the tests and the libvirt network. Create
+  # also image server and E2E emulator containers.
+  ./bin/vbmctl -c "${REPO_ROOT}/test/e2e/config/vbmctl.yaml" create bml
+fi
 
 # Wait for the sushy-tools BMC emulator to become reachable on the provisioning
 # IP. sushy-tools may start before the provisioning bridge IP is assigned,
@@ -191,7 +214,7 @@ wait_for_sushy_tools() {
 }
 
 # Need to do some extra setup for the vbmc emulator
-if [[ "${BMO_E2E_EMULATOR}" == "vbmc" ]]; then
+if [[ "${BMO_E2E_EMULATOR}" == "vbmc" ]] && [[ "${CI_E2E_SKIP_SETUP,,}" != "true" ]]; then
   readarray -t BMCS < <(yq e -o=j -I=0 '.[]' "${E2E_BMCS_CONF_FILE}")
   for bmc in "${BMCS[@]}"; do
     address=$(echo "${bmc}" | jq -r '.address')
@@ -205,7 +228,7 @@ fi
 
 # Generate ssh key pair for verifying provisioned BMHs
 if [[ ! -f "${IMAGE_DIR}/ssh_testkey" ]]; then
-    ssh-keygen -t ed25519 -f "${IMAGE_DIR}/ssh_testkey" -q -N ""
+  ssh-keygen -t ed25519 -f "${IMAGE_DIR}/ssh_testkey" -q -N ""
 fi
 pub_ssh_key=$(cut -d " " -f "1,2" "${IMAGE_DIR}/ssh_testkey.pub")
 
@@ -213,13 +236,13 @@ pub_ssh_key=$(cut -d " " -f "1,2" "${IMAGE_DIR}/ssh_testkey.pub")
 # See https://www.system-rescue.org/scripts/sysrescue-customize/
 # We use the systemrescue ISO and their script for customizing it.
 if [[ ! -f "${IMAGE_DIR}/sysrescue-out.iso" ]];then
-    pushd "${IMAGE_DIR}"
-    wget --no-verbose -O sysrescue-customize https://gitlab.com/systemrescue/systemrescue-sources/-/raw/main/airootfs/usr/share/sysrescue/bin/sysrescue-customize?inline=false
-    chmod +x sysrescue-customize
+  pushd "${IMAGE_DIR}"
+  wget --no-verbose -O sysrescue-customize "https://gitlab.com/systemrescue/systemrescue-sources/-/raw/main/airootfs/usr/share/sysrescue/bin/sysrescue-customize?inline=false"
+  chmod +x sysrescue-customize
 
-    mkdir -p recipe/iso_add/sysrescue.d
-    # Reference: https://www.system-rescue.org/manual/Configuring_SystemRescue/
-    cat << EOF > recipe/iso_add/sysrescue.d/90-config.yaml
+  mkdir -p recipe/iso_add/sysrescue.d
+  # Reference: https://www.system-rescue.org/manual/Configuring_SystemRescue/
+  cat << EOF > recipe/iso_add/sysrescue.d/90-config.yaml
 ---
 global:
     nofirewall: true
@@ -228,8 +251,8 @@ sysconfig:
         "test@example.com": "${pub_ssh_key}"
 EOF
 
-    ./sysrescue-customize --auto --recipe-dir recipe --source "${ISO_FILE}" --dest=sysrescue-out.iso
-    popd
+  ./sysrescue-customize --auto --recipe-dir recipe --source "${ISO_FILE}" --dest=sysrescue-out.iso
+  popd
 fi
 export ISO_IMAGE_URL="http://${IP_ADDRESS}/sysrescue-out.iso"
 
@@ -257,10 +280,12 @@ IRSO_IRONIC_AUTH_DIR="${REPO_ROOT}/test/e2e/data/ironic-standalone-operator/comp
 echo "${IRONIC_USERNAME}" > "${IRSO_IRONIC_AUTH_DIR}/ironic-username"
 echo "${IRONIC_PASSWORD}" > "${IRSO_IRONIC_AUTH_DIR}/ironic-password"
 
-# shellcheck disable=SC2016
-SSH_PUB_KEY_CONTENT="${pub_ssh_key}" envsubst '${SSH_PUB_KEY_CONTENT}' < \
-  "${REPO_ROOT}/test/e2e/data/ironic-standalone-operator/ironic/base/ironic.yaml.tmpl" > \
-  "${REPO_ROOT}/test/e2e/data/ironic-standalone-operator/ironic/base/ironic.yaml"
+if [[ "${CI_E2E_SKIP_SETUP,,}" != "true" ]]; then
+  # shellcheck disable=SC2016
+  SSH_PUB_KEY_CONTENT="${pub_ssh_key}" envsubst '${SSH_PUB_KEY_CONTENT}' < \
+    "${REPO_ROOT}/test/e2e/data/ironic-standalone-operator/ironic/base/ironic.yaml.tmpl" > \
+    "${REPO_ROOT}/test/e2e/data/ironic-standalone-operator/ironic/base/ironic.yaml"
+fi
 
 # We need to gather artifacts/logs before exiting also if there are errors
 set +e


### PR DESCRIPTION
When running the `hack/ci-e2e.sh` script multiple times, it is not necessary to repeat certain parts of it.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

Makes it possible to skip unnecessary parts when running the script again.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
