### PR TITLE
🐛 Fix flaky Go installation in e2e setup

### DIFF
--- a/hack/e2e/ensure_go.sh
+++ b/hack/e2e/ensure_go.sh
@@ -18,13 +18,20 @@ verify_go_version() {
         fi
         if [[ "${OSTYPE}" == "linux-gnu" ]]; then
             echo "go not found, installing"
+            local GO_TARBALL="${MINIMUM_GO_VERSION}.linux-amd64.tar.gz"
+            for attempt in 1 2 3; do
+                echo "Downloading Go (attempt ${attempt}/3)"
+                if curl -fsSL -o "/tmp/${GO_TARBALL}" "https://go.dev/dl/${GO_TARBALL}" && \
+                    curl -fsSL -o "/tmp/${GO_TARBALL}.sha256" "https://dl.google.com/go/${GO_TARBALL}.sha256" && \
+                    echo "$(cat "/tmp/${GO_TARBALL}.sha256")  /tmp/${GO_TARBALL}" | sha256sum --check --quiet; then
+                    break
+                fi
+                rm -f "/tmp/${GO_TARBALL}" "/tmp/${GO_TARBALL}.sha256"
+            done
+            [[ -f "/tmp/${GO_TARBALL}" ]] || { echo "ERROR: failed to download valid Go archive"; return 2; }
             set -x
-            curl -sL \
-                -o "/tmp/${MINIMUM_GO_VERSION}.linux-amd64.tar.gz" \
-                "https://go.dev/dl/${MINIMUM_GO_VERSION}.linux-amd64.tar.gz"
-            sudo tar \
-                -C /usr/local \
-                -xzf "/tmp/${MINIMUM_GO_VERSION}.linux-amd64.tar.gz"
+            sudo tar -C /usr/local -xzf "/tmp/${GO_TARBALL}"
+            rm -f "/tmp/${GO_TARBALL}" "/tmp/${GO_TARBALL}.sha256"
             set +x
             export PATH="${PATH}:/usr/local/go/bin"
             GO="$(command -v go)"


### PR DESCRIPTION
Adds retry loop and checksum verification to the Go tarball download in `ensure_go.sh`. Previously a corrupted or truncated download was piped directly into `tar`, causing `gzip: stdin: not in gzip format` failures.

The fix downloads both the tarball and its published `.sha256`, verifies the checksum before extraction, and retries up to three
times on any failure.

Fixes #2962