### PR TITLE
:seedling: End to end tests for HostClaims

### DIFF
--- a/config/overlays/e2e/cluster-role.yaml
+++ b/config/overlays/e2e/cluster-role.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: baremetal-operator-manager-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: baremetal-operator-manager-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: baremetal-operator-manager-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: baremetal-operator-controller-manager
+  namespace: baremetal-operator-system
+---

--- a/config/overlays/e2e/hostclaims-infra/kustomization.yaml
+++ b/config/overlays/e2e/hostclaims-infra/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../roles-rolebindings
+- namespace.yaml
+
+namespace: hostclaims-infra

--- a/config/overlays/e2e/hostclaims-infra/namespace.yaml
+++ b/config/overlays/e2e/hostclaims-infra/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hostclaims-infra

--- a/config/overlays/e2e/hostclaims-tenant/kustomization.yaml
+++ b/config/overlays/e2e/hostclaims-tenant/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../roles-rolebindings
+- namespace.yaml
+
+namespace: hostclaims-tenant

--- a/config/overlays/e2e/hostclaims-tenant/namespace.yaml
+++ b/config/overlays/e2e/hostclaims-tenant/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hostclaims-tenant

--- a/config/overlays/e2e/kustomization.yaml
+++ b/config/overlays/e2e/kustomization.yaml
@@ -18,6 +18,9 @@ resources:
 - ./re-inspection
 - ./upgrade-bmo
 - ./upgrade-ironic
+- ./hostclaims-infra
+- ./hostclaims-tenant
+- ./cluster-role.yaml
 
 components:
 - ../../components/namespace-scoped

--- a/config/overlays/e2e/kustomization.yaml
+++ b/config/overlays/e2e/kustomization.yaml
@@ -17,6 +17,9 @@ resources:
 - ./re-inspection
 - ./upgrade-bmo
 - ./upgrade-ironic
+- ./hostclaims-infra
+- ./hostclaims-tenant
+- ./cluster-role.yaml
 
 components:
 - ../../components/namespace-scoped

--- a/config/overlays/e2e/namespaced-manager-patch.yaml
+++ b/config/overlays/e2e/namespaced-manager-patch.yaml
@@ -9,5 +9,5 @@ spec:
       containers:
       - env:
         - name: WATCH_NAMESPACE
-          value: basic-ops,external-inspection,externally-provisioned,firmware-settings,inspection,live-iso-ops,provisioning-ops,re-inspection,automated-cleaning,upgrade-bmo,upgrade-ironic,force-detach,network-data,baremetalswitch,firmware-components
+          value: basic-ops,external-inspection,externally-provisioned,firmware-settings,inspection,live-iso-ops,provisioning-ops,re-inspection,automated-cleaning,upgrade-bmo,upgrade-ironic,force-detach,network-data,baremetalswitch,firmware-components,hostclaims-infra,hostclaims-tenant
         name: manager

--- a/config/overlays/e2e/namespaced-manager-patch.yaml
+++ b/config/overlays/e2e/namespaced-manager-patch.yaml
@@ -9,5 +9,5 @@ spec:
       containers:
       - env:
         - name: WATCH_NAMESPACE
-          value: basic-ops,external-inspection,externally-provisioned,firmware-settings,inspection,live-iso-ops,provisioning-ops,re-inspection,automated-cleaning,upgrade-bmo,upgrade-ironic,force-detach,network-data,baremetalswitch,firmware-components,dataimage
+          value: basic-ops,external-inspection,externally-provisioned,firmware-settings,inspection,live-iso-ops,provisioning-ops,re-inspection,automated-cleaning,upgrade-bmo,upgrade-ironic,force-detach,network-data,baremetalswitch,firmware-components,dataimage,hostclaims-infra,hostclaims-tenant
         name: manager

--- a/hack/check-e2e.sh
+++ b/hack/check-e2e.sh
@@ -6,7 +6,8 @@ REPO_ROOT=$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")
 cd "${REPO_ROOT}" || exit 1
 
 WATCH_NS="$(grep -A1 WATCH_NAMESPACE config/overlays/e2e/namespaced-manager-patch.yaml | grep 'value:' | awk '{ print $2; }')"
-EXCEPTIONS=upgrade
+# hostclaims requires two namespaces hostclaims-tenant for hostclaim and hostclaims-infra for bmh.
+EXCEPTIONS=upgrade,hostclaims
 
 EXITCODE=0
 for spec in $(grep -E --no-filename ' *specName +:?=' test/e2e/*_test.go | grep -o '".*"' | tr -d '"'); do

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -1196,3 +1196,19 @@ func ContainCondition(conditionType string, conditionStatus metav1.ConditionStat
 		),
 	)
 }
+
+type WaitForHostClaimConditionInput struct {
+	Client        client.Client
+	HostClaim     *metal3api.HostClaim
+	ConditionType string
+	Status        metav1.ConditionStatus
+}
+
+func WaitForHostClaimCondition(ctx context.Context, input WaitForHostClaimConditionInput, intervals ...interface{}) {
+	Eventually(func(g Gomega) {
+		hostclaim := metal3api.HostClaim{}
+		key := types.NamespacedName{Namespace: input.HostClaim.Namespace, Name: input.HostClaim.Name}
+		g.Expect(input.Client.Get(ctx, key, &hostclaim)).To(Succeed())
+		g.Expect(hostclaim.Status.Conditions).To(ContainCondition(input.ConditionType, input.Status))
+	}, intervals...).Should(Succeed())
+}

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -1189,3 +1189,19 @@ func ContainCondition(conditionType string, conditionStatus metav1.ConditionStat
 		),
 	)
 }
+
+type WaitForHostClaimConditionInput struct {
+	Client        client.Client
+	HostClaim     *metal3api.HostClaim
+	ConditionType string
+	Status        metav1.ConditionStatus
+}
+
+func WaitForHostClaimCondition(ctx context.Context, input WaitForHostClaimConditionInput, intervals ...interface{}) {
+	Eventually(func(g Gomega) {
+		hostclaim := metal3api.HostClaim{}
+		key := types.NamespacedName{Namespace: input.HostClaim.Namespace, Name: input.HostClaim.Name}
+		g.Expect(input.Client.Get(ctx, key, &hostclaim)).To(Succeed())
+		g.Expect(hostclaim.Status.Conditions).To(ContainCondition(input.ConditionType, input.Status))
+	}, intervals...).Should(Succeed())
+}

--- a/test/e2e/config/fixture.yaml
+++ b/test/e2e/config/fixture.yaml
@@ -64,6 +64,8 @@ intervals:
   default/wait-power-state: [ "5s", "10ms" ]
   default/wait-externally-provisioned: [ "1m", "10ms" ]
   baremetalswitch/wait-secret-updated: [ "30s", "500ms" ]
+  hostclaims/wait-associated: [ "10s", "1s" ]
+  hostclaims/wait-deleted: [ "5s", "10ms" ]
 
 bmoUpgradeSpecs:
 - deployIronic: false

--- a/test/e2e/config/ironic.yaml
+++ b/test/e2e/config/ironic.yaml
@@ -92,6 +92,8 @@ intervals:
   default/wait-reconcile: [ "1s", "10ms" ]
   baremetalswitch/wait-secret-updated: [ "30s", "500ms" ]
   default/wait-user-data: [ "5s", "1s" ]
+  hostclaims/wait-associated: [ "10s", "1s" ]
+  hostclaims/wait-deleted: [ "20s", "10ms" ]
 
 kindExtraPortMappings:
 # Expose Ironic ports so they are reachable outside of kind

--- a/test/e2e/config/ironic.yaml
+++ b/test/e2e/config/ironic.yaml
@@ -96,6 +96,8 @@ intervals:
   default/wait-reconcile: [ "1s", "10ms" ]
   baremetalswitch/wait-secret-updated: [ "30s", "500ms" ]
   default/wait-user-data: [ "5s", "1s" ]
+  hostclaims/wait-associated: [ "10s", "1s" ]
+  hostclaims/wait-deleted: [ "20s", "10ms" ]
 
 kindExtraPortMappings:
 # Expose Ironic ports so they are reachable outside of kind

--- a/test/e2e/hostclaim_provisioning_test.go
+++ b/test/e2e/hostclaim_provisioning_test.go
@@ -1,0 +1,198 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"path"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	selectorLabel = "test.metal3.io/class"
+	selectorValue = "selected"
+)
+
+func createBmh(name, namespace string, labels map[string]string, hardwareDetails string) *metal3api.BareMetalHost {
+	bmh := &metal3api.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+			Annotations: map[string]string{
+				metal3api.HardwareDetailsAnnotation: hardwareDetails,
+			},
+		},
+		Spec: metal3api.BareMetalHostSpec{
+			Online: false,
+			BMC: metal3api.BMCDetails{
+				Address:                        bmc.Address,
+				CredentialsName:                "bmc-credentials",
+				DisableCertificateVerification: bmc.DisableCertificateVerification,
+			},
+			BootMode:              metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
+			BootMACAddress:        bmc.BootMacAddress,
+			AutomatedCleaningMode: metal3api.CleaningModeDisabled,
+			InspectionMode:        metal3api.InspectionModeDisabled,
+			RootDeviceHints:       &bmc.RootDeviceHints,
+		},
+	}
+	return bmh
+}
+
+func createHostclaim(namespace string) *metal3api.HostClaim {
+	hostClaim := &metal3api.HostClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "claim",
+			Namespace: namespace,
+		},
+		Spec: metal3api.HostClaimSpec{
+			Image: &metal3api.Image{
+				URL:      e2eConfig.GetVariable("IMAGE_URL"),
+				Checksum: e2eConfig.GetVariable("IMAGE_CHECKSUM"),
+			},
+			HostSelector: metal3api.HostSelector{
+				MatchLabels: map[string]string{selectorLabel: selectorValue},
+			},
+			PoweredOn: true,
+		},
+	}
+	err := clusterProxy.GetClient().Create(ctx, hostClaim)
+	Expect(err).NotTo(HaveOccurred())
+	return hostClaim
+}
+
+func createHostDeployPolicy(namespaceBMH, namespaceClaim string) *metal3api.HostDeployPolicy {
+	hostDeployPolicy := &metal3api.HostDeployPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hdp",
+			Namespace: namespaceBMH,
+		},
+		Spec: metal3api.HostDeployPolicySpec{
+			HostClaimNamespaces: &metal3api.HostClaimNamespaces{
+				Names: []string{namespaceClaim},
+			},
+		},
+	}
+	err := clusterProxy.GetClient().Create(ctx, hostDeployPolicy)
+	Expect(err).NotTo(HaveOccurred())
+	return hostDeployPolicy
+}
+
+func checkAssociation(specName string, hostClaim *metal3api.HostClaim, bmh *metal3api.BareMetalHost) {
+	WaitForHostClaimCondition(ctx, WaitForHostClaimConditionInput{
+		Client:        clusterProxy.GetClient(),
+		HostClaim:     hostClaim,
+		ConditionType: metal3api.AssociatedCondition,
+		Status:        metav1.ConditionTrue,
+	}, e2eConfig.GetIntervals(specName, "wait-associated")...)
+	currentHC := metal3api.HostClaim{}
+	key := client.ObjectKeyFromObject(hostClaim)
+	Expect(clusterProxy.GetClient().Get(ctx, key, &currentHC)).To(Succeed())
+	Expect(currentHC.Status.BareMetalHost).NotTo(BeNil())
+	Expect(currentHC.Status.BareMetalHost.Name).To(Equal(bmh.Name))
+	Expect(currentHC.Status.BareMetalHost.Namespace).To(Equal(bmh.Namespace))
+
+	key = client.ObjectKeyFromObject(bmh)
+	Expect(clusterProxy.GetClient().Get(ctx, key, bmh)).To(Succeed())
+	Expect(bmh.Spec.ConsumerRef).NotTo(BeNil())
+	Expect(bmh.Spec.ConsumerRef.Name).To(Equal(hostClaim.Name))
+	Expect(bmh.Spec.ConsumerRef.Namespace).To(Equal(hostClaim.Namespace))
+}
+
+func checkNoConsumer(specName string, bmh *metal3api.BareMetalHost) {
+	Eventually(func(g Gomega) {
+		currentBmh := metal3api.BareMetalHost{}
+		key := types.NamespacedName{Namespace: bmh.Namespace, Name: bmh.Name}
+		g.Expect(clusterProxy.GetClient().Get(ctx, key, &currentBmh)).To(Succeed())
+		g.Expect(currentBmh.Spec.ConsumerRef).To(BeNil())
+	}, e2eConfig.GetIntervals(specName, "wait-deleted")...).Should(Succeed())
+}
+
+var _ = Describe("Associate a hostclaim to a BMH and delete the claim.", Label("required", "hostclaim"),
+	func() {
+		var (
+			specName       = "hostclaims"
+			secretName     = "bmc-credentials"
+			namespaceBMH   *corev1.Namespace
+			namespaceClaim *corev1.Namespace
+			cancelWatches  context.CancelFunc
+			toCleanupBMH   []client.Object
+			toCleanupClaim []client.Object
+		)
+
+		BeforeEach(func() {
+			toCleanupBMH = nil
+			toCleanupClaim = nil
+			namespaceBMH, cancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
+				Creator:             clusterProxy.GetClient(),
+				ClientSet:           clusterProxy.GetClientSet(),
+				Name:                specName + "-infra",
+				LogFolder:           artifactFolder,
+				IgnoreAlreadyExists: true,
+			})
+			namespaceClaim = framework.CreateNamespace(ctx, framework.CreateNamespaceInput{
+				Creator:             clusterProxy.GetClient(),
+				Name:                specName + "-tenant",
+				IgnoreAlreadyExists: true,
+			})
+		})
+
+		It("Create a claim, associate it to a BMH", func() {
+			By("Creating a secret with BMH credentials")
+			bmcCredentialsData := map[string]string{
+				"username": bmc.User,
+				"password": bmc.Password,
+			}
+			secret := CreateSecret(ctx, clusterProxy.GetClient(), namespaceBMH.Name, secretName, bmcCredentialsData)
+			toCleanupBMH = append(toCleanupBMH, secret)
+
+			By("Creating a BMH with inspection disabled and hardware details added")
+			hardwareDetails := hardwareDetailsFor(&bmc)
+			bmh := createBmh("bmh", namespaceBMH.Name, map[string]string{selectorLabel: selectorValue}, hardwareDetails)
+			err := clusterProxy.GetClient().Create(ctx, bmh)
+			Expect(err).NotTo(HaveOccurred())
+			toCleanupBMH = append(toCleanupBMH, bmh)
+
+			By("Waiting for the BMH to become available")
+			WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+				Client: clusterProxy.GetClient(),
+				Bmh:    *bmh,
+				State:  metal3api.StateAvailable,
+			}, e2eConfig.GetIntervals(specName, "wait-available")...)
+
+			By("Creating a suitable hostDeployPolicy")
+			hostDeployPolicy := createHostDeployPolicy(namespaceBMH.Name, namespaceClaim.Name)
+			toCleanupBMH = append(toCleanupBMH, hostDeployPolicy)
+
+			By("Creating a hostClaim")
+			hostClaim := createHostclaim(namespaceClaim.Name)
+			toCleanupClaim = append(toCleanupClaim, hostClaim)
+
+			By("Waiting for the HostClaim to become associated")
+			checkAssociation(specName, hostClaim, bmh)
+
+			By("Deleting the hostclaim")
+			err = clusterProxy.GetClient().Delete(ctx, hostClaim)
+			Expect(err).NotTo(HaveOccurred())
+			checkNoConsumer(specName, bmh)
+		})
+
+		AfterEach(func() {
+			DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
+			if !skipCleanup {
+				Cleanup(ctx, clusterProxy, namespaceBMH, cancelWatches, e2eConfig, toCleanupBMH)
+				Cleanup(ctx, clusterProxy, namespaceClaim, nil, e2eConfig, toCleanupClaim)
+			}
+		})
+	},
+)

--- a/test/e2e/hostclaim_provisioning_test.go
+++ b/test/e2e/hostclaim_provisioning_test.go
@@ -1,0 +1,167 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"path"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	selectorLabel = "test.metal3.io/class"
+	selectorValue = "selected"
+)
+
+func createBmh(name, namespace string, labels map[string]string, hardwareDetails string) *metal3api.BareMetalHost {
+	bmh := &metal3api.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+			Annotations: map[string]string{
+				metal3api.HardwareDetailsAnnotation: hardwareDetails,
+			},
+		},
+		Spec: metal3api.BareMetalHostSpec{
+			Online: false,
+			BMC: metal3api.BMCDetails{
+				Address:                        bmc.Address,
+				CredentialsName:                "bmc-credentials",
+				DisableCertificateVerification: bmc.DisableCertificateVerification,
+			},
+			BootMode:              metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
+			BootMACAddress:        bmc.BootMacAddress,
+			AutomatedCleaningMode: metal3api.CleaningModeDisabled,
+			InspectionMode:        metal3api.InspectionModeDisabled,
+			RootDeviceHints:       &bmc.RootDeviceHints,
+		},
+	}
+	return bmh
+}
+
+var _ = Describe("Associate a hostclaim to a BMH and delete the claim.", Label("required", "provision", "hostclaim"),
+	func() {
+		var (
+			specName       = "hostclaims"
+			secretName     = "bmc-credentials"
+			namespaceBMH   *corev1.Namespace
+			namespaceClaim *corev1.Namespace
+			cancelWatches  context.CancelFunc
+			toCleanupBMH   []client.Object
+			toCleanupClaim []client.Object
+		)
+
+		BeforeEach(func() {
+			toCleanupBMH = nil
+			toCleanupClaim = nil
+			namespaceBMH, cancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
+				Creator:             clusterProxy.GetClient(),
+				ClientSet:           clusterProxy.GetClientSet(),
+				Name:                specName + "-infra",
+				LogFolder:           artifactFolder,
+				IgnoreAlreadyExists: true,
+			})
+			namespaceClaim = framework.CreateNamespace(ctx, framework.CreateNamespaceInput{
+				Creator:             clusterProxy.GetClient(),
+				Name:                specName + "-tenant",
+				IgnoreAlreadyExists: true,
+			})
+		})
+
+		It("Create a claim, associate it to a BMH", func() {
+			By("Creating a secret with BMH credentials")
+			bmcCredentialsData := map[string]string{
+				"username": bmc.User,
+				"password": bmc.Password,
+			}
+			CreateSecret(ctx, clusterProxy.GetClient(), namespaceBMH.Name, secretName, bmcCredentialsData)
+
+			By("Creating a BMH with inspection disabled and hardware details added")
+			hardwareDetails := hardwareDetailsFor(&bmc)
+			bmh := createBmh("bmh", namespaceBMH.Name, map[string]string{selectorLabel: selectorValue}, hardwareDetails)
+			err := clusterProxy.GetClient().Create(ctx, bmh)
+			Expect(err).NotTo(HaveOccurred())
+			toCleanupBMH = append(toCleanupBMH, bmh)
+
+			By("Waiting for the BMH to become available")
+			WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+				Client: clusterProxy.GetClient(),
+				Bmh:    *bmh,
+				State:  metal3api.StateAvailable,
+			}, e2eConfig.GetIntervals(specName, "wait-available")...)
+
+			By("Creating a suitable hostDeployPolicy")
+			hostDeployPolicy := &metal3api.HostDeployPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      specName,
+					Namespace: namespaceBMH.Name,
+				},
+				Spec: metal3api.HostDeployPolicySpec{
+					HostClaimNamespaces: &metal3api.HostClaimNamespaces{
+						Names: []string{namespaceClaim.Name},
+					},
+				},
+			}
+			err = clusterProxy.GetClient().Create(ctx, hostDeployPolicy)
+			Expect(err).NotTo(HaveOccurred())
+			toCleanupBMH = append(toCleanupBMH, hostDeployPolicy)
+
+			By("Creating a hostClaim")
+			hostClaim := &metal3api.HostClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      specName,
+					Namespace: namespaceClaim.Name,
+				},
+				Spec: metal3api.HostClaimSpec{
+					Image: &metal3api.Image{
+						URL:      e2eConfig.GetVariable("IMAGE_URL"),
+						Checksum: e2eConfig.GetVariable("IMAGE_CHECKSUM"),
+					},
+					HostSelector: metal3api.HostSelector{
+						MatchLabels: map[string]string{selectorLabel: selectorValue},
+					},
+					PoweredOn: true,
+				},
+			}
+			err = clusterProxy.GetClient().Create(ctx, hostClaim)
+			Expect(err).NotTo(HaveOccurred())
+			toCleanupClaim = append(toCleanupClaim, hostClaim)
+
+			By("Waiting for the HostClaim to become associated")
+			WaitForHostClaimCondition(ctx, WaitForHostClaimConditionInput{
+				Client:        clusterProxy.GetClient(),
+				HostClaim:     hostClaim,
+				ConditionType: metal3api.AssociatedCondition,
+				Status:        metav1.ConditionTrue,
+			}, e2eConfig.GetIntervals(specName, "wait-associated")...)
+
+			By("Deleting the hostclaim")
+			err = clusterProxy.GetClient().Delete(ctx, hostClaim)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func(g Gomega) {
+				currentBmh := metal3api.BareMetalHost{}
+				key := types.NamespacedName{Namespace: bmh.Namespace, Name: bmh.Name}
+				g.Expect(clusterProxy.GetClient().Get(ctx, key, &currentBmh)).To(Succeed())
+				g.Expect(currentBmh.Spec.ConsumerRef).To(BeNil())
+			}, e2eConfig.GetIntervals(specName, "wait-deleted")...).Should(Succeed())
+		})
+
+		AfterEach(func() {
+			DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
+			if !skipCleanup {
+				Cleanup(ctx, clusterProxy, namespaceBMH, cancelWatches, e2eConfig, toCleanupBMH)
+				Cleanup(ctx, clusterProxy, namespaceClaim, nil, e2eConfig, toCleanupClaim)
+			}
+		})
+	},
+)


### PR DESCRIPTION
**What this PR does / why we need it**:

End to end tests for HostClaims
    
First end to end test for hostclaim.
Creates a BMH and a security policy authorizing the right namespace.
Associates the hostclaim in that namespace.
The test will be amended when other core life-cycle functions are  implemented.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
