### PR TITLE
🌱 Pin ironic version to 35.0 in default e2e overlay

### DIFF
--- a/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e/ironic.yaml
+++ b/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e/ironic.yaml
@@ -4,7 +4,4 @@ metadata:
   name: ironic
   namespace: baremetal-operator-system
 spec:
-  images:
-    deployRamdiskDownloader: "quay.io/metal3-io/ironic-ipa-downloader:main"
-    ironic: "quay.io/metal3-io/ironic:main"
-    keepalived: "quay.io/metal3-io/keepalived"
+  version: "35.0"


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:Use the plain e2e overlay instead of a versioned one, patched to
pin spec.version to "35.0" rather than "latest".


<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
