### PR TITLE
🌱 Collect BMC emulator logs in e2e tests

### DIFF
--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -214,6 +214,11 @@ mkdir -p "${LOGS_DIR}/qemu"
 sudo sh -c "cp -r /var/log/libvirt/qemu/* ${LOGS_DIR}/qemu/"
 sudo chown -R "${USER}:${USER}" "${LOGS_DIR}/qemu"
 
+# Collect BMC emulator logs, if present (not run against real hardware).
+emulator_container="vbmctl-${BMO_E2E_EMULATOR}"
+docker inspect "${emulator_container}" &>/dev/null &&
+  docker logs "${emulator_container}" > "${LOGS_DIR}/${emulator_container}.log" 2>&1
+
 # Collect all artifacts
 tar --directory test/e2e/ -czf "artifacts-e2e-${BMO_E2E_EMULATOR}-${BMC_PROTOCOL}.tar.gz" _artifacts
 


### PR DESCRIPTION
Collects logs from the BMC emulator container (vbmc or sushy-tools, depending on `BMC_PROTOCOL`) after e2e tests run, and includes them in the artifacts tarball.

As suggested in the issue, this is done in `hack/ci-e2e.sh` rather than the Go test code, since the emulator container isn't guaranteed to exist — e2e can also run against real hardware/BMCs. The log collection is guarded with `docker inspect` so it's a no-op in that case, instead of writing a misleading "no such container" error into the artifacts.

Fixes #3287