### PR TITLE
:sparkles: Implementation of the HostClaim controller

### DIFF
--- a/config/base/manager.yaml
+++ b/config/base/manager.yaml
@@ -23,6 +23,7 @@ spec:
         - /baremetal-operator
         args:
         - --enable-leader-election
+        - --hostclaims
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/config/base/rbac/role.yaml
+++ b/config/base/rbac/role.yaml
@@ -18,6 +18,8 @@ rules:
   - namespaces
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -3150,6 +3150,8 @@ rules:
   - namespaces
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -3364,6 +3366,7 @@ spec:
       containers:
       - args:
         - --enable-leader-election
+        - --hostclaims
         command:
         - /baremetal-operator
         env:

--- a/internal/controller/metal3.io/hostclaim_controller.go
+++ b/internal/controller/metal3.io/hostclaim_controller.go
@@ -37,10 +37,10 @@ import (
 // HostClaimReconciler reconciles a HostClaim object.
 type HostClaimReconciler struct {
 	client.Client
-	Scheme         *runtime.Scheme
-	Log            logr.Logger
-	APIReader      client.Reader
-	NewHostManager func(client client.Client, log logr.Logger, claim *metal3api.HostClaim, apireader client.Reader) hostclaimManager.HostManagerInterface
+	Scheme              *runtime.Scheme
+	Log                 logr.Logger
+	APIReader           client.Reader
+	NewHostClaimManager func(client client.Client, log logr.Logger, claim *metal3api.HostClaim, apireader client.Reader) hostclaimManager.ManagerInterface
 }
 
 //+kubebuilder:rbac:groups=metal3.io,resources=hostclaims,verbs=get;list;watch;create;update;patch;delete
@@ -73,39 +73,39 @@ func (r *HostClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}()
 
 	// Create a helper for managing the baremetal container hosting the machine.
-	hostMgr := r.NewHostManager(r.Client, log, hostClaim, r.APIReader)
+	hostClaimMgr := r.NewHostClaimManager(r.Client, log, hostClaim, r.APIReader)
 
 	// Handle deleted machines
 	if !hostClaim.ObjectMeta.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, hostMgr)
+		return r.reconcileDelete(ctx, hostClaimMgr)
 	}
 
 	// Handle non-deleted machines
-	return r.reconcileNormal(ctx, hostMgr)
+	return r.reconcileNormal(ctx, hostClaimMgr)
 }
 
 func (r *HostClaimReconciler) reconcileNormal(ctx context.Context,
-	hostMgr hostclaimManager.HostManagerInterface,
+	hostClaimMgr hostclaimManager.ManagerInterface,
 ) (ctrl.Result, error) {
 	// If the HostClaim doesn't have finalizer, add it.
-	hostMgr.SetFinalizer()
+	hostClaimMgr.SetFinalizer()
 
 	// if the machine is already provisioned, update and return
-	if hostMgr.IsProvisioned() {
-		return checkHostClaimError(hostMgr.Update(ctx), "Failed to update the HostClaim")
+	if hostClaimMgr.IsProvisioned() {
+		return checkHostClaimError(hostClaimMgr.Update(ctx), "Failed to update the HostClaim")
 	}
 
 	// Check if the hostclaim was associated with a baremetalhost
-	if !hostMgr.IsAssociated() {
-		err := hostMgr.Associate(ctx)
+	if !hostClaimMgr.IsAssociated() {
+		err := hostClaimMgr.Associate(ctx)
 		if err != nil {
 			return checkHostClaimError(err, "failed to associate the HostClaim to a BaremetalHost")
 		}
 	} else {
 		// Update Condition to reflect that we have an associated BMH
-		hostMgr.SetConditionHostToTrue(metal3api.AssociatedCondition, metal3api.BareMetalHostAssociatedReason)
+		hostClaimMgr.SetConditionHostToTrue(metal3api.AssociatedCondition, metal3api.BareMetalHostAssociatedReason)
 	}
-	err := hostMgr.Update(ctx)
+	err := hostClaimMgr.Update(ctx)
 	if err != nil {
 		return checkHostClaimError(err, "failed to update BaremetalHost")
 	}
@@ -113,15 +113,15 @@ func (r *HostClaimReconciler) reconcileNormal(ctx context.Context,
 }
 
 func (r *HostClaimReconciler) reconcileDelete(ctx context.Context,
-	hostMgr hostclaimManager.HostManagerInterface,
+	hostClaimMgr hostclaimManager.ManagerInterface,
 ) (ctrl.Result, error) {
-	hostMgr.SetConditionHostToFalse(metal3api.AssociatedCondition,
+	hostClaimMgr.SetConditionHostToFalse(metal3api.AssociatedCondition,
 		metal3api.HostClaimDeletingReason,
 		"")
 
 	// delete the hostclaim
-	if err := hostMgr.Delete(ctx); err != nil {
-		hostMgr.SetConditionHostToFalse(metal3api.AssociatedCondition,
+	if err := hostClaimMgr.Delete(ctx); err != nil {
+		hostClaimMgr.SetConditionHostToFalse(metal3api.AssociatedCondition,
 			metal3api.HostClaimDeletionFailedReason,
 			err.Error())
 		return checkHostClaimError(err, "failed to delete Host")
@@ -129,7 +129,7 @@ func (r *HostClaimReconciler) reconcileDelete(ctx context.Context,
 
 	// hostclaim is marked for deletion and ready to be deleted,
 	// so remove the finalizer.
-	hostMgr.UnsetFinalizer()
+	hostClaimMgr.UnsetFinalizer()
 
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/metal3.io/hostclaim_controller.go
+++ b/internal/controller/metal3.io/hostclaim_controller.go
@@ -1,5 +1,5 @@
 /*
-
+Copyright 2025 The Metal3 Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,32 +18,185 @@ package controllers
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	"github.com/go-logr/logr"
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	hostclaimManager "github.com/metal3-io/baremetal-operator/pkg/hostclaim"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
 // HostClaimReconciler reconciles a HostClaim object.
 type HostClaimReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme         *runtime.Scheme
+	Log            logr.Logger
+	APIReader      client.Reader
+	NewHostManager func(client client.Client, log logr.Logger, claim *metal3api.HostClaim, apireader client.Reader) hostclaimManager.HostManagerInterface
 }
 
 //+kubebuilder:rbac:groups=metal3.io,resources=hostclaims,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=metal3.io,resources=hostclaims/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=metal3.io,resources=hostclaims/finalizers,verbs=update
 //+kubebuilder:rbac:groups=metal3.io,resources=hostdeploypolicies,verbs=get;list;watch
-//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 
-func (r *HostClaimReconciler) Reconcile(_ context.Context, _ ctrl.Request) (ctrl.Result, error) {
+func (r *HostClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
+	log := r.Log.WithValues("hostclaim", req.NamespacedName)
+	hostClaim := &metal3api.HostClaim{}
+	if err := r.Client.Get(ctx, req.NamespacedName, hostClaim); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Always patch hostClaim exiting this function so we can persist any hostClaim changes.
+	patchHelper, err := patch.NewHelper(hostClaim, r.Client)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to init patch helper: %w", err)
+	}
+
+	defer func() {
+		if err = patchHostClaim(ctx, patchHelper, hostClaim); err != nil {
+			log.Error(err, "failed to Patch HostClaim")
+			rerr = err
+		}
+	}()
+
+	// Create a helper for managing the baremetal container hosting the machine.
+	hostMgr := r.NewHostManager(r.Client, log, hostClaim, r.APIReader)
+
+	// Handle deleted machines
+	if !hostClaim.ObjectMeta.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, hostMgr)
+	}
+
+	// Handle non-deleted machines
+	return r.reconcileNormal(ctx, hostMgr)
+}
+
+func (r *HostClaimReconciler) reconcileNormal(ctx context.Context,
+	hostMgr hostclaimManager.HostManagerInterface,
+) (ctrl.Result, error) {
+	// If the HostClaim doesn't have finalizer, add it.
+	hostMgr.SetFinalizer()
+
+	// if the machine is already provisioned, update and return
+	if hostMgr.IsProvisioned() {
+		return checkHostClaimError(hostMgr.Update(ctx), "Failed to update the HostClaim")
+	}
+
+	// Check if the hostclaim was associated with a baremetalhost
+	if !hostMgr.IsAssociated() {
+		err := hostMgr.Associate(ctx)
+		if err != nil {
+			return checkHostClaimError(err, "failed to associate the HostClaim to a BaremetalHost")
+		}
+	} else {
+		// Update Condition to reflect that we have an associated BMH
+		hostMgr.SetConditionHostToTrue(metal3api.AssociatedCondition, metal3api.BareMetalHostAssociatedReason)
+	}
+	err := hostMgr.Update(ctx)
+	if err != nil {
+		return checkHostClaimError(err, "failed to update BaremetalHost")
+	}
 	return ctrl.Result{}, nil
+}
+
+func (r *HostClaimReconciler) reconcileDelete(ctx context.Context,
+	hostMgr hostclaimManager.HostManagerInterface,
+) (ctrl.Result, error) {
+	hostMgr.SetConditionHostToFalse(metal3api.AssociatedCondition,
+		metal3api.HostClaimDeletingReason,
+		"")
+
+	// delete the hostclaim
+	if err := hostMgr.Delete(ctx); err != nil {
+		hostMgr.SetConditionHostToFalse(metal3api.AssociatedCondition,
+			metal3api.HostClaimDeletionFailedReason,
+			err.Error())
+		return checkHostClaimError(err, "failed to delete Host")
+	}
+
+	// hostclaim is marked for deletion and ready to be deleted,
+	// so remove the finalizer.
+	hostMgr.UnsetFinalizer()
+
+	return ctrl.Result{}, nil
+}
+
+// patchHostClaim patch the HostClaim and ensures that the conditions are initialized.
+// Can be used several times without creating a conflict.
+func patchHostClaim(ctx context.Context, patchHelper *patch.Helper, claim *metal3api.HostClaim, options ...patch.Option) error {
+	// Always update the readyCondition by summarizing the state of other conditions.
+	sumOption := conditions.ForConditionTypes{
+		metal3api.AssociatedCondition, metal3api.SynchronizedCondition, metal3api.ProvisionedCondition}
+	if err := conditions.SetSummaryCondition(claim, claim, metal3api.ReadyCondition, sumOption); err != nil {
+		return err
+	}
+
+	// Patch the object, ignoring conflicts on the conditions owned by this controller.
+	options = append(
+		options,
+		patch.WithOwnedConditions{Conditions: []string{
+			metal3api.ReadyCondition,
+			metal3api.AssociatedCondition,
+			metal3api.SynchronizedCondition,
+			metal3api.ProvisionedCondition,
+			metal3api.AvailableForProvisioningCondition,
+		}},
+		patch.WithStatusObservedGeneration{},
+	)
+	return patchHelper.Patch(ctx, claim, options...)
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *HostClaimReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// This is still applied on client side not server side.
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&metal3api.HostClaim{}).
+		Watches(
+			&metal3api.BareMetalHost{},
+			handler.EnqueueRequestsFromMapFunc(BareMetalHostToHostClaims),
+		).
 		Complete(r)
+}
+
+// BareMetalHostToHostClaims will return a reconcile request for a HostClaim if the event is for a
+// BareMetalHost and that BareMetalHost references a HostClaim.
+func BareMetalHostToHostClaims(_ context.Context, obj client.Object) []ctrl.Request {
+	if host, ok := obj.(*metal3api.BareMetalHost); ok {
+		if host.Spec.ConsumerRef != nil &&
+			host.Spec.ConsumerRef.Kind == hostclaimManager.HostClaimKind &&
+			strings.HasPrefix(host.Spec.ConsumerRef.APIVersion, "metal3.io/") {
+			return []ctrl.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						Name:      host.Spec.ConsumerRef.Name,
+						Namespace: host.Spec.ConsumerRef.Namespace,
+					},
+				},
+			}
+		}
+	}
+	return []ctrl.Request{}
+}
+
+func checkHostClaimError(err error, errMessage string) (ctrl.Result, error) {
+	if err == nil {
+		return ctrl.Result{}, nil
+	}
+	if ok, delay := hostclaimManager.IsRequeueAfterError(err); ok {
+		return ctrl.Result{Requeue: true, RequeueAfter: delay}, nil
+	}
+	return ctrl.Result{}, fmt.Errorf("%s: %w", errMessage, err)
 }

--- a/internal/controller/metal3.io/hostclaim_controller_test.go
+++ b/internal/controller/metal3.io/hostclaim_controller_test.go
@@ -1,0 +1,298 @@
+/*
+Copyright 2025 The Metal3 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	. "github.com/metal3-io/baremetal-operator/internal/testutil"
+	"github.com/metal3-io/baremetal-operator/pkg/hostclaim"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type MockHostManager struct {
+	countSetFinalizer            int
+	countUnsetFinalizer          int
+	countSetConditionHostToFalse int
+	countSetConditionHostToTrue  int
+	countAssociate               int
+	countDelete                  int
+	countUpdate                  int
+	isProvisioned                bool
+	isAssociated                 bool
+	associateError               error
+	updateError                  error
+	deleteError                  error
+	conditions                   map[string]mockCondition
+}
+
+type mockCondition struct {
+	reason  string
+	message string
+	ok      bool
+}
+
+func (m *MockHostManager) SetFinalizer()       { m.countSetFinalizer++ }
+func (m *MockHostManager) UnsetFinalizer()     { m.countUnsetFinalizer++ }
+func (m *MockHostManager) IsProvisioned() bool { return m.isProvisioned }
+func (m *MockHostManager) IsAssociated() bool  { return m.isAssociated }
+func (m *MockHostManager) Associate(ctx context.Context) error {
+	m.countAssociate++
+	return m.associateError
+}
+func (m *MockHostManager) Delete(ctx context.Context) error {
+	m.countDelete++
+	return m.deleteError
+}
+func (m *MockHostManager) Update(ctx context.Context) error {
+	m.countUpdate++
+	return m.updateError
+}
+func (m *MockHostManager) SetConditionHostToFalse(t string, reason string, msg string) {
+	if m.conditions == nil {
+		m.conditions = map[string]mockCondition{}
+	}
+	m.conditions[t] = mockCondition{reason: reason, message: msg, ok: false}
+}
+
+func (m *MockHostManager) SetConditionHostToTrue(t string, reason string) {
+	if m.conditions == nil {
+		m.conditions = map[string]mockCondition{}
+	}
+	m.conditions[t] = mockCondition{reason: reason, ok: true}
+}
+
+// setupSchemes configures schemes.
+func setupScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+
+	if err := metal3api.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+
+	return scheme
+}
+
+const (
+	baremetalName      = "bmh"
+	baremetalNamespace = "ns"
+)
+
+var (
+	defaultConsumerRef = corev1.ObjectReference{
+		Name:       HostclaimName,
+		Namespace:  HostclaimNamespace,
+		Kind:       "HostClaim",
+		APIVersion: "metal3.io/v1alpha1",
+	}
+	errDefault        = errors.New("default")
+	delay             = 30 * time.Second
+	errDefaultRequeue = hostclaim.RequeueAfterError{RequeueAfter: delay}
+)
+
+type testCaseHostClaimReconcile struct {
+	HostClaim            *metal3api.HostClaim
+	HostManager          *MockHostManager
+	DeleteRequested      bool
+	ExpectError          bool
+	ExpectRequeue        bool
+	AssociateCalled      bool
+	UpdateCalled         bool
+	DeleteCalled         bool
+	SetFinalizerCalled   bool
+	UnsetFinalizerCalled bool
+	AssociateError       error
+	UpdateError          error
+	DeleteError          error
+}
+
+var _ = Describe("Test HostClaim Controller",
+	func() {
+		DescribeTable("Test Reconcile",
+			func(tc testCaseHostClaimReconcile) {
+				ctx := context.TODO()
+				objs := []client.Object{tc.HostClaim}
+				key := types.NamespacedName{Name: HostclaimName, Namespace: HostclaimNamespace}
+				scheme := setupScheme()
+				builder := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).WithStatusSubresource(tc.HostClaim)
+				fakeClient := builder.Build()
+				if tc.DeleteRequested {
+					hostClaim := &metal3api.HostClaim{}
+					err := fakeClient.Get(ctx, key, hostClaim)
+					Expect(err).NotTo(HaveOccurred())
+					err = fakeClient.Delete(ctx, hostClaim)
+					Expect(err).NotTo(HaveOccurred())
+				}
+				namespacedName := types.NamespacedName{
+					Namespace: HostclaimNamespace,
+					Name:      HostclaimName,
+				}
+				req := ctrl.Request{NamespacedName: namespacedName}
+				hostclaimCtrl := HostClaimReconciler{
+					Client: fakeClient, Scheme: scheme, Log: GinkgoLogr, APIReader: fakeClient,
+					NewHostManager: func(_ client.Client, _ logr.Logger, _ *metal3api.HostClaim, _ client.Reader,
+					) hostclaim.HostManagerInterface {
+						return tc.HostManager
+					}}
+				result, err := hostclaimCtrl.Reconcile(ctx, req)
+				if tc.ExpectError {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+					if tc.ExpectRequeue {
+						Expect(result.RequeueAfter).NotTo(BeZero())
+					} else {
+						Expect(result.RequeueAfter).To(BeZero())
+					}
+				}
+				if tc.AssociateCalled {
+					Expect(tc.HostManager.countAssociate).To(Equal(1))
+				} else {
+					Expect(tc.HostManager.countAssociate).To(BeZero())
+				}
+				if tc.DeleteCalled {
+					Expect(tc.HostManager.countDelete).To(Equal(1))
+				} else {
+					Expect(tc.HostManager.countDelete).To(BeZero())
+				}
+				if tc.UpdateCalled {
+					Expect(tc.HostManager.countUpdate).To(Equal(1))
+				} else {
+					Expect(tc.HostManager.countUpdate).To(BeZero())
+				}
+				if tc.UnsetFinalizerCalled {
+					Expect(tc.HostManager.countUnsetFinalizer).To(Equal(1))
+				} else {
+					Expect(tc.HostManager.countUnsetFinalizer).To(BeZero())
+				}
+				if tc.SetFinalizerCalled {
+					Expect(tc.HostManager.countSetFinalizer).To(Equal(1))
+				} else {
+					Expect(tc.HostManager.countSetFinalizer).To(BeZero())
+				}
+
+			},
+			Entry("No HostClaim", testCaseHostClaimReconcile{
+				HostClaim:   NewHostclaim("Another").Build(),
+				HostManager: &MockHostManager{},
+			}),
+			Entry("Not associated", testCaseHostClaimReconcile{
+				HostClaim:          NewHostclaim(HostclaimName).Build(),
+				HostManager:        &MockHostManager{},
+				AssociateCalled:    true,
+				UpdateCalled:       true,
+				SetFinalizerCalled: true,
+			}),
+			Entry("Not associated - associate errs", testCaseHostClaimReconcile{
+				HostClaim:          NewHostclaim(HostclaimName).Build(),
+				HostManager:        &MockHostManager{associateError: errDefault},
+				AssociateCalled:    true,
+				ExpectError:        true,
+				SetFinalizerCalled: true,
+			}),
+			Entry("Not associated - associate requeue", testCaseHostClaimReconcile{
+				HostClaim:          NewHostclaim(HostclaimName).Build(),
+				HostManager:        &MockHostManager{associateError: errDefaultRequeue},
+				AssociateCalled:    true,
+				ExpectRequeue:      true,
+				SetFinalizerCalled: true,
+			}),
+			Entry("Not associated - update errs", testCaseHostClaimReconcile{
+				HostClaim:          NewHostclaim(HostclaimName).Build(),
+				HostManager:        &MockHostManager{updateError: errDefault},
+				AssociateCalled:    true,
+				UpdateCalled:       true,
+				ExpectError:        true,
+				SetFinalizerCalled: true,
+			}),
+			Entry("Associated", testCaseHostClaimReconcile{
+				HostClaim:          NewHostclaim(HostclaimName).Build(),
+				HostManager:        &MockHostManager{isAssociated: true},
+				UpdateCalled:       true,
+				SetFinalizerCalled: true,
+			}),
+			Entry("Associated - error", testCaseHostClaimReconcile{
+				HostClaim:          NewHostclaim(HostclaimName).Build(),
+				HostManager:        &MockHostManager{isAssociated: true, updateError: errDefault},
+				ExpectError:        true,
+				UpdateCalled:       true,
+				SetFinalizerCalled: true,
+			}),
+			Entry("Provisioned", testCaseHostClaimReconcile{
+				HostClaim:          NewHostclaim(HostclaimName).Build(),
+				HostManager:        &MockHostManager{isProvisioned: true},
+				UpdateCalled:       true,
+				SetFinalizerCalled: true,
+			}),
+			Entry("Provisioned - error", testCaseHostClaimReconcile{
+				HostClaim:          NewHostclaim(HostclaimName).Build(),
+				HostManager:        &MockHostManager{isProvisioned: true, updateError: errDefault},
+				UpdateCalled:       true,
+				SetFinalizerCalled: true,
+				ExpectError:        true,
+			}),
+			Entry("Delete", testCaseHostClaimReconcile{
+				HostClaim:            NewHostclaim(HostclaimName).SetFinalizer([]string{metal3api.HostClaimFinalizer}).Build(),
+				HostManager:          &MockHostManager{},
+				DeleteRequested:      true,
+				DeleteCalled:         true,
+				UnsetFinalizerCalled: true,
+			}),
+			Entry("Delete - requeue requested", testCaseHostClaimReconcile{
+				HostClaim:       NewHostclaim(HostclaimName).SetFinalizer([]string{metal3api.HostClaimFinalizer}).Build(),
+				HostManager:     &MockHostManager{deleteError: errDefaultRequeue},
+				DeleteRequested: true,
+				DeleteCalled:    true,
+				ExpectRequeue:   true,
+			}),
+		)
+
+		It("Test BareMetalHostToHostClaims (with consumer ref)", func() {
+			bmh := NewBaremetalhost(baremetalName, baremetalNamespace, metal3api.StateAvailable).SetConsumerRef(defaultConsumerRef).Build()
+			reqList := BareMetalHostToHostClaims(context.TODO(), bmh)
+			Expect(reqList).To(HaveLen(1))
+			Expect(reqList[0].Name).To(Equal(HostclaimName))
+			Expect(reqList[0].Namespace).To(Equal(HostclaimNamespace))
+		})
+
+		It("Test BareMetalHostToHostClaims (no consumer ref)", func() {
+			reqList := BareMetalHostToHostClaims(context.TODO(), NewBaremetalhost(baremetalName, baremetalNamespace, metal3api.StateAvailable).Build())
+			Expect(reqList).To(BeEmpty())
+		})
+	},
+)
+
+func TestManagers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Manager Suite")
+}

--- a/internal/controller/metal3.io/hostclaim_controller_test.go
+++ b/internal/controller/metal3.io/hostclaim_controller_test.go
@@ -160,8 +160,8 @@ var _ = Describe("Test HostClaim Controller",
 				req := ctrl.Request{NamespacedName: namespacedName}
 				hostclaimCtrl := HostClaimReconciler{
 					Client: fakeClient, Scheme: scheme, Log: GinkgoLogr, APIReader: fakeClient,
-					NewHostManager: func(_ client.Client, _ logr.Logger, _ *metal3api.HostClaim, _ client.Reader,
-					) hostclaim.HostManagerInterface {
+					NewHostClaimManager: func(_ client.Client, _ logr.Logger, _ *metal3api.HostClaim, _ client.Reader,
+					) hostclaim.ManagerInterface {
 						return tc.HostManager
 					}}
 				result, err := hostclaimCtrl.Reconcile(ctx, req)

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 	metal3iocontroller "github.com/metal3-io/baremetal-operator/internal/controller/metal3.io"
 	webhooks "github.com/metal3-io/baremetal-operator/internal/webhooks/metal3.io/v1alpha1"
 	ppicontroller "github.com/metal3-io/baremetal-operator/pkg/controllers"
+	"github.com/metal3-io/baremetal-operator/pkg/hostclaim"
 	"github.com/metal3-io/baremetal-operator/pkg/imageprovider"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/fixture"
@@ -147,6 +148,7 @@ func main() {
 	var metricsBindAddr string
 	var enableLeaderElection bool
 	var preprovImgEnable bool
+	var hostClaimsEnable bool
 	var devLogging bool
 	var provisionerName string
 	var webhookPort int
@@ -169,6 +171,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&preprovImgEnable, "build-preprov-image", false, "enable integration with the PreprovisioningImage API")
+	flag.BoolVar(&hostClaimsEnable, "hostclaims", false, "enable HostClaims controller")
 	flag.BoolVar(&devLogging, "dev", false, "enable developer logging")
 	flag.StringVar(&provisionerName, "provisioner", defaultProvisionerName,
 		"Name of the provisioner plugin to load. Resolves to "+
@@ -411,13 +414,20 @@ func main() {
 			}
 		}
 	}
-	if err = (&metal3iocontroller.HostClaimReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "HostClaim")
-		os.Exit(1)
+
+	if hostClaimsEnable {
+		if err = (&metal3iocontroller.HostClaimReconciler{
+			Client:         mgr.GetClient(),
+			Log:            ctrl.Log.WithName("controllers").WithName("HostClaim"),
+			Scheme:         mgr.GetScheme(),
+			APIReader:      mgr.GetAPIReader(),
+			NewHostManager: hostclaim.NewHostManager,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "HostClaim")
+			os.Exit(1)
+		}
 	}
+
 	// +kubebuilder:scaffold:builder
 
 	if err = (&metal3iocontroller.HostFirmwareSettingsReconciler{

--- a/main.go
+++ b/main.go
@@ -417,11 +417,11 @@ func main() {
 
 	if hostClaimsEnable {
 		if err = (&metal3iocontroller.HostClaimReconciler{
-			Client:         mgr.GetClient(),
-			Log:            ctrl.Log.WithName("controllers").WithName("HostClaim"),
-			Scheme:         mgr.GetScheme(),
-			APIReader:      mgr.GetAPIReader(),
-			NewHostManager: hostclaim.NewHostManager,
+			Client:              mgr.GetClient(),
+			Log:                 ctrl.Log.WithName("controllers").WithName("HostClaim"),
+			Scheme:              mgr.GetScheme(),
+			APIReader:           mgr.GetAPIReader(),
+			NewHostClaimManager: hostclaim.NewManager,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "HostClaim")
 			os.Exit(1)

--- a/pkg/hostclaim/hostclaim_manager.go
+++ b/pkg/hostclaim/hostclaim_manager.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 type HostManager struct {
@@ -67,13 +68,49 @@ const (
 // An error used when there is no BMH satisfying the constraints.
 var ErrNoAvailableBMH = errors.New("no available BareMetalHost")
 
-func NewHostManager(client client.Client, log logr.Logger, claim *metal3api.HostClaim, apireader client.Reader) (*HostManager, error) {
+type HostManagerInterface interface {
+	SetFinalizer()
+	UnsetFinalizer()
+	IsProvisioned() bool
+	IsAssociated() bool
+	SetConditionHostToFalse(string, string, string)
+	SetConditionHostToTrue(string, string)
+	Associate(context.Context) error
+	Delete(context.Context) error
+	Update(context.Context) error
+}
+
+// NewHostManager returns a new helper for managing a hostclaim.
+func NewHostManager(client client.Client, log logr.Logger, claim *metal3api.HostClaim, apireader client.Reader) HostManagerInterface {
 	return &HostManager{
 		client:    client,
 		HostClaim: claim,
 		Log:       log,
 		APIReader: apireader,
-	}, nil
+	}
+}
+
+// SetFinalizer sets finalizer on the hostClaim.
+func (m *HostManager) SetFinalizer() {
+	if !controllerutil.ContainsFinalizer(m.HostClaim, metal3api.HostClaimFinalizer) {
+		controllerutil.AddFinalizer(m.HostClaim, metal3api.HostClaimFinalizer)
+	}
+}
+
+// UnsetFinalizer unsets finalizer on the hostClaim.
+func (m *HostManager) UnsetFinalizer() {
+	controllerutil.RemoveFinalizer(m.HostClaim, metal3api.HostClaimFinalizer)
+}
+
+// IsProvisioned checks if the baremetalhost associated to the hostclaim is provisioned.
+// This is visible in the Ready field of the status.
+func (m *HostManager) IsProvisioned() bool {
+	return conditions.IsTrue(m.HostClaim, metal3api.ProvisionedCondition)
+}
+
+// IsAssociated checks that the host is marked as associated to a BMH.
+func (m *HostManager) IsAssociated() bool {
+	return m.HostClaim.Status.BareMetalHost != nil
 }
 
 // SetConditionHostToFalse sets Host condition status to False.
@@ -154,6 +191,35 @@ func (m *HostManager) Associate(ctx context.Context) error {
 	// From here the hostClaim is definitely associated
 	m.SetConditionHostToTrue(metal3api.AssociatedCondition, metal3api.BareMetalHostAssociatedReason)
 
+	return nil
+}
+
+// Delete removes the link between the HostClaim and the associated BareMetalHost.
+func (m *HostManager) Delete(ctx context.Context) error {
+	// TODO: to be reimplemented later.
+	if m.HostClaim == nil || m.HostClaim.Status.BareMetalHost == nil {
+		return nil
+	}
+	ref := m.HostClaim.Status.BareMetalHost
+	bmh := &metal3api.BareMetalHost{}
+	if err := m.client.Get(ctx, client.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}, bmh); err != nil {
+		if k8serrors.IsNotFound(err) {
+			m.HostClaim.Status.BareMetalHost = nil
+			return nil
+		}
+		return err
+	}
+	if bmh.Spec.ConsumerRef != nil && consumerRefMatches(bmh.Spec.ConsumerRef, m.HostClaim) {
+		bmh.Spec.ConsumerRef = nil
+		if err := m.client.Update(ctx, bmh); err != nil {
+			return hideConflictError(err)
+		}
+	}
+	m.HostClaim.Status.BareMetalHost = nil
+	return nil
+}
+
+func (m *HostManager) Update(_ context.Context) error {
 	return nil
 }
 

--- a/pkg/hostclaim/hostclaim_manager.go
+++ b/pkg/hostclaim/hostclaim_manager.go
@@ -40,7 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-type HostManager struct {
+type Manager struct {
 	client    client.Client
 	HostClaim *metal3api.HostClaim
 	Log       logr.Logger
@@ -68,7 +68,7 @@ const (
 // An error used when there is no BMH satisfying the constraints.
 var ErrNoAvailableBMH = errors.New("no available BareMetalHost")
 
-type HostManagerInterface interface {
+type ManagerInterface interface {
 	SetFinalizer()
 	UnsetFinalizer()
 	IsProvisioned() bool
@@ -80,9 +80,9 @@ type HostManagerInterface interface {
 	Update(context.Context) error
 }
 
-// NewHostManager returns a new helper for managing a hostclaim.
-func NewHostManager(client client.Client, log logr.Logger, claim *metal3api.HostClaim, apireader client.Reader) HostManagerInterface {
-	return &HostManager{
+// NewManager returns a new helper for managing a hostclaim.
+func NewManager(client client.Client, log logr.Logger, claim *metal3api.HostClaim, apireader client.Reader) ManagerInterface {
+	return &Manager{
 		client:    client,
 		HostClaim: claim,
 		Log:       log,
@@ -91,30 +91,30 @@ func NewHostManager(client client.Client, log logr.Logger, claim *metal3api.Host
 }
 
 // SetFinalizer sets finalizer on the hostClaim.
-func (m *HostManager) SetFinalizer() {
+func (m *Manager) SetFinalizer() {
 	if !controllerutil.ContainsFinalizer(m.HostClaim, metal3api.HostClaimFinalizer) {
 		controllerutil.AddFinalizer(m.HostClaim, metal3api.HostClaimFinalizer)
 	}
 }
 
 // UnsetFinalizer unsets finalizer on the hostClaim.
-func (m *HostManager) UnsetFinalizer() {
+func (m *Manager) UnsetFinalizer() {
 	controllerutil.RemoveFinalizer(m.HostClaim, metal3api.HostClaimFinalizer)
 }
 
 // IsProvisioned checks if the baremetalhost associated to the hostclaim is provisioned.
 // This is visible in the Ready field of the status.
-func (m *HostManager) IsProvisioned() bool {
+func (m *Manager) IsProvisioned() bool {
 	return conditions.IsTrue(m.HostClaim, metal3api.ProvisionedCondition)
 }
 
 // IsAssociated checks that the host is marked as associated to a BMH.
-func (m *HostManager) IsAssociated() bool {
+func (m *Manager) IsAssociated() bool {
 	return m.HostClaim.Status.BareMetalHost != nil
 }
 
 // SetConditionHostToFalse sets Host condition status to False.
-func (m *HostManager) SetConditionHostToFalse(
+func (m *Manager) SetConditionHostToFalse(
 	t string,
 	reason string,
 	message string,
@@ -123,7 +123,7 @@ func (m *HostManager) SetConditionHostToFalse(
 }
 
 // SetConditionHostToFalse sets Host condition status to False.
-func (m *HostManager) SetConditionHostToTrue(
+func (m *Manager) SetConditionHostToTrue(
 	t string,
 	reason string,
 ) {
@@ -137,7 +137,7 @@ func (m *HostManager) SetConditionHostToTrue(
 // If a suitable host is found, update its consumer ref, to ensure it is booked. If an error
 // prevents the update of the status of the claim at the end of the reconciliation logic, the choice logic will
 // ensure that the BareMetalHost already marked is chosen.
-func (m *HostManager) Associate(ctx context.Context) error {
+func (m *Manager) Associate(ctx context.Context) error {
 	m.Log.Info("Associating host")
 
 	// load and validate the config
@@ -195,7 +195,7 @@ func (m *HostManager) Associate(ctx context.Context) error {
 }
 
 // Delete removes the link between the HostClaim and the associated BareMetalHost.
-func (m *HostManager) Delete(ctx context.Context) error {
+func (m *Manager) Delete(ctx context.Context) error {
 	// TODO: to be reimplemented later.
 	if m.HostClaim == nil || m.HostClaim.Status.BareMetalHost == nil {
 		return nil
@@ -219,7 +219,7 @@ func (m *HostManager) Delete(ctx context.Context) error {
 	return nil
 }
 
-func (m *HostManager) Update(_ context.Context) error {
+func (m *Manager) Update(_ context.Context) error {
 	return nil
 }
 
@@ -254,7 +254,7 @@ func consumerRefMatches(consumer *corev1.ObjectReference, claim *metal3api.HostC
 	return true
 }
 
-func (m *HostManager) selectBMH(
+func (m *Manager) selectBMH(
 	availableHosts []*metal3api.BareMetalHost,
 ) (*metal3api.BareMetalHost, error) {
 	// choose a host.
@@ -273,7 +273,7 @@ func (m *HostManager) selectBMH(
 
 // Picks host from list of available hosts, if failureDomain is set, tries to choose from hosts in failureDomain.
 // When none available in failureDomain it chooses from all available hosts.
-func (m *HostManager) pickHost(availableHosts []*metal3api.BareMetalHost) (*metal3api.BareMetalHost, error) {
+func (m *Manager) pickHost(availableHosts []*metal3api.BareMetalHost) (*metal3api.BareMetalHost, error) {
 	var chosenHost *metal3api.BareMetalHost
 	var availableHostsInFailureDomain []*metal3api.BareMetalHost
 
@@ -321,7 +321,7 @@ func (m *HostManager) pickHost(availableHosts []*metal3api.BareMetalHost) (*meta
 // match the namespace of the claim. If the namespace argument is not empty,
 // HostDeployPolicies are only listed in that namespace and the result is either
 // an empty set or a singleton containing that namespace.
-func (m *HostManager) acceptableNamespaces(ctx context.Context, namespace string) (Set[string], error) {
+func (m *Manager) acceptableNamespaces(ctx context.Context, namespace string) (Set[string], error) {
 	m.Log.V(1).Info("Searching for suitable namespaces")
 	hostdeploypolicies := metal3api.HostDeployPolicyList{}
 	options := []client.ListOption{}
@@ -397,7 +397,7 @@ LOOP_POLICY:
 	return namespaces, nil
 }
 
-func (m *HostManager) hostLabelSelectorForHostClaim() (labels.Selector, error) {
+func (m *Manager) hostLabelSelectorForHostClaim() (labels.Selector, error) {
 	labelSelector := labels.NewSelector()
 
 	for labelKey, labelVal := range m.HostClaim.Spec.HostSelector.MatchLabels {
@@ -424,7 +424,7 @@ func (m *HostManager) hostLabelSelectorForHostClaim() (labels.Selector, error) {
 // chooseBMH iterates through known bare-metal hosts and returns one that can be
 // associated with the HostClaim. It searches all hosts in case one already has an
 // association with this HostClaim.
-func (m *HostManager) chooseBMH(ctx context.Context) (*metal3api.BareMetalHost, error) {
+func (m *Manager) chooseBMH(ctx context.Context) (*metal3api.BareMetalHost, error) {
 	namespaces, err := m.acceptableNamespaces(ctx, m.HostClaim.Spec.HostSelector.InNamespace)
 	if err != nil {
 		return nil, err

--- a/pkg/hostclaim/hostclaim_manager_test.go
+++ b/pkg/hostclaim/hostclaim_manager_test.go
@@ -109,7 +109,7 @@ var _ = Describe("HostClaim manager", func() {
 				}
 			}
 			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
-			hostMgr, ok := NewHostManager(fakeClient, GinkgoLogr, tc.HostClaim, fakeClient).(*HostManager)
+			hostMgr, ok := NewManager(fakeClient, GinkgoLogr, tc.HostClaim, fakeClient).(*Manager)
 			Expect(ok).To(BeTrue())
 			bmh, err := hostMgr.chooseBMH(context.TODO())
 			if tc.ExpectedBmhName == "" {
@@ -321,7 +321,7 @@ var _ = Describe("HostClaim manager", func() {
 			}
 			// We patch the status during associate to set the annotation.
 			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).WithStatusSubresource(tc.HostClaim).Build()
-			hostMgr := NewHostManager(fakeClient, GinkgoLogr, tc.HostClaim, fakeClient)
+			hostMgr := NewManager(fakeClient, GinkgoLogr, tc.HostClaim, fakeClient)
 			err := hostMgr.Associate(context.TODO())
 			if tc.ExpectFails {
 				Expect(err).To(HaveOccurred())

--- a/pkg/hostclaim/hostclaim_manager_test.go
+++ b/pkg/hostclaim/hostclaim_manager_test.go
@@ -109,8 +109,8 @@ var _ = Describe("HostClaim manager", func() {
 				}
 			}
 			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
-			hostMgr, err := NewHostManager(fakeClient, GinkgoLogr, tc.HostClaim, fakeClient)
-			Expect(err).NotTo(HaveOccurred())
+			hostMgr, ok := NewHostManager(fakeClient, GinkgoLogr, tc.HostClaim, fakeClient).(*HostManager)
+			Expect(ok).To(BeTrue())
 			bmh, err := hostMgr.chooseBMH(context.TODO())
 			if tc.ExpectedBmhName == "" {
 				Expect(bmh).To(BeNil())
@@ -321,9 +321,8 @@ var _ = Describe("HostClaim manager", func() {
 			}
 			// We patch the status during associate to set the annotation.
 			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).WithStatusSubresource(tc.HostClaim).Build()
-			hostMgr, err := NewHostManager(fakeClient, GinkgoLogr, tc.HostClaim, fakeClient)
-			Expect(err).NotTo(HaveOccurred())
-			err = hostMgr.Associate(context.TODO())
+			hostMgr := NewHostManager(fakeClient, GinkgoLogr, tc.HostClaim, fakeClient)
+			err := hostMgr.Associate(context.TODO())
 			if tc.ExpectFails {
 				Expect(err).To(HaveOccurred())
 				var requeueAfterError RequeueAfterError


### PR DESCRIPTION
**What this PR does / why we need it**:

The controller can be disabled if needed.
The structure of the controller is very similar to the code of the Metal3Machine controller.

As there is only one factory function, it is directly added to the reconciler state.
The missing core actions (update/delete) are stubs. The handling of pause (for pivot) is not integrated yet.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
