### PR TITLE
:bug: Make NeedsMAC semantics consistent across BMC drivers

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -956,6 +956,7 @@ func (r *BareMetalHostReconciler) registerHost(ctx context.Context, prov provisi
 			DisablePowerOff:            info.host.Spec.DisablePowerOff,
 			CPUArchitecture:            getHostArchitecture(info.host),
 			HardwareData:               info.hardwareData,
+			DisableInspection:          info.host.InspectionDisabled(),
 		},
 		credsChanged,
 		info.host.Status.ErrorType == metal3api.RegistrationError)

--- a/pkg/hardwareutils/bmc/access.go
+++ b/pkg/hardwareutils/bmc/access.go
@@ -55,8 +55,12 @@ type AccessDetails interface {
 	// will be used to communicate with it.
 	Type() string
 
-	// NeedsMAC returns true when the host is going to need a separate
-	// port created rather than having it discovered.
+	// NeedsMAC returns true when the driver requires a BootMACAddress to be
+	// populated regardless of whether inspection is enabled, for example
+	// VirtualBMC where the MAC cannot be discovered. Drivers whose MAC can be
+	// discovered during inspection return false; for those, a MAC is only
+	// required when inspection is disabled, which the callers enforce
+	// separately via host.InspectionDisabled().
 	NeedsMAC() bool
 
 	// The name of the driver to instantiate the BMC with. This may differ

--- a/pkg/hardwareutils/bmc/access_test.go
+++ b/pkg/hardwareutils/bmc/access_test.go
@@ -284,7 +284,7 @@ func TestStaticDriverInfo(t *testing.T) {
 		{
 			Scenario:   "redfish",
 			input:      "redfish://192.168.122.1",
-			needsMac:   true,
+			needsMac:   false,
 			driver:     "redfish",
 			bios:       "",
 			boot:       "ipxe",
@@ -332,7 +332,7 @@ func TestStaticDriverInfo(t *testing.T) {
 		{
 			Scenario:   "redfish uefi http boot",
 			input:      "redfish-uefihttp+https://192.168.122.1",
-			needsMac:   true,
+			needsMac:   false,
 			driver:     "redfish",
 			bios:       "",
 			boot:       "redfish-https",
@@ -344,7 +344,7 @@ func TestStaticDriverInfo(t *testing.T) {
 		{
 			Scenario:   "idrac redfish",
 			input:      "idrac-redfish://192.168.122.1",
-			needsMac:   true,
+			needsMac:   false,
 			driver:     "idrac",
 			bios:       "idrac-redfish",
 			boot:       "ipxe",

--- a/pkg/hardwareutils/bmc/idrac_virtualmedia.go
+++ b/pkg/hardwareutils/bmc/idrac_virtualmedia.go
@@ -35,8 +35,10 @@ func (a *redfishiDracVirtualMediaAccessDetails) Type() string {
 }
 
 // NeedsMAC returns false for virtual media drivers since they can boot
-// from virtual media without requiring a pre-configured boot MAC address.
-// The MAC address can be populated after hardware inspection completes.
+// from virtual media without requiring a pre-configured boot MAC address,
+// and the MAC can be populated after hardware inspection completes. When
+// inspection is disabled a MAC is still required, but that requirement is
+// enforced by the callers via host.InspectionDisabled().
 func (a *redfishiDracVirtualMediaAccessDetails) NeedsMAC() bool {
 	return false
 }

--- a/pkg/hardwareutils/bmc/ipmi.go
+++ b/pkg/hardwareutils/bmc/ipmi.go
@@ -46,15 +46,15 @@ func (a *ipmiAccessDetails) Type() string {
 	return a.bmcType
 }
 
-// NeedsMAC returns true when the host is going to need a separate
-// port created rather than having it discovered.
+// NeedsMAC returns true only for VirtualBMC (the libvirt-based hosts used for
+// dev and testing), where a MAC address is required regardless of whether
+// inspection is enabled: VirtualBMC IPMI addresses are not unique and the
+// IPMI address cannot be fetched from inside the VM, so the MAC cannot be
+// discovered automatically. Regular IPMI hosts can have their MAC discovered
+// during inspection, so they return false; a MAC is only required for them
+// when inspection is disabled, which the callers enforce via
+// host.InspectionDisabled().
 func (a *ipmiAccessDetails) NeedsMAC() bool {
-	// libvirt-based hosts used for dev and testing require a MAC
-	// address, specified as part of the host, but we don't want the
-	// provisioner to have to know the rules about which drivers
-	// require what so we hide that detail inside this class and just
-	// let the provisioner know that "some" drivers require a MAC and
-	// it should ask.
 	return a.bmcType == "libvirt"
 }
 

--- a/pkg/hardwareutils/bmc/redfish.go
+++ b/pkg/hardwareutils/bmc/redfish.go
@@ -49,12 +49,16 @@ func (a *redfishAccessDetails) Type() string {
 	return a.bmcType
 }
 
-// NeedsMAC returns true when the host is going to need a separate
-// port created rather than having it discovered.
+// NeedsMAC returns false because the Redfish driver in Ironic can
+// pre-populate MAC addresses during inspection, so a BootMACAddress is not
+// required up front regardless of the boot method. This matches the existing
+// behaviour of the plain IPMI driver, which also boots via iPXE yet already
+// returns false: agent-based inspection reports the MACs back to Ironic
+// rather than relying on a pre-created port. When inspection is disabled a
+// MAC is still required, but that requirement is enforced by the callers via
+// host.InspectionDisabled(), not by this driver-level flag.
 func (a *redfishAccessDetails) NeedsMAC() bool {
-	// For the inspection to work, we need a MAC address
-	// https://github.com/metal3-io/baremetal-operator/pull/284#discussion_r317579040
-	return true
+	return false
 }
 
 func (a *redfishAccessDetails) Driver() string {

--- a/pkg/hardwareutils/bmc/redfish_https.go
+++ b/pkg/hardwareutils/bmc/redfish_https.go
@@ -30,12 +30,13 @@ func (a *redfishHTTPBootMediaAccessDetails) Type() string {
 	return a.bmcType
 }
 
-// NeedsMAC returns true when the host is going to need a separate
-// port created rather than having it discovered.
+// NeedsMAC returns false because the Redfish driver in Ironic can
+// pre-populate MAC addresses during inspection, so a BootMACAddress is not
+// required up front. When inspection is disabled a MAC is still required,
+// but that requirement is enforced by the callers via
+// host.InspectionDisabled(), not by this driver-level flag.
 func (a *redfishHTTPBootMediaAccessDetails) NeedsMAC() bool {
-	// For the inspection to work, we need a MAC address
-	// https://github.com/metal3-io/baremetal-operator/pull/284#discussion_r317579040
-	return true
+	return false
 }
 
 func (a *redfishHTTPBootMediaAccessDetails) Driver() string {

--- a/pkg/hardwareutils/bmc/redfish_virtualmedia.go
+++ b/pkg/hardwareutils/bmc/redfish_virtualmedia.go
@@ -30,8 +30,10 @@ func (a *redfishVirtualMediaAccessDetails) Type() string {
 }
 
 // NeedsMAC returns false for virtual media drivers since they can boot
-// from virtual media without requiring a pre-configured boot MAC address.
-// The MAC address can be populated after hardware inspection completes.
+// from virtual media without requiring a pre-configured boot MAC address,
+// and the MAC can be populated after hardware inspection completes. When
+// inspection is disabled a MAC is still required, but that requirement is
+// enforced by the callers via host.InspectionDisabled().
 func (a *redfishVirtualMediaAccessDetails) NeedsMAC() bool {
 	return false
 }

--- a/pkg/provisioner/ironic/register.go
+++ b/pkg/provisioner/ironic/register.go
@@ -94,9 +94,12 @@ func (p *ironicProvisioner) Register(ctx context.Context, data provisioner.Manag
 		return result, "", err
 	}
 
-	// Some BMC types require a MAC address, so ensure we have one
-	// when we need it. If not, place the host in an error state.
-	if bmcAccess.NeedsMAC() && p.bootMACAddress == "" {
+	// Some BMC types require a MAC address regardless of inspection (for
+	// example VirtualBMC), and any host requires one when inspection is
+	// disabled because the MAC cannot be discovered. Ensure we have one when
+	// we need it; if not, place the host in an error state. This mirrors the
+	// combined rule enforced by the validating webhook.
+	if (bmcAccess.NeedsMAC() || data.DisableInspection) && p.bootMACAddress == "" {
 		msg := fmt.Sprintf("BMC driver %s requires a BootMACAddress value", bmcAccess.Type())
 		p.log.Info(msg)
 		result, err = operationFailed(msg)

--- a/pkg/provisioner/ironic/register_test.go
+++ b/pkg/provisioner/ironic/register_test.go
@@ -75,6 +75,31 @@ func TestRegisterMACOptional(t *testing.T) {
 	assert.Empty(t, result.ErrorMessage)
 }
 
+func TestRegisterNoMACInspectionDisabled(t *testing.T) {
+	// Create a host whose BMC driver does not inherently require a MAC and
+	// without a bootMACAddress, but with inspection disabled. A MAC is then
+	// required because it cannot be discovered through inspection.
+	host := makeHost()
+	host.Spec.BootMACAddress = ""
+	host.Status.Provisioning.ID = "" // so we don't lookup by uuid
+
+	ironic := testserver.NewIronic(t).NoNode(host.Namespace + nameSeparator + host.Name).NoNode(host.Name)
+	ironic.Start()
+	defer ironic.Stop()
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nil, ironic.Endpoint(), auth)
+	if err != nil {
+		t.Fatalf("could not create provisioner: %s", err)
+	}
+
+	result, _, err := prov.Register(t.Context(), provisioner.ManagementAccessData{DisableInspection: true}, false, false)
+	if err != nil {
+		t.Fatalf("error from Register: %s", err)
+	}
+	assert.Contains(t, result.ErrorMessage, "requires a BootMACAddress")
+}
+
 func TestRegisterCreateNode(t *testing.T) {
 	// Create a host without a bootMACAddress and with a BMC that
 	// does not require one.

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -89,6 +89,7 @@ type ManagementAccessData struct {
 	DisablePowerOff            bool
 	CPUArchitecture            string
 	HardwareData               *metal3api.HardwareData
+	DisableInspection          bool
 }
 
 type AdoptData struct {


### PR DESCRIPTION
## Summary

`NeedsMAC()` on the `AccessDetails` interface is meant to declare whether a
driver requires `BootMACAddress` to be populated, but the per-driver
implementations were mutually inconsistent (#3305):

- Redfish virtual media returned `false`.
- Redfish network boot and `redfish-uefihttp` returned `true`.
- IPMI returned `true` only for the `libvirt://` (VirtualBMC) scheme, while
  plain `ipmi://` returned `false` despite also booting via iPXE.

This change settles on a single rule: `NeedsMAC()` reports only the
requirement that holds **regardless of inspection state**. That is true
solely for VirtualBMC, whose IPMI addresses are non-unique and cannot be
fetched from inside the VM, so the MAC can never be discovered. All
Redfish-family drivers now return `false`, matching the existing behaviour of
the plain IPMI driver: Ironic can pre-populate MAC addresses during
inspection, so a `BootMACAddress` is not required up front.

The separate "MAC required when inspection is disabled" guarantee is left to
the consumers. The validating webhook already applied
`NeedsMAC() || host.InspectionDisabled()`; this aligns the ironic `Register`
backstop to the same combined condition by threading `DisableInspection`
through `ManagementAccessData`, so both call sites enforce the rule
identically.

## Why this matters

As the issue author describes, each individual `NeedsMAC()` reasoning made
local sense but the set as a whole was incoherent, and the proposed direction
is to drop the ad-hoc divergence and require `BootMACAddress` only when
inspection is disabled, while still honoring the genuine VirtualBMC
requirement. This makes the driver-level booleans consistent and keeps the
inspection-state rule in one place (the consumers), rather than duplicating
conflicting heuristics across drivers.

## Testing

- `pkg/hardwareutils/bmc`: updated the per-scheme `NeedsMAC()` table cases
  (`redfish`, `redfish uefi http boot`, `idrac redfish` now expect `false`)
  and ran the package tests.
- `pkg/provisioner/ironic`: added `TestRegisterNoMACInspectionDisabled`
  covering the combined condition (a non-VirtualBMC driver with inspection
  disabled and no `BootMACAddress` is rejected), plus the existing
  `TestRegisterNoMAC` / `TestRegisterMACOptional` cases.
- `go vet` and `gofmt` clean on the touched packages; both affected modules
  (main and `pkg/hardwareutils`) pass their unit tests.

Fixes #3305
