### PR TITLE
:sparkles: Add provisioning retry limit to prevent infinite loops

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -865,6 +865,19 @@ type BareMetalHostStatus struct {
 	// +kubebuilder:default:=0
 	ErrorCount int `json:"errorCount"`
 
+	// ProvisioningFailCount records how many times provisioning has failed
+	// consecutively for the current image. Unlike ErrorCount, it is not reset
+	// on deprovisioning and is only cleared on successful provisioning or when
+	// a new image is specified.
+	// +kubebuilder:default:=0
+	ProvisioningFailCount int `json:"provisioningFailCount"`
+
+	// LastAttemptedImage stores the full image spec of the last provisioning
+	// attempt, used to detect user-initiated image changes (URL, checksum,
+	// format, etc.) that should reset the provisioning retry limit counter.
+	// +optional
+	LastAttemptedImage *Image `json:"lastAttemptedImage,omitempty"`
+
 	// Conditions defines current service state of the BareMetalHost.
 	// +optional
 	// +listType=map

--- a/apis/metal3.io/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/metal3.io/v1alpha1/zz_generated.deepcopy.go
@@ -315,6 +315,11 @@ func (in *BareMetalHostStatus) DeepCopyInto(out *BareMetalHostStatus) {
 	in.GoodCredentials.DeepCopyInto(&out.GoodCredentials)
 	in.TriedCredentials.DeepCopyInto(&out.TriedCredentials)
 	in.OperationHistory.DeepCopyInto(&out.OperationHistory)
+	if in.LastAttemptedImage != nil {
+		in, out := &in.LastAttemptedImage, &out.LastAttemptedImage
+		*out = new(Image)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]metav1.Condition, len(*in))

--- a/config/base/crds/bases/metal3.io_baremetalhosts.yaml
+++ b/config/base/crds/bases/metal3.io_baremetalhosts.yaml
@@ -1002,6 +1002,53 @@ spec:
                   The name of the profile matching the hardware details.
                   Hardware profiles are deprecated and should not be relied on.
                 type: string
+              lastAttemptedImage:
+                description: |-
+                  LastAttemptedImage stores the full image spec of the last provisioning
+                  attempt, used to detect user-initiated image changes (URL, checksum,
+                  format, etc.) that should reset the provisioning retry limit counter.
+                properties:
+                  checksum:
+                    description: |-
+                      Checksum is the checksum for the image. Required for all formats
+                      except for "live-iso" and OCI images (oci://).
+                    type: string
+                  checksumType:
+                    description: |-
+                      ChecksumType is the checksum algorithm for the image, e.g md5, sha256 or sha512.
+                      The special value "auto" can be used to detect the algorithm from the checksum.
+                      If missing, MD5 is used. If in doubt, use "auto".
+                    enum:
+                    - md5
+                    - sha256
+                    - sha512
+                    - auto
+                    type: string
+                  format:
+                    description: |-
+                      Format contains the format of the image (raw, qcow2, ...).
+                      When set to "live-iso", an ISO 9660 image referenced by the url will
+                      be live-booted and not deployed to disk.
+                    enum:
+                    - raw
+                    - qcow2
+                    - vdi
+                    - vmdk
+                    - live-iso
+                    type: string
+                  ociAuthSecretName:
+                    description: |-
+                      OCIAuthSecretName optionally names a Docker-config secret containing
+                      registry credentials for oci:// images. Must be in the same namespace
+                      as the BareMetalHost. Allowed types: kubernetes.io/dockerconfigjson|dockercfg.
+                      Only used when Image.URL has the oci:// scheme.
+                    type: string
+                  url:
+                    description: URL is a location of an image to deploy.
+                    type: string
+                required:
+                - url
+                type: object
               lastUpdated:
                 description: LastUpdated identifies when this status was last observed.
                 format: date-time
@@ -1413,6 +1460,14 @@ spec:
                 - ID
                 - state
                 type: object
+              provisioningFailCount:
+                default: 0
+                description: |-
+                  ProvisioningFailCount records how many times provisioning has failed
+                  consecutively for the current image. Unlike ErrorCount, it is not reset
+                  on deprovisioning and is only cleared on successful provisioning or when
+                  a new image is specified.
+                type: integer
               triedCredentials:
                 description: The last credentials we sent to the provisioning backend.
                 properties:
@@ -1440,6 +1495,7 @@ spec:
             - operationalStatus
             - poweredOn
             - provisioning
+            - provisioningFailCount
             type: object
         type: object
     served: true

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -1002,6 +1002,53 @@ spec:
                   The name of the profile matching the hardware details.
                   Hardware profiles are deprecated and should not be relied on.
                 type: string
+              lastAttemptedImage:
+                description: |-
+                  LastAttemptedImage stores the full image spec of the last provisioning
+                  attempt, used to detect user-initiated image changes (URL, checksum,
+                  format, etc.) that should reset the provisioning retry limit counter.
+                properties:
+                  checksum:
+                    description: |-
+                      Checksum is the checksum for the image. Required for all formats
+                      except for "live-iso" and OCI images (oci://).
+                    type: string
+                  checksumType:
+                    description: |-
+                      ChecksumType is the checksum algorithm for the image, e.g md5, sha256 or sha512.
+                      The special value "auto" can be used to detect the algorithm from the checksum.
+                      If missing, MD5 is used. If in doubt, use "auto".
+                    enum:
+                    - md5
+                    - sha256
+                    - sha512
+                    - auto
+                    type: string
+                  format:
+                    description: |-
+                      Format contains the format of the image (raw, qcow2, ...).
+                      When set to "live-iso", an ISO 9660 image referenced by the url will
+                      be live-booted and not deployed to disk.
+                    enum:
+                    - raw
+                    - qcow2
+                    - vdi
+                    - vmdk
+                    - live-iso
+                    type: string
+                  ociAuthSecretName:
+                    description: |-
+                      OCIAuthSecretName optionally names a Docker-config secret containing
+                      registry credentials for oci:// images. Must be in the same namespace
+                      as the BareMetalHost. Allowed types: kubernetes.io/dockerconfigjson|dockercfg.
+                      Only used when Image.URL has the oci:// scheme.
+                    type: string
+                  url:
+                    description: URL is a location of an image to deploy.
+                    type: string
+                required:
+                - url
+                type: object
               lastUpdated:
                 description: LastUpdated identifies when this status was last observed.
                 format: date-time
@@ -1413,6 +1460,14 @@ spec:
                 - ID
                 - state
                 type: object
+              provisioningFailCount:
+                default: 0
+                description: |-
+                  ProvisioningFailCount records how many times provisioning has failed
+                  consecutively for the current image. Unlike ErrorCount, it is not reset
+                  on deprovisioning and is only cleared on successful provisioning or when
+                  a new image is specified.
+                type: integer
               triedCredentials:
                 description: The last credentials we sent to the provisioning backend.
                 properties:
@@ -1440,6 +1495,7 @@ spec:
             - operationalStatus
             - poweredOn
             - provisioning
+            - provisioningFailCount
             type: object
         type: object
     served: true

--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -67,10 +67,11 @@ const (
 // BareMetalHostReconciler reconciles a BareMetalHost object.
 type BareMetalHostReconciler struct {
 	client.Client
-	Log                logr.Logger
-	ProvisionerFactory provisioner.Factory
-	APIReader          client.Reader
-	Recorder           record.EventRecorder
+	Log                    logr.Logger
+	ProvisionerFactory     provisioner.Factory
+	APIReader              client.Reader
+	Recorder               record.EventRecorder
+	MaxProvisioningRetries int
 }
 
 // Instead of passing a zillion arguments to the action of a phase,
@@ -2044,6 +2045,23 @@ func (r *BareMetalHostReconciler) actionManageSteadyState(ctx context.Context, p
 func (r *BareMetalHostReconciler) actionManageAvailable(ctx context.Context, prov provisioner.Provisioner, info *reconcileInfo) actionResult {
 	info.log.V(VerbosityLevelTrace).Info("actionManageAvailable started")
 	if info.host.NeedsProvisioning() {
+		if !reflect.DeepEqual(info.host.Spec.Image, info.host.Status.LastAttemptedImage) {
+			if info.host.Status.ProvisioningFailCount > 0 {
+				info.log.Info("image spec changed, resetting provisioning fail count")
+			}
+			info.host.Status.ProvisioningFailCount = 0
+		}
+
+		limit := r.MaxProvisioningRetries
+		if limit > 0 && info.host.Status.ProvisioningFailCount >= limit {
+			info.log.Info("provisioning retry limit reached, not retrying",
+				"failCount", info.host.Status.ProvisioningFailCount,
+				"limit", limit)
+			return recordActionFailure(info, metal3api.ProvisioningError,
+				fmt.Sprintf("provisioning failed %d times, retry limit (%d) reached; change image or reset provisioningFailCount to retry",
+					info.host.Status.ProvisioningFailCount, limit))
+		}
+
 		clearError(info.host)
 		return actionComplete{}
 	}

--- a/internal/controller/metal3.io/host_state_machine.go
+++ b/internal/controller/metal3.io/host_state_machine.go
@@ -495,6 +495,14 @@ func (hsm *hostStateMachine) handleAvailable(ctx context.Context, info *reconcil
 		return actionComplete{}
 	}
 
+	if info.host.Spec.Image == nil || info.host.Spec.Image.URL == "" {
+		if info.host.Status.ProvisioningFailCount > 0 {
+			info.log.Info("host is available with no image requested, resetting provisioning fail count")
+			info.host.Status.ProvisioningFailCount = 0
+			info.host.Status.LastAttemptedImage = nil
+		}
+	}
+
 	// ErrorCount is cleared when appropriate inside actionManageAvailable
 	actResult := hsm.Reconciler.actionManageAvailable(ctx, hsm.Provisioner, info)
 	if _, complete := actResult.(actionComplete); complete {
@@ -543,14 +551,27 @@ func (hsm *hostStateMachine) imageProvisioningCancelled() bool {
 
 func (hsm *hostStateMachine) handleProvisioning(ctx context.Context, info *reconcileInfo) actionResult {
 	if hsm.Host.Status.ErrorType != "" || hsm.provisioningCancelled() {
+		if hsm.Host.Status.ErrorType != "" {
+			hsm.Host.Status.ProvisioningFailCount++
+			info.log.Info("provisioning failed, incrementing fail count",
+				"provisioningFailCount", hsm.Host.Status.ProvisioningFailCount)
+		}
 		hsm.NextState = metal3api.StateDeprovisioning
 		return actionComplete{}
+	}
+
+	// Snapshot the image spec before invoking the provisioner so that
+	// LastAttemptedImage reflects what was actually attempted, not what
+	// the spec contains when a prior error is processed on a later reconcile.
+	if hsm.Host.Spec.Image != nil {
+		hsm.Host.Status.LastAttemptedImage = hsm.Host.Spec.Image.DeepCopy()
 	}
 
 	actResult := hsm.Reconciler.actionProvisioning(ctx, hsm.Provisioner, info)
 	if _, complete := actResult.(actionComplete); complete {
 		hsm.NextState = metal3api.StateProvisioned
 		hsm.Host.Status.ErrorCount = 0
+		hsm.Host.Status.ProvisioningFailCount = 0
 	}
 	return actResult
 }

--- a/internal/controller/metal3.io/host_state_machine_test.go
+++ b/internal/controller/metal3.io/host_state_machine_test.go
@@ -1482,3 +1482,149 @@ func TestUpdateBootModeStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestProvisioningRetryLimit(t *testing.T) {
+	testCases := []struct {
+		Scenario string
+
+		Host                   *metal3api.BareMetalHost
+		MaxProvisioningRetries int
+
+		ExpectedState             metal3api.ProvisioningState
+		ExpectedProvisioningFail  int
+		ExpectedOperationalStatus metal3api.OperationalStatus
+	}{
+		{
+			Scenario: "provisioning-error-increments-fail-count",
+			Host: func() *metal3api.BareMetalHost {
+				h := host(metal3api.StateProvisioning).build()
+				h.Status.ErrorType = metal3api.ProvisioningError
+				h.Status.ErrorMessage = "deploy failed"
+				h.Status.ProvisioningFailCount = 2
+				return h
+			}(),
+			MaxProvisioningRetries: 5,
+
+			ExpectedState:             metal3api.StateDeprovisioning,
+			ExpectedProvisioningFail:  3,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+		},
+		{
+			Scenario: "retry-limit-reached-stays-available",
+			Host: func() *metal3api.BareMetalHost {
+				h := host(metal3api.StateAvailable).SaveHostProvisioningSettings().build()
+				h.Status.ProvisioningFailCount = 5
+				h.Status.LastAttemptedImage = &metal3api.Image{URL: "not-empty"}
+				return h
+			}(),
+			MaxProvisioningRetries: 5,
+
+			ExpectedState:             metal3api.StateAvailable,
+			ExpectedProvisioningFail:  5,
+			ExpectedOperationalStatus: metal3api.OperationalStatusError,
+		},
+		{
+			Scenario: "below-retry-limit-allows-provisioning",
+			Host: func() *metal3api.BareMetalHost {
+				h := host(metal3api.StateAvailable).SaveHostProvisioningSettings().build()
+				h.Status.ProvisioningFailCount = 4
+				h.Status.LastAttemptedImage = &metal3api.Image{URL: "not-empty"}
+				return h
+			}(),
+			MaxProvisioningRetries: 5,
+
+			ExpectedState:             metal3api.StateProvisioning,
+			ExpectedProvisioningFail:  4,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+		},
+		{
+			Scenario: "image-url-change-resets-fail-count",
+			Host: func() *metal3api.BareMetalHost {
+				h := host(metal3api.StateAvailable).SaveHostProvisioningSettings().build()
+				h.Status.ProvisioningFailCount = 5
+				h.Status.LastAttemptedImage = &metal3api.Image{URL: "old-image-url", Checksum: "abc123"}
+				h.Spec.Image = &metal3api.Image{URL: "new-image-url", Checksum: "abc123"}
+				return h
+			}(),
+			MaxProvisioningRetries: 5,
+
+			ExpectedState:             metal3api.StateProvisioning,
+			ExpectedProvisioningFail:  0,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+		},
+		{
+			Scenario: "checksum-change-resets-fail-count",
+			Host: func() *metal3api.BareMetalHost {
+				h := host(metal3api.StateAvailable).SaveHostProvisioningSettings().build()
+				h.Status.ProvisioningFailCount = 5
+				h.Status.LastAttemptedImage = &metal3api.Image{URL: "not-empty", Checksum: "old-checksum"}
+				h.Spec.Image = &metal3api.Image{URL: "not-empty", Checksum: "new-checksum"}
+				return h
+			}(),
+			MaxProvisioningRetries: 5,
+
+			ExpectedState:             metal3api.StateProvisioning,
+			ExpectedProvisioningFail:  0,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+		},
+		{
+			Scenario: "same-image-does-not-reset-fail-count",
+			Host: func() *metal3api.BareMetalHost {
+				h := host(metal3api.StateAvailable).SaveHostProvisioningSettings().build()
+				h.Status.ProvisioningFailCount = 3
+				h.Status.LastAttemptedImage = &metal3api.Image{URL: "not-empty", Checksum: "abc123"}
+				h.Spec.Image = &metal3api.Image{URL: "not-empty", Checksum: "abc123"}
+				return h
+			}(),
+			MaxProvisioningRetries: 5,
+
+			ExpectedState:             metal3api.StateProvisioning,
+			ExpectedProvisioningFail:  3,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+		},
+		{
+			Scenario: "limit-zero-disables-retry-limit",
+			Host: func() *metal3api.BareMetalHost {
+				h := host(metal3api.StateAvailable).SaveHostProvisioningSettings().build()
+				h.Status.ProvisioningFailCount = 100
+				h.Status.LastAttemptedImage = &metal3api.Image{URL: "not-empty"}
+				return h
+			}(),
+			MaxProvisioningRetries: 0,
+
+			ExpectedState:             metal3api.StateProvisioning,
+			ExpectedProvisioningFail:  100,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+		},
+		{
+			Scenario: "successful-provisioning-resets-fail-count",
+			Host: func() *metal3api.BareMetalHost {
+				h := host(metal3api.StateProvisioning).build()
+				h.Status.ProvisioningFailCount = 3
+				return h
+			}(),
+			MaxProvisioningRetries: 5,
+
+			ExpectedState:             metal3api.StateProvisioned,
+			ExpectedProvisioningFail:  0,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			prov := newMockProvisioner()
+			prov.setHasCapacity(true)
+			reconciler := testNewReconciler(tc.Host)
+			reconciler.MaxProvisioningRetries = tc.MaxProvisioningRetries
+			hsm := newHostStateMachine(tc.Host, reconciler, prov, true)
+			info := makeDefaultReconcileInfo(tc.Host)
+
+			hsm.ReconcileState(t.Context(), info)
+
+			assert.Equal(t, tc.ExpectedState, tc.Host.Status.Provisioning.State)
+			assert.Equal(t, tc.ExpectedProvisioningFail, tc.Host.Status.ProvisioningFailCount)
+			assert.Equal(t, tc.ExpectedOperationalStatus, tc.Host.Status.OperationalStatus)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -184,6 +184,7 @@ func main() {
 	var restConfigQPS float64
 	var restConfigBurst int
 	var controllerConcurrency int
+	var maxProvisioningRetries int
 	var leaseDurationSeconds string
 	var renewDeadlineSeconds string
 	var retryPeriodSeconds string
@@ -241,6 +242,8 @@ func main() {
 			"Possible values: "+strings.Join(supportedTLSCurvesNames, ", ")+".")
 	flag.IntVar(&controllerConcurrency, "controller-concurrency", 0,
 		"Number of CRs of each type to process simultaneously")
+	flag.IntVar(&maxProvisioningRetries, "max-provisioning-retries", 5, //nolint:mnd
+		"Maximum number of provisioning retries before giving up. Set to 0 to disable the limit (infinite retries).")
 
 	flag.StringVar(&leaseDurationSeconds, "lease-duration-seconds", os.Getenv("LEASE_DURATION_SECONDS"), "Leader election duration in seconds.")
 	flag.StringVar(&renewDeadlineSeconds, "renew-deadline-seconds", os.Getenv("RENEW_DEADLINE_SECONDS"), "Leader election renew deadline duration in seconds.")
@@ -426,11 +429,18 @@ func main() {
 		os.Exit(1)
 	}
 
+	if maxProvisioningRetries < 0 {
+		setupLog.Error(fmt.Errorf("invalid value %d", maxProvisioningRetries),
+			"--max-provisioning-retries must be 0 (unlimited) or a positive integer")
+		os.Exit(1)
+	}
+
 	if err = (&metal3iocontroller.BareMetalHostReconciler{
-		Client:             mgr.GetClient(),
-		Log:                ctrl.Log.WithName("controllers").WithName("BareMetalHost"),
-		ProvisionerFactory: provisionerFactory,
-		APIReader:          mgr.GetAPIReader(),
+		Client:                 mgr.GetClient(),
+		Log:                    ctrl.Log.WithName("controllers").WithName("BareMetalHost"),
+		ProvisionerFactory:     provisionerFactory,
+		APIReader:              mgr.GetAPIReader(),
+		MaxProvisioningRetries: maxProvisioningRetries,
 	}).SetupWithManager(mgr, preprovImgEnable, maxConcurrency); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BareMetalHost")
 		os.Exit(1)


### PR DESCRIPTION
BMO currently retries provisioning indefinitely when deployment fails
repeatedly: the host is deprovisioned, ErrorCount resets to 0, and
provisioning is immediately re-triggered with no limit. Against
persistent failures (e.g. disk errors, virtual media issues) this
causes hours or days of futile retries with no way to break the cycle
short of manually deleting the BMH object.

Introduce a ProvisioningFailCount status field that tracks cumulative
provisioning failures across deprovision cycles. When the count reaches
a configurable limit (default 5), BMO stops retrying and reports an
error. The counter resets on successful provisioning, when the user
changes the image spec, or when the image is removed entirely.

A new --max-provisioning-retries flag controls the limit; set to 0
to preserve the previous unlimited behavior.

