### PR TITLE
🐛 Only create ports in stable provision states

### DIFF
--- a/pkg/provisioner/ironic/register.go
+++ b/pkg/provisioner/ironic/register.go
@@ -159,13 +159,22 @@ func (p *ironicProvisioner) Register(ctx context.Context, data provisioner.Manag
 		// below.
 	}
 
-	// Try to create ports from two sources
-	// bootMACAddress if available
-	// HardwareData whenever inspection data is available.
-	err = p.createPortsForNode(ctx, ironicNode, data.HardwareData)
-	if err != nil {
-		result, err = transientError(err)
-		return result, provID, err
+	// NOTE(dtantsur): don't try to create ports in states where it's
+	// either impossible because of a lock or potentially disruptive.
+	switch nodes.ProvisionState(ironicNode.ProvisionState) {
+	case nodes.Enroll, nodes.Manageable, nodes.Available, nodes.Active,
+		// A failure can be caused by wrong ports, so allow creating.
+		// TODO(dtantsur): add Hold states once they're supported by Gophercloud
+		nodes.AdoptFail, nodes.InspectFail, nodes.CleanFail, nodes.DeployFail, nodes.ServiceFail, nodes.Error:
+		// Try to create ports from two sources
+		// bootMACAddress if available
+		// HardwareData whenever inspection data is available.
+		err = p.createPortsForNode(ctx, ironicNode, data.HardwareData)
+		if err != nil {
+			result, err = transientError(err)
+			return result, provID, err
+		}
+	default:
 	}
 
 	// If no PreprovisioningImage builder is enabled we set the Node network_data
@@ -284,16 +293,14 @@ func (p *ironicProvisioner) enrollNode(ctx context.Context, data provisioner.Man
 }
 
 func (p *ironicProvisioner) createPortsForNode(ctx context.Context, ironicNode *nodes.Node, hardwareData *metal3api.HardwareData) error {
-	if p.bootMACAddress == "" && (hardwareData == nil || hardwareData.Spec.HardwareDetails == nil) {
-		// we don't have anything to process, gracefully returning
-		return nil
-	}
-
-	// Mac/PXE status map
-	portMacsToCreate := map[string]bool{}
 	var nics []metal3api.NIC
 	if hardwareData != nil && hardwareData.Spec.HardwareDetails != nil {
 		nics = hardwareData.Spec.HardwareDetails.NIC
+	}
+
+	if p.bootMACAddress == "" && len(nics) == 0 {
+		// we don't have anything to process, gracefully returning
+		return nil
 	}
 
 	ironicNodePorts, err := p.getPorts(ctx, ironicNode.UUID, "")
@@ -306,6 +313,8 @@ func (p *ironicProvisioner) createPortsForNode(ctx context.Context, ironicNode *
 		ironicNodePortsList[port.Address] = port
 	}
 
+	// Mac/PXE status map
+	portMacsToCreate := map[string]bool{}
 	for _, nic := range nics {
 		if _, ok := ironicNodePortsList[nic.MAC]; nic.MAC != "" && !ok {
 			portMacsToCreate[nic.MAC] = nic.PXE

--- a/pkg/provisioner/ironic/register_test.go
+++ b/pkg/provisioner/ironic/register_test.go
@@ -1480,8 +1480,9 @@ func TestRegisterExistingNodeWithHardwareData(t *testing.T) {
 	host.Status.Provisioning.ID = "node-uuid"
 
 	existingNode := nodes.Node{
-		Name: host.Namespace + nameSeparator + host.Name,
-		UUID: "node-uuid",
+		Name:           host.Namespace + nameSeparator + host.Name,
+		UUID:           "node-uuid",
+		ProvisionState: string(nodes.Enroll),
 	}
 
 	// Create HardwareData with NIC information
@@ -1557,17 +1558,14 @@ func TestRegisterExistingNodeWithoutHardwareData(t *testing.T) {
 	host.Status.Provisioning.ID = "node-uuid"
 
 	existingNode := nodes.Node{
-		Name: host.Namespace + nameSeparator + host.Name,
-		UUID: "node-uuid",
+		Name:           host.Namespace + nameSeparator + host.Name,
+		UUID:           "node-uuid",
+		ProvisionState: string(nodes.Enroll),
 	}
 
 	ironic := testserver.NewIronic(t).Node(existingNode).NodeUpdate(nodes.Node{
 		UUID: "node-uuid",
 	})
-
-	// Set up handler to capture port creation
-	createdPorts := []ports.Port{}
-	ironic.Handler("/v1/ports", setupPortHandler(&createdPorts))
 
 	ironic.Start()
 	defer ironic.Stop()
@@ -1585,6 +1583,7 @@ func TestRegisterExistingNodeWithoutHardwareData(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.ErrorMessage)
 	assert.Equal(t, "node-uuid", provID)
+	assert.NotContains(t, ironic.Requests, "/v1/ports")
 }
 
 // TestRegisterExistingNodeWithEmptyHardwareData ensures registration works when
@@ -1595,8 +1594,9 @@ func TestRegisterExistingNodeWithEmptyHardwareData(t *testing.T) {
 	host.Status.Provisioning.ID = "node-uuid"
 
 	existingNode := nodes.Node{
-		Name: host.Namespace + nameSeparator + host.Name,
-		UUID: "node-uuid",
+		Name:           host.Namespace + nameSeparator + host.Name,
+		UUID:           "node-uuid",
+		ProvisionState: string(nodes.Enroll),
 	}
 
 	// Create HardwareData with no NICs
@@ -1611,10 +1611,6 @@ func TestRegisterExistingNodeWithEmptyHardwareData(t *testing.T) {
 	ironic := testserver.NewIronic(t).Node(existingNode).NodeUpdate(nodes.Node{
 		UUID: "node-uuid",
 	})
-
-	// Set up handler to capture port creation
-	createdPorts := []ports.Port{}
-	ironic.Handler("/v1/ports", setupPortHandler(&createdPorts))
 
 	ironic.Start()
 	defer ironic.Stop()
@@ -1632,6 +1628,65 @@ func TestRegisterExistingNodeWithEmptyHardwareData(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.ErrorMessage)
 	assert.Equal(t, "node-uuid", provID)
+	assert.NotContains(t, ironic.Requests, "/v1/ports")
+}
+
+// TestRegisterExistingNodeWrongStateForPortCreate ensures ports are not created
+// in transient states.
+func TestRegisterExistingNodeWrongStateForPortCreate(t *testing.T) {
+	host := makeHost()
+	host.Spec.BootMACAddress = "aa:bb:cc:dd:ee:ff"
+	host.Status.Provisioning.ID = "node-uuid"
+
+	existingNode := nodes.Node{
+		Name:           host.Namespace + nameSeparator + host.Name,
+		UUID:           "node-uuid",
+		ProvisionState: string(nodes.Inspecting),
+	}
+
+	// Create HardwareData with NIC information
+	hardwareData := &metal3api.HardwareData{
+		Spec: metal3api.HardwareDataSpec{
+			HardwareDetails: &metal3api.HardwareDetails{
+				NIC: []metal3api.NIC{
+					{
+						MAC: "aa:bb:cc:dd:ee:ff",
+						PXE: true,
+					},
+					{
+						MAC: "11:22:33:44:55:66",
+						PXE: false,
+					},
+					{
+						MAC: "77:88:99:aa:bb:cc",
+						PXE: false,
+					},
+				},
+			},
+		},
+	}
+
+	ironic := testserver.NewIronic(t).Node(existingNode).NodeUpdate(nodes.Node{
+		UUID: "node-uuid",
+	})
+
+	ironic.Start()
+	defer ironic.Stop()
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher, ironic.Endpoint(), auth)
+	if err != nil {
+		t.Fatalf("could not create provisioner: %s", err)
+	}
+
+	result, provID, err := prov.Register(t.Context(), provisioner.ManagementAccessData{
+		HardwareData: hardwareData,
+	}, false, false)
+
+	require.NoError(t, err)
+	assert.Empty(t, result.ErrorMessage)
+	assert.Equal(t, "node-uuid", provID)
+	assert.NotContains(t, ironic.Requests, "/v1/ports")
 }
 
 // setupPortHandler is a helper function that creates a port handler for test servers.
@@ -1677,6 +1732,35 @@ func setupPortHandler(createdPorts *[]ports.Port) func(http.ResponseWriter, *htt
 	}
 }
 
+func setupNodeHandlerForRegister(provisionState string) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		var node nodes.Node
+		if err := json.Unmarshal(body, &node); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		node.UUID = "new-node-uuid"
+		node.ProvisionState = provisionState
+
+		response, _ := json.Marshal(node)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write(response)
+	}
+}
+
 // TestRegisterNewNodeWithHardwareData tests the scenario where the Ironic DB is dropped
 // (node not found) and re-enrollment happens via the ironicNode == nil path.
 // This ensures ports are recreated from HardwareData even when the node doesn't exist.
@@ -1710,7 +1794,6 @@ func TestRegisterNewNodeWithHardwareData(t *testing.T) {
 
 	// Track created ports
 	createdPorts := []ports.Port{}
-	var nodeCreated *nodes.Node
 
 	ironic := testserver.NewIronic(t)
 
@@ -1718,35 +1801,12 @@ func TestRegisterNewNodeWithHardwareData(t *testing.T) {
 	ironic.AddDefaultResponse("/v1/nodes/myns"+nameSeparator+"myhost", "GET", http.StatusNotFound, "")
 	ironic.AddDefaultResponse("/v1/nodes/myhost", "GET", http.StatusNotFound, "")
 	// Return OK for PATCH on the new node
-	ironic.AddDefaultResponse("/v1/nodes/new-node-uuid", "PATCH", http.StatusOK, "{\"uuid\": \"new-node-uuid\"}")
+	ironic.AddDefaultResponse("/v1/nodes/new-node-uuid", "PATCH", http.StatusOK,
+		`{"uuid": "new-node-uuid", "provision_state": "enroll"}`)
+	ironic.AddDefaultResponse("/v1/nodes/new-node-uuid/states/provision", "PUT", http.StatusAccepted, "{}")
 
 	// Set up handler for node creation (POST)
-	ironic.Handler("/v1/nodes", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		var node nodes.Node
-		if err := json.Unmarshal(body, &node); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		node.UUID = "new-node-uuid"
-		nodeCreated = &node
-
-		response, _ := json.Marshal(node)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		w.Write(response)
-	})
+	ironic.Handler("/v1/nodes", setupNodeHandlerForRegister(string(nodes.Enroll)))
 
 	// Set up handler to capture port creation
 	ironic.Handler("/v1/ports", setupPortHandler(&createdPorts))
@@ -1767,7 +1827,6 @@ func TestRegisterNewNodeWithHardwareData(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.ErrorMessage)
 	assert.Equal(t, "new-node-uuid", provID)
-	assert.NotNil(t, nodeCreated, "Node should have been created")
 
 	// Verify that all three ports were created:
 	// - Boot MAC is created during enrollNode
@@ -1817,43 +1876,19 @@ func TestRegisterNewNodeWithoutBootMACButWithHardwareData(t *testing.T) {
 
 	// Track created ports
 	createdPorts := []ports.Port{}
-	var nodeCreated *nodes.Node
 
 	ironic := testserver.NewIronic(t)
 
 	// Return 404 for node lookups (simulating DB drop)
 	ironic.AddDefaultResponse("/v1/nodes/myns"+nameSeparator+"myhost", "GET", http.StatusNotFound, "")
 	ironic.AddDefaultResponse("/v1/nodes/myhost", "GET", http.StatusNotFound, "")
-	// Return OK for PATCH on the new node
-	ironic.AddDefaultResponse("/v1/nodes/new-node-uuid", "PATCH", http.StatusOK, "{\"uuid\": \"new-node-uuid\"}")
+	// Return OK for PATCH on the new node and PUT on its state
+	ironic.AddDefaultResponse("/v1/nodes/new-node-uuid", "PATCH", http.StatusOK,
+		`{"uuid": "new-node-uuid", "provision_state": "enroll"}`)
+	ironic.AddDefaultResponse("/v1/nodes/new-node-uuid/states/provision", "PUT", http.StatusAccepted, "{}")
 
 	// Set up handler for node creation (POST)
-	ironic.Handler("/v1/nodes", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		var node nodes.Node
-		if err := json.Unmarshal(body, &node); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		node.UUID = "new-node-uuid"
-		nodeCreated = &node
-
-		response, _ := json.Marshal(node)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		w.Write(response)
-	})
+	ironic.Handler("/v1/nodes", setupNodeHandlerForRegister(string(nodes.Enroll)))
 
 	// Set up handler to capture port creation
 	ironic.Handler("/v1/ports", setupPortHandler(&createdPorts))
@@ -1874,7 +1909,6 @@ func TestRegisterNewNodeWithoutBootMACButWithHardwareData(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.ErrorMessage)
 	assert.Equal(t, "new-node-uuid", provID)
-	assert.NotNil(t, nodeCreated, "Node should have been created")
 
 	// Verify that both ports were created from HardwareData
 	// Since no boot MAC is configured, enrollNode doesn't create any ports


### PR DESCRIPTION
Follow-up to f20dfc776bd3efa3fd782c50a13b8bc767f3045b: only create ports
in provision states where it's reasonable, i.e. stable and failure
states. This is an optimization to save one request to Ports API per
each reconciliation.

Similarly, do not list ports if there NICs are empty.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
