### PR TITLE
:seedling: Add pierrecregut as a reviewer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,6 +14,7 @@ aliases:
   - adilGhaffarDev
   - iurygregory
   - peppi-lotta
+  - pierrecregut
   - s3rj1k
   - smoshiur1237
   - Sunnatillo


### PR DESCRIPTION
pierrecregut has been contributing to the project for considerable time, pierrecregut displayed consistency and dedication to stick around and maintain PRs, Issues and discussions. pierrecregut also shown deep understanding of BMO internal processes and played a driving role in the HostClaim related development work. All that said I would like to propose him as a reviewer.
