### PR TITLE
:seedling: vbmctl: Refactor BMC emulator config handling

### DIFF
--- a/test/vbmctl/README.md
+++ b/test/vbmctl/README.md
@@ -225,7 +225,7 @@ func main() {
     }
 
     // Create a network
-    network, err := networkManager.CreateNetwork(ctx, vbmctlapi.NetworkConfig{
+    network, err := networkManager.CreateNetwork(ctx, api.NetworkConfig{
         Name:    "baremetal-e2e",
         Bridge:  "metal3",
         Address: "192.168.222.1",
@@ -277,11 +277,15 @@ func main() {
     }
 
     // Create a BMC emulator
-    err = containers.CreateBMCEmulatorInstance(ctx, &api.BMCEmulatorConfig{
-        Image:         "my-bmc-emulator:latest",
-        Type:          "sushy-tools",
+    emulatorConfig := &api.BMCEmulatorConfig{
+        Type:  "sushy-tools",
+        Image: "my-bmc-emulator:latest",
+    }
+    emulatorConfig.SushyToolsConfig = api.SushyToolsConfig{
         ConfigFile:    "/path/to/config/file",
-    })
+    }
+
+    err = containers.CreateBMCEmulatorInstance(ctx, emulatorConfig)
     if err != nil {
         log.Fatal(err)
     }

--- a/test/vbmctl/cmd/vbmctl/config.go
+++ b/test/vbmctl/cmd/vbmctl/config.go
@@ -6,7 +6,9 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 
+	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
 	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/config"
 	"github.com/spf13/cobra"
 )
@@ -89,13 +91,28 @@ func newConfigViewCmd() *cobra.Command {
 			}
 
 			if cfg.Spec.BMCEmulator != nil {
+				var sushyConfig *vbmctlapi.SushyToolsConfig
+
+				if cfg.Spec.BMCEmulator.Type == vbmctlapi.BMCEmulatorTypeSushyTools {
+					sushyConfig = &cfg.Spec.BMCEmulator.SushyToolsConfig
+				}
 				//nolint:forbidigo // CLI output is intentional
-				fmt.Printf("BMC Emulator:\n  Emulator Type: %s\n  Config File: %s\n  Image: %s\n  Listen Address: %s\n  Listen Port: %d\n",
+				fmt.Printf("BMC Emulator:\n  Emulator Type: %s\n  Image: %s\n",
 					cfg.Spec.BMCEmulator.Type,
-					cfg.Spec.BMCEmulator.ConfigFile,
-					cfg.Spec.BMCEmulator.Image,
-					cfg.Spec.BMCEmulator.ListenAddress,
-					cfg.Spec.BMCEmulator.ListenPort)
+					cfg.Spec.BMCEmulator.Image)
+
+				if sushyConfig != nil {
+					//nolint:forbidigo // CLI output is intentional
+					fmt.Printf("  Config File: %s\n  Listening: %s%s\n",
+						sushyConfig.ConfigFile,
+						sushyConfig.ListenAddress,
+						func() string {
+							if sushyConfig.ListenPort == 0 {
+								return ""
+							}
+							return ":" + strconv.FormatUint(uint64(sushyConfig.ListenPort), 10)
+						}())
+				}
 			}
 
 			return nil

--- a/test/vbmctl/cmd/vbmctl/create.go
+++ b/test/vbmctl/cmd/vbmctl/create.go
@@ -453,19 +453,20 @@ func newCreateBMCEmulatorCmd() *cobra.Command {
 			if image == "" {
 				if effective.Image != "" {
 					image = effective.Image
-				} else if emulatorType == config.BMCEmulatorTypeSushyTools {
+				} else if emulatorType == vbmctlapi.BMCEmulatorTypeSushyTools {
 					image = config.DefaultBMCEmulatorSushyToolsImage
 				} else {
 					image = config.DefaultBMCEmulatorVBMCImage
 				}
 			}
 
-			if emulatorType == config.BMCEmulatorTypeSushyTools {
+			if emulatorType == vbmctlapi.BMCEmulatorTypeSushyTools {
+				sushyConfig := &effective.SushyToolsConfig
 				if configFile == "" {
 					// There is no default config file for sushy-tools, so no
 					// need to check if the value from config file is empty
 					// before using it.
-					configFile = effective.ConfigFile
+					configFile = sushyConfig.ConfigFile
 				}
 
 				// If using command line arguments to configure sushy-tools, apply the
@@ -473,15 +474,15 @@ func newCreateBMCEmulatorCmd() *cobra.Command {
 				// explicitly set. In case a sushy-tools config file is specified,
 				// defaults are not applied.
 				if listenAddress == "" {
-					if effective.ListenAddress != "" {
-						listenAddress = effective.ListenAddress
+					if sushyConfig.ListenAddress != "" {
+						listenAddress = sushyConfig.ListenAddress
 					} else if configFile == "" {
 						listenAddress = config.DefaultNetworkAddress
 					}
 				}
 				if listenPort == 0 {
-					if effective.ListenPort != 0 {
-						listenPort = effective.ListenPort
+					if sushyConfig.ListenPort != 0 {
+						listenPort = sushyConfig.ListenPort
 					} else if configFile == "" {
 						listenPort = config.DefaultBMCEmulatorSushyToolsListenPort
 					}
@@ -491,27 +492,31 @@ func newCreateBMCEmulatorCmd() *cobra.Command {
 				fmt.Printf("Using storage pool '%s' and libvirt URI '%s' for sushy-tools BMC emulator\n", cfg.Spec.Pool.Name, cfg.Spec.Libvirt.URI)
 			}
 
-			// Note that storage pool and libvirt URI are only relevant for sushy-tools,
-			// but we set them for vbmc as well since they don't cause any issues and
-			// it simplifies the logic by not having to conditionally set them based
-			// on the emulator type.
-			return containers.CreateBMCEmulatorInstance(ctx, &vbmctlapi.BMCEmulatorConfig{
-				Type:          emulatorType,
-				Image:         image,
-				ConfigFile:    configFile,
-				StoragePool:   cfg.Spec.Pool.Name,
-				ListenAddress: listenAddress,
-				ListenPort:    listenPort,
-				LibvirtURI:    cfg.Spec.Libvirt.URI,
-			})
+			emulatorConfig := &vbmctlapi.BMCEmulatorConfig{
+				Type:  emulatorType,
+				Image: image,
+			}
+			switch emulatorType {
+			case vbmctlapi.BMCEmulatorTypeSushyTools:
+				emulatorConfig.SushyToolsConfig = vbmctlapi.SushyToolsConfig{
+					ConfigFile:    configFile,
+					StoragePool:   cfg.Spec.Pool.Name,
+					ListenAddress: listenAddress,
+					ListenPort:    listenPort,
+					LibvirtURI:    cfg.Spec.Libvirt.URI,
+				}
+			case vbmctlapi.BMCEmulatorTypeVBMC:
+				emulatorConfig.VBMCConfig = vbmctlapi.VBMCConfig{}
+			}
+			return containers.CreateBMCEmulatorInstance(ctx, emulatorConfig)
 		},
 	}
 
-	cmd.Flags().StringVar(&emulatorType, "emulator-type", "", "type of the BMC emulator (vbmc or sushy-tools, default is "+config.DefaultBMCEmulatorType+" if not set in config file)")
-	cmd.Flags().StringVar(&image, "image", "", "container image to use for the BMC emulator (default is "+config.DefaultBMCEmulatorVBMCImage+" or "+config.DefaultBMCEmulatorSushyToolsImage+" if not set in config file)")
+	cmd.Flags().StringVar(&emulatorType, "emulator-type", "", "type of the BMC emulator (vbmc or sushy-tools, default is "+config.DefaultBMCEmulatorType+" if not set in the VBMCTL config file)")
+	cmd.Flags().StringVar(&image, "image", "", "container image to use for the BMC emulator (default is "+config.DefaultBMCEmulatorVBMCImage+" or "+config.DefaultBMCEmulatorSushyToolsImage+" if not set in the VBMCTL config file)")
 	cmd.Flags().StringVar(&configFile, "config-file", "", "configuration file to use for the BMC emulator in case of sushy-tools (default is none)")
-	cmd.Flags().StringVar(&listenAddress, "listen-address", "", "address for the BMC emulator to listen on for incoming connections (only applicable for sushy-tools, default is "+config.DefaultNetworkAddress+" if not set in config file and no config file is used)")
-	cmd.Flags().Uint16Var(&listenPort, "listen-port", 0, "port for the BMC emulator to listen on for incoming connections (only applicable for sushy-tools, default is "+strconv.Itoa(int(config.DefaultBMCEmulatorSushyToolsListenPort))+" if not set in config file and no config file is used)")
+	cmd.Flags().StringVar(&listenAddress, "listen-address", "", "address for the BMC emulator to listen on for incoming connections (only applicable for sushy-tools, default is "+config.DefaultNetworkAddress+" if not set in the VBMCTL config file and no sushy-tools config file is specified)")
+	cmd.Flags().Uint16Var(&listenPort, "listen-port", 0, "port for the BMC emulator to listen on for incoming connections (only applicable for sushy-tools, default is "+strconv.Itoa(int(config.DefaultBMCEmulatorSushyToolsListenPort))+" if not set in the VBMCTL config file and no sushy-tools config file is specified)")
 
 	return cmd
 }

--- a/test/vbmctl/pkg/api/types.go
+++ b/test/vbmctl/pkg/api/types.go
@@ -2,7 +2,9 @@
 // bare metal environments.
 package vbmctlapi
 
-import "k8s.io/utils/ptr"
+import (
+	"k8s.io/utils/ptr"
+)
 
 // VMConfig represents the configuration for a virtual machine.
 type VMConfig struct {
@@ -64,27 +66,14 @@ type VolumeMount struct {
 
 // BMCEmulatorConfig represents the configuration for the BMC emulator.
 type BMCEmulatorConfig struct {
-	// BMC Emulator type
+	// BMC Emulator type.
 	Type string `json:"type" yaml:"type"`
 
-	// ConfigFile is the path to the sushy-tools config file and is only
-	// applicable when Type is "sushy-tools".
-	ConfigFile string `json:"configFile" yaml:"configFile"`
+	// SushyToolsConfig. Required when Type is sushy-tools.
+	SushyToolsConfig SushyToolsConfig `json:"sushyToolsConfig" yaml:"sushyToolsConfig"`
 
-	// ListenAddress is the address that the BMC emulator listens on to
-	// use for sushy-tools when not using a config file.
-	ListenAddress string `json:"listenAddress" yaml:"listenAddress"`
-
-	// ListenPort is the port that the BMC emulator listens on to
-	// use for sushy-tools when not using a config file.
-	ListenPort uint16 `json:"listenPort" yaml:"listenPort"`
-
-	// StoragePool is the name of the libvirt storage pool to use for
-	// sushy-tools.
-	StoragePool string `json:"storagePool" yaml:"storagePool"`
-
-	// LibvirtURI is the libvirt URI that sushy-tools should connect to.
-	LibvirtURI string `json:"libvirtURI" yaml:"libvirtUri"`
+	// VBMCConfig. Required when Type is vbmc.
+	VBMCConfig VBMCConfig `json:"vbmcConfig" yaml:"vbmcConfig"`
 
 	// Image is the container image to use for the BMC emulator.
 	Image string `json:"image" yaml:"image"`
@@ -101,6 +90,36 @@ type BMCEmulatorConfig struct {
 	// VolumeMounts is an internal runtime list of host-to-container volume bindings.
 	VolumeMounts []VolumeMount `json:"-" yaml:"-"`
 }
+
+// BMC emulator types.
+const (
+	// BMC emulator type: vbmc.
+	BMCEmulatorTypeVBMC = "vbmc"
+
+	// BMC emulator type: sushy-tools.
+	BMCEmulatorTypeSushyTools = "sushy-tools"
+)
+
+// SushyToolsConfig contains settings specific to the sushy-tools emulator.
+type SushyToolsConfig struct {
+	// ConfigFile is the path to the sushy-tools config file.
+	ConfigFile string `json:"configFile,omitempty" yaml:"configFile,omitempty"`
+
+	// ListenAddress is the address that the emulator listens on when not using a config file.
+	ListenAddress string `json:"listenAddress,omitempty" yaml:"listenAddress,omitempty"`
+
+	// ListenPort is the port that the emulator listens on when not using a config file.
+	ListenPort uint16 `json:"listenPort,omitempty" yaml:"listenPort,omitempty"`
+
+	// StoragePool is the name of the libvirt storage pool to use.
+	StoragePool string `json:"storagePool,omitempty" yaml:"storagePool,omitempty"`
+
+	// LibvirtURI is the libvirt URI that sushy-tools should connect to.
+	LibvirtURI string `json:"libvirtURI,omitempty" yaml:"libvirtUri,omitempty"`
+}
+
+// VBMCConfig contains settings specific to the vbmc emulator.
+type VBMCConfig struct{}
 
 // NetworkAttachment represents a network interface attached to a VM.
 type NetworkAttachment struct {
@@ -280,4 +299,66 @@ func (c DockerBridgeNetwork) Defaults() DockerBridgeNetwork {
 		cfg.IPv6 = ptr.To(false)
 	}
 	return cfg
+}
+
+// UnmarshalYAML populates the emulator-specific config fields from the legacy flat YAML shape.
+func (c *BMCEmulatorConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type rawBMCEmulatorConfig struct {
+		Type          string `yaml:"type"`
+		Image         string `yaml:"image"`
+		ConfigFile    string `yaml:"configFile"`
+		ListenAddress string `yaml:"listenAddress"`
+		ListenPort    uint16 `yaml:"listenPort"`
+		StoragePool   string `yaml:"storagePool"`
+		LibvirtURI    string `yaml:"libvirtUri"`
+	}
+
+	var raw rawBMCEmulatorConfig
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+
+	c.Type = raw.Type
+	c.Image = raw.Image
+
+	switch c.Type {
+	case BMCEmulatorTypeSushyTools:
+		c.SushyToolsConfig = SushyToolsConfig{
+			ConfigFile:    raw.ConfigFile,
+			ListenAddress: raw.ListenAddress,
+			ListenPort:    raw.ListenPort,
+			StoragePool:   raw.StoragePool,
+			LibvirtURI:    raw.LibvirtURI,
+		}
+	case BMCEmulatorTypeVBMC:
+		c.VBMCConfig = VBMCConfig{}
+	}
+
+	return nil
+}
+
+// MarshalYAML flattens the emulator-specific config back into the legacy flat YAML shape.
+func (c BMCEmulatorConfig) MarshalYAML() (interface{}, error) {
+	type marshaledBMCEmulatorConfig struct {
+		Type          string `yaml:"type"`
+		Image         string `yaml:"image"`
+		ConfigFile    string `yaml:"configFile,omitempty"`
+		ListenAddress string `yaml:"listenAddress,omitempty"`
+		ListenPort    uint16 `yaml:"listenPort,omitempty"`
+		StoragePool   string `yaml:"storagePool,omitempty"`
+		LibvirtURI    string `yaml:"libvirtUri,omitempty"`
+	}
+
+	var marshaled marshaledBMCEmulatorConfig
+	marshaled.Type = c.Type
+	marshaled.Image = c.Image
+	if c.Type == BMCEmulatorTypeSushyTools {
+		marshaled.ConfigFile = c.SushyToolsConfig.ConfigFile
+		marshaled.ListenAddress = c.SushyToolsConfig.ListenAddress
+		marshaled.ListenPort = c.SushyToolsConfig.ListenPort
+		marshaled.StoragePool = c.SushyToolsConfig.StoragePool
+		marshaled.LibvirtURI = c.SushyToolsConfig.LibvirtURI
+	}
+
+	return marshaled, nil
 }

--- a/test/vbmctl/pkg/api/types_test.go
+++ b/test/vbmctl/pkg/api/types_test.go
@@ -1,7 +1,10 @@
 package vbmctlapi
 
 import (
+	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v2"
 )
 
 func TestVMConfigDefaults(t *testing.T) {
@@ -48,6 +51,42 @@ func TestVMConfigDefaults(t *testing.T) {
 				t.Errorf("VCPUs: got %d, want %d", result.VCPUs, tt.expected.VCPUs)
 			}
 		})
+	}
+}
+
+func TestBMCEmulatorConfigMarshalYAMLUsesLegacyFlatShapeForValues(t *testing.T) {
+	cfg := BMCEmulatorConfig{
+		Type: BMCEmulatorTypeSushyTools,
+		SushyToolsConfig: SushyToolsConfig{
+			ConfigFile:    "/etc/sushy-tools.conf",
+			ListenAddress: "192.0.2.10",
+			ListenPort:    8001,
+			StoragePool:   "pool-1",
+			LibvirtURI:    "qemu:///system",
+		},
+	}
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("yaml.Marshal returned error: %v", err)
+	}
+
+	output := string(data)
+	for _, expected := range []string{
+		"type: sushy-tools",
+		"configFile: /etc/sushy-tools.conf",
+		"listenAddress: 192.0.2.10",
+		"listenPort: 8001",
+		"storagePool: pool-1",
+		"libvirtUri: qemu:///system",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("expected marshaled YAML to contain %q, got:\n%s", expected, output)
+		}
+	}
+
+	if strings.Contains(output, "sushyToolsConfig:") {
+		t.Fatalf("expected legacy flat YAML shape, got:\n%s", output)
 	}
 }
 

--- a/test/vbmctl/pkg/config/config.go
+++ b/test/vbmctl/pkg/config/config.go
@@ -76,7 +76,7 @@ const (
 	DefaultImageServerContainerName = "vbmctl-image-server"
 
 	// DefaultBMCEmulatorType is the default BMC emulator type.
-	DefaultBMCEmulatorType = BMCEmulatorTypeVBMC
+	DefaultBMCEmulatorType = vbmctlapi.BMCEmulatorTypeVBMC
 
 	// DefaultBMCEmulatorVBMCImage is the default container image for the VBMC BMC emulator.
 	DefaultBMCEmulatorVBMCImage = "quay.io/metal3-io/vbmc"
@@ -86,15 +86,6 @@ const (
 
 	// DefaultBMCEmulatorSushyToolsListenPort is the default listen port for the sushy-tools BMC emulator.
 	DefaultBMCEmulatorSushyToolsListenPort = 8000
-)
-
-// BMC emulator types.
-const (
-	// BMC emulator type: vbmc.
-	BMCEmulatorTypeVBMC = "vbmc"
-
-	// BMC emulator type: sushy-tools.
-	BMCEmulatorTypeSushyTools = "sushy-tools"
 )
 
 // Config is the top-level configuration for vbmctl.
@@ -291,17 +282,18 @@ func (c *Config) Validate() error {
 		if c.Spec.BMCEmulator.Type == "" {
 			return errors.New("BMC emulator type is required")
 		}
-		if c.Spec.BMCEmulator.Type != BMCEmulatorTypeVBMC && c.Spec.BMCEmulator.Type != BMCEmulatorTypeSushyTools {
+		if c.Spec.BMCEmulator.Type != vbmctlapi.BMCEmulatorTypeVBMC && c.Spec.BMCEmulator.Type != vbmctlapi.BMCEmulatorTypeSushyTools {
 			return fmt.Errorf("unsupported BMC emulator type: %s", c.Spec.BMCEmulator.Type)
 		}
 		if c.Spec.BMCEmulator.Image == "" {
 			return errors.New("BMC emulator container image is required")
 		}
-		if c.Spec.BMCEmulator.Type == BMCEmulatorTypeSushyTools {
-			if c.Spec.BMCEmulator.ListenAddress == "" && c.Spec.BMCEmulator.ConfigFile == "" {
+		if c.Spec.BMCEmulator.Type == vbmctlapi.BMCEmulatorTypeSushyTools {
+			sushy := &c.Spec.BMCEmulator.SushyToolsConfig
+			if sushy.ListenAddress == "" && sushy.ConfigFile == "" {
 				return errors.New("either listen address or config file must be specified for sushy-tools BMC emulator")
 			}
-			if c.Spec.BMCEmulator.ListenPort == 0 && c.Spec.BMCEmulator.ConfigFile == "" {
+			if sushy.ListenPort == 0 && sushy.ConfigFile == "" {
 				return errors.New("either listen port or config file must be specified for sushy-tools BMC emulator")
 			}
 		}
@@ -418,25 +410,28 @@ func (c *Config) ApplyDefaults() {
 		}
 		if c.Spec.BMCEmulator.Image == "" {
 			switch c.Spec.BMCEmulator.Type {
-			case BMCEmulatorTypeVBMC:
+			case vbmctlapi.BMCEmulatorTypeVBMC:
 				c.Spec.BMCEmulator.Image = DefaultBMCEmulatorVBMCImage
-			case BMCEmulatorTypeSushyTools:
+			case vbmctlapi.BMCEmulatorTypeSushyTools:
 				c.Spec.BMCEmulator.Image = DefaultBMCEmulatorSushyToolsImage
 			default:
 				// If the type is unrecognized, we won't set a default image
 			}
 		}
-		if c.Spec.BMCEmulator.Type == BMCEmulatorTypeSushyTools {
-			if c.Spec.BMCEmulator.ListenPort == 0 && c.Spec.BMCEmulator.ConfigFile == "" {
-				c.Spec.BMCEmulator.ListenPort = DefaultBMCEmulatorSushyToolsListenPort
+		if c.Spec.BMCEmulator.Type == vbmctlapi.BMCEmulatorTypeSushyTools {
+			sushy := &c.Spec.BMCEmulator.SushyToolsConfig
+			if sushy.ListenPort == 0 && sushy.ConfigFile == "" {
+				sushy.ListenPort = DefaultBMCEmulatorSushyToolsListenPort
 			}
-			if c.Spec.BMCEmulator.ListenAddress == "" && c.Spec.BMCEmulator.ConfigFile == "" {
-				c.Spec.BMCEmulator.ListenAddress = DefaultNetworkAddress
+			if sushy.ListenAddress == "" && sushy.ConfigFile == "" {
+				sushy.ListenAddress = DefaultNetworkAddress
 			}
+			sushy.StoragePool = c.Spec.Pool.Name
+			sushy.LibvirtURI = c.Spec.Libvirt.URI
 		}
-		// Set storage pool and libvirt URI for BMC emulator to match the main config
-		c.Spec.BMCEmulator.StoragePool = c.Spec.Pool.Name
-		c.Spec.BMCEmulator.LibvirtURI = c.Spec.Libvirt.URI
+		if c.Spec.BMCEmulator.Type == vbmctlapi.BMCEmulatorTypeVBMC {
+			c.Spec.BMCEmulator.VBMCConfig = vbmctlapi.VBMCConfig{}
+		}
 	}
 
 	if len(c.Spec.Networks) > 0 {

--- a/test/vbmctl/pkg/config/config_test.go
+++ b/test/vbmctl/pkg/config/config_test.go
@@ -135,20 +135,20 @@ spec:
 		t.Errorf("expected BMC emulator type 'sushy-tools', got %s", cfg.Spec.BMCEmulator.Type)
 	}
 
-	if cfg.Spec.BMCEmulator.ConfigFile != "vbmc-emulator-file" {
-		t.Errorf("expected BMC emulator config file 'vbmc-emulator-file', got %s", cfg.Spec.BMCEmulator.ConfigFile)
+	if cfg.Spec.BMCEmulator.SushyToolsConfig.ConfigFile != "vbmc-emulator-file" {
+		t.Errorf("expected BMC emulator config file 'vbmc-emulator-file', got %s", cfg.Spec.BMCEmulator.SushyToolsConfig.ConfigFile)
 	}
 
 	if cfg.Spec.BMCEmulator.Image != "test/bmc-emulator:latest" {
 		t.Errorf("expected BMC emulator image 'test/bmc-emulator:latest', got %s", cfg.Spec.BMCEmulator.Image)
 	}
 
-	if cfg.Spec.BMCEmulator.ListenAddress != "1.2.3.4" {
-		t.Errorf("expected BMC emulator listen address '1.2.3.4', got %s", cfg.Spec.BMCEmulator.ListenAddress)
+	if cfg.Spec.BMCEmulator.SushyToolsConfig.ListenAddress != "1.2.3.4" {
+		t.Errorf("expected BMC emulator listen address '1.2.3.4', got %s", cfg.Spec.BMCEmulator.SushyToolsConfig.ListenAddress)
 	}
 
-	if cfg.Spec.BMCEmulator.ListenPort != 1234 {
-		t.Errorf("expected BMC emulator listen port 1234, got %d", cfg.Spec.BMCEmulator.ListenPort)
+	if cfg.Spec.BMCEmulator.SushyToolsConfig.ListenPort != 1234 {
+		t.Errorf("expected BMC emulator listen port 1234, got %d", cfg.Spec.BMCEmulator.SushyToolsConfig.ListenPort)
 	}
 
 	// Libvirt network tests
@@ -237,11 +237,13 @@ func TestLoadAndSave(t *testing.T) {
 		ContainerName:    "vbmctl-image-server",
 	}
 	cfg.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
-		Type:          BMCEmulatorTypeSushyTools,
-		ConfigFile:    "vbmc-emulator-file",
-		Image:         "test/bmc-emulator:latest",
-		ListenAddress: "1.2.3.4",
-		ListenPort:    1234,
+		Type:  vbmctlapi.BMCEmulatorTypeSushyTools,
+		Image: "test/bmc-emulator:latest",
+		SushyToolsConfig: vbmctlapi.SushyToolsConfig{
+			ConfigFile:    "vbmc-emulator-file",
+			ListenAddress: "1.2.3.4",
+			ListenPort:    1234,
+		},
 	}
 	cfg.Spec.DockerNetworks = []vbmctlapi.DockerBridgeNetwork{{
 		Name:       "kind",
@@ -307,24 +309,24 @@ func TestLoadAndSave(t *testing.T) {
 		t.Fatal("expected BMC emulator config, got nil")
 	}
 
-	if loadedCfg.Spec.BMCEmulator.Type != BMCEmulatorTypeSushyTools {
-		t.Errorf("expected BMC emulator type '%s', got %s", BMCEmulatorTypeSushyTools, loadedCfg.Spec.BMCEmulator.Type)
+	if loadedCfg.Spec.BMCEmulator.Type != vbmctlapi.BMCEmulatorTypeSushyTools {
+		t.Errorf("expected BMC emulator type '%s', got %s", vbmctlapi.BMCEmulatorTypeSushyTools, loadedCfg.Spec.BMCEmulator.Type)
 	}
 
-	if loadedCfg.Spec.BMCEmulator.ConfigFile != "vbmc-emulator-file" {
-		t.Errorf("expected BMC emulator config file 'vbmc-emulator-file', got %s", loadedCfg.Spec.BMCEmulator.ConfigFile)
+	if loadedCfg.Spec.BMCEmulator.SushyToolsConfig.ConfigFile != "vbmc-emulator-file" {
+		t.Errorf("expected BMC emulator config file 'vbmc-emulator-file', got %s", loadedCfg.Spec.BMCEmulator.SushyToolsConfig.ConfigFile)
 	}
 
 	if loadedCfg.Spec.BMCEmulator.Image != "test/bmc-emulator:latest" {
 		t.Errorf("expected BMC emulator image 'test/bmc-emulator:latest', got %s", loadedCfg.Spec.BMCEmulator.Image)
 	}
 
-	if loadedCfg.Spec.BMCEmulator.ListenAddress != "1.2.3.4" {
-		t.Errorf("expected BMC emulator listen address '1.2.3.4', got %s", loadedCfg.Spec.BMCEmulator.ListenAddress)
+	if loadedCfg.Spec.BMCEmulator.SushyToolsConfig.ListenAddress != "1.2.3.4" {
+		t.Errorf("expected BMC emulator listen address '1.2.3.4', got %s", loadedCfg.Spec.BMCEmulator.SushyToolsConfig.ListenAddress)
 	}
 
-	if loadedCfg.Spec.BMCEmulator.ListenPort != 1234 {
-		t.Errorf("expected BMC emulator listen port '1234', got %d", loadedCfg.Spec.BMCEmulator.ListenPort)
+	if loadedCfg.Spec.BMCEmulator.SushyToolsConfig.ListenPort != 1234 {
+		t.Errorf("expected BMC emulator listen port '1234', got %d", loadedCfg.Spec.BMCEmulator.SushyToolsConfig.ListenPort)
 	}
 
 	// DockerNetworks tests
@@ -510,7 +512,7 @@ func TestValidate(t *testing.T) {
 			name: "valid BMC emulator config (vbmc)",
 			modify: func(c *Config) {
 				c.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
-					Type:  BMCEmulatorTypeVBMC,
+					Type:  vbmctlapi.BMCEmulatorTypeVBMC,
 					Image: "test/bmc-emulator:latest",
 				}
 			},
@@ -520,10 +522,12 @@ func TestValidate(t *testing.T) {
 			name: "valid BMC emulator config (sushy-tools) no config file specified",
 			modify: func(c *Config) {
 				c.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
-					Type:          BMCEmulatorTypeSushyTools,
-					Image:         "test/bmc-emulator:latest",
-					ListenAddress: "1.2.3.4",
-					ListenPort:    1234,
+					Type:  vbmctlapi.BMCEmulatorTypeSushyTools,
+					Image: "test/bmc-emulator:latest",
+					SushyToolsConfig: vbmctlapi.SushyToolsConfig{
+						ListenAddress: "1.2.3.4",
+						ListenPort:    1234,
+					},
 				}
 			},
 			wantErr: false,
@@ -532,9 +536,11 @@ func TestValidate(t *testing.T) {
 			name: "valid BMC emulator config (sushy-tools) with config file specified",
 			modify: func(c *Config) {
 				c.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
-					Type:       BMCEmulatorTypeSushyTools,
-					Image:      "test/bmc-emulator:latest",
-					ConfigFile: "vbmc-emulator-file",
+					Type:  vbmctlapi.BMCEmulatorTypeSushyTools,
+					Image: "test/bmc-emulator:latest",
+					SushyToolsConfig: vbmctlapi.SushyToolsConfig{
+						ConfigFile: "vbmc-emulator-file",
+					},
 				}
 			},
 			wantErr: false,
@@ -543,12 +549,14 @@ func TestValidate(t *testing.T) {
 			name: "valid BMC emulator config (sushy-tools) with all values specified",
 			modify: func(c *Config) {
 				c.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
-					Type:          BMCEmulatorTypeSushyTools,
-					Image:         "test/bmc-emulator:latest",
-					ConfigFile:    "vbmc-emulator-file",
-					StoragePool:   "custom-storage-pool",
-					ListenAddress: "1.2.3.4",
-					ListenPort:    1234,
+					Type:  vbmctlapi.BMCEmulatorTypeSushyTools,
+					Image: "test/bmc-emulator:latest",
+					SushyToolsConfig: vbmctlapi.SushyToolsConfig{
+						ConfigFile:    "vbmc-emulator-file",
+						StoragePool:   "custom-storage-pool",
+						ListenAddress: "1.2.3.4",
+						ListenPort:    1234,
+					},
 				}
 			},
 			wantErr: false,
@@ -557,8 +565,10 @@ func TestValidate(t *testing.T) {
 			name: "invalid BMC emulator config - missing type",
 			modify: func(c *Config) {
 				c.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
-					ConfigFile: "vbmc-emulator-file",
-					Image:      "test/bmc-emulator:latest",
+					Image: "test/bmc-emulator:latest",
+					SushyToolsConfig: vbmctlapi.SushyToolsConfig{
+						ConfigFile: "vbmc-emulator-file",
+					},
 				}
 			},
 			wantErr: true,
@@ -567,9 +577,11 @@ func TestValidate(t *testing.T) {
 			name: "invalid BMC emulator config - missing either config file or listen address for sushy-tools",
 			modify: func(c *Config) {
 				c.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
-					Type:       BMCEmulatorTypeSushyTools,
-					Image:      "test/bmc-emulator:latest",
-					ListenPort: 1234,
+					Type:  vbmctlapi.BMCEmulatorTypeSushyTools,
+					Image: "test/bmc-emulator:latest",
+					SushyToolsConfig: vbmctlapi.SushyToolsConfig{
+						ListenPort: 1234,
+					},
 				}
 			},
 			wantErr: true,
@@ -578,9 +590,11 @@ func TestValidate(t *testing.T) {
 			name: "invalid BMC emulator config - missing either config file or listen port for sushy-tools",
 			modify: func(c *Config) {
 				c.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
-					Type:          BMCEmulatorTypeSushyTools,
-					Image:         "test/bmc-emulator:latest",
-					ListenAddress: "1.2.3.4",
+					Type:  vbmctlapi.BMCEmulatorTypeSushyTools,
+					Image: "test/bmc-emulator:latest",
+					SushyToolsConfig: vbmctlapi.SushyToolsConfig{
+						ListenAddress: "1.2.3.4",
+					},
 				}
 			},
 			wantErr: true,
@@ -589,8 +603,10 @@ func TestValidate(t *testing.T) {
 			name: "invalid BMC emulator config - missing image",
 			modify: func(c *Config) {
 				c.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
-					Type:       BMCEmulatorTypeVBMC,
-					ConfigFile: "vbmc-emulator-file",
+					Type: vbmctlapi.BMCEmulatorTypeVBMC,
+					SushyToolsConfig: vbmctlapi.SushyToolsConfig{
+						ConfigFile: "vbmc-emulator-file",
+					},
 				}
 			},
 			wantErr: true,
@@ -728,7 +744,7 @@ func TestApplyDefaults(t *testing.T) {
 	// If BMCEmulator type is vbmc, vbmc image default should be applied
 	vbmcCfg := &Config{}
 	vbmcCfg.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
-		Type: BMCEmulatorTypeVBMC,
+		Type: vbmctlapi.BMCEmulatorTypeVBMC,
 	}
 	vbmcCfg.ApplyDefaults()
 	if vbmcCfg.Spec.BMCEmulator.Image != DefaultBMCEmulatorVBMCImage {
@@ -739,37 +755,37 @@ func TestApplyDefaults(t *testing.T) {
 	// that the listen address and listen port defaults are applied when no config file is specified.
 	sushyCfg := &Config{}
 	sushyCfg.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
-		Type: BMCEmulatorTypeSushyTools,
+		Type: vbmctlapi.BMCEmulatorTypeSushyTools,
 	}
 	sushyCfg.ApplyDefaults()
 	if sushyCfg.Spec.BMCEmulator.Image != DefaultBMCEmulatorSushyToolsImage {
 		t.Errorf("expected BMC Emulator Image %s, got %s", DefaultBMCEmulatorSushyToolsImage, sushyCfg.Spec.BMCEmulator.Image)
 	}
-	if sushyCfg.Spec.BMCEmulator.ListenAddress != DefaultNetworkAddress {
-		t.Errorf("expected BMC Emulator Listen Address %s, got %s", DefaultNetworkAddress, sushyCfg.Spec.BMCEmulator.ListenAddress)
+	if sushyCfg.Spec.BMCEmulator.SushyToolsConfig.ListenAddress != DefaultNetworkAddress {
+		t.Errorf("expected BMC Emulator Listen Address %s, got %s", DefaultNetworkAddress, sushyCfg.Spec.BMCEmulator.SushyToolsConfig.ListenAddress)
 	}
-	if sushyCfg.Spec.BMCEmulator.ListenPort != DefaultBMCEmulatorSushyToolsListenPort {
-		t.Errorf("expected BMC Emulator Listen Port %d, got %d", DefaultBMCEmulatorSushyToolsListenPort, sushyCfg.Spec.BMCEmulator.ListenPort)
+	if sushyCfg.Spec.BMCEmulator.SushyToolsConfig.ListenPort != DefaultBMCEmulatorSushyToolsListenPort {
+		t.Errorf("expected BMC Emulator Listen Port %d, got %d", DefaultBMCEmulatorSushyToolsListenPort, sushyCfg.Spec.BMCEmulator.SushyToolsConfig.ListenPort)
 	}
-	if sushyCfg.Spec.BMCEmulator.StoragePool != DefaultPoolName {
-		t.Errorf("expected BMC Emulator Storage Pool %s, got %s", DefaultPoolName, sushyCfg.Spec.BMCEmulator.StoragePool)
+	if sushyCfg.Spec.BMCEmulator.SushyToolsConfig.StoragePool != DefaultPoolName {
+		t.Errorf("expected BMC Emulator Storage Pool %s, got %s", DefaultPoolName, sushyCfg.Spec.BMCEmulator.SushyToolsConfig.StoragePool)
 	}
-	if sushyCfg.Spec.BMCEmulator.LibvirtURI != DefaultLibvirtURI {
-		t.Errorf("expected BMC Emulator Libvirt URI %s, got %s", DefaultLibvirtURI, sushyCfg.Spec.BMCEmulator.LibvirtURI)
+	if sushyCfg.Spec.BMCEmulator.SushyToolsConfig.LibvirtURI != DefaultLibvirtURI {
+		t.Errorf("expected BMC Emulator Libvirt URI %s, got %s", DefaultLibvirtURI, sushyCfg.Spec.BMCEmulator.SushyToolsConfig.LibvirtURI)
 	}
 
 	// However, if a config file is specified for sushy-tools, the listen address and listen port defaults should not be applied.
 	sushyWithConfigFileCfg := &Config{}
 	sushyWithConfigFileCfg.Spec.BMCEmulator = &vbmctlapi.BMCEmulatorConfig{
-		Type:       BMCEmulatorTypeSushyTools,
-		ConfigFile: "vbmc-emulator-file",
+		Type: vbmctlapi.BMCEmulatorTypeSushyTools,
 	}
+	sushyWithConfigFileCfg.Spec.BMCEmulator.SushyToolsConfig = vbmctlapi.SushyToolsConfig{ConfigFile: "vbmc-emulator-file"}
 	sushyWithConfigFileCfg.ApplyDefaults()
-	if sushyWithConfigFileCfg.Spec.BMCEmulator.ListenAddress != "" {
-		t.Errorf("expected BMC Emulator Listen Address <empty>, got %s", sushyWithConfigFileCfg.Spec.BMCEmulator.ListenAddress)
+	if sushyWithConfigFileCfg.Spec.BMCEmulator.SushyToolsConfig.ListenAddress != "" {
+		t.Errorf("expected BMC Emulator Listen Address <empty>, got %s", sushyWithConfigFileCfg.Spec.BMCEmulator.SushyToolsConfig.ListenAddress)
 	}
-	if sushyWithConfigFileCfg.Spec.BMCEmulator.ListenPort != 0 {
-		t.Errorf("expected BMC Emulator Listen Port <empty>, got %d", sushyWithConfigFileCfg.Spec.BMCEmulator.ListenPort)
+	if sushyWithConfigFileCfg.Spec.BMCEmulator.SushyToolsConfig.ListenPort != 0 {
+		t.Errorf("expected BMC Emulator Listen Port <empty>, got %d", sushyWithConfigFileCfg.Spec.BMCEmulator.SushyToolsConfig.ListenPort)
 	}
 }
 

--- a/test/vbmctl/pkg/containers/bmc_emulator.go
+++ b/test/vbmctl/pkg/containers/bmc_emulator.go
@@ -5,12 +5,12 @@ package containers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
 
 	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
-	"github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/config"
 	container "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 )
@@ -70,7 +70,7 @@ func deleteEmulatorInstance(ctx context.Context, containerName string) error {
 
 func createVBMCEmulatorInstance(ctx context.Context, cfg *vbmctlapi.BMCEmulatorConfig) error {
 	// Fill in configuration
-	cfg.ContainerName = ensureVbmctlPrefix(config.BMCEmulatorTypeVBMC)
+	cfg.ContainerName = ensureVbmctlPrefix(vbmctlapi.BMCEmulatorTypeVBMC)
 	cfg.VolumeMounts = []vbmctlapi.VolumeMount{
 		{HostPath: "/var/run/libvirt/libvirt-sock", BindSpec: "/var/run/libvirt/libvirt-sock"},
 		{HostPath: "/var/run/libvirt/libvirt-sock-ro", BindSpec: "/var/run/libvirt/libvirt-sock-ro"},
@@ -82,26 +82,27 @@ func createVBMCEmulatorInstance(ctx context.Context, cfg *vbmctlapi.BMCEmulatorC
 }
 
 func deleteVBMCEmulatorInstance(ctx context.Context) error {
-	return deleteEmulatorInstance(ctx, ensureVbmctlPrefix(config.BMCEmulatorTypeVBMC))
+	return deleteEmulatorInstance(ctx, ensureVbmctlPrefix(vbmctlapi.BMCEmulatorTypeVBMC))
 }
 
 func getVBMCEmulatorInfo(ctx context.Context) (info string, err error) {
-	return GetContainerInfo(ctx, ensureVbmctlPrefix(config.BMCEmulatorTypeVBMC))
+	return GetContainerInfo(ctx, ensureVbmctlPrefix(vbmctlapi.BMCEmulatorTypeVBMC))
 }
 
 func createSushyToolsEmulatorInstance(ctx context.Context, cfg *vbmctlapi.BMCEmulatorConfig) error {
 	// Validate that the config file if it is specified exists and is a file
-	if cfg.ConfigFile != "" {
-		info, err := os.Stat(cfg.ConfigFile)
+	sushyCfg := &cfg.SushyToolsConfig
+	if sushyCfg.ConfigFile != "" {
+		info, err := os.Stat(sushyCfg.ConfigFile)
 		if err != nil {
-			return fmt.Errorf("failed to access sushy-tools config file %q: %w", cfg.ConfigFile, err)
+			return fmt.Errorf("failed to access sushy-tools config file %q: %w", sushyCfg.ConfigFile, err)
 		} else if info.IsDir() {
-			return fmt.Errorf("sushy-tools config file %q is a directory", cfg.ConfigFile)
+			return fmt.Errorf("sushy-tools config file %q is a directory", sushyCfg.ConfigFile)
 		}
 	}
 
 	// Fill in configuration
-	cfg.ContainerName = ensureVbmctlPrefix(config.BMCEmulatorTypeSushyTools)
+	cfg.ContainerName = ensureVbmctlPrefix(vbmctlapi.BMCEmulatorTypeSushyTools)
 	cfg.VolumeMounts = []vbmctlapi.VolumeMount{
 		{HostPath: "/var/run/libvirt", BindSpec: "/var/run/libvirt:Z"},
 	}
@@ -111,40 +112,44 @@ func createSushyToolsEmulatorInstance(ctx context.Context, cfg *vbmctlapi.BMCEmu
 	// If a config file is specified, set the environment variable and volume mount for it.
 	// We use ":Z" in the bind spec to ensure proper SELinux labeling in case the host is
 	// running with SELinux enabled.
-	if cfg.ConfigFile != "" {
+	if sushyCfg.ConfigFile != "" {
 		cfg.Env["SUSHY_EMULATOR_CONFIG"] = "/etc/sushy/sushy-emulator.conf"
-		cfg.VolumeMounts = append(cfg.VolumeMounts, vbmctlapi.VolumeMount{HostPath: cfg.ConfigFile, BindSpec: "/etc/sushy/sushy-emulator.conf:Z"})
+		cfg.VolumeMounts = append(cfg.VolumeMounts, vbmctlapi.VolumeMount{HostPath: sushyCfg.ConfigFile, BindSpec: "/etc/sushy/sushy-emulator.conf:Z"})
 	}
 
 	// Set command-line arguments for the emulator based on the provided configuration.
-	if cfg.ListenAddress != "" {
-		cfg.Cmd = append(cfg.Cmd, "--interface", cfg.ListenAddress)
+	if sushyCfg.ListenAddress != "" {
+		cfg.Cmd = append(cfg.Cmd, "--interface", sushyCfg.ListenAddress)
 	}
 
-	if cfg.ListenPort != 0 {
-		cfg.Cmd = append(cfg.Cmd, "--port", strconv.FormatUint(uint64(cfg.ListenPort), 10))
+	if sushyCfg.ListenPort != 0 {
+		cfg.Cmd = append(cfg.Cmd, "--port", strconv.FormatUint(uint64(sushyCfg.ListenPort), 10))
 	}
 
 	// Overwrite specific configuration with values provided by vbmctl
-	cfg.Cmd = append(cfg.Cmd, "--storage-pool", cfg.StoragePool)
-	cfg.Cmd = append(cfg.Cmd, "--libvirt-uri", cfg.LibvirtURI)
+	cfg.Cmd = append(cfg.Cmd, "--storage-pool", sushyCfg.StoragePool)
+	cfg.Cmd = append(cfg.Cmd, "--libvirt-uri", sushyCfg.LibvirtURI)
 
 	return createEmulatorInstance(ctx, cfg)
 }
 
 func deleteSushyToolsEmulatorInstance(ctx context.Context) error {
-	return deleteEmulatorInstance(ctx, ensureVbmctlPrefix(config.BMCEmulatorTypeSushyTools))
+	return deleteEmulatorInstance(ctx, ensureVbmctlPrefix(vbmctlapi.BMCEmulatorTypeSushyTools))
 }
 
 func getSushyToolsEmulatorInfo(ctx context.Context) (info string, err error) {
-	return GetContainerInfo(ctx, ensureVbmctlPrefix(config.BMCEmulatorTypeSushyTools))
+	return GetContainerInfo(ctx, ensureVbmctlPrefix(vbmctlapi.BMCEmulatorTypeSushyTools))
 }
 
 func CreateBMCEmulatorInstance(ctx context.Context, cfg *vbmctlapi.BMCEmulatorConfig) error {
+	if cfg == nil {
+		return errors.New("invalid BMC emulator configuration")
+	}
+
 	switch cfg.Type {
-	case config.BMCEmulatorTypeVBMC:
+	case vbmctlapi.BMCEmulatorTypeVBMC:
 		return createVBMCEmulatorInstance(ctx, cfg)
-	case config.BMCEmulatorTypeSushyTools:
+	case vbmctlapi.BMCEmulatorTypeSushyTools:
 		return createSushyToolsEmulatorInstance(ctx, cfg)
 	default:
 		return fmt.Errorf("unsupported BMC emulator type: %s", cfg.Type)
@@ -153,9 +158,9 @@ func CreateBMCEmulatorInstance(ctx context.Context, cfg *vbmctlapi.BMCEmulatorCo
 
 func DeleteBMCEmulatorInstance(ctx context.Context, emulatorType string) error {
 	switch emulatorType {
-	case config.BMCEmulatorTypeVBMC:
+	case vbmctlapi.BMCEmulatorTypeVBMC:
 		return deleteVBMCEmulatorInstance(ctx)
-	case config.BMCEmulatorTypeSushyTools:
+	case vbmctlapi.BMCEmulatorTypeSushyTools:
 		return deleteSushyToolsEmulatorInstance(ctx)
 	default:
 		return fmt.Errorf("unsupported BMC emulator type: %s", emulatorType)
@@ -164,9 +169,9 @@ func DeleteBMCEmulatorInstance(ctx context.Context, emulatorType string) error {
 
 func GetBMCEmulatorInfo(ctx context.Context, emulatorType string) (info string, err error) {
 	switch emulatorType {
-	case config.BMCEmulatorTypeVBMC:
+	case vbmctlapi.BMCEmulatorTypeVBMC:
 		return getVBMCEmulatorInfo(ctx)
-	case config.BMCEmulatorTypeSushyTools:
+	case vbmctlapi.BMCEmulatorTypeSushyTools:
 		return getSushyToolsEmulatorInfo(ctx)
 	default:
 		return "", fmt.Errorf("unsupported BMC emulator type: %s", emulatorType)

--- a/test/vbmctl/pkg/containers/doc.go
+++ b/test/vbmctl/pkg/containers/doc.go
@@ -56,30 +56,39 @@
 //
 // For the "vbmc" type, only the Image field is required.
 //
-//	err := containers.CreateBMCEmulatorInstance(ctx, &api.BMCEmulatorConfig{
+//	emulatorConfig := &api.BMCEmulatorConfig{
 //	    Type:          "vbmc",
 //	    Image:         "my-vbmc:latest",
-//	})
+//	}
+//	// Empty configuration would also be assumed if not set
+//	emulatorConfig.VBMCConfig = api.VBMCConfig{}
+//	err := containers.CreateBMCEmulatorInstance(ctx, emulatorConfig)
 //
 // For the "sushy-tools" type, ConfigFile must point to a Sushy-tools configuration
 // file that already exists on the host in which case the configuration file will be
 // bind-mounted into the container.
 //
-//	err := containers.CreateBMCEmulatorInstance(ctx, &api.BMCEmulatorConfig{
+//	emulatorConfig := &api.BMCEmulatorConfig{
 //	    Type:          "sushy-tools",
 //	    Image:         "my-sushy-tools:latest",
+//	}
+//	emulatorConfig.SushyToolsConfig = api.SushyToolsConfig{
 //	    ConfigFile:    "/path/to/existing/config/file",
-//	})
+//	}
+//	err := containers.CreateBMCEmulatorInstance(ctx, emulatorConfig)
 //
 // Alternatively, if ConfigFile is not specified for the "sushy-tools" type, the
 // ListenAddress and ListenPort fields can be used for configuration.
 //
-//	err := containers.CreateBMCEmulatorInstance(ctx, &api.BMCEmulatorConfig{
+//	emulatorConfig := &api.BMCEmulatorConfig{
 //	    Type:          "sushy-tools",
 //	    Image:         "my-sushy-tools:latest",
+//	}
+//	emulatorConfig.SushyToolsConfig = api.SushyToolsConfig{
 //	    ListenAddress: "1.2.3.4",
 //	    ListenPort:    1234,
-//	})
+//	}
+//	err := containers.CreateBMCEmulatorInstance(ctx, emulatorConfig)
 //
 // It should be noted that if using command line arguments to configure
 // sushy-tools, the listen address and listen port defaults will be applied if


### PR DESCRIPTION
Create sushy-tools and vmbc specific configuration structures. Update config loading, defaults, CLI creation flow, and related tests to use the new structures consistently.

The config file still uses the same flat YAML shape, so `UnmarshalYAML` and `MarshalYAML` bridge the old on-disk format with the new structured representation. This keeps backward compatibility for existing configs and avoids forcing users to rewrite their configuration files. Currently, however, `MarshalYAML` is not used, but is included for completeness.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Currently, the `BMCEmulatorConfig` structure contains all possible configuration parameters, including those specific to only one BMC emulator type. Moving type-specific parameters into their own dedicated structures makes the configuration easier to maintain and allows the list of supported emulator types to be expanded more cleanly.
