### PR TITLE
🌱 e2e: disable cleaning before the test is over

### DIFF
--- a/test/e2e/automated_cleaning_test.go
+++ b/test/e2e/automated_cleaning_test.go
@@ -201,6 +201,12 @@ var _ = Describe("Automated cleaning", Label("required", "automated-cleaning", "
 		Expect(err).NotTo(HaveOccurred())
 		Expect(output).To(ContainSubstring("file not found"), "Test file /mnt/data/test_file_vdb.txt should have been cleaned")
 
+		By("Disabling cleaning to allow quick deletion")
+		helper, err = patch.NewHelper(&bmh, clusterProxy.GetClient())
+		Expect(err).NotTo(HaveOccurred())
+		bmh.Spec.AutomatedCleaningMode = metal3api.CleaningModeDisabled
+		Expect(helper.Patch(ctx, &bmh)).To(Succeed())
+
 	})
 	AfterEach(func() {
 		CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))


### PR DESCRIPTION
Otherwise, cleanup may take too long, leaving the host dangling.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
