### PR TITLE
🐛 Omit empty checksum from provisioning error message

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1263,7 +1263,11 @@ func (p *ironicProvisioner) Provision(ctx context.Context, data provisioner.Prov
 			}
 			p.log.Info("found error", "msg", ironicNode.LastError)
 			checksum, _, _ := data.Image.GetChecksum()
-			return operationFailed(fmt.Sprintf("Image provisioning failed (url: %s, checksum: %s): %s", data.Image.URL, checksum, ironicNode.LastError))
+			imageInfo := "url: " + data.Image.URL
+			if checksum != "" {
+				imageInfo += ", checksum: " + checksum
+			}
+			return operationFailed(fmt.Sprintf("Image provisioning failed (%s): %s", imageInfo, ironicNode.LastError))
 		}
 		p.log.Info("recovering from previous failure")
 		if provResult, err = p.setUpForProvisioning(ctx, ironicNode, data); err != nil || provResult.Dirty || provResult.ErrorMessage != "" {

--- a/pkg/provisioner/ironic/provision_test.go
+++ b/pkg/provisioner/ironic/provision_test.go
@@ -69,6 +69,23 @@ func TestProvision(t *testing.T) {
 			expectedErrorMessage: "Image provisioning failed (url: http://test-image, checksum: abcd): no work today",
 		},
 		{
+			name: "deployFail state - same OCI image",
+			ironic: testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
+				ProvisionState: string(nodes.DeployFail),
+				UUID:           nodeUUID,
+				InstanceInfo: map[string]any{
+					"image_source": "oci://quay.io/example/image@sha256:abc123",
+				},
+				LastError: "image not found",
+			}),
+			image: &metal3api.Image{
+				URL: "oci://quay.io/example/image@sha256:abc123",
+			},
+			expectedRequestAfter: 0,
+			expectedDirty:        false,
+			expectedErrorMessage: "Image provisioning failed (url: oci://quay.io/example/image@sha256:abc123): image not found",
+		},
+		{
 			name: "cleanFail state",
 			ironic: testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
 				ProvisionState: string(nodes.CleanFail),


### PR DESCRIPTION
**What this PR does / why we need it**:

For OCI images, the checksum is embedded in the URL (`@sha256:...`) and `GetChecksum()` returns an empty string. The provisioning error message introduced in #3298 was showing an empty `checksum:` field for OCI images, which is misleading.

This change omits the checksum field from the error message when it is empty.

**Before (OCI image):**
```
Image provisioning failed (url: oci://quay.io/example/image@sha256:abc123, checksum: ): <ironic error>
```

**After (OCI image):**
```
Image provisioning failed (url: oci://quay.io/example/image@sha256:abc123): <ironic error>
```

Non-OCI images with a checksum continue to show it as before:
```
Image provisioning failed (url: http://example.com/image, checksum: abc123): <ironic error>
```

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.