### PR TITLE
✨ Add vendor, model, serial_number to HostFirmwareComponents status

### DIFF
--- a/apis/metal3.io/v1alpha1/hostfirmwarecomponents_types.go
+++ b/apis/metal3.io/v1alpha1/hostfirmwarecomponents_types.go
@@ -36,6 +36,12 @@ type FirmwareComponentStatus struct {
 	CurrentVersion     string      `json:"currentVersion,omitempty"`
 	LastVersionFlashed string      `json:"lastVersionFlashed,omitempty"`
 	UpdatedAt          metav1.Time `json:"updatedAt,omitempty"`
+	// +optional
+	Vendor string `json:"vendor,omitempty"`
+	// +optional
+	Model string `json:"model,omitempty"`
+	// +optional
+	SerialNumber string `json:"serialNumber,omitempty"`
 }
 
 type UpdatesConditionType string

--- a/config/base/crds/bases/metal3.io_hostfirmwarecomponents.yaml
+++ b/config/base/crds/bases/metal3.io_hostfirmwarecomponents.yaml
@@ -75,8 +75,14 @@ spec:
                       type: string
                     lastVersionFlashed:
                       type: string
+                    model:
+                      type: string
+                    serialNumber:
+                      type: string
                     updatedAt:
                       format: date-time
+                      type: string
+                    vendor:
                       type: string
                   required:
                   - component

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -2590,8 +2590,14 @@ spec:
                       type: string
                     lastVersionFlashed:
                       type: string
+                    model:
+                      type: string
+                    serialNumber:
+                      type: string
                     updatedAt:
                       format: date-time
+                      type: string
+                    vendor:
                       type: string
                   required:
                   - component

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -2722,8 +2722,14 @@ spec:
                       type: string
                     lastVersionFlashed:
                       type: string
+                    model:
+                      type: string
+                    serialNumber:
+                      type: string
                     updatedAt:
                       format: date-time
+                      type: string
+                    vendor:
                       type: string
                   required:
                   - component

--- a/go.mod
+++ b/go.mod
@@ -114,3 +114,5 @@ require (
 replace github.com/metal3-io/baremetal-operator/apis => ./apis
 
 replace github.com/metal3-io/baremetal-operator/pkg/hardwareutils => ./pkg/hardwareutils
+
+replace github.com/gophercloud/gophercloud/v2 => github.com/karampok/gophercloud/v2 v2.0.0-20260713104001-5438daa63be0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-logr/logr v1.4.4
 	github.com/google/safetext v0.0.0-20230106111101-7156a760e523
 	github.com/google/uuid v1.6.0
-	github.com/gophercloud/gophercloud/v2 v2.13.0
+	github.com/gophercloud/gophercloud/v2 v2.14.0
 	github.com/metal3-io/baremetal-operator/apis v0.5.1
 	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.5.1
 	github.com/metal3-io/ironic-standalone-operator/api v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/google/safetext v0.0.0-20230106111101-7156a760e523 h1:i4NsbmB9pD5+Ggp
 github.com/google/safetext v0.0.0-20230106111101-7156a760e523/go.mod h1:mJNEy0r5YPHC7ChQffpOszlGB4L1iqjXWpIEKcFpr9s=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gophercloud/gophercloud/v2 v2.13.0 h1:yEyJG+kABd8x2ttTqLsomihU6Kg2YheJSZhvP/QSx+8=
-github.com/gophercloud/gophercloud/v2 v2.13.0/go.mod h1:KZRLVs6gcoy/pEFdkZqFjdYqnS0emMHv66UqdM5lMjU=
+github.com/gophercloud/gophercloud/v2 v2.14.0 h1:xGxKCvyaOxJDc5FqrnKDNqtdYn43ocQPuJ2Cm4KX/cs=
+github.com/gophercloud/gophercloud/v2 v2.14.0/go.mod h1:4fs5I9VH6Wg2LyocDL9xf0ASb8VD63tyLA8sgAX/69U=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,6 @@ github.com/google/safetext v0.0.0-20230106111101-7156a760e523 h1:i4NsbmB9pD5+Ggp
 github.com/google/safetext v0.0.0-20230106111101-7156a760e523/go.mod h1:mJNEy0r5YPHC7ChQffpOszlGB4L1iqjXWpIEKcFpr9s=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gophercloud/gophercloud/v2 v2.13.0 h1:yEyJG+kABd8x2ttTqLsomihU6Kg2YheJSZhvP/QSx+8=
-github.com/gophercloud/gophercloud/v2 v2.13.0/go.mod h1:KZRLVs6gcoy/pEFdkZqFjdYqnS0emMHv66UqdM5lMjU=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -90,6 +88,8 @@ github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE
 github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/karampok/gophercloud/v2 v2.0.0-20260713104001-5438daa63be0 h1:urIVBGdrsHmff7ka9vGM0kOTWOEjuE21CM4so/MZgX0=
+github.com/karampok/gophercloud/v2 v2.0.0-20260713104001-5438daa63be0/go.mod h1:lUwIcx5qcYuxl+yLvth8YlMKhBdomKIBmGfDwEWL5Jc=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/pkg/provisioner/ironic/clients/features.go
+++ b/pkg/provisioner/ironic/clients/features.go
@@ -47,7 +47,8 @@ func (af AvailableFeatures) Log(logger logr.Logger) {
 		"virtualMediaGET", af.HasVirtualMediaGetAPI(),
 		"disablePowerOff", af.HasDisablePowerOff(),
 		"healthAPI", af.HasHealthAPI(),
-		"deploymentAbort", af.HasDeploymentAbort())
+		"deploymentAbort", af.HasDeploymentAbort(),
+		"firmwareIdentity", af.HasFirmwareIdentity())
 }
 
 func (af AvailableFeatures) HasVirtualMediaGetAPI() bool {
@@ -66,7 +67,15 @@ func (af AvailableFeatures) HasDeploymentAbort() bool {
 	return af.MaxVersion >= 110 //nolint:mnd
 }
 
+func (af AvailableFeatures) HasFirmwareIdentity() bool {
+	return af.MaxVersion >= 114 //nolint:mnd
+}
+
 func (af AvailableFeatures) ChooseMicroversion() string {
+	if af.HasFirmwareIdentity() {
+		return "1.114"
+	}
+
 	if af.HasDeploymentAbort() {
 		return "1.110"
 	}

--- a/pkg/provisioner/ironic/clients/features_test.go
+++ b/pkg/provisioner/ironic/clients/features_test.go
@@ -50,6 +50,20 @@ func TestAvailableFeatures_ChooseMicroversion(t *testing.T) {
 			want: "1.110",
 		},
 		{
+			name: "MaxVersion = 113 return 1.110",
+			feature: fields{
+				MaxVersion: 113,
+			},
+			want: "1.110",
+		},
+		{
+			name: "MaxVersion = 114 return 1.114",
+			feature: fields{
+				MaxVersion: 114,
+			},
+			want: "1.114",
+		},
+		{
 			name: "MaxVersion >= 114 return 1.114",
 			feature: fields{
 				MaxVersion: 115,

--- a/pkg/provisioner/ironic/clients/features_test.go
+++ b/pkg/provisioner/ironic/clients/features_test.go
@@ -43,11 +43,18 @@ func TestAvailableFeatures_ChooseMicroversion(t *testing.T) {
 			want: "1.109",
 		},
 		{
-			name: "MaxVersion > 109 return 1.110",
+			name: "MaxVersion = 112 return 1.110",
+			feature: fields{
+				MaxVersion: 112,
+			},
+			want: "1.110",
+		},
+		{
+			name: "MaxVersion >= 114 return 1.114",
 			feature: fields{
 				MaxVersion: 115,
 			},
-			want: "1.110",
+			want: "1.114",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/provisioner/ironic/firmware_test.go
+++ b/pkg/provisioner/ironic/firmware_test.go
@@ -1,0 +1,103 @@
+package ironic
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/testserver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetFirmwareComponents(t *testing.T) {
+	nodeUUID := "158c5d59-9ace-9631-ed51-d842a45f1c52"
+
+	vendor := "HPE"
+	model := "ProLiant DL380 Gen10"
+	serial := "CZ12345678"
+
+	cases := []struct {
+		name               string
+		nodeUUID           string
+		expectedComponents []metal3api.FirmwareComponentStatus
+		ironic             *testserver.IronicMock
+		wantErr            error
+	}{
+		{
+			name:     "with-identity-fields",
+			nodeUUID: nodeUUID,
+			expectedComponents: []metal3api.FirmwareComponentStatus{
+				{
+					Component:      "bios",
+					InitialVersion: "U30 v2.36 (07/16/2020)",
+					CurrentVersion: "U30 v2.36 (07/16/2020)",
+					Vendor:         "HPE",
+					Model:          "ProLiant DL380 Gen10",
+					SerialNumber:   "CZ12345678",
+				},
+			},
+			ironic: testserver.NewIronic(t).FirmwareComponents(nodeUUID, []nodes.FirmwareComponent{
+				{
+					Component:      "bios",
+					InitialVersion: "U30 v2.36 (07/16/2020)",
+					CurrentVersion: "U30 v2.36 (07/16/2020)",
+					Vendor:         &vendor,
+					Model:          &model,
+					SerialNumber:   &serial,
+				},
+			}),
+		},
+		{
+			name:     "without-identity-fields",
+			nodeUUID: nodeUUID,
+			expectedComponents: []metal3api.FirmwareComponentStatus{
+				{
+					Component:      "bmc",
+					InitialVersion: "iLO 5 v2.78",
+					CurrentVersion: "iLO 5 v2.81",
+				},
+			},
+			ironic: testserver.NewIronic(t).FirmwareComponents(nodeUUID, []nodes.FirmwareComponent{
+				{
+					Component:      "bmc",
+					InitialVersion: "iLO 5 v2.78",
+					CurrentVersion: "iLO 5 v2.81",
+				},
+			}),
+		},
+		{
+			name:               "not-registered",
+			nodeUUID:           "",
+			expectedComponents: nil,
+			ironic:             testserver.NewIronic(t).NoFirmwareComponents(nodeUUID),
+			wantErr:            provisioner.ErrNeedsRegistration,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.ironic.Start()
+			defer tc.ironic.Stop()
+
+			host := makeHost()
+			host.Name = "node-1"
+			host.Status.Provisioning.ID = tc.nodeUUID
+
+			auth := clients.AuthConfig{Type: clients.NoAuth}
+
+			prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher, tc.ironic.Endpoint(), auth)
+			if err != nil {
+				t.Fatalf("could not create provisioner: %s", err)
+			}
+
+			components, err := prov.GetFirmwareComponents(t.Context())
+
+			require.ErrorIs(t, err, tc.wantErr)
+			assert.Equal(t, tc.expectedComponents, components)
+		})
+	}
+}

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -788,6 +788,15 @@ func (p *ironicProvisioner) GetFirmwareComponents(ctx context.Context) ([]metal3
 			CurrentVersion:     fwc.CurrentVersion,
 			LastVersionFlashed: fwc.LastVersionFlashed,
 		}
+		if fwc.Vendor != nil {
+			component.Vendor = *fwc.Vendor
+		}
+		if fwc.Model != nil {
+			component.Model = *fwc.Model
+		}
+		if fwc.SerialNumber != nil {
+			component.SerialNumber = *fwc.SerialNumber
+		}
 		// Check if UpdatedAt is nil before adding it.
 		if fwc.UpdatedAt != nil {
 			component.UpdatedAt = metav1.Time{
@@ -795,7 +804,7 @@ func (p *ironicProvisioner) GetFirmwareComponents(ctx context.Context) ([]metal3
 			}
 		}
 		componentsInfo = append(componentsInfo, component)
-		p.log.V(1).Info("firmware component found for node", "component", fwc.Component, "node", p.nodeID)
+		p.log.V(1).Info("firmware component found for node", "component", fwc.Component, "vendor", component.Vendor, "model", component.Model, "serialNumber", component.SerialNumber, "node", p.nodeID)
 	}
 
 	return componentsInfo, err

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -793,6 +793,15 @@ func (p *ironicProvisioner) GetFirmwareComponents(ctx context.Context) ([]metal3
 			CurrentVersion:     fwc.CurrentVersion,
 			LastVersionFlashed: fwc.LastVersionFlashed,
 		}
+		if fwc.Vendor != nil {
+			component.Vendor = *fwc.Vendor
+		}
+		if fwc.Model != nil {
+			component.Model = *fwc.Model
+		}
+		if fwc.SerialNumber != nil {
+			component.SerialNumber = *fwc.SerialNumber
+		}
 		// Check if UpdatedAt is nil before adding it.
 		if fwc.UpdatedAt != nil {
 			component.UpdatedAt = metav1.Time{
@@ -800,7 +809,7 @@ func (p *ironicProvisioner) GetFirmwareComponents(ctx context.Context) ([]metal3
 			}
 		}
 		componentsInfo = append(componentsInfo, component)
-		p.log.V(1).Info("firmware component found for node", "component", fwc.Component, "node", p.nodeID)
+		p.log.V(1).Info("firmware component found for node", "component", fwc.Component, "vendor", component.Vendor, "model", component.Model, "serialNumber", component.SerialNumber, "node", p.nodeID)
 	}
 
 	return componentsInfo, err

--- a/pkg/provisioner/ironic/testserver/ironic.go
+++ b/pkg/provisioner/ironic/testserver/ironic.go
@@ -482,6 +482,29 @@ func (m *IronicMock) NoBIOS(nodeUUID string) *IronicMock {
 	return m
 }
 
+// FirmwareComponents configures the server with a valid response for /v1/nodes/<node>/firmware.
+func (m *IronicMock) FirmwareComponents(nodeUUID string, components []nodes.FirmwareComponent) *IronicMock {
+	resp := struct {
+		Firmware []nodes.FirmwareComponent `json:"firmware"`
+	}{
+		Firmware: components,
+	}
+	m.ResponseJSON(m.buildURL(v1node+nodeUUID+"/firmware", http.MethodGet), resp)
+	m.AddDefaultResponseJSON(v1node+nodeUUID, "", http.StatusOK, nodes.Node{
+		UUID: nodeUUID,
+	})
+	return m
+}
+
+// NoFirmwareComponents configures the server so /v1/nodes/<node>/firmware returns a 404.
+func (m *IronicMock) NoFirmwareComponents(nodeUUID string) *IronicMock {
+	m.ErrorResponse(v1node+nodeUUID+"/firmware", http.StatusNotFound)
+	m.AddDefaultResponseJSON(v1node+nodeUUID, "", http.StatusOK, nodes.Node{
+		UUID: nodeUUID,
+	})
+	return m
+}
+
 // WithInventory configures the server with a valid response for /v1/nodes/<node>/inventory.
 func (m *IronicMock) WithInventory(nodeUUID string, data nodes.InventoryData) *IronicMock {
 	m.ResponseJSON(v1node+nodeUUID+"/inventory", data)


### PR DESCRIPTION
## Summary
- Extend `FirmwareComponentStatus` with `vendor`, `model`, and `serialNumber` fields from Ironic firmware API
- Add support for Ironic API microversion 1.114 which exposes firmware component identity information
- Populate new fields in `GetFirmwareComponents` when available from Ironic response

