### PR TITLE
:sparkles: vbmctl: validate BMC is running

### DIFF
--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -145,51 +145,6 @@ envsubst '${BMO_E2E_EMULATOR},${IP_ADDRESS},${BMO_E2E_IMAGE},${BMO_E2E_LISTEN_PO
 # also image server and E2E emulator containers.
 ./bin/vbmctl -c "${REPO_ROOT}/test/e2e/config/vbmctl.yaml" create bml
 
-# Wait for the sushy-tools BMC emulator to become reachable on the provisioning
-# IP. sushy-tools may start before the provisioning bridge IP is assigned,
-# failing to bind ("Cannot assign requested address"). If Ironic later tries to
-# register a BMH before the emulator is listening it fails with
-# "Connection refused", which surfaces much later as an opaque BMH registration
-# error. Poll the Redfish endpoint, restarting the container if needed, and fail
-# loudly if it never comes up
-wait_for_sushy_tools() {
-  local redfish_url="http://${IP_ADDRESS}:${BMO_E2E_LISTEN_PORT}/redfish/v1/"
-  local container attempts=0 max_attempts=30
-
-  # Detect the sushy-tools container name (vbmctl may name it with or without an
-  # "-e2e" suffix depending on version), so the restart is not silently skipped.
-  for name in vbmctl-sushy-tools vbmctl-sushy-tools-e2e; do
-    if docker inspect "${name}" &>/dev/null; then
-      container="${name}"
-      break
-    fi
-  done
-  if [[ -z "${container:-}" ]]; then
-    echo "ERROR: sushy-tools BMC emulator container not found" >&2
-    docker ps -a --format '{{.Names}}' | grep -i sushy >&2 || true
-    return 1
-  fi
-
-  echo "Waiting for sushy-tools (${container}) to serve ${redfish_url}..."
-  while (( attempts < max_attempts )); do
-    if curl -sSf --connect-timeout 3 --max-time 5 "${redfish_url}" > /dev/null; then
-      echo "sushy-tools is reachable."
-      return 0
-    fi
-    # After every 5 attempts, restart to recover from the bind race.
-    attempts=$((attempts + 1))
-    if (( attempts < max_attempts && attempts % 5 == 0 )); then
-      echo "sushy-tools not reachable yet; restarting ${container} to pick up the bridge IP..."
-      docker restart "${container}" || true
-    fi
-    sleep 2
-  done
-
-  echo "ERROR: sushy-tools did not become reachable at ${redfish_url}" >&2
-  docker logs --tail 50 "${container}" >&2 || true
-  return 1
-}
-
 # Need to do some extra setup for the vbmc emulator
 if [[ "${BMO_E2E_EMULATOR}" == "vbmc" ]]; then
   readarray -t BMCS < <(yq e -o=j -I=0 '.[]' "${E2E_BMCS_CONF_FILE}")
@@ -199,8 +154,6 @@ if [[ "${BMO_E2E_EMULATOR}" == "vbmc" ]]; then
     vbmc_port="${address##*:}"
     "${REPO_ROOT}/tools/bmh_test/vm2vbmc.sh" "${hostName}" "${vbmc_port}" "${IP_ADDRESS}"
   done
-elif [[ "${BMO_E2E_EMULATOR}" == "sushy-tools" ]]; then
-  wait_for_sushy_tools
 fi
 
 # Generate ssh key pair for verifying provisioned BMHs

--- a/test/vbmctl/cmd/vbmctl/create.go
+++ b/test/vbmctl/cmd/vbmctl/create.go
@@ -242,6 +242,10 @@ Example configuration:
 				if err != nil {
 					return err
 				}
+				err = containers.WaitForBMCEmulatorReadiness(ctx, cfg.Spec.BMCEmulator)
+				if err != nil {
+					return err
+				}
 			} else {
 				//nolint:forbidigo // CLI output is intentional
 				fmt.Println("No BMC emulator configuration found in the config file.")

--- a/test/vbmctl/cmd/vbmctl/create_test.go
+++ b/test/vbmctl/cmd/vbmctl/create_test.go
@@ -1,0 +1,83 @@
+//go:build vbmctl
+// +build vbmctl
+
+package main
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
+	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/config"
+	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/containers"
+)
+
+func TestBuildBMCEmulatorHealthCheckURL(t *testing.T) {
+	t.Parallel()
+
+	cfg := &vbmctlapi.BMCEmulatorConfig{
+		Type:          config.BMCEmulatorTypeSushyTools,
+		ListenAddress: "127.0.0.1",
+		ListenPort:    8000,
+	}
+
+	got := containers.BuildBMCEmulatorHealthCheckURL(cfg)
+	want := "http://127.0.0.1:8000/redfish/v1/"
+	if got != want {
+		t.Fatalf("BuildBMCEmulatorHealthCheckURL() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildBMCEmulatorHealthCheckURLDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := &vbmctlapi.BMCEmulatorConfig{Type: config.BMCEmulatorTypeSushyTools}
+
+	got := containers.BuildBMCEmulatorHealthCheckURL(cfg)
+	want := "http://" + config.DefaultNetworkAddress + ":" + strconv.Itoa(config.DefaultBMCEmulatorSushyToolsListenPort) + "/redfish/v1/"
+	if got != want {
+		t.Fatalf("BuildBMCEmulatorHealthCheckURL() = %q, want %q", got, want)
+	}
+}
+
+func TestWaitForBMCEmulatorReadinessSucceedsWhenEndpointIsReachable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	host, port, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("SplitHostPort() failed: %v", err)
+	}
+	if host == "" || host == "::" || host == "[::]" {
+		host = "127.0.0.1"
+	}
+
+	cfg := &vbmctlapi.BMCEmulatorConfig{
+		Type:          config.BMCEmulatorTypeSushyTools,
+		ListenAddress: host,
+		ListenPort:    uint16(mustParsePort(t, port)),
+	}
+
+	if err := containers.WaitForBMCEmulatorReadiness(context.Background(), cfg); err != nil {
+		t.Fatalf("WaitForBMCEmulatorReadiness() returned error: %v", err)
+	}
+}
+
+func mustParsePort(t *testing.T, value string) int {
+	t.Helper()
+
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		t.Fatalf("failed to parse port %q: %v", value, err)
+	}
+
+	return parsed
+}

--- a/test/vbmctl/pkg/containers/bmc_emulator.go
+++ b/test/vbmctl/pkg/containers/bmc_emulator.go
@@ -4,10 +4,16 @@
 package containers
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"net"
+	"net/http"
 	"os"
+	"regexp"
 	"strconv"
+	"strings"
+	"time"
 
 	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
 	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/config"
@@ -37,6 +43,100 @@ func envMapToSlice(envMap map[string]string) []string {
 		envSlice = append(envSlice, fmt.Sprintf("%s=%s", key, value))
 	}
 	return envSlice
+}
+
+// parseSushyConfig extracts key=value pairs from a sushy-tools config file.
+// The file is valid Python, so inline comments (#) and string prefixes
+// (u, b, r, f) are handled accordingly.
+func parseSushyConfig(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	lineRe := regexp.MustCompile(`^\s*([A-Z][A-Z_0-9]*)\s*=\s*(.+)$`)
+
+	result := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Skip full-line comments and blank lines.
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		m := lineRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		key := m[1]
+		rawVal := strings.TrimSpace(m[2])
+
+		val, ok := parsePythonValue(rawVal)
+		if !ok {
+			continue
+		}
+		result[key] = val
+	}
+	return result, scanner.Err()
+}
+
+// parsePythonValue extracts a value from the RHS of a Python assignment.
+// It handles:
+//   - Quoted strings with optional prefix (u, b, r, f): u'val', "val", etc.
+//   - Bare values (integers, True/False): strips inline comments.
+func parsePythonValue(raw string) (string, bool) {
+	if raw == "" {
+		return "", false
+	}
+
+	// Check for a quoted string (with optional u/b/r/f prefix).
+	s := raw
+	if len(s) > 1 && strings.ContainsRune("ubfrUBFR", rune(s[0])) && (s[1] == '\'' || s[1] == '"') {
+		s = s[1:] // skip prefix
+	}
+
+	if s != "" && (s[0] == '\'' || s[0] == '"') {
+		quote := s[0]
+		// Find the matching closing quote.
+		end := strings.IndexByte(s[1:], quote)
+		if end < 0 {
+			return "", false // unterminated string
+		}
+		return s[1 : end+1], true
+	}
+
+	// Bare value (number, bool, etc.) — strip inline comment.
+	if idx := strings.IndexByte(raw, '#'); idx >= 0 {
+		raw = strings.TrimSpace(raw[:idx])
+	}
+	if raw == "" {
+		return "", false
+	}
+	return raw, true
+}
+
+func parseSushyEmulatorConfigFile(configPath string) (string, uint16, error) {
+	cfg, err := parseSushyConfig(configPath)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to parse sushy-tools config file %q: %w", configPath, err)
+	}
+
+	listenAddress := cfg["SUSHY_EMULATOR_LISTEN_IP"]
+	portStr := cfg["SUSHY_EMULATOR_LISTEN_PORT"]
+
+	var listenPort uint16
+	if portStr != "" {
+		port, err := strconv.ParseUint(portStr, 10, 16)
+		if err != nil {
+			return "", 0, fmt.Errorf("invalid SUSHY_EMULATOR_LISTEN_PORT value %q: %w", portStr, err)
+		}
+		listenPort = uint16(port)
+	}
+
+	return listenAddress, listenPort, nil
 }
 
 func createEmulatorInstance(ctx context.Context, cfg *vbmctlapi.BMCEmulatorConfig) error {
@@ -171,4 +271,119 @@ func GetBMCEmulatorInfo(ctx context.Context, emulatorType string) (info string, 
 	default:
 		return "", fmt.Errorf("unsupported BMC emulator type: %s", emulatorType)
 	}
+}
+
+func WaitForBMCEmulatorReadiness(ctx context.Context, cfg *vbmctlapi.BMCEmulatorConfig) error {
+	// default retry policy (keeps backward compatibility)
+	const (
+		defaultMaxAttempts    = 5
+		defaultRequestTimeout = 3 * time.Second
+		defaultRetryDelay     = 2 * time.Second
+	)
+
+	return WaitForBMCEmulatorReadinessWithPolicy(ctx, cfg, defaultMaxAttempts, defaultRequestTimeout, defaultRetryDelay)
+}
+
+// WaitForBMCEmulatorReadinessWithPolicy waits for the emulator using an injectable
+// retry policy. Tests should call this with small values to exercise retry
+// exhaustion and cancellation without long sleeps.
+func WaitForBMCEmulatorReadinessWithPolicy(ctx context.Context, cfg *vbmctlapi.BMCEmulatorConfig, maxAttempts int, requestTimeout, retryDelay time.Duration) error {
+	const successStatusLimit = 400
+
+	if cfg == nil || cfg.Type != config.BMCEmulatorTypeSushyTools {
+		return nil
+	}
+
+	endpoint := BuildBMCEmulatorHealthCheckURL(cfg)
+	//nolint:forbidigo // CLI output is intentional
+	fmt.Printf("Waiting for BMC emulator to become reachable at %s ... ", endpoint)
+
+	httpClient := &http.Client{Timeout: requestTimeout}
+	for attempt := range maxAttempts {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)
+		if err != nil {
+			return err
+		}
+
+		//nolint:gosec // endpoint is from config under test
+		resp, err := httpClient.Do(req)
+		// If the context was cancelled/expired during the request, propagate
+		// that error immediately so callers see the real cause (including on
+		// the final attempt).
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		if err == nil {
+			if resp.StatusCode < successStatusLimit {
+				_ = resp.Body.Close()
+				//nolint:forbidigo // CLI output is intentional
+				fmt.Println("BMC emulator is reachable.")
+				return nil
+			}
+			_ = resp.Body.Close()
+		}
+
+		if attempt == maxAttempts-1 {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(retryDelay):
+		}
+	}
+
+	info, infoErr := GetBMCEmulatorInfo(ctx, cfg.Type)
+	if infoErr != nil {
+		//nolint:forbidigo // CLI output is intentional
+		fmt.Printf("Failed to get BMC emulator status: %v\n", infoErr)
+	} else {
+		//nolint:forbidigo // CLI output is intentional
+		fmt.Printf("BMC emulator status: %s\n", info)
+	}
+
+	return fmt.Errorf("BMC emulator did not become reachable at %s", endpoint)
+}
+
+func BuildBMCEmulatorHealthCheckURL(cfg *vbmctlapi.BMCEmulatorConfig) string {
+	if cfg == nil {
+		return ""
+	}
+
+	// Set default listen address and port to match those in the VBMCTL
+	// configuration file because they overwrite other settings.
+	listenAddress := cfg.ListenAddress
+	listenPort := cfg.ListenPort
+
+	// If the values are still empty, check next the sushy-tools configuration
+	// file if it is specified. If it does, we will attempt to read the listen
+	// address and port from it.
+	if cfg.ConfigFile != "" && (listenAddress == "" || listenPort == 0) {
+		parsedAddress, parsedPort, err := parseSushyEmulatorConfigFile(cfg.ConfigFile)
+		if err == nil {
+			if listenAddress == "" {
+				if parsedAddress != "" {
+					listenAddress = parsedAddress
+				} else {
+					// If no listen address is specified in the config file,
+					// sushy-tools defaults to "127.0.0.1".
+					listenAddress = "127.0.0.1"
+				}
+			}
+			if listenPort == 0 {
+				listenPort = parsedPort
+			}
+		}
+	}
+
+	// Finally, fallback to the default values if they are still empty.
+	if listenAddress == "" {
+		listenAddress = config.DefaultNetworkAddress
+	}
+	if listenPort == 0 {
+		listenPort = config.DefaultBMCEmulatorSushyToolsListenPort
+	}
+
+	return "http://" + net.JoinHostPort(listenAddress, strconv.Itoa(int(listenPort))) + "/redfish/v1/"
 }

--- a/test/vbmctl/pkg/containers/bmc_emulator_test.go
+++ b/test/vbmctl/pkg/containers/bmc_emulator_test.go
@@ -1,0 +1,172 @@
+//go:build vbmctl
+// +build vbmctl
+
+package containers
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
+	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/config"
+)
+
+func TestParseSushyEmulatorConfigFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "sushy.conf")
+
+	content := `# Listen on the local IP address 192.168.222.1
+SUSHY_EMULATOR_LISTEN_IP = u'127.0.0.1'
+
+# Bind to TCP port 8000
+SUSHY_EMULATOR_LISTEN_PORT = 9000 # This is a comment
+
+# The libvirt URI to use. This option enables libvirt driver.
+SUSHY_EMULATOR_LIBVIRT_URI = u'qemu:///system'
+SUSHY_EMULATOR_STORAGE_POOL = 'baremetal-e2e'
+`
+
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	address, port, err := parseSushyEmulatorConfigFile(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error parsing config file: %v", err)
+	}
+
+	if address != "127.0.0.1" {
+		t.Fatalf("expected address %q, got %q", "127.0.0.1", address)
+	}
+
+	if port != 9000 {
+		t.Fatalf("expected port %d, got %d", 9000, port)
+	}
+}
+
+func TestParseSushyEmulatorConfigFileWithQuotes(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "sushy.conf")
+
+	content := `SUSHY_EMULATOR_LISTEN_IP = "192.168.222.2"
+SUSHY_EMULATOR_LISTEN_PORT = '8001' # This is a comment
+`
+
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	address, port, err := parseSushyEmulatorConfigFile(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error parsing config file: %v", err)
+	}
+
+	if address != "192.168.222.2" {
+		t.Fatalf("expected address %q, got %q", "192.168.222.2", address)
+	}
+
+	if port != 8001 {
+		t.Fatalf("expected port %d, got %d", 8001, port)
+	}
+}
+
+func TestParseSushyEmulatorConfigFileMissingValues(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "sushy.conf")
+
+	content := `# Listen address missing
+# SUSHY_EMULATOR_LISTEN_IP = u'127.0.0.1'
+
+# Listen port missing
+# SUSHY_EMULATOR_LISTEN_PORT = 9000
+`
+
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	address, port, err := parseSushyEmulatorConfigFile(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error parsing config file: %v", err)
+	}
+
+	if address != "" {
+		t.Fatalf("expected empty address, got %q", address)
+	}
+
+	if port != 0 {
+		t.Fatalf("expected port 0, got %d", port)
+	}
+}
+
+func TestWaitForBMCEmulatorReadiness_Exhaustion(t *testing.T) {
+	// Start a controlled HTTP server on an OS-assigned port. The handler will
+	// return a 503 Service Unavailable status.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen on loopback: %v", err)
+	}
+	defer ln.Close()
+
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})}
+	go srv.Serve(ln)
+	defer srv.Close()
+
+	//nolint:forcetypeassert
+	addr := ln.Addr().(*net.TCPAddr)
+	cfg := &vbmctlapi.BMCEmulatorConfig{
+		Type:          config.BMCEmulatorTypeSushyTools,
+		ListenAddress: "127.0.0.1",
+		ListenPort:    uint16(addr.Port),
+	}
+
+	// Use a very small retry policy to make the test fast.
+	err = WaitForBMCEmulatorReadinessWithPolicy(context.Background(), cfg, 3, 50*time.Millisecond, 20*time.Millisecond)
+	if err == nil {
+		t.Fatalf("expected error when emulator is unreachable, got nil")
+	}
+}
+
+func TestWaitForBMCEmulatorReadiness_Cancellation(t *testing.T) {
+	// Start a controlled HTTP server on an OS-assigned port. The handler will
+	// block until the request context is done so that client-side cancellation
+	// during the request is deterministic.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen on loopback: %v", err)
+	}
+	defer ln.Close()
+
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	})}
+	go srv.Serve(ln)
+	defer srv.Close()
+
+	//nolint:forcetypeassert
+	addr := ln.Addr().(*net.TCPAddr)
+	cfg := &vbmctlapi.BMCEmulatorConfig{
+		Type:          config.BMCEmulatorTypeSushyTools,
+		ListenAddress: "127.0.0.1",
+		ListenPort:    uint16(addr.Port),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 75*time.Millisecond)
+	defer cancel()
+
+	err = WaitForBMCEmulatorReadinessWithPolicy(ctx, cfg, 10, 500*time.Millisecond, 20*time.Millisecond)
+	if err == nil {
+		t.Fatalf("expected error due to context cancellation or timeout, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation error, got: %v", err)
+	}
+}


### PR DESCRIPTION
Validate that the BMC emulator instance is running by attempting to reach it over HTTP when the `create bml` command runs. This check occurs before the VMs are created and fails the command if the instance cannot be reached within a predefined timeout. The implementation attempts up to 5 times, with each attempt using a 3-second timeout. Because the network components are now created before launching the instance, there is no
need to  restart the instance between attempts.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

This feature will make it possible to remove the external readiness check implemented in `wait_for_sushy_tools()`.

