### PR TITLE
🌱 Use proper IPA cache address

### DIFF
--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -164,7 +164,7 @@ fi
 # This saves time, especially during ironic upgrade tests and also
 # gives us early failure in case there is some issue downloading it.
 IPA_FILE="ipa-centos9-master.tar.gz"
-IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib/
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote/ironic-python-agent/dib/
 if [[ ! -f "${IMAGE_DIR}/${IPA_FILE}" ]]; then
     wget --quiet -P "${IMAGE_DIR}/" "${IPA_BASEURI}/${IPA_FILE}"
 fi

--- a/ironic-deployment/overlays/e2e/ironic_bmo_configmap.env
+++ b/ironic-deployment/overlays/e2e/ironic_bmo_configmap.env
@@ -1,7 +1,7 @@
 HTTP_PORT=6180
 PROVISIONING_INTERFACE=eth0
 CACHEURL=http://192.168.222.1/images
-IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote/ironic-python-agent/dib
 IRONIC_HTTP_URL=http://192.168.222.1:6180
 IRONIC_BASE_URL=https://192.168.222.1:6385
 IRONIC_EXTERNAL_CALLBACK_URL=https://192.168.222.1:6385


### PR DESCRIPTION
This commit:
 - Makes sure that the correct IPA Nordix proxy is used.

Previous address circumvented the proper cache refresh trigger so in case the cache was empty after a cleanup, cache refresh was not triggered.
