### PR TITLE
🐛 Add a timeout for Ironic endpoint validation

### DIFF
--- a/cmd/get-hardware-details/main.go
+++ b/cmd/get-hardware-details/main.go
@@ -57,7 +57,7 @@ func main() {
 		endpoint = parsedEndpoint.String()
 	}
 
-	ironic, err := clients.IronicClient(endpoint, opts.AuthConfig, tlsConf)
+	ironic, err := clients.IronicClient(endpoint, opts.AuthConfig, tlsConf, clients.DefaultTimeout)
 	if err != nil {
 		log.Fatalf("could not get ironic client: %s", err)
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,9 @@ client certificate SAN validation.
 `IRONIC_CLIENT_CACHE_TTL` -- Duration during which an Ironic client and its
 parameters are cached. Defaults to "5s". Set to "0" to disable caching.
 
+`IRONIC_CLIENT_TIMEOUT` -- Timeout for HTTP requests to the Ironic API.
+Must be positive. Defaults to "30s".
+
 `BMO_CONCURRENCY` -- The number of concurrent reconciles performed by the
 Operator. Default is the number of CPUs, but no less than 2 and no more than 8.
 

--- a/pkg/provisioner/ironic/clients/client.go
+++ b/pkg/provisioner/ironic/clients/client.go
@@ -14,6 +14,9 @@ import (
 
 var tlsConnectionTimeout = time.Second * 30
 
+// DefaultTimeout is the default HTTP client timeout for requests to Ironic.
+const DefaultTimeout = 30 * time.Second
+
 // TLSConfig contains the TLS configuration for the Ironic connection.
 // Using Go default values for this will result in no additional trusted
 // CA certificates and a secure connection.
@@ -27,7 +30,11 @@ type TLSConfig struct {
 	SkipClientSANVerify   bool
 }
 
-func updateHTTPClient(client *gophercloud.ServiceClient, tlsConf TLSConfig) error {
+func updateHTTPClient(client *gophercloud.ServiceClient, tlsConf TLSConfig, timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+
 	tlsInfo := transport.TLSInfo{
 		TrustedCAFile:       tlsConf.TrustedCAFile,
 		CertFile:            tlsConf.ClientCertificateFile,
@@ -66,13 +73,14 @@ func updateHTTPClient(client *gophercloud.ServiceClient, tlsConf TLSConfig) erro
 	}
 	c := http.Client{
 		Transport: tlsTransport,
+		Timeout:   timeout,
 	}
 	client.HTTPClient = c
 	return nil
 }
 
 // IronicClient creates a client for Ironic.
-func IronicClient(ironicEndpoint string, auth AuthConfig, tls TLSConfig) (client *gophercloud.ServiceClient, err error) {
+func IronicClient(ironicEndpoint string, auth AuthConfig, tls TLSConfig, timeout time.Duration) (client *gophercloud.ServiceClient, err error) {
 	switch auth.Type {
 	case NoAuth:
 		client, err = noauth.NewBareMetalNoAuth(noauth.EndpointOpts{
@@ -93,6 +101,6 @@ func IronicClient(ironicEndpoint string, auth AuthConfig, tls TLSConfig) (client
 
 	client.Microversion = baselineVersionString
 
-	err = updateHTTPClient(client, tls)
+	err = updateHTTPClient(client, tls, timeout)
 	return
 }

--- a/pkg/provisioner/ironic/clients/client_test.go
+++ b/pkg/provisioner/ironic/clients/client_test.go
@@ -3,6 +3,7 @@ package clients
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/stretchr/testify/assert"
@@ -47,7 +48,7 @@ func TestIronicClientInvalidAuthType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotClient, err := IronicClient(tt.args.ironicEndpoint, tt.args.auth, tt.args.tls)
+			gotClient, err := IronicClient(tt.args.ironicEndpoint, tt.args.auth, tt.args.tls, 0)
 			require.Error(t, err)
 			assert.Nil(t, gotClient)
 		})
@@ -76,7 +77,7 @@ func TestIronicClientValidAuthType(t *testing.T) {
 			SkipClientSANVerify:   true,
 		},
 	}
-	noAuthClient, _ := IronicClient(noAuthClientArgs.ironicEndpoint, noAuthClientArgs.auth, noAuthClientArgs.tls)
+	noAuthClient, _ := IronicClient(noAuthClientArgs.ironicEndpoint, noAuthClientArgs.auth, noAuthClientArgs.tls, 0)
 
 	noAuthTlsClientArgs := args{
 		ironicEndpoint: "https://localhost",
@@ -93,7 +94,7 @@ func TestIronicClientValidAuthType(t *testing.T) {
 			SkipClientSANVerify:   true,
 		},
 	}
-	noAuthTlsClient, _ := IronicClient(noAuthTlsClientArgs.ironicEndpoint, noAuthTlsClientArgs.auth, noAuthTlsClientArgs.tls)
+	noAuthTlsClient, _ := IronicClient(noAuthTlsClientArgs.ironicEndpoint, noAuthTlsClientArgs.auth, noAuthTlsClientArgs.tls, 0)
 
 	basicAuthClientArgs := args{
 		ironicEndpoint: "http://localhost",
@@ -110,7 +111,7 @@ func TestIronicClientValidAuthType(t *testing.T) {
 			SkipClientSANVerify:   true,
 		},
 	}
-	basicAuthClient, _ := IronicClient(basicAuthClientArgs.ironicEndpoint, basicAuthClientArgs.auth, basicAuthClientArgs.tls)
+	basicAuthClient, _ := IronicClient(basicAuthClientArgs.ironicEndpoint, basicAuthClientArgs.auth, basicAuthClientArgs.tls, 0)
 
 	basicAuthTlsClientArgs := args{
 		ironicEndpoint: "https://localhost",
@@ -127,7 +128,7 @@ func TestIronicClientValidAuthType(t *testing.T) {
 			SkipClientSANVerify:   true,
 		},
 	}
-	basicAuthTlsClient, _ := IronicClient(basicAuthTlsClientArgs.ironicEndpoint, basicAuthTlsClientArgs.auth, basicAuthTlsClientArgs.tls)
+	basicAuthTlsClient, _ := IronicClient(basicAuthTlsClientArgs.ironicEndpoint, basicAuthTlsClientArgs.auth, basicAuthTlsClientArgs.tls, 0)
 
 	tests := []struct {
 		name       string
@@ -157,13 +158,29 @@ func TestIronicClientValidAuthType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotClient, err := IronicClient(tt.args.ironicEndpoint, tt.args.auth, tt.args.tls)
+			gotClient, err := IronicClient(tt.args.ironicEndpoint, tt.args.auth, tt.args.tls, 0)
 			require.NoError(t, err)
 			assert.NotNil(t, gotClient)
 			assert.Equalf(t, gotClient.Endpoint, tt.wantClient.Endpoint, "IronicClient() gotClient = %v, want %v", gotClient.Endpoint, tt.wantClient.Endpoint)
 			assert.Truef(t, reflect.DeepEqual(gotClient.MoreHeaders, tt.wantClient.MoreHeaders), "IronicClient() gotClient = %v, want %v", gotClient.MoreHeaders, tt.wantClient.MoreHeaders)
 		})
 	}
+}
+
+func TestIronicClientCustomTimeout(t *testing.T) {
+	tlsConf := TLSConfig{
+		TrustedCAFile:         "",
+		ClientCertificateFile: "",
+		ClientPrivateKeyFile:  "",
+		InsecureSkipVerify:    true,
+		SkipClientSANVerify:   true,
+	}
+
+	customTimeout := 120 * time.Second
+	gotClient, err := IronicClient("http://localhost", AuthConfig{Type: NoAuth}, tlsConf, customTimeout)
+	require.NoError(t, err)
+	assert.NotNil(t, gotClient)
+	assert.Equal(t, customTimeout, gotClient.HTTPClient.Timeout)
 }
 
 func Test_updateHTTPClient(t *testing.T) {
@@ -201,12 +218,13 @@ func Test_updateHTTPClient(t *testing.T) {
 		Username: "",
 		Password: "",
 	},
-		emptyTlsConfig,
+		emptyTlsConfig, 0,
 	)
 
 	tests := []struct {
-		name string
-		args args
+		name    string
+		args    args
+		timeout time.Duration
 	}{
 		{
 			name: "tls config with empty values does not fail",
@@ -229,11 +247,24 @@ func Test_updateHTTPClient(t *testing.T) {
 				tlsConf: updatedTlsConfig,
 			},
 		},
+		{
+			name: "custom timeout",
+			args: args{
+				client:  emptyClient,
+				tlsConf: emptyTlsConfig,
+			},
+			timeout: 120 * time.Second,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := updateHTTPClient(tt.args.client, tt.args.tlsConf)
+			err := updateHTTPClient(tt.args.client, tt.args.tlsConf, tt.timeout)
 			require.NoError(t, err)
+			expectedTimeout := tt.timeout
+			if expectedTimeout == 0 {
+				expectedTimeout = DefaultTimeout
+			}
+			assert.Equal(t, expectedTimeout, tt.args.client.HTTPClient.Timeout)
 		})
 	}
 }

--- a/pkg/provisioner/ironic/factory.go
+++ b/pkg/provisioner/ironic/factory.go
@@ -53,6 +53,9 @@ type ironicProvisionerFactory struct {
 	// Information to cache between reconciliations
 	cache    *ironicProvisionerCache
 	cacheTTL time.Duration
+
+	// HTTP client timeout for all requests to Ironic
+	clientTimeout time.Duration
 }
 
 func NewProvisionerFactory(logger logr.Logger, havePreprovImgBuilder bool) (provisioner.Factory, error) {
@@ -92,6 +95,16 @@ func (f *ironicProvisionerFactory) init(havePreprovImgBuilder bool) error {
 		}
 	} else {
 		f.cacheTTL = ironicProvisionerCacheDefaultTTL
+	}
+
+	if timeoutString := os.Getenv("IRONIC_CLIENT_TIMEOUT"); timeoutString != "" {
+		f.clientTimeout, err = time.ParseDuration(timeoutString)
+		if err != nil {
+			return fmt.Errorf("invalid IRONIC_CLIENT_TIMEOUT %q: %w", timeoutString, err)
+		}
+		if f.clientTimeout <= 0 {
+			return fmt.Errorf("invalid IRONIC_CLIENT_TIMEOUT %q: must be > 0", timeoutString)
+		}
 	}
 
 	f.config, err = loadConfigFromEnv(havePreprovImgBuilder)
@@ -141,7 +154,7 @@ func (f *ironicProvisionerFactory) init(havePreprovImgBuilder bool) error {
 		"SkipClientSANVerify", tlsConf.SkipClientSANVerify,
 	)
 
-	f.clientIronic, err = clients.IronicClient(ironicEndpoint, ironicAuth, tlsConf)
+	f.clientIronic, err = clients.IronicClient(ironicEndpoint, ironicAuth, tlsConf, f.clientTimeout)
 	if err != nil {
 		return err
 	}
@@ -258,7 +271,7 @@ func (f ironicProvisionerFactory) ironicProvisioner(ctx context.Context, hostDat
 				"CACertFile", tlsConf.TrustedCAFile,
 			)
 
-			ironicClient, err := clients.IronicClient(ironicEndpoint, ironicAuth, tlsConf)
+			ironicClient, err := clients.IronicClient(ironicEndpoint, ironicAuth, tlsConf, f.clientTimeout)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create a client from Ironic resource %s/%s: %w", f.ironicNamespace, f.ironicName, err)
 			}

--- a/pkg/provisioner/ironic/factory_test.go
+++ b/pkg/provisioner/ironic/factory_test.go
@@ -485,6 +485,73 @@ func TestRefreshCacheDoesNotCacheOnNoDrivers(t *testing.T) {
 	assert.True(t, factory.cache.expiresAt.IsZero())
 }
 
+func TestInitClientTimeout(t *testing.T) {
+	cases := []struct {
+		name            string
+		envValue        string
+		expectedTimeout time.Duration
+		expectedError   string
+	}{
+		{
+			name:            "not set uses zero (default)",
+			envValue:        "",
+			expectedTimeout: 0,
+		},
+		{
+			name:            "valid timeout",
+			envValue:        "60s",
+			expectedTimeout: 60 * time.Second,
+		},
+		{
+			name:            "valid timeout in minutes",
+			envValue:        "2m",
+			expectedTimeout: 2 * time.Minute,
+		},
+		{
+			name:          "invalid format",
+			envValue:      "not-a-duration",
+			expectedError: "invalid IRONIC_CLIENT_TIMEOUT",
+		},
+		{
+			name:          "zero is not allowed",
+			envValue:      "0s",
+			expectedError: "must be > 0",
+		},
+		{
+			name:          "negative is not allowed",
+			envValue:      "-1s",
+			expectedError: "must be > 0",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := EnvFixture{
+				ironicEndpoint: "http://ironic.test",
+				kernelURL:      "http://kernel",
+				ramdiskURL:     "http://ramdisk",
+			}
+			env.SetUp()
+			defer env.TearDown()
+
+			t.Setenv("IRONIC_CLIENT_TIMEOUT", tc.envValue)
+
+			factory := ironicProvisionerFactory{
+				log:   logr.Discard(),
+				cache: new(ironicProvisionerCache),
+			}
+			err := factory.init(false)
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedTimeout, factory.clientTimeout)
+			}
+		})
+	}
+}
+
 func TestRefreshCacheDisabled(t *testing.T) {
 	ironic := testserver.NewIronic(t).WithDrivers()
 	ironic.Start()

--- a/pkg/provisioner/ironic/ironic_test.go
+++ b/pkg/provisioner/ironic/ironic_test.go
@@ -38,7 +38,7 @@ func newProvisionerWithSettings(host metal3api.BareMetalHost, bmcCreds bmc.Crede
 	hostData := provisioner.BuildHostData(host, bmcCreds)
 
 	tlsConf := clients.TLSConfig{}
-	clientIronic, err := clients.IronicClient(ironicURL, ironicAuthSettings, tlsConf)
+	clientIronic, err := clients.IronicClient(ironicURL, ironicAuthSettings, tlsConf, 0)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Otherwise, the client initialization code may hang for a very long time.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
