### PR TITLE
🌱Pin ironic version to 31.0 in E2E tests for release-0.12

### DIFF
--- a/test/e2e/config/ironic.yaml
+++ b/test/e2e/config/ironic.yaml
@@ -30,7 +30,7 @@ variables:
   DEPLOY_CERT_MANAGER: "true"
   IRSO_KUSTOMIZATION: "data/ironic-standalone-operator/operator"
   BMO_KUSTOMIZATION: "../../config/overlays/e2e"
-  IRONIC_KUSTOMIZATION: "data/ironic-standalone-operator/ironic/overlays/e2e"
+  IRONIC_KUSTOMIZATION: "data/ironic-standalone-operator/ironic/overlays/e2e-release-31.0"
 
   # These settings are for the separate cluster that are used for upgrade tests
   UPGRADE_DEPLOY_CERT_MANAGER: "true"


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

  Pin the e2e kustomization to the e2e-release-31.0 overlay, which patches the Ironic CR version to "31.0" instead of "latest" to prevent the redfish e2e test from persistently failing (due to an issue with the config drive resolution for non-virtual-media redfish)

  

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
