### PR TITLE
🐛 preserve phased-reboot annotations instead of deleting them on soft-reboot fallback

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -473,10 +473,14 @@ func isRebootAnnotation(annotation string) bool {
 	return strings.HasPrefix(annotation, metal3api.RebootAnnotationPrefix+"/") || annotation == metal3api.RebootAnnotationPrefix
 }
 
-// clearRebootAnnotations deletes all reboot annotations exist on the provided host.
+func isBaseRebootAnnotation(annotation string) bool {
+	return annotation == metal3api.RebootAnnotationPrefix
+}
+
+// clearRebootAnnotations deletes the base reboot annotation if it exists on the provided host.
 func clearRebootAnnotations(host *metal3api.BareMetalHost) (dirty bool) {
 	for annotation := range host.Annotations {
-		if isRebootAnnotation(annotation) {
+		if isBaseRebootAnnotation(annotation) {
 			delete(host.Annotations, annotation)
 			dirty = true
 		}

--- a/internal/controller/metal3.io/baremetalhost_controller_test.go
+++ b/internal/controller/metal3.io/baremetalhost_controller_test.go
@@ -804,6 +804,69 @@ func TestHasRebootAnnotation(t *testing.T) {
 	}
 }
 
+func TestClearRebootAnnotations(t *testing.T) {
+	testCases := []struct {
+		Scenario            string
+		Annotations         map[string]string
+		ExpectedAnnotations map[string]string
+		ExpectedDirty       bool
+	}{
+		{
+			Scenario: "Base reboot annotation",
+			Annotations: map[string]string{
+				metal3api.RebootAnnotationPrefix: "",
+			},
+			ExpectedAnnotations: map[string]string{},
+			ExpectedDirty:       true,
+		},
+		{
+			Scenario: "Suffixed reboot annotation",
+			Annotations: map[string]string{
+				metal3api.RebootAnnotationPrefix + "/foo": "",
+			},
+			ExpectedAnnotations: map[string]string{
+				metal3api.RebootAnnotationPrefix + "/foo": "",
+			},
+			ExpectedDirty: false,
+		},
+		{
+			Scenario: "Base and suffixed reboot annotations",
+			Annotations: map[string]string{
+				metal3api.RebootAnnotationPrefix:          "",
+				metal3api.RebootAnnotationPrefix + "/foo": "",
+				metal3api.RebootAnnotationPrefix + "/bar": "{\"mode\":\"hard\"}",
+			},
+			ExpectedAnnotations: map[string]string{
+				metal3api.RebootAnnotationPrefix + "/foo": "",
+				metal3api.RebootAnnotationPrefix + "/bar": "{\"mode\":\"hard\"}",
+			},
+			ExpectedDirty: true,
+		},
+		{
+			Scenario: "No reboot annotations",
+			Annotations: map[string]string{
+				"example.metal3.io/not-reboot": "true",
+			},
+			ExpectedAnnotations: map[string]string{
+				"example.metal3.io/not-reboot": "true",
+			},
+			ExpectedDirty: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			host := newDefaultHost(t)
+			host.Annotations = tc.Annotations
+
+			dirty := clearRebootAnnotations(host)
+
+			assert.Equal(t, tc.ExpectedDirty, dirty)
+			assert.Equal(t, tc.ExpectedAnnotations, host.Annotations)
+		})
+	}
+}
+
 // TestRebootWithSuffixlessAnnotation tests full reboot cycle with suffixless
 // annotation which doesn't wait for annotation removal before power on.
 func TestRebootWithSuffixlessAnnotation(t *testing.T) {


### PR DESCRIPTION
🐛 fix: preserve suffixed phased-reboot annotations in clearRebootAnnotations

## Summary

`clearRebootAnnotations` now removes only the bare `reboot.metal3.io` annotation, leaving suffixed `reboot.metal3.io/<key>` phased-reboot annotations in place.

## Why this matters

#3271: setting `reboot.metal3.io/my-test-annotation=""` makes BMO log "No reboot annotation value specified, assuming soft-reboot" and then delete the annotation, contrary to the phased-reboot docs at book.metal3.io which expect suffixed annotations to remain. The clear path matched both the bare annotation and any suffixed one via `isRebootAnnotation`. The bare `reboot.metal3.io` annotation is the consumed "reboot now" request and is safe to clear once acted on; the suffixed annotations are caller-managed phased-reboot gates BMO must not remove on the caller's behalf. The narrowing is local to the clear site, so `isRebootAnnotation` keeps its detection semantics for every other consumer.

## Testing

A unit test in `baremetalhost_controller_test.go` covers a suffixed phased annotation surviving the clear while the bare annotation is removed.

Fixes #3271

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
