### PR TITLE
:sparkles: Add TLS curve preferences support

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,9 +59,20 @@ const (
 )
 
 type TLSOptions struct {
-	TLSMaxVersion   string
-	TLSMinVersion   string
-	TLSCipherSuites string
+	TLSMaxVersion       string
+	TLSMinVersion       string
+	TLSCipherSuites     string
+	TLSCurvePreferences string
+}
+
+// Supported TLS Curves mapping for go1.25, make sure to update it
+// when go version is updated.
+var supportedTLSCurvesPreferences = map[string]tls.CurveID{
+	"X25519":         tls.X25519,
+	"CurveP256":      tls.CurveP256,
+	"CurveP384":      tls.CurveP384,
+	"CurveP521":      tls.CurveP521,
+	"X25519MLKEM768": tls.X25519MLKEM768,
 }
 
 var (
@@ -156,6 +167,10 @@ func main() {
 	var leaseDurationSeconds string
 	var renewDeadlineSeconds string
 	var retryPeriodSeconds string
+	var supportedTLSCurvesNames = make([]string, 0, len(supportedTLSCurvesPreferences))
+	for name := range supportedTLSCurvesPreferences {
+		supportedTLSCurvesNames = append(supportedTLSCurvesNames, name)
+	}
 
 	// From CAPI point of view, BMO should be able to watch all namespaces
 	// in case of a deployment that is not multi-tenant. If the deployment
@@ -199,6 +214,10 @@ func main() {
 			"If omitted, the default Go cipher suites will be used. \n"+
 			"Preferred values: "+strings.Join(tlsCipherPreferredValues, ", ")+". \n"+
 			"Insecure values: "+strings.Join(tlsCipherInsecureValues, ", ")+".")
+	flag.StringVar(&tlsOptions.TLSCurvePreferences, "tls-curve-preferences", "",
+		"Comma-separated list of curve/group preferences for the webhook and metrics servers. "+
+			"If omitted, the default Go curve preferences will be used. "+
+			"Possible values: "+strings.Join(supportedTLSCurvesNames, ", ")+".")
 	flag.IntVar(&controllerConcurrency, "controller-concurrency", 0,
 		"Number of CRs of each type to process simultaneously")
 
@@ -564,6 +583,22 @@ func GetTLSOptionOverrideFuncs(options TLSOptions) ([]func(*tls.Config), error) 
 		}
 		tlsOptions = append(tlsOptions, func(cfg *tls.Config) {
 			cfg.CipherSuites = suites
+		})
+	}
+
+	if options.TLSCurvePreferences != "" {
+		curveNames := strings.Split(options.TLSCurvePreferences, ",")
+		curves := make([]tls.CurveID, 0, len(curveNames))
+		for _, name := range curveNames {
+			name = strings.TrimSpace(name)
+			curveID, exists := supportedTLSCurvesPreferences[name]
+			if !exists {
+				return nil, fmt.Errorf("unrecognized TLS curve preference %q", name)
+			}
+			curves = append(curves, curveID)
+		}
+		tlsOptions = append(tlsOptions, func(cfg *tls.Config) {
+			cfg.CurvePreferences = curves
 		})
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -146,3 +146,99 @@ func TestTLSOptions(t *testing.T) {
 		g.Expect(err).ShouldNot(HaveOccurred())
 	})
 }
+
+func TestTLSCurvePreferences(t *testing.T) {
+	t.Run("valid curve preferences should be parsed correctly", func(t *testing.T) {
+		g := NewWithT(t)
+		tlsMockOptions := TLSOptions{
+			TLSMinVersion:       "TLS12",
+			TLSMaxVersion:       "TLS13",
+			TLSCurvePreferences: "X25519,CurveP256,CurveP384",
+		}
+		tlsOptionOverrides, err := GetTLSOptionOverrideFuncs(tlsMockOptions)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		var tlsConfig tls.Config
+		for _, apply := range tlsOptionOverrides {
+			apply(&tlsConfig)
+		}
+
+		g.Expect(tlsConfig.CurvePreferences).To(Equal([]tls.CurveID{
+			tls.X25519,
+			tls.CurveP256,
+			tls.CurveP384,
+		}))
+	})
+	t.Run("all supported curve names should be accepted", func(t *testing.T) {
+		g := NewWithT(t)
+		tlsMockOptions := TLSOptions{
+			TLSMinVersion:       "TLS12",
+			TLSMaxVersion:       "TLS13",
+			TLSCurvePreferences: "X25519,CurveP256,CurveP384,CurveP521,X25519MLKEM768",
+		}
+		tlsOptionOverrides, err := GetTLSOptionOverrideFuncs(tlsMockOptions)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		var tlsConfig tls.Config
+		for _, apply := range tlsOptionOverrides {
+			apply(&tlsConfig)
+		}
+
+		g.Expect(tlsConfig.CurvePreferences).To(Equal([]tls.CurveID{
+			tls.X25519,
+			tls.CurveP256,
+			tls.CurveP384,
+			tls.CurveP521,
+			tls.X25519MLKEM768,
+		}))
+	})
+	t.Run("empty curve preferences should have no effect", func(t *testing.T) {
+		g := NewWithT(t)
+		tlsMockOptions := TLSOptions{
+			TLSMinVersion: "TLS12",
+			TLSMaxVersion: "TLS13",
+		}
+		tlsOptionOverrides, err := GetTLSOptionOverrideFuncs(tlsMockOptions)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		var tlsConfig tls.Config
+		for _, apply := range tlsOptionOverrides {
+			apply(&tlsConfig)
+		}
+
+		g.Expect(tlsConfig.CurvePreferences).To(BeNil())
+	})
+	t.Run("invalid curve name should return error", func(t *testing.T) {
+		g := NewWithT(t)
+		tlsMockOptions := TLSOptions{
+			TLSMinVersion:       "TLS12",
+			TLSMaxVersion:       "TLS13",
+			TLSCurvePreferences: "X25519,InvalidCurve",
+		}
+		_, err := GetTLSOptionOverrideFuncs(tlsMockOptions)
+		g.Expect(err).Should(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("unrecognized TLS curve preference"))
+		g.Expect(err.Error()).To(ContainSubstring("InvalidCurve"))
+	})
+	t.Run("whitespace around names should be tolerated", func(t *testing.T) {
+		g := NewWithT(t)
+		tlsMockOptions := TLSOptions{
+			TLSMinVersion:       "TLS12",
+			TLSMaxVersion:       "TLS13",
+			TLSCurvePreferences: "X25519, CurveP256, CurveP384",
+		}
+		tlsOptionOverrides, err := GetTLSOptionOverrideFuncs(tlsMockOptions)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		var tlsConfig tls.Config
+		for _, apply := range tlsOptionOverrides {
+			apply(&tlsConfig)
+		}
+
+		g.Expect(tlsConfig.CurvePreferences).To(Equal([]tls.CurveID{
+			tls.X25519,
+			tls.CurveP256,
+			tls.CurveP384,
+		}))
+	})
+}


### PR DESCRIPTION
Extend TLS settings by including TLS curves preferences cli flag. 