### PR TITLE
🐛Delete BMHs before other resources in cleanup for e2e tests, when BMO is ns-scoped

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -410,13 +410,20 @@ func Cleanup(ctx context.Context, clusterProxy framework.ClusterProxy, namespace
 	} else {
 		// When namespace-scoped, the namespace is reused between tests; clean up
 		// individual resources to allow the next run to start clean.
+		// Delete BMHs before other tracked resources so that dependent secrets
+		// remain available for deprovisioning and finalizer handling.
+		bmhIntervals := cfg.GetIntervals("default", "wait-bmh-deleted")
 		for _, obj := range toCleanup {
 			if bmh, ok := obj.(*metal3api.BareMetalHost); ok {
-				CleanupBMH(ctx, clusterProxy.GetClient(), bmh, cfg.GetIntervals("default", "wait-bmh-deleted")...)
-			} else {
-				if err := clusterProxy.GetClient().Delete(ctx, obj); err != nil && !k8serrors.IsNotFound(err) {
-					Expect(err).NotTo(HaveOccurred(), "Unable to delete %T %s/%s", obj, obj.GetNamespace(), obj.GetName())
-				}
+				CleanupBMH(ctx, clusterProxy.GetClient(), bmh, bmhIntervals...)
+			}
+		}
+		for _, obj := range toCleanup {
+			if _, ok := obj.(*metal3api.BareMetalHost); ok {
+				continue
+			}
+			if err := clusterProxy.GetClient().Delete(ctx, obj); err != nil && !k8serrors.IsNotFound(err) {
+				Expect(err).NotTo(HaveOccurred(), "Unable to delete %T %s/%s", obj, obj.GetNamespace(), obj.GetName())
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
When cleaning up resources in e2e tests, when the BMO is namespace-scoped, delete the BMHs before other resources. This will ensure that resources like Secrets that the BMHs might need, are not deleted before the BMHs are. 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
