### PR TITLE
🌱 e2e: fix breakage caused by hardcoded MAC address in hardwareDetails

### DIFF
--- a/test/e2e/automated_cleaning_test.go
+++ b/test/e2e/automated_cleaning_test.go
@@ -50,10 +50,6 @@ var _ = Describe("Automated cleaning", Label("required", "automated-cleaning"), 
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      specName,
 				Namespace: namespace.Name,
-				Annotations: map[string]string{
-					metal3api.InspectAnnotationPrefix:   "disabled",
-					metal3api.HardwareDetailsAnnotation: hardwareDetails,
-				},
 			},
 			Spec: metal3api.BareMetalHostSpec{
 				Online: true,
@@ -65,6 +61,7 @@ var _ = Describe("Automated cleaning", Label("required", "automated-cleaning"), 
 				BootMode:              metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
 				BootMACAddress:        bmc.BootMacAddress,
 				AutomatedCleaningMode: metal3api.CleaningModeMetadata,
+				InspectionMode:        metal3api.InspectionModeDisabled,
 			},
 		}
 		err := clusterProxy.GetClient().Create(ctx, &bmh)

--- a/test/e2e/external_inspection_test.go
+++ b/test/e2e/external_inspection_test.go
@@ -4,9 +4,11 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"path"
+	"text/template"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
@@ -18,7 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const hardwareDetails = `
+var hardwareDetailsTemplate = template.Must(template.New("hardwareDetails").Parse(`
 {
   "cpu": {
     "arch": "x86_64",
@@ -138,15 +140,15 @@ const hardwareDetails = `
   "hostname": "localhost.localdomain",
   "nics": [
     {
-      "ip": "192.168.222.122",
-      "mac": "00:60:2f:31:81:01",
+      {{ if .IPAddress }}"ip": "{{ .IPAddress }}",{{ end }}
+      "mac": "{{ .BootMacAddress }}",
       "model": "0x1af4 0x0001",
       "name": "enp1s0",
       "pxe": true
     },
     {
       "ip": "fe80::570a:edf2:a3a7:4eb8%enp1s0",
-      "mac": "00:60:2f:31:81:01",
+      "mac": "{{ .BootMacAddress }}",
       "model": "0x1af4 0x0001",
       "name": "enp1s0",
       "pxe": true
@@ -171,7 +173,14 @@ const hardwareDetails = `
     "productName": "Standard PC (Q35 + ICH9, 2009)"
   }
 }
-`
+`))
+
+func hardwareDetailsFor(bmc *BMC) string {
+	buf := new(bytes.Buffer)
+	err := hardwareDetailsTemplate.Execute(buf, bmc)
+	Expect(err).NotTo(HaveOccurred())
+	return buf.String()
+}
 
 var _ = Describe("External Inspection", Label("required", "external-inspection"), func() {
 	var (
@@ -202,6 +211,7 @@ var _ = Describe("External Inspection", Label("required", "external-inspection")
 		toCleanup = append(toCleanup, secret)
 
 		By("creating a BMH with inspection disabled and hardware details added")
+		hardwareDetails := hardwareDetailsFor(&bmc)
 		bmh := metal3api.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      specName + "-annotation",
@@ -263,6 +273,7 @@ var _ = Describe("External Inspection", Label("required", "external-inspection")
 				HardwareDetails: &metal3api.HardwareDetails{},
 			},
 		}
+		hardwareDetails := hardwareDetailsFor(&bmc)
 		err := json.Unmarshal([]byte(hardwareDetails), hwdata.Spec.HardwareDetails)
 		Expect(err).NotTo(HaveOccurred())
 		err = clusterProxy.GetClient().Create(ctx, &hwdata)

--- a/test/e2e/live_iso_test.go
+++ b/test/e2e/live_iso_test.go
@@ -61,15 +61,11 @@ var _ = Describe("Live-ISO", Label("required", "live-iso"), func() {
 		secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, "bmc-credentials", bmcCredentialsData)
 		toCleanup = append(toCleanup, secret)
 
-		By("Creating a BMH with inspection disabled and hardware details added")
+		By("Creating a BMH with inspection disabled")
 		bmh := metal3api.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      specName,
 				Namespace: namespace.Name,
-				Annotations: map[string]string{
-					metal3api.InspectAnnotationPrefix:   "disabled",
-					metal3api.HardwareDetailsAnnotation: hardwareDetails,
-				},
 			},
 			Spec: metal3api.BareMetalHostSpec{
 				Online: true,
@@ -85,6 +81,7 @@ var _ = Describe("Live-ISO", Label("required", "live-iso"), func() {
 				BootMode:              metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
 				BootMACAddress:        bmc.BootMacAddress,
 				AutomatedCleaningMode: metal3api.CleaningModeDisabled,
+				InspectionMode:        metal3api.InspectionModeDisabled,
 			},
 		}
 		err := clusterProxy.GetClient().Create(ctx, &bmh)

--- a/test/e2e/provisioning_and_annotation_test.go
+++ b/test/e2e/provisioning_and_annotation_test.go
@@ -15,6 +15,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -49,15 +50,11 @@ var _ = Describe("Provision, detach, recreate from status and deprovision", Labe
 			secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, "bmc-credentials", bmcCredentialsData)
 			toCleanup = append(toCleanup, secret)
 
-			By("Creating a BMH with inspection disabled and hardware details added")
+			By("Creating a BMH with inspection disabled")
 			bmh := metal3api.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      specName,
 					Namespace: namespace.Name,
-					Annotations: map[string]string{
-						metal3api.InspectAnnotationPrefix:   "disabled",
-						metal3api.HardwareDetailsAnnotation: hardwareDetails,
-					},
 				},
 				Spec: metal3api.BareMetalHostSpec{
 					Online: true,
@@ -68,7 +65,8 @@ var _ = Describe("Provision, detach, recreate from status and deprovision", Labe
 					},
 					BootMode:              metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
 					BootMACAddress:        bmc.BootMacAddress,
-					AutomatedCleaningMode: "disabled",
+					AutomatedCleaningMode: metal3api.CleaningModeDisabled,
+					InspectionMode:        metal3api.InspectionModeDisabled,
 				},
 			}
 			err := clusterProxy.GetClient().Create(ctx, &bmh)
@@ -137,7 +135,7 @@ var _ = Describe("Provision, detach, recreate from status and deprovision", Labe
 			Expect(err).NotTo(HaveOccurred())
 
 			// Add the detached annotation; "true" is used explicitly to clarify intent.
-			bmh.ObjectMeta.Annotations["baremetalhost.metal3.io/detached"] = "true"
+			AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, metal3api.DetachedAnnotation, ptr.To("true"))
 
 			Expect(helper.Patch(ctx, &bmh)).To(Succeed())
 

--- a/test/e2e/re_inspection_test.go
+++ b/test/e2e/re_inspection_test.go
@@ -51,6 +51,7 @@ var _ = Describe("Re-Inspection", Label("required", "re-inspection"), func() {
 		toCleanup = append(toCleanup, secret)
 
 		By("creating a BMH with inspection disabled and hardware details added with wrong HostName")
+		hardwareDetails := hardwareDetailsFor(&bmc)
 		newHardwareDetails := strings.Replace(hardwareDetails, "localhost.localdomain", wrongHostName, 1)
 		bmh := metal3api.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -119,6 +119,7 @@ func RunUpgradeTest(ctx context.Context, input *BMOIronicUpgradeInput, upgradeCl
 	CreateSecret(ctx, upgradeClusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
 
 	By("Creating a BMH with inspection disabled and hardware details added")
+	hardwareDetails := hardwareDetailsFor(&bmc)
 	bmh := metal3api.BareMetalHost{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testCaseName,


### PR DESCRIPTION
After f20dfc776bd3efa3fd782c50a13b8bc767f3045b, ports are created for
all NICs in HardwareData. However, hardwareDetails used in tests
hardcodes the MAC address of one of the testing nodes, causing tests
that hit this code path to fail with 50% chance.

While here, remove usage of hardware details from tests where it's not
relevant. Inspection can simply be skipped instead.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
