### PR TITLE
:bug: Fix OperationalStatusAllowed and ErrorTypeAllowed to match CRD enums

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -252,7 +252,7 @@ const (
 )
 
 // OperationalStatusAllowed represents the allowed values of OperationalStatus.
-var OperationalStatusAllowed = []string{"", string(OperationalStatusOK), string(OperationalStatusDiscovered), string(OperationalStatusError), string(OperationalStatusDelayed), string(OperationalStatusDetached)}
+var OperationalStatusAllowed = []string{"", string(OperationalStatusOK), string(OperationalStatusDiscovered), string(OperationalStatusError), string(OperationalStatusDelayed), string(OperationalStatusDetached), string(OperationalStatusServicing)}
 
 // ErrorType indicates the class of problem that has caused the Host resource
 // to enter an error state.
@@ -287,7 +287,7 @@ const (
 )
 
 // ErrorTypeAllowed represents the allowed values of ErrorType.
-var ErrorTypeAllowed = []string{"", string(ProvisionedRegistrationError), string(RegistrationError), string(InspectionError), string(PreparationError), string(ProvisioningError), string(PowerManagementError)}
+var ErrorTypeAllowed = []string{"", string(ProvisionedRegistrationError), string(RegistrationError), string(InspectionError), string(PreparationError), string(ProvisioningError), string(PowerManagementError), string(DetachError), string(ServicingError)}
 
 // ProvisioningState defines the states the provisioner will report
 // the host has having.
@@ -769,7 +769,7 @@ type BareMetalHostStatus struct {
 
 	// ErrorType indicates the type of failure encountered when the
 	// OperationalStatus is OperationalStatusError
-	// +kubebuilder:validation:Enum=provisioned registration error;registration error;inspection error;preparation error;provisioning error;power management error;servicing error
+	// +kubebuilder:validation:Enum=provisioned registration error;registration error;inspection error;preparation error;provisioning error;power management error;detach error;servicing error
 	ErrorType ErrorType `json:"errorType,omitempty"`
 
 	// LastUpdated identifies when this status was last observed.

--- a/config/base/crds/bases/metal3.io_baremetalhosts.yaml
+++ b/config/base/crds/bases/metal3.io_baremetalhosts.yaml
@@ -715,6 +715,7 @@ spec:
                 - preparation error
                 - provisioning error
                 - power management error
+                - detach error
                 - servicing error
                 type: string
               goodCredentials:

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -715,6 +715,7 @@ spec:
                 - preparation error
                 - provisioning error
                 - power management error
+                - detach error
                 - servicing error
                 type: string
               goodCredentials:

--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -698,6 +698,51 @@ func TestValidateCreate(t *testing.T) {
 			wantedErr: "invalid operationalStatus 'NotOK' in the baremetalhost.metal3.io/status annotation",
 		},
 		{
+			name: "validStatusAnnotationServicing",
+			newBMH: &metal3api.BareMetalHost{
+				TypeMeta: tm,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						metal3api.StatusAnnotation: `{"operationalStatus": "servicing"}`,
+					},
+				},
+			},
+			oldBMH:    nil,
+			wantedErr: "",
+		},
+		{
+			name: "validStatusAnnotationDetachError",
+			newBMH: &metal3api.BareMetalHost{
+				TypeMeta: tm,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						metal3api.StatusAnnotation: `{"errorType":"detach error"}`,
+					},
+				},
+			},
+			oldBMH:    nil,
+			wantedErr: "",
+		},
+		{
+			name: "validStatusAnnotationServicingError",
+			newBMH: &metal3api.BareMetalHost{
+				TypeMeta: tm,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						metal3api.StatusAnnotation: `{"errorType":"servicing error"}`,
+					},
+				},
+			},
+			oldBMH:    nil,
+			wantedErr: "",
+		},
+		{
 			name: "invalidErrtypeStatusAnnotation",
 			newBMH: &metal3api.BareMetalHost{
 				TypeMeta: tm,


### PR DESCRIPTION
The OperationalStatusAllowed slice was missing "servicing" and ErrorTypeAllowed was missing "detach error" and "servicing error", causing the status annotation webhook to reject valid values that are accepted by the CRD schema.
