### PR TITLE
:seedling: Remove gopher and ftp from allowed URL schemes

### DIFF
--- a/internal/webhooks/metal3.io/v1alpha1/common_validation.go
+++ b/internal/webhooks/metal3.io/v1alpha1/common_validation.go
@@ -29,7 +29,7 @@ func validateURL(input string) error {
 	}
 
 	// Check the URL scheme
-	allowed := []string{"http", "https", "ftp", "gopher", "oci"}
+	allowed := []string{"http", "https", "oci"}
 	if !slices.Contains(allowed, urlObj.Scheme) {
 		return fmt.Errorf("invalid scheme in URL, \"%s\" not allowed", urlObj.Scheme)
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

removes gopher and ftp from allowed URL schemes in webhook.

Followup to https://github.com/metal3-io/baremetal-operator/pull/3333 where this was asked for.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] E2E tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
