### PR TITLE
:bug: Fix OCI pull secret credential format sent to Ironic

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller_test.go
+++ b/internal/controller/metal3.io/baremetalhost_controller_test.go
@@ -3564,10 +3564,8 @@ func TestGetImageAuthSecret_OCIImageWithValidSecret(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, credentials, "expected non-empty credentials")
 
-	// Verify credentials are base64 encoded and in correct format
-	decoded, err := base64.StdEncoding.DecodeString(credentials)
-	require.NoError(t, err)
-	assert.Equal(t, "testuser:testpass", string(decoded))
+	// Verify credentials are in plain text username:password format
+	assert.Equal(t, "testuser:testpass", credentials)
 }
 
 // TestGetImageAuthSecret_OCIImageWithoutSecret tests that no error occurs

--- a/internal/controller/metal3.io/image_auth_validator_test.go
+++ b/internal/controller/metal3.io/image_auth_validator_test.go
@@ -167,15 +167,9 @@ func TestValidate_ValidDockerConfigJSON(t *testing.T) {
 		t.Error("expected credentials to be populated")
 	}
 
-	// Verify credentials are base64 encoded.
-	decoded, err := base64.StdEncoding.DecodeString(credentials)
-	if err != nil {
-		t.Fatalf("credentials are not valid base64: %v", err)
-	}
-
-	// Verify credentials contain username:password format.
-	if string(decoded) != "testuser:testpass" {
-		t.Errorf("expected credentials to be 'testuser:testpass', got '%s'", string(decoded))
+	// Verify credentials are in plain text username:password format.
+	if credentials != "testuser:testpass" {
+		t.Errorf("expected credentials to be 'testuser:testpass', got '%s'", credentials)
 	}
 
 	// No event should be emitted on success (validator only emits warnings).
@@ -374,13 +368,7 @@ func TestIntegration_ValidateAndExtractCredentials(t *testing.T) {
 		t.Fatal("expected credentials to be populated")
 	}
 
-	// Verify the credentials can be decoded.
-	decoded, err := base64.StdEncoding.DecodeString(credentials)
-	if err != nil {
-		t.Fatalf("failed to decode credentials: %v", err)
-	}
-
-	if string(decoded) != "myuser:mypassword" {
-		t.Errorf("expected decoded credentials to be 'myuser:mypassword', got '%s'", string(decoded))
+	if credentials != "myuser:mypassword" {
+		t.Errorf("expected credentials to be 'myuser:mypassword', got '%s'", credentials)
 	}
 }

--- a/pkg/provisioner/ironic/clients/updateopts_test.go
+++ b/pkg/provisioner/ironic/clients/updateopts_test.go
@@ -468,7 +468,7 @@ func TestSanitisedValue(t *testing.T) {
 		"foo":               "bar",
 		"password":          "secret",
 		"ipmi_password":     "secret",
-		"image_pull_secret": "dXNlcjpwYXNz",
+		"image_pull_secret": "user:pass",
 	}
 	safe := map[string]any{
 		"foo":               "bar",

--- a/pkg/provisioner/ironic/provision_test.go
+++ b/pkg/provisioner/ironic/provision_test.go
@@ -1642,7 +1642,7 @@ func TestGetUpdateOptsForNodeOCIWithPullSecret(t *testing.T) {
 	provData := provisioner.ProvisionData{
 		Image:           *host.Spec.Image,
 		BootMode:        metal3api.DefaultBootMode,
-		ImagePullSecret: "dXNlcjpwYXNz",
+		ImagePullSecret: "user:pass",
 	}
 	patches := prov.getInstanceUpdateOpts(ironicNode, provData).Updates
 
@@ -1658,7 +1658,7 @@ func TestGetUpdateOptsForNodeOCIWithPullSecret(t *testing.T) {
 		},
 		{
 			Path:  "/instance_info/image_pull_secret",
-			Value: "dXNlcjpwYXNz",
+			Value: "user:pass",
 		},
 	}
 
@@ -1733,7 +1733,7 @@ func TestGetUpdateOptsForNodeOCIClearPullSecret(t *testing.T) {
 	ironicNode := &nodes.Node{
 		InstanceInfo: map[string]any{
 			"image_source":      "oci://quay.io/test/old-image:v1",
-			"image_pull_secret": "b2xkLXNlY3JldA==",
+			"image_pull_secret": "old-user:old-pass",
 		},
 	}
 

--- a/pkg/secretutils/dockerconfig.go
+++ b/pkg/secretutils/dockerconfig.go
@@ -1,7 +1,6 @@
 package secretutils
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,9 +14,8 @@ import (
 // ExtractRegistryCredentials extracts the registry credentials from a Kubernetes secret
 // for the registry associated with the given image URL.
 // It supports both kubernetes.io/dockerconfigjson and kubernetes.io/dockercfg secret types.
-// Returns ONLY the minimal credential in the format expected by Ironic:
-// base64-encoded "username:password" (NOT the entire Docker config JSON).
-// This is what Ironic accepts in instance_info[image_pull_secret].
+// Returns credentials as plain text "username:password", which is the format
+// Ironic expects in instance_info[image_pull_secret].
 func ExtractRegistryCredentials(secret *corev1.Secret, imageURL string) (string, error) {
 	if secret == nil {
 		return "", errors.New("secret is nil")
@@ -60,9 +58,7 @@ func ExtractRegistryCredentials(secret *corev1.Secret, imageURL string) (string,
 		return "", fmt.Errorf("registry %s not found in auth config", registryHost)
 	}
 
-	// Return credentials in the format expected by Ironic (base64-encoded "username:password")
-	credentials := fmt.Sprintf("%s:%s", username, password)
-	return base64.StdEncoding.EncodeToString([]byte(credentials)), nil
+	return fmt.Sprintf("%s:%s", username, password), nil
 }
 
 // extractRegistryHost extracts the registry hostname from an OCI image URL.

--- a/pkg/secretutils/dockerconfig_test.go
+++ b/pkg/secretutils/dockerconfig_test.go
@@ -45,18 +45,11 @@ func runCredentialsTest(t *testing.T, tc credentialsTestCase) {
 		return
 	}
 
-	// Verify credentials are base64 encoded.
-	decoded, decodeErr := base64.StdEncoding.DecodeString(result)
-	if decodeErr != nil {
-		t.Errorf("credentials are not valid base64: %v", decodeErr)
-		return
-	}
-
-	// Verify credentials contain username:password format.
+	// Verify credentials are in plain text username:password format.
 	const credentialParts = 2
-	parts := strings.SplitN(string(decoded), ":", credentialParts)
+	parts := strings.SplitN(result, ":", credentialParts)
 	if len(parts) != credentialParts {
-		t.Errorf("expected credentials in username:password format, got: %s", string(decoded))
+		t.Errorf("expected credentials in username:password format, got: %s", result)
 	}
 }
 


### PR DESCRIPTION
## What this PR does

Fixes the credential format sent to Ironic for OCI image pull secrets. `ExtractRegistryCredentials` was base64-encoding the `username:password` string before passing it to Ironic via `instance_info[image_pull_secret]`. However, Ironic expects plain text `username:password` and splits on `:` to extract the credentials:

```python
# ironic/common/image_service.py
split_secret = secret.split(":", 1)
return {"username": split_secret[0], "password": split_secret[1]}
```

Since the base64-encoded string typically does not contain `:`, Ironic treated the entire encoded string as the password with an empty username, causing `401 Unauthorized` errors when pulling from private OCI registries.

## Why it went unnoticed

The issue only manifests during real provisioning against a private OCI registry. Unit tests verified the base64 encoding was produced correctly but did not validate what Ironic actually expects.

## Changes

- Remove base64 encoding from `ExtractRegistryCredentials`, return plain text `username:password`
- Remove unused `encoding/base64` import from `dockerconfig.go`
- Update all tests to expect plain text credentials instead of base64-encoded values

/kind bug