### PR TITLE
fix: add missing import

### DIFF
--- a/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
+++ b/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 


### PR DESCRIPTION
Broken build, missing `errors` import.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
