### PR TITLE
:seedling: e2e: test network data

### DIFF
--- a/config/overlays/e2e/kustomization.yaml
+++ b/config/overlays/e2e/kustomization.yaml
@@ -11,7 +11,7 @@ resources:
 - ./force-detach
 - ./inspection
 - ./live-iso-ops
-- ./pp-network-data
+- ./network-data
 - ./provisioning-ops
 - ./re-inspection
 - ./upgrade-bmo

--- a/config/overlays/e2e/namespaced-manager-patch.yaml
+++ b/config/overlays/e2e/namespaced-manager-patch.yaml
@@ -9,5 +9,5 @@ spec:
       containers:
       - env:
         - name: WATCH_NAMESPACE
-          value: basic-ops,external-inspection,externally-provisioned,firmware-settings,inspection,live-iso-ops,provisioning-ops,re-inspection,automated-cleaning,upgrade-bmo,upgrade-ironic,force-detach,pp-network-data,baremetalswitch
+          value: basic-ops,external-inspection,externally-provisioned,firmware-settings,inspection,live-iso-ops,provisioning-ops,re-inspection,automated-cleaning,upgrade-bmo,upgrade-ironic,force-detach,network-data,baremetalswitch
         name: manager

--- a/config/overlays/e2e/network-data/kustomization.yaml
+++ b/config/overlays/e2e/network-data/kustomization.yaml
@@ -4,4 +4,4 @@ resources:
 - ../roles-rolebindings
 - namespace.yaml
 
-namespace: pp-network-data
+namespace: network-data

--- a/config/overlays/e2e/network-data/namespace.yaml
+++ b/config/overlays/e2e/network-data/namespace.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: pp-network-data
+  name: network-data

--- a/test/e2e/network_data_test.go
+++ b/test/e2e/network_data_test.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	metal3bmc "github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -22,58 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Network Data", Label("required", "network-data"), func() {
-	var (
-		specName      = "network-data"
-		namespace     *corev1.Namespace
-		cancelWatches context.CancelFunc
-		toCleanup     []client.Object
-	)
-
-	BeforeEach(func() {
-		toCleanup = nil
-
-		accessDetails, err := metal3bmc.NewAccessDetails(bmc.Address, false)
-		Expect(err).NotTo(HaveOccurred())
-		if !accessDetails.SupportsISOPreprovisioningImage() {
-			Skip("BMC does not support virtual media, required for network data test. BMC address: " + bmc.Address)
-		}
-		if !e2eConfig.GetBoolVariable("DEPLOY_IRONIC") {
-			Skip("Network data test requires a real Ironic deployment")
-		}
-
-		namespace, cancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
-			Creator:             clusterProxy.GetClient(),
-			ClientSet:           clusterProxy.GetClientSet(),
-			Name:                specName,
-			LogFolder:           artifactFolder,
-			IgnoreAlreadyExists: true,
-		})
-	})
-
-	It("should apply preprovisioning network data during inspection and provisioning", func() {
-		bmhName := specName + "-pp"
-		secretName := bmhName + "-bmc"
-		networkDataSecretName := bmhName + "-network-data"
-
-		By("Creating a secret with BMH credentials")
-		bmcCredentialsData := map[string]string{
-			"username": bmc.User,
-			"password": bmc.Password,
-		}
-		secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
-		toCleanup = append(toCleanup, secret)
-
-		By("Creating a network data secret with static IP configuration")
-		// Derive a test IP from bmc.IPAddress by flipping the top bit of the
-		// last octet. This keeps us on the same subnet while avoiding collisions
-		// with the real address (e.g. 192.168.222.122 -> 192.168.222.250).
-		ip := net.ParseIP(bmc.IPAddress).To4()
-		Expect(ip).NotTo(BeNil(), "failed to parse BMC IP address %q", bmc.IPAddress)
-		ip[3] ^= 0x80
-		staticIP := ip.String()
-
-		networkData := fmt.Sprintf(`{
+const networkDataTemplate = `{
   "links": [
     {"id": "iface0", "type": "phy", "ethernet_mac_address": "%s"}
   ],
@@ -88,10 +36,89 @@ var _ = Describe("Network Data", Label("required", "network-data"), func() {
     }
   ],
   "services": []
-}`, strings.ToUpper(bmc.BootMacAddress), staticIP)
-		CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, networkDataSecretName, map[string]string{
+}`
+
+type simpleNetworkData struct {
+	Links    []map[string]string `json:"links"`
+	Networks []map[string]string `json:"networks"`
+}
+
+func getNetworkData(specName, connectIP string) simpleNetworkData {
+	sshClient := EstablishSSHConnection(e2eConfig, connectIP)
+	defer sshClient.Close()
+
+	var output string
+	Eventually(func(g Gomega) {
+		command := "sudo mkdir -p /mnt/cdtest && sudo mount $(blkid -L config-2) /mnt/cdtest && cat /mnt/cdtest/openstack/latest/network_data.json"
+		var err error
+		output, err = executeSSHCommand(sshClient, command)
+		g.Expect(err).NotTo(HaveOccurred(), "Failed to read network_data.json from the config drive")
+	}, e2eConfig.GetIntervals(specName, "wait-user-data")...).Should(Succeed())
+	Expect(output).NotTo(BeEmpty())
+
+	var parsed simpleNetworkData
+	Expect(json.Unmarshal([]byte(output), &parsed)).To(Succeed(), "network_data.json is not valid JSON: "+output)
+	return parsed
+}
+
+func getNewIPAddress() string {
+	// Derive a test IP from bmc.IPAddress by flipping the top bit of the
+	// last octet. This keeps us on the same subnet while avoiding collisions
+	// with the real address (e.g. 192.168.222.122 -> 192.168.222.250).
+	ip := net.ParseIP(bmc.IPAddress).To4()
+	Expect(ip).NotTo(BeNil(), "failed to parse BMC IP address %q", bmc.IPAddress)
+	ip[3] ^= 0x80
+	return ip.String()
+}
+
+var _ = Describe("Network Data", Label("required", "network-data"), func() {
+	var (
+		specName      = "network-data"
+		namespace     *corev1.Namespace
+		cancelWatches context.CancelFunc
+		toCleanup     []client.Object
+	)
+
+	BeforeEach(func() {
+		toCleanup = nil
+
+		namespace, cancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
+			Creator:             clusterProxy.GetClient(),
+			ClientSet:           clusterProxy.GetClientSet(),
+			Name:                specName,
+			LogFolder:           artifactFolder,
+			IgnoreAlreadyExists: true,
+		})
+	})
+
+	It("should apply preprovisioning network data during inspection and provisioning", func() {
+		if !bmc.AccessDetails.SupportsISOPreprovisioningImage() {
+			Skip("BMC does not support virtual media, required for network data test. BMC address: " + bmc.Address)
+		}
+		if !e2eConfig.GetBoolVariable("DEPLOY_IRONIC") {
+			Skip("Preprovisioning network data test requires a real Ironic deployment")
+		}
+
+		bmhName := specName + "-pp"
+		secretName := bmhName + "-bmc"
+		networkDataSecretName := bmhName + "-network-data"
+		expectedMAC := strings.ToUpper(bmc.BootMacAddress)
+
+		By("Creating a secret with BMH credentials")
+		bmcCredentialsData := map[string]string{
+			"username": bmc.User,
+			"password": bmc.Password,
+		}
+		secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+		toCleanup = append(toCleanup, secret)
+
+		By("Creating a network data secret with static IP configuration")
+		staticIP := getNewIPAddress()
+		networkData := fmt.Sprintf(networkDataTemplate, expectedMAC, staticIP)
+		netSecret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, networkDataSecretName, map[string]string{
 			"networkData": networkData,
 		})
+		toCleanup = append(toCleanup, netSecret)
 
 		By("Creating a BMH with preprovisioning network data")
 		bmh := metal3api.BareMetalHost{
@@ -105,6 +132,7 @@ var _ = Describe("Network Data", Label("required", "network-data"), func() {
 					CredentialsName:                secretName,
 					DisableCertificateVerification: bmc.DisableCertificateVerification,
 				},
+				AutomatedCleaningMode:          metal3api.CleaningModeDisabled,
 				BootMode:                       metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
 				BootMACAddress:                 bmc.BootMacAddress,
 				Online:                         true,
@@ -140,7 +168,7 @@ var _ = Describe("Network Data", Label("required", "network-data"), func() {
 		By("Provisioning the BMH to verify network data defaults to preprovisioning network data")
 		var userDataSecret *corev1.SecretReference
 		if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
-			userDataSecretName := "user-data"
+			userDataSecretName := bmhName + "-user-data"
 			sshPubKeyPath := e2eConfig.GetVariable("SSH_PUB_KEY")
 			createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
 			userDataSecret = &corev1.SecretReference{
@@ -166,17 +194,105 @@ var _ = Describe("Network Data", Label("required", "network-data"), func() {
 
 		if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
 			By("Verifying the network data file on the config drive")
-			sshClient := EstablishSSHConnection(e2eConfig, bmc.IPAddress)
-			defer sshClient.Close()
+			parsed := getNetworkData(specName, bmc.IPAddress)
+			Expect(parsed.Links).To(ContainElement(HaveKeyWithValue("ethernet_mac_address", expectedMAC)))
+			Expect(parsed.Networks).To(ContainElement(HaveKeyWithValue("ip_address", staticIP)))
+		} else {
+			Logf("WARNING: Skipping SSH check since SSH_CHECK_PROVISIONED != true")
+		}
+	})
 
-			command := "mkdir -p /mnt/cdtest && mount /dev/disk/by-label/config-2 /mnt/cdtest && cat /mnt/cdtest/openstack/latest/network_data.json"
-			output, err := executeSSHCommand(sshClient, fmt.Sprintf("sh -c '%s'", command))
-			Expect(err).NotTo(HaveOccurred(), "Failed to read network_data.json from the config drive")
+	It("should apply network data during provisioning", func() {
+		if bmc.IPAddress == "" {
+			// Fixture tests don't have an IP address we could use
+			Skip("network data test requires configuring a static IP address")
+		}
 
-			var parsed map[string]interface{}
-			Expect(json.Unmarshal([]byte(output), &parsed)).To(Succeed(), "network_data.json is not valid JSON")
-			Expect(output).To(ContainSubstring(strings.ToUpper(bmc.BootMacAddress)))
-			Expect(output).To(ContainSubstring(staticIP))
+		bmhName := specName + "-nd"
+		secretName := bmhName + "-bmc"
+		networkDataSecretName := bmhName + "-network-data"
+		expectedMAC := strings.ToUpper(bmc.BootMacAddress)
+
+		By("Creating a secret with BMH credentials")
+		bmcCredentialsData := map[string]string{
+			"username": bmc.User,
+			"password": bmc.Password,
+		}
+		secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+		toCleanup = append(toCleanup, secret)
+
+		By("Creating a network data secret with static IP configuration")
+		staticIP := getNewIPAddress()
+		networkData := fmt.Sprintf(networkDataTemplate, expectedMAC, staticIP)
+		netSecret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, networkDataSecretName, map[string]string{
+			"networkData": networkData,
+		})
+		toCleanup = append(toCleanup, netSecret)
+
+		By("Creating a BMH with network data set, inspection and cleaning disabled")
+		bmh := metal3api.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			},
+			Spec: metal3api.BareMetalHostSpec{
+				BMC: metal3api.BMCDetails{
+					Address:                        bmc.Address,
+					CredentialsName:                secretName,
+					DisableCertificateVerification: bmc.DisableCertificateVerification,
+				},
+				AutomatedCleaningMode: metal3api.CleaningModeDisabled,
+				BootMode:              metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
+				BootMACAddress:        bmc.BootMacAddress,
+				InspectionMode:        metal3api.InspectionModeDisabled,
+				NetworkData: &corev1.SecretReference{
+					Name: networkDataSecretName,
+				},
+				Online: true,
+			},
+		}
+		Expect(clusterProxy.GetClient().Create(ctx, &bmh)).To(Succeed())
+		toCleanup = append(toCleanup, &bmh)
+
+		By("Waiting for the BMH to become available")
+		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.StateAvailable,
+		}, e2eConfig.GetIntervals(specName, "wait-available")...)
+
+		By("Provisioning the BMH to verify network data")
+		var userDataSecret *corev1.SecretReference
+		if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
+			userDataSecretName := bmhName + "-user-data"
+			sshPubKeyPath := e2eConfig.GetVariable("SSH_PUB_KEY")
+			createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
+			userDataSecret = &corev1.SecretReference{
+				Name:      userDataSecretName,
+				Namespace: namespace.Name,
+			}
+		}
+		Expect(PatchBMHForProvisioning(ctx, PatchBMHForProvisioningInput{
+			client:         clusterProxy.GetClient(),
+			bmh:            &bmh,
+			bmc:            bmc,
+			e2eConfig:      e2eConfig,
+			namespace:      namespace.Name,
+			userDataSecret: userDataSecret,
+		})).To(Succeed())
+
+		By("Waiting for the BMH to be provisioned")
+		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.StateProvisioned,
+		}, e2eConfig.GetIntervals(specName, "wait-provisioned")...)
+
+		if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
+			By("Verifying the network data file on the config drive")
+			parsed := getNetworkData(specName, bmc.IPAddress)
+			Expect(parsed.Links).To(ContainElement(HaveKeyWithValue("ethernet_mac_address", expectedMAC)))
+			Expect(parsed.Networks).To(ContainElement(HaveKeyWithValue("ip_address", staticIP)))
 		} else {
 			Logf("WARNING: Skipping SSH check since SSH_CHECK_PROVISIONED != true")
 		}

--- a/test/e2e/network_data_test.go
+++ b/test/e2e/network_data_test.go
@@ -22,9 +22,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Preprovisioning Network Data", Label("required", "pp-network-data"), func() {
+var _ = Describe("Network Data", Label("required", "network-data"), func() {
 	var (
-		specName      = "pp-network-data"
+		specName      = "network-data"
 		namespace     *corev1.Namespace
 		cancelWatches context.CancelFunc
 		toCleanup     []client.Object
@@ -36,10 +36,10 @@ var _ = Describe("Preprovisioning Network Data", Label("required", "pp-network-d
 		accessDetails, err := metal3bmc.NewAccessDetails(bmc.Address, false)
 		Expect(err).NotTo(HaveOccurred())
 		if !accessDetails.SupportsISOPreprovisioningImage() {
-			Skip("BMC does not support virtual media, required for preprovisioning network data. BMC address: " + bmc.Address)
+			Skip("BMC does not support virtual media, required for network data test. BMC address: " + bmc.Address)
 		}
 		if !e2eConfig.GetBoolVariable("DEPLOY_IRONIC") {
-			Skip("Preprovisioning network data test requires a real Ironic deployment")
+			Skip("Network data test requires a real Ironic deployment")
 		}
 
 		namespace, cancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
@@ -51,8 +51,8 @@ var _ = Describe("Preprovisioning Network Data", Label("required", "pp-network-d
 		})
 	})
 
-	It("should apply preprovisioning network data during inspection", func() {
-		bmhName := specName
+	It("should apply preprovisioning network data during inspection and provisioning", func() {
+		bmhName := specName + "-pp"
 		secretName := bmhName + "-bmc"
 		networkDataSecretName := bmhName + "-network-data"
 
@@ -84,7 +84,7 @@ var _ = Describe("Preprovisioning Network Data", Label("required", "pp-network-d
       "type": "ipv4",
       "ip_address": "%s",
       "netmask": "255.255.255.0",
-      "network_id": "test-pp-network"
+      "network_id": "test-network"
     }
   ],
   "services": []
@@ -128,16 +128,16 @@ var _ = Describe("Preprovisioning Network Data", Label("required", "pp-network-d
 			State:  metal3api.StateAvailable,
 		}, e2eConfig.GetIntervals(specName, "wait-available")...)
 
-		By("Verifying that HardwareData contains a NIC with the preprovisioned static IP")
+		By("Verifying that HardwareData contains a NIC with the static IP from network data")
 		hwData := metal3api.HardwareData{}
 		key := types.NamespacedName{Namespace: namespace.Name, Name: bmhName}
 		Expect(clusterProxy.GetClient().Get(ctx, key, &hwData)).To(Succeed())
 		Expect(hwData.Spec.HardwareDetails).NotTo(BeNil())
 		Expect(hwData.Spec.HardwareDetails.NIC).To(
 			ContainElement(HaveField("IP", staticIP)),
-			"Expected a NIC with the preprovisioned static IP "+staticIP)
+			"Expected a NIC with the static IP from network data: "+staticIP)
 
-		By("Provisioning the BMH with NetworkData defaulting to PreprovisioningNetworkData")
+		By("Provisioning the BMH to verify network data defaults to preprovisioning network data")
 		var userDataSecret *corev1.SecretReference
 		if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
 			userDataSecretName := "user-data"

--- a/test/e2e/preprovisioning_network_data_test.go
+++ b/test/e2e/preprovisioning_network_data_test.go
@@ -5,6 +5,7 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"path"
@@ -106,6 +107,7 @@ var _ = Describe("Preprovisioning Network Data", Label("required", "pp-network-d
 				},
 				BootMode:                       metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
 				BootMACAddress:                 bmc.BootMacAddress,
+				Online:                         true,
 				PreprovisioningNetworkDataName: networkDataSecretName,
 			},
 		}
@@ -134,6 +136,50 @@ var _ = Describe("Preprovisioning Network Data", Label("required", "pp-network-d
 		Expect(hwData.Spec.HardwareDetails.NIC).To(
 			ContainElement(HaveField("IP", staticIP)),
 			"Expected a NIC with the preprovisioned static IP "+staticIP)
+
+		By("Provisioning the BMH with NetworkData defaulting to PreprovisioningNetworkData")
+		var userDataSecret *corev1.SecretReference
+		if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
+			userDataSecretName := "user-data"
+			sshPubKeyPath := e2eConfig.GetVariable("SSH_PUB_KEY")
+			createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
+			userDataSecret = &corev1.SecretReference{
+				Name:      userDataSecretName,
+				Namespace: namespace.Name,
+			}
+		}
+		Expect(PatchBMHForProvisioning(ctx, PatchBMHForProvisioningInput{
+			client:         clusterProxy.GetClient(),
+			bmh:            &bmh,
+			bmc:            bmc,
+			e2eConfig:      e2eConfig,
+			namespace:      namespace.Name,
+			userDataSecret: userDataSecret,
+		})).To(Succeed())
+
+		By("Waiting for the BMH to be provisioned")
+		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.StateProvisioned,
+		}, e2eConfig.GetIntervals(specName, "wait-provisioned")...)
+
+		if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
+			By("Verifying the network data file on the config drive")
+			sshClient := EstablishSSHConnection(e2eConfig, bmc.IPAddress)
+			defer sshClient.Close()
+
+			command := "mkdir -p /mnt/cdtest && mount /dev/disk/by-label/config-2 /mnt/cdtest && cat /mnt/cdtest/openstack/latest/network_data.json"
+			output, err := executeSSHCommand(sshClient, fmt.Sprintf("sh -c '%s'", command))
+			Expect(err).NotTo(HaveOccurred(), "Failed to read network_data.json from the config drive")
+
+			var parsed map[string]interface{}
+			Expect(json.Unmarshal([]byte(output), &parsed)).To(Succeed(), "network_data.json is not valid JSON")
+			Expect(output).To(ContainSubstring(strings.ToUpper(bmc.BootMacAddress)))
+			Expect(output).To(ContainSubstring(staticIP))
+		} else {
+			Logf("WARNING: Skipping SSH check since SSH_CHECK_PROVISIONED != true")
+		}
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
Change the existing preprovisioningNetworkData test to also cover:

1. Defaulting NetworkData and PreprovisioningNetworkData
2. Passing NetworkData to the instance

Unfortunately, we cannot test the effect of NetworkData because
Cirros does not support it.

Partial fix for #2626

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
