### PR TITLE
⚠️ Deprecate BMH Taints field

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -507,12 +507,10 @@ type NetworkInterface struct {
 
 // BareMetalHostSpec defines the desired state of BareMetalHost.
 type BareMetalHostSpec struct {
-	// Important: Run "make generate manifests" to regenerate code
-	// after modifying this file
-
 	// Taints is the full, authoritative list of taints to apply to
-	// the corresponding Machine. This list will overwrite any
-	// modifications made to the Machine on an ongoing basis.
+	// the corresponding Machine.
+	//
+	// Deprecated: the Taints field was never actually implemented.
 	// +optional
 	Taints []corev1.Taint `json:"taints,omitempty"`
 

--- a/config/base/crds/bases/metal3.io_baremetalhosts.yaml
+++ b/config/base/crds/bases/metal3.io_baremetalhosts.yaml
@@ -655,8 +655,9 @@ spec:
               taints:
                 description: |-
                   Taints is the full, authoritative list of taints to apply to
-                  the corresponding Machine. This list will overwrite any
-                  modifications made to the Machine on an ongoing basis.
+                  the corresponding Machine.
+
+                  Deprecated: the Taints field was never actually implemented.
                 items:
                   description: |-
                     The node this Taint is attached to has the "effect" on

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -655,8 +655,9 @@ spec:
               taints:
                 description: |-
                   Taints is the full, authoritative list of taints to apply to
-                  the corresponding Machine. This list will overwrite any
-                  modifications made to the Machine on an ongoing basis.
+                  the corresponding Machine.
+
+                  Deprecated: the Taints field was never actually implemented.
                 items:
                   description: |-
                     The node this Taint is attached to has the "effect" on


### PR DESCRIPTION
This field was added in the very first revision of the BMH API but has
never been implemented in BMO and CAPM3. Deprecate it to avoid confusion.

Also remove an obvious comment from the same time.

Fixes: #3453 
Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
