### PR TITLE
🌱 Fix lint error

### DIFF
--- a/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
+++ b/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 


### PR DESCRIPTION
The current code in BMO fails to build because of a missing import

Error: hostfirmwarecomponents_controller.go:132:6: undefined: errors (typecheck)

This commit fixes this issue.