### PR TITLE
🌱 Bump minimum required go version to 1.26.0

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,7 +11,7 @@ formatters:
     - mock*
 
 run:
-  go: "1.25"
+  go: "1.26"
   build-tags:
   - e2e
   - vbmctl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.25.12@sha256:d7912cedddfa15b2900a8dfb7187df0af5ec2cb424a371139b5b352fd3e6b740
+ARG BUILD_IMAGE=docker.io/golang:1.26.5@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647
 ARG BASE_IMAGE=gcr.io/distroless/base-debian13:nonroot@sha256:a557d784ac275c287d2bdf3172f47bece8d2a0ef3c0fdefb712e95084a04a562
 
 # Shared SDK stage: pinned Go toolchain, modules, and checked-out tree.

--- a/Dockerfile.plugin-test
+++ b/Dockerfile.plugin-test
@@ -11,7 +11,7 @@
 #                      reproduction of an external author depending on BMO)
 #   plugin-load-tester runs plugin-load-test against the .so, build fails on
 #                      any error
-ARG BUILD_IMAGE=docker.io/golang:1.25.12@sha256:d7912cedddfa15b2900a8dfb7187df0af5ec2cb424a371139b5b352fd3e6b740
+ARG BUILD_IMAGE=docker.io/golang:1.26.5@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647
 
 FROM $BUILD_IMAGE AS bmo-builder
 WORKDIR /bmo

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GO_TEST_FLAGS = $(TEST_FLAGS)
 DEBUG = --debug
 COVER_PROFILE = cover.out
 GO := $(shell type -P go)
-GO_VERSION ?= 1.25.12
+GO_VERSION ?= 1.26.5
 
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -61,7 +61,7 @@ def validate_auth():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.25 as tilt-helper
+FROM golang:1.26 as tilt-helper
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/baremetal-operator/apis
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/baremetal-operator
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/cpuguy83/dockercfg v0.3.2

--- a/hack/e2e/ensure_go.sh
+++ b/hack/e2e/ensure_go.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-MINIMUM_GO_VERSION=go1.25.12
+MINIMUM_GO_VERSION=go1.26.5
 
 # Verify mode turned off by default
 VERIFY_ONLY="${VERIFY_ONLY:-false}"

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -35,6 +35,6 @@ else
         --volume "${PWD}:${WORKDIR}:ro,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        quay.io/metal3-io/basic-checks:golang-1.25 \
+        quay.io/metal3-io/basic-checks:golang-1.26 \
         "${WORKDIR}"/hack/generate.sh "$@"
 fi

--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -42,6 +42,6 @@ else
         --volume "${PWD}:${WORKDIR}:ro,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        quay.io/metal3-io/basic-checks:golang-1.25 \
+        quay.io/metal3-io/basic-checks:golang-1.26 \
         "${WORKDIR}"/hack/gomod.sh "$@"
 fi

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/baremetal-operator/hack/tools
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/blang/semver v3.5.1+incompatible

--- a/main.go
+++ b/main.go
@@ -67,14 +67,16 @@ type TLSOptions struct {
 	TLSCurvePreferences string
 }
 
-// Supported TLS Curves mapping for go1.25, make sure to update it
+// Supported TLS Curves mapping for go1.26, make sure to update it
 // when go version is updated.
 var supportedTLSCurvesPreferences = map[string]tls.CurveID{
-	"X25519":         tls.X25519,
-	"CurveP256":      tls.CurveP256,
-	"CurveP384":      tls.CurveP384,
-	"CurveP521":      tls.CurveP521,
-	"X25519MLKEM768": tls.X25519MLKEM768,
+	"X25519":             tls.X25519,
+	"CurveP256":          tls.CurveP256,
+	"CurveP384":          tls.CurveP384,
+	"CurveP521":          tls.CurveP521,
+	"X25519MLKEM768":     tls.X25519MLKEM768,
+	"SecP256r1MLKEM768":  tls.SecP256r1MLKEM768,
+	"SecP384r1MLKEM1024": tls.SecP384r1MLKEM1024,
 }
 
 var (

--- a/pkg/hardwareutils/bmc/access_test.go
+++ b/pkg/hardwareutils/bmc/access_test.go
@@ -223,13 +223,13 @@ func TestParse(t *testing.T) {
 			}
 
 			if len(url.Query()) != len(tc.Query) {
-				t.Fatalf("unexpected query length: %q , expected %q",
+				t.Fatalf("unexpected query length: %d , expected %d",
 					len(url.Query()), len(tc.Query))
 			}
 
 			for queryKey, queryArg := range tc.Query {
 				if len(url.Query()[queryKey]) != len(queryArg) {
-					t.Fatalf("unexpected query length: %q , expected %q",
+					t.Fatalf("unexpected query length: %d , expected %d",
 						len(url.Query()[queryKey]), len(queryArg))
 				}
 

--- a/pkg/hardwareutils/go.mod
+++ b/pkg/hardwareutils/go.mod
@@ -1,3 +1,3 @@
 module github.com/metal3-io/baremetal-operator/pkg/hardwareutils
 
-go 1.25.0
+go 1.26.0

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/baremetal-operator/test
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/cert-manager/cert-manager v1.20.3


### PR DESCRIPTION
This PR:
 - Modifies all go.mod files to require go version 1.26.0 for go binary compilation.
 - Adjust hack scripts, Makefile and Dockerfiles to be aligned with the new go requirement
 - Align access_test to comply with the stricter character substitution standards introduced by go 1.26
 - Adds 2 new supported TLS curves:
    - SecP256r1MLKEM768  (P-256 + ML-KEM-768)
    - SecP384r1MLKEM1024  (P-384 + ML-KEM-1024)