### PR TITLE
🌱 vbmctl: Make VM template portable across distros

### DIFF
--- a/test/vbmctl/pkg/libvirt/templates/VM.xml.tpl
+++ b/test/vbmctl/pkg/libvirt/templates/VM.xml.tpl
@@ -4,7 +4,7 @@
   <currentMemory unit='KiB'>{{ .Memory }}</currentMemory>
   <vcpu placement='static'>{{ .VCPUs }}</vcpu>
   <os firmware="efi">
-    <type arch='x86_64' machine='pc-q35-6.2'>hvm</type>
+    <type arch='x86_64' machine='q35'>hvm</type>
     <firmware>
       <feature enabled="no" name="secure-boot"/>
     </firmware>
@@ -18,7 +18,6 @@
   <cpu mode='host-passthrough' check='none' migratable='on'/>
   <clock offset='utc'/>
   <devices>
-    <emulator>/usr/bin/qemu-system-x86_64</emulator>
     <disk type='file' device='cdrom'>
       <driver name='qemu' type='raw'/>
       <target dev='sdb' bus='sata'/>
@@ -96,7 +95,7 @@
     </graphics>
     <audio id='1' type='none'/>
     <video>
-      <model type='cirrus' vram='16384' heads='1' primary='yes'/>
+      <model type='virtio' heads='1' primary='yes'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x0'/>
     </video>
     <memballoon model='virtio'>


### PR DESCRIPTION
The VM.xml.tpl template had values hardcoded for Ubuntu's QEMU packages
that prevented vbmctl from working on CentOS/RHEL:

1. `machine='pc-q35-6.2'` — a versioned machine type only available in
   Ubuntu's QEMU. CentOS/RHEL uses different versions (`pc-q35-rhel9.*`),
   causing "unsupported machine type" errors.

2. `<emulator>/usr/bin/qemu-system-x86_64</emulator>` — Ubuntu's QEMU
   binary path. On CentOS/RHEL it's at `/usr/libexec/qemu-kvm`.

3. `<model type='cirrus' .../>` — the Cirrus VGA adapter is deprecated
   and not available on all QEMU builds.

Fix:
- Use the `q35` machine type alias, which resolves to the latest
  available q35 version on any distro.
- Remove the `<emulator>` element so libvirt auto-detects the correct
  QEMU binary path for the host.
- Switch video model from `cirrus` to `virtio`, which is supported
  across all modern QEMU/libvirt versions.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
