### PR TITLE
:bug: Clean-up temporary CA files when Ironic CR are used

### DIFF
--- a/pkg/provisioner/ironic/clients/client.go
+++ b/pkg/provisioner/ironic/clients/client.go
@@ -20,11 +20,12 @@ var tlsConnectionTimeout = time.Second * 30
 // When specifying Certificate and Private key, TLS connection will use
 // client certificate authentication.
 type TLSConfig struct {
-	TrustedCAFile         string
-	ClientCertificateFile string
-	ClientPrivateKeyFile  string
-	InsecureSkipVerify    bool
-	SkipClientSANVerify   bool
+	TrustedCAFile            string
+	TrustedCAFileIsTemporary bool
+	ClientCertificateFile    string
+	ClientPrivateKeyFile     string
+	InsecureSkipVerify       bool
+	SkipClientSANVerify      bool
 }
 
 func updateHTTPClient(client *gophercloud.ServiceClient, tlsConf TLSConfig) error {

--- a/pkg/provisioner/ironic/factory.go
+++ b/pkg/provisioner/ironic/factory.go
@@ -247,6 +247,14 @@ func (f ironicProvisionerFactory) ironicProvisioner(ctx context.Context, hostDat
 	if f.ironicName != "" && f.ironicNamespace != "" && f.k8sClient != nil {
 		createClient = func() (*gophercloud.ServiceClient, error) {
 			ironicEndpoint, ironicAuth, tlsConf, err := f.loadConfigFromIronicCR(ctx)
+			// NOTE(dtantsur): the file may be created even if an error is returned, so plan deletion before checking err.
+			if tlsConf.TrustedCAFileIsTemporary {
+				defer func() {
+					if rmErr := os.Remove(tlsConf.TrustedCAFile); rmErr != nil && !os.IsNotExist(rmErr) {
+						provisionerLogger.Error(rmErr, "failed to remove temporary CA file", "file", tlsConf.TrustedCAFile)
+					}
+				}()
+			}
 			if err != nil {
 				return nil, fmt.Errorf("failed to load configuration from Ironic resource %s/%s: %w", f.ironicNamespace, f.ironicName, err)
 			}
@@ -435,19 +443,21 @@ func (f *ironicProvisionerFactory) loadConfigFromIronicCR(ctx context.Context) (
 
 	endpoint = fmt.Sprintf("http://%s.%s.svc", f.ironicName, f.ironicNamespace)
 
-	// Handle TLS
+	// Handle authentication
+	auth, err = f.loadAuthConfigFromIronicCR(ctx, &sm, ironicCR)
+	if err != nil {
+		return "", clients.AuthConfig{}, clients.TLSConfig{}, err
+	}
+
+	// Handle TLS.
+	// Do it last because it may create a temporary file that will need to be cleaned up
+	// by the caller even in case of an error.
 	if ironicCR.Spec.TLS.CertificateName != "" {
 		endpoint = fmt.Sprintf("https://%s.%s.svc", f.ironicName, f.ironicNamespace)
 		tlsConfig, err = f.loadTLSConfigFromIronicCR(ctx, &sm, ironicCR)
 		if err != nil {
 			return "", clients.AuthConfig{}, clients.TLSConfig{}, err
 		}
-	}
-
-	// Handle authentication
-	auth, err = f.loadAuthConfigFromIronicCR(ctx, &sm, ironicCR)
-	if err != nil {
-		return "", clients.AuthConfig{}, clients.TLSConfig{}, err
 	}
 
 	return endpoint, auth, tlsConfig, nil
@@ -499,6 +509,7 @@ func (f *ironicProvisionerFactory) loadTLSConfigFromIronicCR(ctx context.Context
 			return clients.TLSConfig{}, fmt.Errorf("failed to write CA certificate: %w", err)
 		}
 		tlsConfig.TrustedCAFile = caFile
+		tlsConfig.TrustedCAFileIsTemporary = true
 	}
 
 	return tlsConfig, nil
@@ -511,10 +522,15 @@ func writeTempFile(prefix string, data []byte) (string, error) {
 	}
 	defer tmpFile.Close()
 
+	name := tmpFile.Name()
 	_, err = tmpFile.Write(data)
 	if err != nil {
+		if rmErr := os.Remove(name); rmErr != nil && !os.IsNotExist(rmErr) { //nolint:gosec // name is from os.CreateTemp, not user input
+			rmErr = fmt.Errorf("failed to delete temporary file during clean-up: %w", rmErr)
+			return "", errors.Join(err, rmErr)
+		}
 		return "", err
 	}
 
-	return tmpFile.Name(), nil
+	return name, nil
 }

--- a/pkg/provisioner/ironic/factory_test.go
+++ b/pkg/provisioner/ironic/factory_test.go
@@ -1,20 +1,35 @@
 package ironic
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
+	"math/big"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/noauth"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/testserver"
+	ironicv1alpha1 "github.com/metal3-io/ironic-standalone-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type EnvFixture struct {
@@ -507,4 +522,128 @@ func TestRefreshCacheDisabled(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, callCount, "createClient should always be called when cache is disabled")
 	assert.True(t, factory.cache.expiresAt.IsZero(), "cache should not be populated when disabled")
+}
+
+func generateTestCACert(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+}
+
+func TestIronicProvisionerFromCR_CleansTempCAFile(t *testing.T) {
+	env := EnvFixture{}
+	defer env.TearDown()
+	env.SetUp()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, ironicv1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	ironicCR := &ironicv1alpha1.Ironic{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-ironic",
+			Namespace:  "test-ns",
+			Generation: 1,
+		},
+		Spec: ironicv1alpha1.IronicSpec{
+			TLS: ironicv1alpha1.TLS{
+				CertificateName: "ironic-tls-cert",
+			},
+			APICredentialsName: "ironic-auth",
+		},
+		Status: ironicv1alpha1.IronicStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(ironicv1alpha1.IronicStatusReady),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+				},
+			},
+		},
+	}
+
+	tlsSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ironic-tls-cert",
+			Namespace: "test-ns",
+		},
+		Data: map[string][]byte{
+			"tls.crt": generateTestCACert(t),
+		},
+	}
+
+	authSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ironic-auth",
+			Namespace: "test-ns",
+		},
+		Data: map[string][]byte{
+			"username": []byte("admin"),
+			"password": []byte("password"),
+		},
+	}
+
+	k8sClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(ironicCR, tlsSecret, authSecret).
+		WithStatusSubresource(ironicCR).
+		Build()
+
+	factory := ironicProvisionerFactory{
+		log:             logf.Log,
+		config:          ironicConfig{maxBusyHosts: 20},
+		cache:           new(ironicProvisionerCache),
+		cacheTTL:        5 * time.Second,
+		k8sClient:       k8sClient,
+		apiReader:       k8sClient,
+		ironicName:      "test-ironic",
+		ironicNamespace: "test-ns",
+	}
+
+	host := metal3api.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-host",
+			Namespace: "test-ns",
+			UID:       "test-uid",
+		},
+		Spec: metal3api.BareMetalHostSpec{
+			BMC: metal3api.BMCDetails{
+				Address: "test://test.bmc/",
+			},
+		},
+	}
+	hostData := provisioner.BuildHostData(host, bmc.Credentials{})
+
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir)
+
+	getTempCAFiles := func() (result []string) {
+		files, err := os.ReadDir(tempDir)
+		require.NoError(t, err)
+		for _, f := range files {
+			if strings.HasPrefix(f.Name(), "ironic-ca-") {
+				result = append(result, f.Name())
+			}
+		}
+		return
+	}
+
+	require.Empty(t, getTempCAFiles())
+
+	// ironicProvisioner will fail because the Ironic CR endpoint is not
+	// reachable, but the createClient closure must still clean up the
+	// temp CA file via defer.
+	_, err := factory.ironicProvisioner(t.Context(), hostData, nullEventPublisher)
+	require.Error(t, err)
+	// ErrNotReady means the client was created successfully (the CA file
+	// was read and the TLS transport configured), but Ironic is unreachable.
+	require.ErrorIs(t, err, provisioner.ErrNotReady)
+
+	assert.Empty(t, getTempCAFiles(), "temp CA file was not cleaned up")
 }


### PR DESCRIPTION
Currently, temporary stored files keep accummulating.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
