### PR TITLE
🌱 e2e: Add user data secrets to cleanup list

### DIFF
--- a/test/e2e/automated_cleaning_test.go
+++ b/test/e2e/automated_cleaning_test.go
@@ -78,7 +78,8 @@ var _ = Describe("Automated cleaning", Label("required", "automated-cleaning"), 
 		By("Patching the BMH to trigger provisioning")
 		userDataSecretName := "user-data-disk-test"
 		sshPubKeyPath := e2eConfig.GetVariable("SSH_PUB_KEY")
-		createDiskTestUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
+		obj := createDiskTestUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
+		toCleanup = append(toCleanup, obj)
 		userDataSecret := &corev1.SecretReference{
 			Name:      userDataSecretName,
 			Namespace: namespace.Name,
@@ -148,7 +149,8 @@ var _ = Describe("Automated cleaning", Label("required", "automated-cleaning"), 
 
 		By("Patching the BMH again to trigger re-provisioning")
 		userDataSecretName = "user-data-ssh-setup"
-		createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
+		obj = createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
+		toCleanup = append(toCleanup, obj)
 		userDataSecret = &corev1.SecretReference{
 			Name:      userDataSecretName,
 			Namespace: namespace.Name,

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -550,7 +550,7 @@ func EstablishSSHConnection(e2eConfig *Config, ipAddress string) *ssh.Client {
 
 // createSSHSetupUserdata creates a Kubernetes secret intended for cloud-init usage.
 // This userdata sets up SSH authorized keys during BMH's initialization.
-func createSSHSetupUserdata(ctx context.Context, client client.Client, namespace string, secretName string, sshPubKeyPath string, staticIP string) {
+func createSSHSetupUserdata(ctx context.Context, client client.Client, namespace string, secretName string, sshPubKeyPath string, staticIP string) *corev1.Secret {
 	sshPubKeyData, err := os.ReadFile(sshPubKeyPath) // #nosec G304
 	Expect(err).NotTo(HaveOccurred(), "Failed to read SSH public key file")
 
@@ -560,13 +560,13 @@ mkdir /root/.ssh
 chmod 700 /root/.ssh
 echo "%s" >> /root/.ssh/authorized_keys`, staticIP, sshPubKeyData)
 
-	CreateSecret(ctx, client, namespace, secretName, map[string]string{"userData": userDataContent})
+	return CreateSecret(ctx, client, namespace, secretName, map[string]string{"userData": userDataContent})
 }
 
 // createDiskTestUserdata creates a Kubernetes secret with cloud-init userdata for disk operations.
 // This userdata configures a static IP, sets up SSH authorized keys, formats /dev/vdb, mounts it,
 // and creates test files on both disks. Intended for testing automated cleaning of disks.
-func createDiskTestUserdata(ctx context.Context, client client.Client, namespace string, secretName string, sshPubKeyPath string, staticIP string) {
+func createDiskTestUserdata(ctx context.Context, client client.Client, namespace string, secretName string, sshPubKeyPath string, staticIP string) *corev1.Secret {
 	sshPubKeyData, err := os.ReadFile(sshPubKeyPath) // #nosec G304
 	Expect(err).NotTo(HaveOccurred(), "Failed to read SSH public key file")
 	userDataContent := fmt.Sprintf(`#!/bin/sh
@@ -584,7 +584,7 @@ mount /dev/vdb /mnt/data
 touch /mnt/data/test_file_vdb.txt
 touch /test_file_vda.txt`, staticIP, sshPubKeyData)
 
-	CreateSecret(ctx, client, namespace, secretName, map[string]string{"userData": userDataContent})
+	return CreateSecret(ctx, client, namespace, secretName, map[string]string{"userData": userDataContent})
 }
 
 // PerformSSHBootCheck performs an SSH check to verify the node's boot source.

--- a/test/e2e/firmware_settings_test.go
+++ b/test/e2e/firmware_settings_test.go
@@ -314,7 +314,8 @@ var _ = Describe("Host Firmware Settings", Label("required", "firmware"), func()
 		if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
 			userDataSecretName := "user-data"
 			sshPubKeyPath := e2eConfig.GetVariable("SSH_PUB_KEY")
-			createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
+			obj := createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
+			toCleanup = append(toCleanup, obj)
 			userDataSecret = &corev1.SecretReference{
 				Name:      userDataSecretName,
 				Namespace: namespace.Name,

--- a/test/e2e/forced_detachment_test.go
+++ b/test/e2e/forced_detachment_test.go
@@ -299,7 +299,8 @@ var _ = Describe("Start provisioning, force detachment, delete and recreate, pro
 			if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
 				userDataSecretName := "user-data"
 				sshPubKeyPath := e2eConfig.GetVariable("SSH_PUB_KEY")
-				createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
+				obj := createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
+				toCleanup = append(toCleanup, obj)
 				userDataSecret = &corev1.SecretReference{
 					Name:      userDataSecretName,
 					Namespace: namespace.Name,

--- a/test/e2e/network_data_test.go
+++ b/test/e2e/network_data_test.go
@@ -170,7 +170,8 @@ var _ = Describe("Network Data", Label("required", "network-data"), func() {
 		if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
 			userDataSecretName := bmhName + "-user-data"
 			sshPubKeyPath := e2eConfig.GetVariable("SSH_PUB_KEY")
-			createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
+			obj := createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
+			toCleanup = append(toCleanup, obj)
 			userDataSecret = &corev1.SecretReference{
 				Name:      userDataSecretName,
 				Namespace: namespace.Name,
@@ -266,7 +267,8 @@ var _ = Describe("Network Data", Label("required", "network-data"), func() {
 		if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
 			userDataSecretName := bmhName + "-user-data"
 			sshPubKeyPath := e2eConfig.GetVariable("SSH_PUB_KEY")
-			createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
+			obj := createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
+			toCleanup = append(toCleanup, obj)
 			userDataSecret = &corev1.SecretReference{
 				Name:      userDataSecretName,
 				Namespace: namespace.Name,

--- a/test/e2e/provisioning_and_annotation_test.go
+++ b/test/e2e/provisioning_and_annotation_test.go
@@ -85,7 +85,8 @@ var _ = Describe("Provision, detach, recreate from status and deprovision", Labe
 			if e2eConfig.GetVariable("SSH_CHECK_PROVISIONED") == "true" {
 				userDataSecretName := "user-data"
 				sshPubKeyPath := e2eConfig.GetVariable("SSH_PUB_KEY")
-				createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
+				obj := createSSHSetupUserdata(ctx, clusterProxy.GetClient(), namespace.Name, userDataSecretName, sshPubKeyPath, bmc.IPAddress)
+				toCleanup = append(toCleanup, obj)
 				userDataSecret = &corev1.SecretReference{
 					Name:      userDataSecretName,
 					Namespace: namespace.Name,


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensure that functions generating user-data secrets return the generated secret and append the value to toCleanup in the scenarios using userData.

Fixes: #3436
