### PR TITLE
:bug: Fix common logging code and move to reusable location

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -190,6 +190,9 @@ linters:
       text: should not use dot imports
     - path: (test|e2e)/.*.go
       text: should not use dot imports
+    # Dot imports of logging utils is a convenience.
+    - source: '. "github.com/metal3-io/baremetal-operator/pkg/logging"'
+      text: should not use dot imports
     # Exclude deprecated packages of CAPI still used in the codebase.
     - linters:
       - staticcheck

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -190,8 +190,8 @@ linters:
       text: should not use dot imports
     - path: (test|e2e)/.*.go
       text: should not use dot imports
-    # Dot imports of logging utils is a convenience.
-    - source: '. "github.com/metal3-io/baremetal-operator/pkg/logging"'
+    # Dot imports of logging utils are a convenience.
+    - source: '^\s*\.\s+"github.com/metal3-io/baremetal-operator/pkg/logging"$'
       text: should not use dot imports
     # Exclude deprecated packages of CAPI still used in the codebase.
     - linters:

--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/profile"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/imageprovider"
+	. "github.com/metal3-io/baremetal-operator/pkg/logging"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/secretutils"
 	"github.com/prometheus/client_golang/prometheus"

--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -690,7 +690,7 @@ func (r *BareMetalHostReconciler) detachHost(ctx context.Context, prov provision
 		info.host.Status.ErrorCount = 0
 	}
 	if info.host.SetOperationalStatus(metal3api.OperationalStatusDetached) {
-		info.log.V(VerbosityLevelDebug).Info("host is detached, removed from provisioner")
+		info.log.Info("host is detached, removed from provisioner")
 		return actionUpdate{slowPoll}
 	}
 	return slowPoll
@@ -896,7 +896,7 @@ func (r *BareMetalHostReconciler) registerHost(ctx context.Context, prov provisi
 
 	credsChanged := !info.host.Status.TriedCredentials.Match(*info.bmcCredsSecret)
 	if credsChanged {
-		info.log.V(VerbosityLevelDebug).Info("new credentials detected",
+		info.log.Info("new credentials detected",
 			"newVersion", info.bmcCredsSecret.ResourceVersion)
 		info.host.UpdateTriedCredentials(*info.bmcCredsSecret)
 		info.postSaveCallbacks = append(info.postSaveCallbacks, updatedCredentials.Inc)
@@ -1673,7 +1673,7 @@ func (r *BareMetalHostReconciler) manageHostPower(ctx context.Context, prov prov
 	}
 
 	if hwState.PoweredOn != nil && *hwState.PoweredOn != info.host.Status.PoweredOn {
-		info.log.V(VerbosityLevelDebug).Info("updating power status",
+		info.log.Info("updating power status",
 			LogFieldPoweredOn, *hwState.PoweredOn)
 		info.host.Status.PoweredOn = *hwState.PoweredOn
 		if info.host.Status.OperationalStatus == metal3api.OperationalStatusError && info.host.Status.ErrorType == metal3api.PowerManagementError {
@@ -1743,7 +1743,7 @@ func (r *BareMetalHostReconciler) manageHostPower(ctx context.Context, prov prov
 		return steadyStateResult
 	}
 
-	info.log.V(VerbosityLevelDebug).Info("power state change needed",
+	info.log.Info("power state change needed",
 		"expected", desiredPowerOnState,
 		"actual", info.host.Status.PoweredOn,
 		"rebootMode", desiredRebootMode,
@@ -1873,7 +1873,7 @@ func (r *BareMetalHostReconciler) handleDataImageActions(ctx context.Context, pr
 	if deleteDataImage {
 		info.log.V(VerbosityLevelDebug).Info("DataImage requested for deletion")
 		if isImageAttached {
-			info.log.V(VerbosityLevelDebug).Info("detaching DataImage as its deletion has been requested")
+			info.log.Info("detaching DataImage as its deletion has been requested")
 			err := r.detachDataImage(ctx, prov, info, dataImage)
 			if err != nil {
 				return actionError{fmt.Errorf("failed to detach, %w", err)}
@@ -1891,7 +1891,7 @@ func (r *BareMetalHostReconciler) handleDataImageActions(ctx context.Context, pr
 	if requestedURL != attachedURL {
 		info.log.V(VerbosityLevelDebug).Info("DataImage change detected")
 		if attachedURL != "" {
-			info.log.V(VerbosityLevelDebug).Info("detaching DataImage")
+			info.log.Info("detaching DataImage as its URL has changed")
 			err := r.detachDataImage(ctx, prov, info, dataImage)
 			if err != nil {
 				return actionError{fmt.Errorf("failed to detach, %w", err)}
@@ -1903,7 +1903,7 @@ func (r *BareMetalHostReconciler) handleDataImageActions(ctx context.Context, pr
 			return actionContinue{dataImageRetryBackoff}
 		}
 		if requestedURL != "" {
-			info.log.V(VerbosityLevelDebug).Info("attaching DataImage",
+			info.log.Info("attaching DataImage",
 				LogFieldDataImage, requestedURL)
 			err := r.attachDataImage(ctx, prov, info, dataImage)
 			if err != nil {
@@ -2077,7 +2077,7 @@ func saveHostProvisioningSettings(host *metal3api.BareMetalHost, info *reconcile
 		}
 	}
 	if !reflect.DeepEqual(host.Status.Provisioning.RAID, specRAID) {
-		info.log.V(VerbosityLevelDebug).Info("RAID settings have changed",
+		info.log.Info("RAID settings have changed",
 			"old", host.Status.Provisioning.RAID,
 			"new", specRAID)
 		host.Status.Provisioning.RAID = specRAID
@@ -2283,7 +2283,7 @@ func (r *BareMetalHostReconciler) getHostFirmwareSettings(ctx context.Context, i
 		return false, nil, fmt.Errorf("hostFirmwareSettings not ready yet: %w", err)
 	}
 	if !valid {
-		info.log.V(VerbosityLevelDebug).Info("hostFirmwareSettings not valid",
+		info.log.Info("hostFirmwareSettings not valid",
 			LogFieldNamespace, info.request.NamespacedName)
 		return false, hfs, nil
 	}
@@ -2294,7 +2294,7 @@ func (r *BareMetalHostReconciler) getHostFirmwareSettings(ctx context.Context, i
 			return false, nil, errors.New("host firmware status settings not available")
 		}
 
-		info.log.V(VerbosityLevelDebug).Info("hostFirmwareSettings indicating ChangeDetected",
+		info.log.Info("hostFirmwareSettings indicating ChangeDetected",
 			LogFieldNamespace, info.request.NamespacedName)
 		return true, hfs, nil
 	}
@@ -2325,12 +2325,12 @@ func (r *BareMetalHostReconciler) getHostFirmwareComponents(ctx context.Context,
 		return false, nil, fmt.Errorf("hostFirmwareComponents not ready yet: %w", err)
 	}
 	if !valid {
-		info.log.V(VerbosityLevelDebug).Info("hostFirmwareComponents not valid",
+		info.log.Info("hostFirmwareComponents not valid",
 			LogFieldNamespace, info.request.NamespacedName)
 		return false, hfc, nil
 	}
 	if changed {
-		info.log.V(VerbosityLevelDebug).Info("hostFirmwareComponents indicating ChangeDetected",
+		info.log.Info("hostFirmwareComponents indicating ChangeDetected",
 			LogFieldNamespace, info.request.NamespacedName)
 		return true, hfc, nil
 	}
@@ -2607,7 +2607,7 @@ func (r *BareMetalHostReconciler) publishEvent(ctx context.Context, request ctrl
 		"message", event.Message)
 	err := r.Create(ctx, &event)
 	if err != nil {
-		reqLogger.V(VerbosityLevelDebug).Info("failed to record event, ignoring",
+		reqLogger.Info("failed to record event, ignoring",
 			LogFieldReason, event.Reason,
 			"message", event.Message,
 			LogFieldError, err)
@@ -2700,7 +2700,7 @@ func (r *BareMetalHostReconciler) reconcileHostData(ctx context.Context, host *m
 		objStatus, err := r.getHostStatusFromAnnotation(host)
 
 		if err == nil && objStatus != nil {
-			reqLogger.V(VerbosityLevelDebug).Info("reconstructing Status from hardwareData and annotation")
+			reqLogger.Info("reconstructing Status from hardwareData and annotation")
 			// hardwareData takes predence over statusAnnotation data
 			if hardwareData.Spec.HardwareDetails != nil && objStatus.HardwareDetails != hardwareData.Spec.HardwareDetails {
 				objStatus.HardwareDetails = hardwareData.Spec.HardwareDetails

--- a/internal/controller/metal3.io/host_state_machine.go
+++ b/internal/controller/metal3.io/host_state_machine.go
@@ -114,7 +114,7 @@ func (hsm *hostStateMachine) updateHostStateFrom(ctx context.Context, initialSta
 		default:
 		}
 
-		info.log.V(VerbosityLevelDebug).Info("changing provisioning state",
+		info.log.Info("changing provisioning state",
 			"old", initialState,
 			"new", hsm.NextState)
 		now := metav1.Now()
@@ -358,7 +358,7 @@ func (hsm *hostStateMachine) ensureRegistered(ctx context.Context, info *reconci
 	default:
 		if hsm.Host.Status.ErrorType == metal3api.RegistrationError ||
 			!hsm.Host.Status.GoodCredentials.Match(*info.bmcCredsSecret) {
-			info.log.V(VerbosityLevelDebug).Info("retrying registration",
+			info.log.Info("retrying registration",
 				"lastError", hsm.Host.Status.ErrorMessage)
 			recordStateBegin(hsm.Host, metal3api.StateRegistering, metav1.Now())
 		}

--- a/internal/controller/metal3.io/host_state_machine.go
+++ b/internal/controller/metal3.io/host_state_machine.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	. "github.com/metal3-io/baremetal-operator/pkg/logging"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
+++ b/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	. "github.com/metal3-io/baremetal-operator/pkg/logging"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"

--- a/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
+++ b/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
@@ -255,11 +255,11 @@ func (r *HostFirmwareComponentsReconciler) updateEventHandler(e event.UpdateEven
 	// NOTE(dtantsur): the only realistic case of a changed owner reference is when pre-created HFC is adopted by a BMH that was created later.
 	// In this case, it's reasonable to reconcile the resource using the information from the new BMH.
 	if !reflect.DeepEqual(e.ObjectNew.GetOwnerReferences(), e.ObjectOld.GetOwnerReferences()) {
-		r.Log.Info("processing event for changed owner reference", "namespace", e.ObjectNew.GetNamespace(), "name", e.ObjectNew.GetName())
+		r.Log.V(VerbosityLevelDebug).Info("processing event for changed owner reference", "namespace", e.ObjectNew.GetNamespace(), "name", e.ObjectNew.GetName())
 		return true
 	}
 
-	r.Log.V(1).Info("ignoring event that did not change generation or owners", "namespace", e.ObjectNew.GetNamespace(), "name", e.ObjectNew.GetName())
+	r.Log.V(VerbosityLevelDebug).Info("ignoring event that did not change generation or owners", "namespace", e.ObjectNew.GetNamespace(), "name", e.ObjectNew.GetName())
 	return false
 }
 
@@ -281,7 +281,7 @@ func (r *HostFirmwareComponentsReconciler) publishEvent(ctx context.Context, req
 		"message", event.Message)
 	err := r.Create(ctx, &event)
 	if err != nil {
-		reqLogger.V(VerbosityLevelDebug).Info("failed to record event, ignoring",
+		reqLogger.Info("failed to record event, ignoring",
 			LogFieldReason, event.Reason,
 			"message", event.Message,
 			LogFieldError, err)

--- a/internal/controller/metal3.io/hostfirmwaresettings_controller.go
+++ b/internal/controller/metal3.io/hostfirmwaresettings_controller.go
@@ -229,7 +229,7 @@ func (r *HostFirmwareSettingsReconciler) updateStatus(ctx context.Context, info 
 	for k, v := range info.hfs.Spec.Settings {
 		if statusVal, ok := newStatus.Settings[k]; ok {
 			if v.String() != statusVal {
-				info.log.V(VerbosityLevelDebug).Info("spec value different than status",
+				info.log.Info("spec value different than status",
 					"name", k,
 					"specValue", v.String(),
 					"statusValue", statusVal)
@@ -385,11 +385,11 @@ func (r *HostFirmwareSettingsReconciler) updateEventHandler(e event.UpdateEvent)
 	// NOTE(dtantsur): the only realistic case of a changed owner reference is when pre-created HFS is adopted by a BMH that was created later.
 	// In this case, it's reasonable to reconcile the resource using the information from the new BMH.
 	if !reflect.DeepEqual(e.ObjectNew.GetOwnerReferences(), e.ObjectOld.GetOwnerReferences()) {
-		r.Log.Info("processing event for changed owner reference", "namespace", e.ObjectNew.GetNamespace(), "name", e.ObjectNew.GetName())
+		r.Log.V(VerbosityLevelDebug).Info("processing event for changed owner reference", "namespace", e.ObjectNew.GetNamespace(), "name", e.ObjectNew.GetName())
 		return true
 	}
 
-	r.Log.V(1).Info("ignoring event that did not change generation or owners", "namespace", e.ObjectNew.GetNamespace(), "name", e.ObjectNew.GetName())
+	r.Log.V(VerbosityLevelDebug).Info("ignoring event that did not change generation or owners", "namespace", e.ObjectNew.GetNamespace(), "name", e.ObjectNew.GetName())
 	return false
 }
 

--- a/internal/controller/metal3.io/hostfirmwaresettings_controller.go
+++ b/internal/controller/metal3.io/hostfirmwaresettings_controller.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/go-logr/logr"
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	. "github.com/metal3-io/baremetal-operator/pkg/logging"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"

--- a/internal/controller/metal3.io/hostfirmwaresettings_controller.go
+++ b/internal/controller/metal3.io/hostfirmwaresettings_controller.go
@@ -36,6 +36,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -200,6 +201,12 @@ func (r *HostFirmwareSettingsReconciler) updateHostFirmwareSettings(ctx context.
 	return nil
 }
 
+type hfsDiff struct {
+	Name   string
+	Spec   string
+	Status *string
+}
+
 // Update the HostFirmwareSettings resource using the settings and schema from provisioner.
 func (r *HostFirmwareSettingsReconciler) updateStatus(ctx context.Context, info *rInfo, settings metal3api.SettingsMap, schema *metal3api.FirmwareSchema) (err error) {
 	dirty := false
@@ -225,20 +232,23 @@ func (r *HostFirmwareSettingsReconciler) updateStatus(ctx context.Context, info 
 		!reflect.DeepEqual(info.hfs.Status.Settings, newStatus.Settings)
 
 	// Check if any Spec settings are different than Status
-	specMismatch := false
+	var specMismatch []hfsDiff
 	for k, v := range info.hfs.Spec.Settings {
+		specVal := v.String()
 		if statusVal, ok := newStatus.Settings[k]; ok {
-			if v.String() != statusVal {
-				info.log.Info("spec value different than status",
-					"name", k,
-					"specValue", v.String(),
-					"statusValue", statusVal)
-				specMismatch = true
-				break
+			if specVal != statusVal {
+				specMismatch = append(specMismatch, hfsDiff{
+					Name:   k,
+					Spec:   specVal,
+					Status: ptr.To(statusVal),
+				})
 			}
 		} else {
 			// Spec setting is not in Status, this will be handled by validateHostFirmwareSettings
-			specMismatch = true
+			specMismatch = append(specMismatch, hfsDiff{
+				Name: k,
+				Spec: specVal,
+			})
 			break
 		}
 	}
@@ -247,8 +257,16 @@ func (r *HostFirmwareSettingsReconciler) updateStatus(ctx context.Context, info 
 	reason := reasonSuccess
 	generation := info.hfs.GetGeneration()
 
-	if specMismatch {
+	if len(specMismatch) > 0 {
 		if setCondition(generation, &newStatus, info, metal3api.FirmwareSettingsChangeDetected, metav1.ConditionTrue, reason, "") {
+			// This is the first time we detect a change, log the diff
+			diffParts := make([]string, 0, len(specMismatch))
+			for _, part := range specMismatch {
+				diffParts = append(diffParts,
+					fmt.Sprintf("%s: %q != %q", part.Name, part.Spec, ptr.Deref(part.Status, "<nil>")))
+			}
+			info.log.Info("current HostFirmwareSettings do not match the requested settings",
+				LogFieldDifference, strings.Join(diffParts, ", "))
 			dirty = true
 		}
 
@@ -276,6 +294,7 @@ func (r *HostFirmwareSettingsReconciler) updateStatus(ctx context.Context, info 
 			dirty = true
 		}
 		if setCondition(generation, &newStatus, info, metal3api.FirmwareSettingsChangeDetected, metav1.ConditionFalse, reason, "") {
+			info.log.Info("current HostFirmwareSettings match the requested (or no changes are requested)")
 			dirty = true
 		}
 	}

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -17,18 +17,16 @@ limitations under the License.
 package controllers
 
 // Log verbosity levels for structured logging.
-// Use VerbosityLevelDebug for key decision points and important state changes.
-// Use VerbosityLevelTrace for detailed step-by-step flow tracing (function entry/exit).
 //
 // TODO: Review all existing info.log.Info() calls to determine if they should be:
-// - V(VerbosityLevelDebug) for key decision points (state changes, important branches)
+// - V(VerbosityLevelDebug) for minor decision points of little interest to operators
 // - V(VerbosityLevelTrace) for function entry/exit and detailed flow
-// - Left as Info() for critical operational messages visible by default
+// - Left as Info() for important operational messages visible by default
 //
 // Guidelines for log levels:
-// - Info() (level 0): Critical operational messages, errors, state transitions
+// - Info() (level 0): Important operational messages, major decision points, errors, state transitions
 // - V(1-3): Reserved for controller-runtime internal use
-// - V(VerbosityLevelDebug=4): Decision points, important branches, config changes
+// - V(VerbosityLevelDebug=4): Minor decision points and branches, config changes
 // - V(VerbosityLevelTrace=5): Function entry/exit, detailed flow tracing.
 const (
 	VerbosityLevelDebug = 4

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package logging
 
 // Log verbosity levels for structured logging.
 //

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -204,4 +204,7 @@ const (
 
 	// LogFieldStatusConditionStatus is the status of a condition.
 	LogFieldStatusConditionStatus = "conditionStatus"
+
+	// LogFieldDifference is a difference between some values.
+	LogFieldDifference = "difference"
 )

--- a/pkg/provisioner/ironic/factory.go
+++ b/pkg/provisioner/ironic/factory.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/drivers"
 	"github.com/gophercloud/gophercloud/v2/pagination"
+	. "github.com/metal3-io/baremetal-operator/pkg/logging"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
 	"github.com/metal3-io/baremetal-operator/pkg/secretutils"
@@ -160,9 +161,9 @@ func (f ironicProvisionerFactory) refreshCache(ctx context.Context, createClient
 			return f.cache.clientIronic, f.cache.availableFeatures, nil // cache is up-to-date
 		}
 
-		f.log.Info("client cache expired, refreshing", "TTL", f.cacheTTL, "HasGlobalClient", f.ironicName == "")
+		f.log.V(VerbosityLevelDebug).Info("client cache expired, refreshing", "TTL", f.cacheTTL, "HasGlobalClient", f.ironicName == "")
 	} else {
-		f.log.V(1).Info("creating and verifying a client (cache disabled)", "HasGlobalClient", f.ironicName == "")
+		f.log.V(VerbosityLevelDebug).Info("creating and verifying a client (cache disabled)", "HasGlobalClient", f.ironicName == "")
 	}
 
 	newClient, err := createClient()


### PR DESCRIPTION
Follow-up to 903bb5cee08130958398fa79c23998ca15f0d07c:

Move the logging code to a common location so that we can use the same
constants in the provisioners and potentially API. Allow dotimports for
these to avoid bloating the code.

Fix incorrect guidance: things like "key decision points" and "important
branches" must be logged as INFO, this is implied by the words "key" and
"importants".

As an example, I'm adjusting (back) some of the changes log messages.
From my experience, these are critical to reconstruct the sequence of events.
I won't be able to fix anyone with their bugs if they don't have these on.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
