### PR TITLE
:seedling: vbmctl: launch BMC emulator after network initialization

### DIFF
--- a/test/vbmctl/cmd/vbmctl/create.go
+++ b/test/vbmctl/cmd/vbmctl/create.go
@@ -192,16 +192,6 @@ Example configuration:
 				fmt.Println("No image server configuration found in the config file.")
 			}
 
-			if cfg.Spec.BMCEmulator != nil {
-				err = containers.CreateBMCEmulatorInstance(ctx, cfg.Spec.BMCEmulator)
-				if err != nil {
-					return err
-				}
-			} else {
-				//nolint:forbidigo // CLI output is intentional
-				fmt.Println("No BMC emulator configuration found in the config file.")
-			}
-
 			conn, err := libvirtgo.NewConnect(cfg.Spec.Libvirt.URI)
 			if err != nil {
 				return fmt.Errorf("failed to connect to libvirt: %w", err)
@@ -245,6 +235,16 @@ Example configuration:
 			for _, pair := range cfg.Spec.VethPairs {
 				//nolint:forbidigo // CLI output is intentional
 				fmt.Printf("  - between %s and %s\n", pair.Link1, pair.Link2)
+			}
+
+			if cfg.Spec.BMCEmulator != nil {
+				err = containers.CreateBMCEmulatorInstance(ctx, cfg.Spec.BMCEmulator)
+				if err != nil {
+					return err
+				}
+			} else {
+				//nolint:forbidigo // CLI output is intentional
+				fmt.Println("No BMC emulator configuration found in the config file.")
 			}
 
 			vmManager, err := libvirt.NewVMManager(conn, libvirt.VMManagerOptions{


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

It is better to launch a BMC emulator instance after networks are created. This is required in order to ensure the BMC emulator is created only after the network-dependent environment is ready, so startup is more reliable and provisioning can reach it consistently.
