### PR TITLE
:bug: Fix credentials not persisted while waiting for PreprovisioningImage

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -965,7 +965,16 @@ func (r *BareMetalHostReconciler) registerHost(ctx context.Context, prov provisi
 		preprovImgFormats != nil {
 		if preprovImg == nil {
 			waitingForPreprovImage.Inc()
-			return actionContinue{preprovImageRetryDelay}
+			result := actionContinue{preprovImageRetryDelay}
+			if dirty {
+				// Persist any pending changes (e.g. newly detected
+				// credentials) even though registration cannot complete
+				// yet. Otherwise they are re-detected and re-applied on
+				// every reconcile while waiting for the image, producing
+				// confusing repeated log output.
+				return actionUpdate{result}
+			}
+			return result
 		}
 		return recordActionFailure(info, metal3api.RegistrationError,
 			"Preprovisioning Image is not acceptable to provisioner")

--- a/internal/controller/metal3.io/host_state_machine_test.go
+++ b/internal/controller/metal3.io/host_state_machine_test.go
@@ -215,6 +215,49 @@ func TestDeprovisioningCapacity(t *testing.T) {
 	}
 }
 
+// TestRegisterHostPersistsCredentialsWhileWaitingForPreprovisioningImage
+// ensures that, when registration cannot complete because the
+// PreprovisioningImage is not yet available, any state already detected
+// during this reconcile (such as newly tried credentials) is still saved.
+// Otherwise the same work is repeated, and logged, on every reconcile
+// until the image becomes available.
+func TestRegisterHostPersistsCredentialsWhileWaitingForPreprovisioningImage(t *testing.T) {
+	testHost := host(metal3api.StateInspecting).build()
+	// Simulate credentials that have not been tried yet.
+	testHost.Status.TriedCredentials.Version = "99"
+
+	reconciler := testNewReconciler(testHost)
+	prov := newMockProvisioner()
+	prov.preprovImageFormats = []metal3api.ImageFormat{metal3api.ImageFormatISO}
+	prov.registerErr = provisioner.ErrNeedsPreprovisioningImage
+
+	info := makeDefaultReconcileInfo(testHost)
+
+	result := reconciler.registerHost(t.Context(), prov, info)
+
+	assert.True(t, result.Dirty(), "expected a dirty result so newly tried credentials are persisted")
+	assert.Equal(t, info.bmcCredsSecret.ResourceVersion, testHost.Status.TriedCredentials.Version)
+}
+
+// TestRegisterHostNotDirtyWhileWaitingForPreprovisioningImage ensures that,
+// when there is nothing new to persist, waiting for the PreprovisioningImage
+// still results in a plain (non-dirty) retry rather than forcing an
+// unnecessary status update on every reconcile.
+func TestRegisterHostNotDirtyWhileWaitingForPreprovisioningImage(t *testing.T) {
+	testHost := host(metal3api.StateInspecting).build()
+
+	reconciler := testNewReconciler(testHost)
+	prov := newMockProvisioner()
+	prov.preprovImageFormats = []metal3api.ImageFormat{metal3api.ImageFormatISO}
+	prov.registerErr = provisioner.ErrNeedsPreprovisioningImage
+
+	info := makeDefaultReconcileInfo(testHost)
+
+	result := reconciler.registerHost(t.Context(), prov, info)
+
+	assert.False(t, result.Dirty(), "expected no forced status update when nothing changed")
+}
+
 func TestDetach(t *testing.T) {
 	testCases := []struct {
 		Scenario                  string
@@ -1279,9 +1322,11 @@ func newMockProvisioner() *mockProvisioner {
 }
 
 type mockProvisioner struct {
-	hasCapacity  bool
-	nextResults  map[string]provisioner.Result
-	callsNoError map[string]bool
+	hasCapacity         bool
+	nextResults         map[string]provisioner.Result
+	callsNoError        map[string]bool
+	registerErr         error
+	preprovImageFormats []metal3api.ImageFormat
 }
 
 func (m *mockProvisioner) getNextResultByMethod(name string) (result provisioner.Result) {
@@ -1316,11 +1361,11 @@ func (m *mockProvisioner) calledNoError(methodName string) bool {
 }
 
 func (m *mockProvisioner) Register(_ context.Context, _ provisioner.ManagementAccessData, _, _ bool) (result provisioner.Result, provID string, err error) {
-	return m.getNextResultByMethod("ValidateManagementAccess"), "", err
+	return m.getNextResultByMethod("ValidateManagementAccess"), "", m.registerErr
 }
 
 func (m *mockProvisioner) PreprovisioningImageFormats(_ context.Context) ([]metal3api.ImageFormat, error) {
-	return nil, nil
+	return m.preprovImageFormats, nil
 }
 
 func (m *mockProvisioner) InspectHardware(_ context.Context, _ provisioner.InspectData, _, _, _ bool) (result provisioner.Result, started bool, details *metal3api.HardwareDetails, err error) {


### PR DESCRIPTION
Motivation:

When a host's registration is blocked because its PreprovisioningImage
is not yet ready, BMO logs a confusing repeating sequence: "new
credentials detected", "updating option data", etc., over and over on
every reconcile until the image becomes available (metal3-io/baremetal-operator#2366).

Approach:

In registerHost(), when prov.Register() returns
ErrNeedsPreprovisioningImage and no PreprovisioningImage is available
yet, the function returns early with actionContinue{...}. actionContinue
reports Dirty() == false, so the top-level Reconcile() skips saving host
status. Any state already detected earlier in the same call - most
notably newly tried BMC credentials recorded via
UpdateTriedCredentials() - is therefore mutated only in memory and never
persisted to the BareMetalHost status.

On the next reconcile the host is re-fetched with the old
TriedCredentials, the same credentials look "new" again, and the whole
detection/update sequence (and its log lines) repeats, indefinitely,
while waiting for the image. This does not change the final state the
host eventually reaches; it only causes needless repeated work and log
spam while waiting.

The fix mirrors the existing "if dirty { return actionUpdate{result} }"
pattern already used a few lines below in the same function for the
provResult.Dirty case: when returning early because the
PreprovisioningImage isn't ready yet, wrap the result in actionUpdate if
dirty is set, so any already-detected changes are saved once instead of
being silently discarded and re-detected on every reconcile.

Validation:

Added TestRegisterHostPersistsCredentialsWhileWaitingForPreprovisioningImage,
which reproduces the bug (fails without the fix, with error "expected a
dirty result so newly tried credentials are persisted") and passes with
it. Also added TestRegisterHostNotDirtyWhileWaitingForPreprovisioningImage
to confirm no unnecessary status update is forced when there is nothing
new to persist.

  go test ./internal/controller/metal3.io/...

... passes, along with `go build ./internal/...`, `go vet
./internal/controller/metal3.io/...`, `gofmt -l`, and `golangci-lint run
./internal/controller/metal3.io/...` (0 issues).

Fixes #2366

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>