### PR TITLE
:seedling: Switch  generate.sh script to use ro mount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ CONTAINER_RUNTIME = docker
 SOURCE_GIT_COMMIT ?= $(shell git rev-parse --short HEAD)
 BUILD_VERSION ?= $(shell git describe --always --abbrev=40 --dirty)
 VERSION_URI = "github.com/metal3-io/baremetal-operator/pkg/version"
-export LDFLAGS="-X $(VERSION_URI).Raw=${BUILD_VERSION} \
+LDFLAGS = "-X $(VERSION_URI).Raw=${BUILD_VERSION} \
                 -X $(VERSION_URI).Commit=${SOURCE_GIT_COMMIT} \
                 -X $(VERSION_URI).BuildTime=$(shell date +%Y-%m-%dT%H:%M:%S%z)"
 

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -12,11 +12,13 @@ CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 WORKDIR="${WORKDIR:-/workdir}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
-    # we need to tell git its OK to use dir owned by someone else
-    git config --global safe.directory "${WORKDIR}"
     export XDG_CACHE_HOME="/tmp/.cache"
 
-    INPUT_FILES="$(git ls-files config) $(git ls-files | grep zz_generated)"
+    mkdir /tmp/generate
+    cp -r . /tmp/generate
+    cd /tmp/generate
+
+    INPUT_FILES="$(find config -type f) $(find . -name 'zz_generated*' -type f)"
     cksum ${INPUT_FILES} > "${ARTIFACTS}/lint.cksums.before"
     export VERBOSE="--verbose"
     make generate manifests
@@ -30,7 +32,7 @@ else
         --env DEPLOY_KERNEL_URL=http://172.22.0.1/images/ironic-python-agent.kernel \
         --env DEPLOY_RAMDISK_URL=http://172.22.0.1/images/ironic-python-agent.initramfs \
         --env IRONIC_ENDPOINT=http://localhost:6385/v1/ \
-        --volume "${PWD}:${WORKDIR}:rw,z" \
+        --volume "${PWD}:${WORKDIR}:ro,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
         quay.io/metal3-io/basic-checks:golang-1.25 \


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

Compare to `hack/gomod.sh`: it is ro and running `go mod tidy`. All other projects in Metal3 also use ro for everything. By this logic `generate.sh` should be ro as well but it is rw now. This PR is changing  `generate.sh` mount from rw to ro.

I'm also removing the export from Makefile's `LDFLAGS` variable. The variable is explicitly given to those make target that use it. By removing the export I can remove the `git config --global safe.directory "${WORKDIR}"` from `generate.sh` file as well. 

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
