### PR TITLE
🌱 Safeguard against empty slice when fetching ports

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -275,7 +275,7 @@ func (p *ironicProvisioner) createNodePort(ctx context.Context, uuid string, mac
 		p.log.Info("failed to look for existing ports in Ironic", "MAC", macAddress)
 		return errPortList
 	}
-	if portsList != nil {
+	if len(portsList) > 0 {
 		for _, port := range portsList {
 			if port.NodeUUID != uuid {
 				return fmt.Errorf("port belongs to another node %s, MAC: %s can't register for node %s", port.NodeUUID, macAddress, uuid)

--- a/test/e2e/ironic_helpers.go
+++ b/test/e2e/ironic_helpers.go
@@ -104,6 +104,7 @@ func getIronicNodePorts(ctx context.Context, e2eConfig *Config, nodeName string)
 			Logf("Ironic node %s not found, skipping ports retrieval", nodeName)
 			return nil, nil
 		}
+		return nil, errNode
 	}
 	Logf("Found node with name %s with uuid %s, checking ports", nodeName, node.UUID)
 


### PR DESCRIPTION
Apparently, getPorts returns nil when no results are provided, but this
is by no means guaranteed to always hold or obvious. Use len() to cover
both nil and empty slice.

Also fix missing error handling in the functional tests.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
