### PR TITLE
:book: Clarify security disclaimers in README and configuration files for development use only

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -53,6 +53,13 @@ in `hack/ci-e2e.sh`, and put them directly in the `e2e` overlays.
       Kubernetes cluster, they can share the secret created for Ironic. The CA
       should be in a secret `ironic-cacert`.
 - **default** - A minimal, fully working, BMO kustomization including configmap.
-   Use only for development! There is no TLS or basic-auth.
+
+   > **⚠️ WARNING: Development use only!** Default kustomization is provided
+   > solely for local development and testing convenience. It uses plain HTTP
+   > for the Ironic endpoint (no TLS), has no basic-auth, and connects to
+   > Ironic without any transport integrity protection. **Do not use in
+   > production.** For production deployments, use
+   > overlays with the `tls` and `basic-auth` components
+   > enabled.
 - **overlays** - Here you will find ready made overlays that use the above
    mentioned components. These can be used as examples.

--- a/config/default/ironic.env
+++ b/config/default/ironic.env
@@ -1,5 +1,10 @@
 HTTP_PORT=6180
 PROVISIONING_INTERFACE=eth2
 DHCP_RANGE=172.22.0.10,172.22.0.100
+# Plain HTTP endpoint — no TLS or authentication.
 IRONIC_ENDPOINT=http://172.22.0.2:6385/v1/
+# Local image cache URL. Defaults to the host itself (172.22.0.1).
+# Uses plain HTTP since the cache server is co-located on the same host.
+# If your cache server is on a different host, use HTTPS to protect
+# image integrity in transit.
 CACHEURL=http://172.22.0.1/images

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -95,6 +95,11 @@ There is a script available that will run a set of containers locally using
 
 See `tools/run_local_ironic.sh`.
 
+> **⚠️ Development use only.** This script runs Ironic without TLS or
+> basic-auth by default. It is not suitable for production or shared
+> environments. If you need authentication, export `IRONIC_USERNAME` and
+> `IRONIC_PASSWORD` before running the script (see below).
+
 Note that this script may need customizations to some of the `podman run`
 commands, to include environment variables that configure the containers for
 your environment. All ironic related environment variables are set by default
@@ -112,7 +117,11 @@ The following environment variables can be passed to configure the ironic:
 - DEPLOY_KERNEL_URL - the URL of the kernel to deploy ironic-python-agent
 - DEPLOY_RAMDISK_URL - the URL of the ramdisk to deploy ironic-python-agent
 - IRONIC_ENDPOINT - the endpoint of the ironic
-- CACHEURL - the URL of the cached images
+- CACHEURL - the URL of the cached images. Defaults to
+  `http://${PROVISIONING_IP}/images` (typically `http://172.22.0.1/images`).
+  This points to a local HTTP server on the host itself. In production
+  deployments where the cache server is on a different host or network
+  segment, consider using HTTPS to protect image integrity in transit.
 - IRONIC_FAST_TRACK - whether to enable fast_track provisioning or not
   (default true)
 - IRONIC_KERNEL_PARAMS - Kernel parameters to pass to IPA (default console=ttyS0)
@@ -268,6 +277,14 @@ The `make-virt-host` utility can be used to generate a YAML file for
 registering a host. It takes as input the name of the `virsh` domain
 and produces as output the basic YAML to register that host properly,
 with the boot MAC address and BMC address filled in.
+
+> **⚠️ Security note:** This tool generates manifests with hard-coded HTTP
+> image URLs and MD5 checksum references (co-located on the same HTTP
+> server). This is acceptable for local development with virtual machines
+> but provides **no integrity guarantee** against network-level attackers.
+> Do not copy this pattern into production deployments. For production,
+> use HTTPS image URLs with inline SHA-256/SHA-512 checksums or OCI image
+> references pinned by digest.
 
 ```bash
 $ go run cmd/make-virt-host/main.go openshift_worker_1

--- a/ironic-deployment/README.md
+++ b/ironic-deployment/README.md
@@ -45,7 +45,19 @@ Here is a basic introduction of the kustomize structure:
    - **mariadb** - Use MariaDB instead of SQLite. TLS required for this
      to work.
 - **default** - A minimal, fully working, Ironic kustomization including
-  configmap and password. Use only for development! The DB password is
-  hard coded in the repo and there is no TLS or basic-auth.
+  configmap and password.
+
+  > **⚠️ WARNING: Development use only!** Default kustomization is intended
+  > solely for local development and testing. It does **not** follow security
+  > best practices:
+  >
+  > - No TLS (all traffic is plain HTTP)
+  > - No basic-auth (Ironic API is unauthenticated)
+  > - Hard-coded database password
+  > - Unpinned container images (`imagePullPolicy: Always` with mutable tags)
+  >
+  > These settings exist for ease of development, not as a deployment
+  > reference. **Do not use in production or as a template for production
+  > deployments.**
 - **overlays** - Here you will find ready made overlays that use the
   above mentioned components.


### PR DESCRIPTION
`config/default` and `ironic-deployment/default` don't following security best practices. They are for development usage only. I think we can make the security disclaimers a bit clearer. 

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
