### PR TITLE
🌱 e2e: introduce a new tag "ironic"

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -36,7 +36,7 @@ the e2e Makefile target directly with `make test-e2e`, you may need to adjust yo
 
 Currently there are two sets of tests, which cannot be ran together in the same
 cluster. One is the "optional" set, currently consists of only the
-[upgrade tests](upgrade_test.go), and the "main" set, which are the ones
+upgrade tests (`upgrade_*_test.go`), and the "main" set, which are the ones
 required to run in every BMO PR. One can switch between these sets by
 manipulating the `GINKGO_FOCUS` and `GINKGO_SKIP` env vars. In the default
 setting, the script sets `GINKGO_SKIP` to `upgrade`.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -77,6 +77,9 @@ Could be used with:
 export GINKGO_FOCUS="basic should control power"
 ```
 
+A special tag `ironic` can be used to run all tests that exercise the Ironic
+provisioner (as opposed to only BMO itself).
+
 Additionally, if you wish to run multiple different tests, just maually
 add another `--focus=` with string to the root Makefile's `test-e2e`
 target.

--- a/test/e2e/automated_cleaning_test.go
+++ b/test/e2e/automated_cleaning_test.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Automated cleaning", Label("required", "automated-cleaning"), func() {
+var _ = Describe("Automated cleaning", Label("required", "automated-cleaning", "ironic"), func() {
 	var (
 		specName      = "automated-cleaning"
 		namespace     *corev1.Namespace

--- a/test/e2e/basic_ops_test.go
+++ b/test/e2e/basic_ops_test.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("basic", Label("required", "basic"), func() {
+var _ = Describe("basic", Label("required", "basic", "ironic"), func() {
 	var (
 		specName      = "basic-ops"
 		namespace     *corev1.Namespace

--- a/test/e2e/externally_provisioned_test.go
+++ b/test/e2e/externally_provisioned_test.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Create as externally provisioned, deprovision", Label("required", "provision", "deprovision"),
+var _ = Describe("External Provisioning", Label("required", "provision", "deprovision", "ironic"),
 	func() {
 		var (
 			specName      = "externally-provisioned"

--- a/test/e2e/firmware_components_test.go
+++ b/test/e2e/firmware_components_test.go
@@ -48,7 +48,7 @@ func waitForBIOSFirmwareUpdate(ctx context.Context, cl client.Client, hfc *metal
 	}, intervals...).Should(Succeed())
 }
 
-var _ = Describe("Host Firmware Components", Label("required", "firmware-components"), func() {
+var _ = Describe("Host Firmware Components", Label("required", "firmware-components", "ironic"), func() {
 	var (
 		specName      = "firmware-components"
 		namespace     *corev1.Namespace

--- a/test/e2e/firmware_settings_test.go
+++ b/test/e2e/firmware_settings_test.go
@@ -34,7 +34,7 @@ const (
 	hfsTestNewValue3  = "ABCDEF"
 )
 
-var _ = Describe("Host Firmware Settings", Label("required", "firmware"), func() {
+var _ = Describe("Host Firmware Settings", Label("required", "firmware", "ironic"), func() {
 	var (
 		specName      = "firmware-settings"
 		namespace     *corev1.Namespace

--- a/test/e2e/forced_detachment_test.go
+++ b/test/e2e/forced_detachment_test.go
@@ -19,7 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Start provisioning, force detachment, delete and recreate, provision, detach again and delete", Label("required", "provision", "detach", "force-detach"),
+var _ = Describe("Forced Detachment", Label("required", "provision", "detach", "force-detach", "ironic"),
 	func() {
 		var (
 			specName      = "force-detach"

--- a/test/e2e/inspection_test.go
+++ b/test/e2e/inspection_test.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Inspection", Label("required", "inspection"), func() {
+var _ = Describe("Inspection", Label("required", "inspection", "ironic"), func() {
 	var (
 		specName      = "inspection"
 		namespace     *corev1.Namespace

--- a/test/e2e/live_iso_test.go
+++ b/test/e2e/live_iso_test.go
@@ -19,7 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Live-ISO", Label("required", "live-iso"), func() {
+var _ = Describe("Live-ISO", Label("required", "live-iso", "ironic"), func() {
 	var (
 		specName      = "live-iso-ops"
 		namespace     *corev1.Namespace

--- a/test/e2e/network_data_test.go
+++ b/test/e2e/network_data_test.go
@@ -71,7 +71,7 @@ func getNewIPAddress() string {
 	return ip.String()
 }
 
-var _ = Describe("Network Data", Label("required", "network-data"), func() {
+var _ = Describe("Network Data", Label("required", "network-data", "ironic"), func() {
 	var (
 		specName      = "network-data"
 		namespace     *corev1.Namespace

--- a/test/e2e/provisioning_and_annotation_test.go
+++ b/test/e2e/provisioning_and_annotation_test.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Provision, detach, recreate from status and deprovision", Label("required", "provision", "detach", "status", "deprovision"),
+var _ = Describe("Provisioning and Detachment", Label("required", "provision", "detach", "status", "deprovision", "ironic"),
 	func() {
 		var (
 			specName      = "provisioning-ops"

--- a/test/e2e/re_inspection_test.go
+++ b/test/e2e/re_inspection_test.go
@@ -19,7 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Re-Inspection", Label("required", "re-inspection"), func() {
+var _ = Describe("Re-Inspection", Label("required", "re-inspection", "ironic"), func() {
 	var (
 		specName      = "re-inspection"
 		namespace     *corev1.Namespace


### PR DESCRIPTION
This tag marks tests that exercise the Ironic provisioner, not just BMO
internals. The idea is to use GINKGO_FOCUS=ironic on ironic-image and
Ironic itself to avoid running unrelated tests.

While here, fix a couple of Describe() statements to produce readable
test descriptions (they're combined with It() in the report).

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
