### PR TITLE
🌱 3 minor improvement for hardware switch management

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -466,7 +466,7 @@ type FirmwareConfig struct {
 // SwitchPort defines the attributes required to identify a switch port.
 type SwitchPort struct {
 	// SwitchID is expected to be the management MAC address of the switch
-	// +kubebuilder:validation:Pattern=`[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}`
+	// +kubebuilder:validation:Pattern=`^[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}$`
 	SwitchID string `json:"switchID"`
 
 	// PortID is expected to be the configuration name of the port in the
@@ -488,7 +488,7 @@ type NetworkInterface struct {
 	// of a NIC discovered during inspection (see HardwareData resource).
 	// Mutually exclusive with Name.
 	// +optional
-	// +kubebuilder:validation:Pattern=`[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}`
+	// +kubebuilder:validation:Pattern=`^[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}$`
 	MACAddress string `json:"macAddress,omitempty"`
 
 	// HostNetworkAttachment references the HostNetworkAttachment for this interface

--- a/config/base/crds/bases/metal3.io_baremetalhosts.yaml
+++ b/config/base/crds/bases/metal3.io_baremetalhosts.yaml
@@ -375,7 +375,7 @@ spec:
                         MAC address of the network interface.  This must match the MAC address
                         of a NIC discovered during inspection (see HardwareData resource).
                         Mutually exclusive with Name.
-                      pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
+                      pattern: ^[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}$
                       type: string
                     name:
                       description: |-
@@ -403,7 +403,7 @@ spec:
                         switchID:
                           description: SwitchID is expected to be the management MAC
                             address of the switch
-                          pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
+                          pattern: ^[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}$
                           type: string
                       required:
                       - portID

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -375,7 +375,7 @@ spec:
                         MAC address of the network interface.  This must match the MAC address
                         of a NIC discovered during inspection (see HardwareData resource).
                         Mutually exclusive with Name.
-                      pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
+                      pattern: ^[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}$
                       type: string
                     name:
                       description: |-
@@ -403,7 +403,7 @@ spec:
                         switchID:
                           description: SwitchID is expected to be the management MAC
                             address of the switch
-                          pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
+                          pattern: ^[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}$
                           type: string
                       required:
                       - portID

--- a/internal/webhooks/metal3.io/v1alpha1/hostnetworkattachment_validation.go
+++ b/internal/webhooks/metal3.io/v1alpha1/hostnetworkattachment_validation.go
@@ -19,11 +19,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -58,7 +58,7 @@ func (webhook *HostNetworkAttachment) validateUpdate(ctx context.Context, oldAtt
 	}
 
 	// Check if spec has changed
-	if reflect.DeepEqual(oldAttachment.Spec, newAttachment.Spec) {
+	if equality.Semantic.DeepEqual(oldAttachment.Spec, newAttachment.Spec) {
 		// No spec changes, allow the update (probably just metadata or status)
 		return warnings, nil
 	}

--- a/internal/webhooks/metal3.io/v1alpha1/hostnetworkattachment_validation_test.go
+++ b/internal/webhooks/metal3.io/v1alpha1/hostnetworkattachment_validation_test.go
@@ -227,7 +227,7 @@ func TestValidateAttachment(t *testing.T) {
 
 func TestFindBMHReferences(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = metal3api.AddToScheme(scheme)
+	require.NoError(t, metal3api.AddToScheme(scheme))
 
 	attachment := &metal3api.HostNetworkAttachment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -349,7 +349,7 @@ func TestFindBMHReferences(t *testing.T) {
 
 func TestHNAValidateUpdate(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = metal3api.AddToScheme(scheme)
+	require.NoError(t, metal3api.AddToScheme(scheme))
 
 	oldAttachment := &metal3api.HostNetworkAttachment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -499,7 +499,7 @@ func TestHNAValidateUpdate(t *testing.T) {
 
 func TestHNAValidateDelete(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = metal3api.AddToScheme(scheme)
+	require.NoError(t, metal3api.AddToScheme(scheme))
 
 	attachment := &metal3api.HostNetworkAttachment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -590,7 +590,7 @@ func TestHNAValidateDelete(t *testing.T) {
 
 func TestFindBMHReferencesCrossNamespace(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = metal3api.AddToScheme(scheme)
+	require.NoError(t, metal3api.AddToScheme(scheme))
 
 	attachment := &metal3api.HostNetworkAttachment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -666,7 +666,7 @@ func TestFindBMHReferencesCrossNamespace(t *testing.T) {
 
 func TestHNAValidateUpdateFailClosed(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = metal3api.AddToScheme(scheme)
+	require.NoError(t, metal3api.AddToScheme(scheme))
 
 	oldAttachment := &metal3api.HostNetworkAttachment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -705,7 +705,7 @@ func TestHNAValidateUpdateFailClosed(t *testing.T) {
 
 func TestHNAValidateDeleteFailClosed(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = metal3api.AddToScheme(scheme)
+	require.NoError(t, metal3api.AddToScheme(scheme))
 
 	attachment := &metal3api.HostNetworkAttachment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -729,7 +729,7 @@ func TestHNAValidateDeleteFailClosed(t *testing.T) {
 
 func TestHNAValidateUpdateWarnings(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = metal3api.AddToScheme(scheme)
+	require.NoError(t, metal3api.AddToScheme(scheme))
 
 	oldAttachment := &metal3api.HostNetworkAttachment{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-attachment", Namespace: "test-ns"},
@@ -777,7 +777,7 @@ func TestHNAValidateUpdateWarnings(t *testing.T) {
 
 func TestHNAValidateDeleteWarnings(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = metal3api.AddToScheme(scheme)
+	require.NoError(t, metal3api.AddToScheme(scheme))
 
 	attachment := &metal3api.HostNetworkAttachment{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-attachment", Namespace: "test-ns"},
@@ -821,7 +821,7 @@ func TestHNAValidateDeleteWarnings(t *testing.T) {
 
 func TestFindBMHReferencesMultipleInterfacesSameBMH(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = metal3api.AddToScheme(scheme)
+	require.NoError(t, metal3api.AddToScheme(scheme))
 
 	attachment := &metal3api.HostNetworkAttachment{
 		ObjectMeta: metav1.ObjectMeta{Name: "shared-attachment", Namespace: "test-ns"},


### PR DESCRIPTION
This is addresses minor review comments from a downstream merge.  See: https://github.com/openshift/baremetal-operator/pull/510

In detail:

 - Replace discarded AddToScheme returns with require.NoError so setup
failures are caught immediately rather than silently ignored.

 - Replace reflect.DeepEqual with equality.Semantic.DeepEqual when
checking if the HNA spec changed during updates. reflect.DeepEqual
treats nil and empty slices as different, which would incorrectly
block metadata-only updates when a client sends an empty AllowedVLANs
slice instead of omitting the field.

- Add ^ and $ anchors to kubebuilder validation patterns for
NetworkInterface.MACAddress and SwitchPort.SwitchID to prevent
accepting strings that merely contain a valid MAC as a substring.
