### PR TITLE
:warning: Add fast Redfish-based inspection mode

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -81,6 +81,11 @@ const (
 
 	// InspectionModeAgent runs standard agent-based inspection.
 	InspectionModeAgent InspectionMode = "agent"
+
+	// InspectionModeFast runs out-of-band inspection via the BMC (e.g.
+	// Redfish) without booting a ramdisk. It completes in seconds but
+	// may return fewer details than agent-based inspection.
+	InspectionModeFast InspectionMode = "fast"
 )
 
 // RootDeviceHints holds the hints for specifying the storage location
@@ -642,8 +647,9 @@ type BareMetalHostSpec struct {
 	// Specifies the mode for host inspection.
 	// "disabled" - no inspection will be performed
 	// "agent" - normal agent-based inspection will run
+	// "fast" - out-of-band inspection via BMC (Redfish), no ramdisk boot
 	// +optional
-	// +kubebuilder:validation:Enum=disabled;agent
+	// +kubebuilder:validation:Enum=disabled;agent;fast
 	InspectionMode InspectionMode `json:"inspectionMode,omitempty"`
 
 	// NetworkInterfaces defines the network configuration for each interface.

--- a/config/base/crds/bases/metal3.io_baremetalhosts.yaml
+++ b/config/base/crds/bases/metal3.io_baremetalhosts.yaml
@@ -309,9 +309,11 @@ spec:
                   Specifies the mode for host inspection.
                   "disabled" - no inspection will be performed
                   "agent" - normal agent-based inspection will run
+                  "fast" - out-of-band inspection via BMC (Redfish), no ramdisk boot
                 enum:
                 - disabled
                 - agent
+                - fast
                 type: string
               metaData:
                 description: |-

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -309,9 +309,11 @@ spec:
                   Specifies the mode for host inspection.
                   "disabled" - no inspection will be performed
                   "agent" - normal agent-based inspection will run
+                  "fast" - out-of-band inspection via BMC (Redfish), no ramdisk boot
                 enum:
                 - disabled
                 - agent
+                - fast
                 type: string
               metaData:
                 description: |-

--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -922,6 +922,11 @@ func (r *BareMetalHostReconciler) registerHost(ctx context.Context, prov provisi
 		if info.host.Spec.AutomatedCleaningMode == metal3api.CleaningModeDisabled {
 			preprovImgFormats = nil
 		}
+	case metal3api.StateInspecting:
+		// Fast inspection uses the BMC directly, no ramdisk needed
+		if info.host.Spec.InspectionMode == metal3api.InspectionModeFast {
+			preprovImgFormats = nil
+		}
 	default:
 	}
 
@@ -958,6 +963,7 @@ func (r *BareMetalHostReconciler) registerHost(ctx context.Context, prov provisi
 			CPUArchitecture:            getHostArchitecture(info.host),
 			HardwareData:               info.hardwareData,
 			DisableInspection:          info.host.InspectionDisabled(),
+			InspectionMode:             info.host.Spec.InspectionMode,
 		},
 		credsChanged,
 		info.host.Status.ErrorType == metal3api.RegistrationError)
@@ -1115,6 +1121,7 @@ func (r *BareMetalHostReconciler) actionInspecting(ctx context.Context, prov pro
 		provisioner.InspectData{
 			BootMode:        info.host.Status.Provisioning.BootMode,
 			CPUArchitecture: getHostArchitecture(info.host),
+			InspectionMode:  info.host.Spec.InspectionMode,
 		},
 		info.host.Status.ErrorType == metal3api.InspectionError,
 		refresh,

--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation.go
@@ -81,7 +81,7 @@ func (webhook *BareMetalHost) validateHost(host *metal3api.BareMetalHost) []erro
 		errs = append(errs, annotationErrors...)
 	}
 
-	if err := validateInspectionMode(host); err != nil {
+	if err := validateInspectionMode(host, bmcAccess); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -420,7 +420,7 @@ func (webhook *BareMetalHost) validateCrossNamespaceSecretReferences(host *metal
 	return errs
 }
 
-func validateInspectionMode(host *metal3api.BareMetalHost) error {
+func validateInspectionMode(host *metal3api.BareMetalHost, bmcAccess bmc.AccessDetails) error {
 	inspectAnnotation := host.Annotations[metal3api.InspectAnnotationPrefix]
 
 	// Check for contradicting values when both are set
@@ -438,8 +438,13 @@ func validateInspectionMode(host *metal3api.BareMetalHost) error {
 	// but we validate here for safety)
 	if host.Spec.InspectionMode != "" &&
 		host.Spec.InspectionMode != metal3api.InspectionModeDisabled &&
-		host.Spec.InspectionMode != metal3api.InspectionModeAgent {
-		return fmt.Errorf("invalid inspectionMode value: %s, allowed values are 'disabled' or 'agent'", host.Spec.InspectionMode)
+		host.Spec.InspectionMode != metal3api.InspectionModeAgent &&
+		host.Spec.InspectionMode != metal3api.InspectionModeFast {
+		return fmt.Errorf("invalid inspectionMode value: %s, allowed values are 'disabled', 'agent', or 'fast'", host.Spec.InspectionMode)
+	}
+
+	if host.Spec.InspectionMode == metal3api.InspectionModeFast && bmcAccess != nil && bmcAccess.InspectInterface() == "" {
+		return fmt.Errorf("BMC driver %s does not support fast (out-of-band) inspection", bmcAccess.Type())
 	}
 
 	return nil

--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -1046,6 +1046,21 @@ func TestValidateCreate(t *testing.T) {
 			wantedErr: "",
 		},
 		{
+			name: "validInspectionModeFastIDracRedfish",
+			newBMH: &metal3api.BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: metal3api.BareMetalHostSpec{
+					BMC: metal3api.BMCDetails{
+						Address:         "idrac-redfish://192.168.122.1",
+						CredentialsName: "secretRefName",
+					},
+					InspectionMode: metal3api.InspectionModeFast,
+				},
+			},
+			wantedErr: "",
+		},
+		{
 			name: "validInspectionModeFastRedfishVirtualMedia",
 			newBMH: &metal3api.BareMetalHost{
 				TypeMeta:   tm,
@@ -1053,6 +1068,21 @@ func TestValidateCreate(t *testing.T) {
 				Spec: metal3api.BareMetalHostSpec{
 					BMC: metal3api.BMCDetails{
 						Address:         "redfish-virtualmedia://192.168.122.1",
+						CredentialsName: "secretRefName",
+					},
+					InspectionMode: metal3api.InspectionModeFast,
+				},
+			},
+			wantedErr: "",
+		},
+		{
+			name: "validInspectionModeFastIDracVirtualMedia",
+			newBMH: &metal3api.BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: metal3api.BareMetalHostSpec{
+					BMC: metal3api.BMCDetails{
+						Address:         "idrac-virtualmedia://192.168.122.1",
 						CredentialsName: "secretRefName",
 					},
 					InspectionMode: metal3api.InspectionModeFast,

--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -1031,6 +1031,68 @@ func TestValidateCreate(t *testing.T) {
 			wantedErr: "",
 		},
 		{
+			name: "validInspectionModeFastRedfish",
+			newBMH: &metal3api.BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: metal3api.BareMetalHostSpec{
+					BMC: metal3api.BMCDetails{
+						Address:         "redfish://192.168.122.1",
+						CredentialsName: "secretRefName",
+					},
+					InspectionMode: metal3api.InspectionModeFast,
+				},
+			},
+			wantedErr: "",
+		},
+		{
+			name: "validInspectionModeFastRedfishVirtualMedia",
+			newBMH: &metal3api.BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: metal3api.BareMetalHostSpec{
+					BMC: metal3api.BMCDetails{
+						Address:         "redfish-virtualmedia://192.168.122.1",
+						CredentialsName: "secretRefName",
+					},
+					InspectionMode: metal3api.InspectionModeFast,
+				},
+			},
+			wantedErr: "",
+		},
+		{
+			name: "inspectionModeFastWithIPMI",
+			newBMH: &metal3api.BareMetalHost{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: metal3api.BareMetalHostSpec{
+					BMC: metal3api.BMCDetails{
+						Address:         "ipmi://192.168.122.1:6233",
+						CredentialsName: "secretRefName",
+					},
+					InspectionMode: metal3api.InspectionModeFast,
+				},
+			},
+			wantedErr: "BMC driver ipmi does not support fast (out-of-band) inspection",
+		},
+		{
+			name: "inspectionModeFastAndAnnotationConflict",
+			newBMH: &metal3api.BareMetalHost{
+				TypeMeta: tm,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						metal3api.InspectAnnotationPrefix: "disabled",
+					},
+				},
+				Spec: metal3api.BareMetalHostSpec{
+					InspectionMode: metal3api.InspectionModeFast,
+				},
+			},
+			wantedErr: "inspect.metal3.io annotation and inspectionMode field have contradicting values",
+		},
+		{
 			name: "hardwareDetailsWithInspectionModeDisabled",
 			newBMH: &metal3api.BareMetalHost{
 				TypeMeta: tm,

--- a/pkg/hardwareutils/bmc/access.go
+++ b/pkg/hardwareutils/bmc/access.go
@@ -90,6 +90,11 @@ type AccessDetails interface {
 	// Whether the driver supports changing secure boot state.
 	SupportsSecureBoot() bool
 
+	// InspectInterface returns the Ironic inspect interface to use for
+	// out-of-band inspection (e.g. "redfish"). An empty string means
+	// the BMC type does not support out-of-band inspection.
+	InspectInterface() string
+
 	// Whether the driver supports booting a preprovisioning image in ISO format
 	SupportsISOPreprovisioningImage() bool
 

--- a/pkg/hardwareutils/bmc/access_test.go
+++ b/pkg/hardwareutils/bmc/access_test.go
@@ -252,6 +252,7 @@ func TestStaticDriverInfo(t *testing.T) {
 		driver     string
 		bios       string
 		boot       string
+		inspect    string
 		firmware   string
 		management string
 		power      string
@@ -264,6 +265,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:     "ipmi",
 			bios:       "",
 			boot:       "ipxe",
+			inspect:    "",
 			firmware:   "",
 			management: "",
 			power:      "",
@@ -276,6 +278,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:     "ipmi",
 			bios:       "",
 			boot:       "ipxe",
+			inspect:    "",
 			firmware:   "",
 			management: "",
 			power:      "",
@@ -288,6 +291,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:     "redfish",
 			bios:       "",
 			boot:       "ipxe",
+			inspect:    "redfish",
 			firmware:   "redfish",
 			management: "",
 			power:      "",
@@ -300,6 +304,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:     "redfish",
 			bios:       "",
 			boot:       "redfish-virtual-media",
+			inspect:    "redfish",
 			firmware:   "redfish",
 			management: "",
 			power:      "",
@@ -312,6 +317,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:     "redfish",
 			bios:       "",
 			boot:       "redfish-virtual-media",
+			inspect:    "redfish",
 			firmware:   "redfish",
 			management: "",
 			power:      "",
@@ -324,6 +330,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:     "redfish",
 			bios:       "",
 			boot:       "redfish-virtual-media",
+			inspect:    "redfish",
 			firmware:   "redfish",
 			management: "",
 			power:      "",
@@ -336,6 +343,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:     "redfish",
 			bios:       "",
 			boot:       "redfish-https",
+			inspect:    "redfish",
 			firmware:   "redfish",
 			management: "",
 			power:      "",
@@ -348,6 +356,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:     "idrac",
 			bios:       "idrac-redfish",
 			boot:       "ipxe",
+			inspect:    "redfish",
 			firmware:   "redfish",
 			management: "idrac-redfish",
 			power:      "idrac-redfish",
@@ -361,6 +370,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:   "redfish",
 			bios:     "",
 			boot:     "redfish-virtual-media",
+			inspect:  "redfish",
 			firmware: "redfish",
 		},
 
@@ -371,6 +381,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:   "redfish",
 			bios:     "",
 			boot:     "redfish-virtual-media",
+			inspect:  "redfish",
 			firmware: "redfish",
 		},
 
@@ -381,6 +392,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:   "redfish",
 			bios:     "",
 			boot:     "redfish-virtual-media",
+			inspect:  "redfish",
 			firmware: "redfish",
 		},
 
@@ -391,6 +403,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:     "idrac",
 			bios:       "idrac-redfish",
 			boot:       "idrac-redfish-virtual-media",
+			inspect:    "redfish",
 			firmware:   "redfish",
 			management: "idrac-redfish",
 			power:      "idrac-redfish",
@@ -404,6 +417,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:     "idrac",
 			bios:       "idrac-redfish",
 			boot:       "idrac-redfish-virtual-media",
+			inspect:    "redfish",
 			firmware:   "redfish",
 			management: "idrac-redfish",
 			power:      "idrac-redfish",
@@ -417,6 +431,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:     "idrac",
 			bios:       "idrac-redfish",
 			boot:       "idrac-redfish-virtual-media",
+			inspect:    "redfish",
 			firmware:   "redfish",
 			management: "idrac-redfish",
 			power:      "idrac-redfish",
@@ -441,6 +456,10 @@ func TestStaticDriverInfo(t *testing.T) {
 			if acc.BIOSInterface() != tc.bios {
 				t.Fatalf("Unexpected bios interface %q, expected %q",
 					acc.BIOSInterface(), tc.bios)
+			}
+			if acc.InspectInterface() != tc.inspect {
+				t.Fatalf("Unexpected inspect interface %q, expected %q",
+					acc.InspectInterface(), tc.inspect)
 			}
 			if acc.FirmwareInterface() != tc.firmware {
 				t.Fatalf("Unexpected firmware interface %q, expected %q",

--- a/pkg/hardwareutils/bmc/idrac_virtualmedia.go
+++ b/pkg/hardwareutils/bmc/idrac_virtualmedia.go
@@ -74,6 +74,11 @@ func (a *redfishiDracVirtualMediaAccessDetails) FirmwareInterface() string {
 	return redfish
 }
 
+func (a *redfishiDracVirtualMediaAccessDetails) InspectInterface() string {
+	// FIXME(dtantsur): this should be using idracRedfish, but it's not currently enabled in ironic-image.
+	return redfish
+}
+
 func (a *redfishiDracVirtualMediaAccessDetails) ManagementInterface() string {
 	return idracRedfish
 }

--- a/pkg/hardwareutils/bmc/ipmi.go
+++ b/pkg/hardwareutils/bmc/ipmi.go
@@ -117,6 +117,10 @@ func (a *ipmiAccessDetails) VendorInterface() string {
 	return ""
 }
 
+func (a *ipmiAccessDetails) InspectInterface() string {
+	return ""
+}
+
 func (a *ipmiAccessDetails) SupportsSecureBoot() bool {
 	return false
 }

--- a/pkg/hardwareutils/bmc/redfish.go
+++ b/pkg/hardwareutils/bmc/redfish.go
@@ -138,6 +138,10 @@ func (a *redfishAccessDetails) SupportsSecureBoot() bool {
 	return true
 }
 
+func (a *redfishAccessDetails) InspectInterface() string {
+	return redfish
+}
+
 func (a *redfishAccessDetails) SupportsISOPreprovisioningImage() bool {
 	return false
 }
@@ -167,6 +171,11 @@ func (a *redfishiDracAccessDetails) BootInterface() string {
 }
 
 func (a *redfishiDracAccessDetails) FirmwareInterface() string {
+	return redfish
+}
+
+func (a *redfishiDracAccessDetails) InspectInterface() string {
+	// FIXME(dtantsur): this should be using idracRedfish, but it's not currently enabled in ironic-image.
 	return redfish
 }
 

--- a/pkg/hardwareutils/bmc/redfish_https.go
+++ b/pkg/hardwareutils/bmc/redfish_https.go
@@ -99,6 +99,10 @@ func (a *redfishHTTPBootMediaAccessDetails) SupportsSecureBoot() bool {
 	return true
 }
 
+func (a *redfishHTTPBootMediaAccessDetails) InspectInterface() string {
+	return redfish
+}
+
 func (a *redfishHTTPBootMediaAccessDetails) SupportsISOPreprovisioningImage() bool {
 	return true
 }

--- a/pkg/provisioner/ironic/inspecthardware.go
+++ b/pkg/provisioner/ironic/inspecthardware.go
@@ -32,14 +32,30 @@ func (p *ironicProvisioner) startInspection(ctx context.Context, data provisione
 	if data.CPUArchitecture != "" {
 		opts["cpu_arch"] = data.CPUArchitecture
 	}
+
+	updater := clients.UpdateOptsBuilder(p.log).
+		SetPropertiesOpts(opts, ironicNode)
+
+	bmcAccess, bmcErr := p.bmcAccess()
+	if bmcErr != nil {
+		result, err = operationFailed(bmcErr.Error())
+		return result, started, err
+	}
+	if data.InspectionMode == metal3api.InspectionModeFast && bmcAccess.InspectInterface() == "" {
+		result, err = operationFailed(fmt.Sprintf("BMC driver %s does not support fast (out-of-band) inspection", bmcAccess.Type()))
+		return result, started, err
+	}
+	updater.SetTopLevelOpt("inspect_interface",
+		inspectInterfaceForMode(data.InspectionMode, bmcAccess),
+		ironicNode.InspectInterface)
+
 	_, started, result, err = p.tryUpdateNode(
 		ctx,
 		ironicNode,
-		clients.UpdateOptsBuilder(p.log).
-			SetPropertiesOpts(opts, ironicNode),
+		updater,
 	)
 	if !started {
-		return
+		return result, started, err
 	}
 
 	p.log.Info("starting new hardware inspection")
@@ -51,7 +67,7 @@ func (p *ironicProvisioner) startInspection(ctx context.Context, data provisione
 	if started {
 		p.publisher("InspectionStarted", "Hardware inspection started")
 	}
-	return
+	return result, started, err
 }
 
 // InspectHardware updates the HardwareDetails field of the host with

--- a/pkg/provisioner/ironic/inspecthardware.go
+++ b/pkg/provisioner/ironic/inspecthardware.go
@@ -105,7 +105,11 @@ func (p *ironicProvisioner) InspectHardware(ctx context.Context, data provisione
 		fallthrough
 	case nodes.Inspecting:
 		p.log.Info("inspection in progress")
-		result, err = operationContinuing(longRetryDelay)
+		delay := longRetryDelay
+		if data.InspectionMode == metal3api.InspectionModeFast {
+			delay = shortRetryDelay
+		}
+		result, err = operationContinuing(delay)
 		return result, started, details, err
 	case nodes.InspectFail:
 		if !restartOnFailure {

--- a/pkg/provisioner/ironic/inspecthardware_test.go
+++ b/pkg/provisioner/ironic/inspecthardware_test.go
@@ -239,3 +239,81 @@ func TestInspectHardware(t *testing.T) {
 		})
 	}
 }
+
+func TestInspectHardwareFastInspection(t *testing.T) {
+	nodeUUID := "33ce8659-7400-4c68-9535-d10766f07a58"
+
+	ironic := testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
+		UUID:           nodeUUID,
+		ProvisionState: "manageable",
+	}).NodeUpdate(nodes.Node{
+		UUID:           nodeUUID,
+		ProvisionState: "manageable",
+	}).WithNodeStatesProvisionUpdate(nodeUUID).WithInventoryFailed(nodeUUID, http.StatusNotFound)
+	ironic.Start()
+	defer ironic.Stop()
+
+	host := makeHost()
+	host.Spec.BMC.Address = "redfish://192.168.122.1/redfish/v1/Systems/1"
+	host.Spec.BootMACAddress = ""
+	host.Status.Provisioning.ID = nodeUUID
+
+	publishedMsg := ""
+	publisher := func(reason, message string) {
+		publishedMsg = reason + " " + message
+	}
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, publisher, ironic.Endpoint(), auth)
+	require.NoError(t, err)
+
+	result, started, _, err := prov.InspectHardware(t.Context(),
+		provisioner.InspectData{
+			BootMode:       metal3api.DefaultBootMode,
+			InspectionMode: metal3api.InspectionModeFast,
+		},
+		false, false, false)
+
+	require.NoError(t, err)
+	assert.True(t, started)
+	assert.True(t, result.Dirty)
+	assert.Equal(t, "InspectionStarted Hardware inspection started", publishedMsg)
+
+	updates := ironic.GetLastNodeUpdateRequestFor(nodeUUID)
+	var foundInspectInterface bool
+	for _, update := range updates {
+		if update.Path == "/inspect_interface" {
+			assert.Equal(t, "redfish", update.Value)
+			foundInspectInterface = true
+		}
+	}
+	assert.True(t, foundInspectInterface, "expected inspect_interface to be set to redfish")
+}
+
+func TestInspectHardwareFastInspectionUnsupported(t *testing.T) {
+	nodeUUID := "33ce8659-7400-4c68-9535-d10766f07a58"
+
+	ironic := testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
+		UUID:           nodeUUID,
+		ProvisionState: "manageable",
+	}).WithInventoryFailed(nodeUUID, http.StatusNotFound)
+	ironic.Start()
+	defer ironic.Stop()
+
+	host := makeHost()
+	host.Status.Provisioning.ID = nodeUUID
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher, ironic.Endpoint(), auth)
+	require.NoError(t, err)
+
+	result, started, _, err := prov.InspectHardware(t.Context(),
+		provisioner.InspectData{
+			BootMode:       metal3api.DefaultBootMode,
+			InspectionMode: metal3api.InspectionModeFast,
+		},
+		false, false, false)
+
+	require.NoError(t, err)
+	assert.False(t, started)
+	assert.Contains(t, result.ErrorMessage, "does not support fast (out-of-band) inspection")
+}

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -342,6 +342,11 @@ func (p *ironicProvisioner) configureNode(ctx context.Context, data provisioner.
 		return result, nil
 	}
 
+	if data.State == metal3api.StateInspecting && data.InspectionMode == metal3api.InspectionModeFast {
+		// Fast inspection uses the BMC directly, no ramdisk needed
+		return result, nil
+	}
+
 	switch data.State {
 	case metal3api.StateDeprovisioning,
 		metal3api.StateInspecting,

--- a/pkg/provisioner/ironic/prepare_test.go
+++ b/pkg/provisioner/ironic/prepare_test.go
@@ -30,6 +30,7 @@ func (r *RAIDTestBMC) ManagementInterface() string                   { return ""
 func (r *RAIDTestBMC) PowerInterface() string                        { return "" }
 func (r *RAIDTestBMC) RAIDInterface() string                         { return "" }
 func (r *RAIDTestBMC) VendorInterface() string                       { return "" }
+func (r *RAIDTestBMC) InspectInterface() string                      { return "" }
 func (r *RAIDTestBMC) SupportsSecureBoot() bool                      { return false }
 func (r *RAIDTestBMC) RequiresProvisioningNetwork() bool             { return true }
 func (r *RAIDTestBMC) BuildBIOSSettings(_ *bmc.FirmwareConfig) ([]map[string]string, error) {

--- a/pkg/provisioner/ironic/register.go
+++ b/pkg/provisioner/ironic/register.go
@@ -55,6 +55,13 @@ func (p *ironicProvisioner) Register(ctx context.Context, data provisioner.Manag
 		return result, "", err
 	}
 
+	if data.InspectionMode == metal3api.InspectionModeFast && bmcAccess.InspectInterface() == "" {
+		msg := fmt.Sprintf("BMC driver %s does not support fast (out-of-band) inspection", bmcAccess.Type())
+		p.log.Info(msg)
+		result, err = operationFailed(msg)
+		return result, "", err
+	}
+
 	if data.BootMode == metal3api.UEFISecureBoot && !bmcAccess.SupportsSecureBoot() {
 		msg := fmt.Sprintf("BMC driver %s does not support secure boot", bmcAccess.Type())
 		p.log.Info(msg)
@@ -261,6 +268,15 @@ func (p *ironicProvisioner) Register(ctx context.Context, data provisioner.Manag
 	}
 }
 
+func inspectInterfaceForMode(mode metal3api.InspectionMode, bmcAccess bmc.AccessDetails) string {
+	if mode == metal3api.InspectionModeFast {
+		if iface := bmcAccess.InspectInterface(); iface != "" {
+			return iface
+		}
+	}
+	return defaultInspectInterface
+}
+
 func (p *ironicProvisioner) enrollNode(ctx context.Context, data provisioner.ManagementAccessData, bmcAccess bmc.AccessDetails, driverInfo map[string]any) (ironicNode *nodes.Node, retry bool, err error) {
 	nodeCreateOpts := nodes.CreateOpts{
 		Driver:              bmcAccess.Driver(),
@@ -270,7 +286,7 @@ func (p *ironicProvisioner) enrollNode(ctx context.Context, data provisioner.Man
 		DriverInfo:          driverInfo,
 		FirmwareInterface:   bmcAccess.FirmwareInterface(),
 		DeployInterface:     p.deployInterface(data),
-		InspectInterface:    defaultInspectInterface,
+		InspectInterface:    inspectInterfaceForMode(data.InspectionMode, bmcAccess),
 		ManagementInterface: bmcAccess.ManagementInterface(),
 		PowerInterface:      bmcAccess.PowerInterface(),
 		RAIDInterface:       bmcAccess.RAIDInterface(),

--- a/pkg/provisioner/ironic/register_test.go
+++ b/pkg/provisioner/ironic/register_test.go
@@ -136,6 +136,66 @@ func TestRegisterCreateNode(t *testing.T) {
 	assert.Equal(t, "agent", createdNode.InspectInterface)
 }
 
+func TestRegisterCreateNodeFastInspection(t *testing.T) {
+	host := makeHost()
+	host.Spec.BMC.Address = "redfish://192.168.122.1/redfish/v1/Systems/1"
+	host.Spec.BootMACAddress = ""
+	host.Spec.Image = nil
+	host.Status.Provisioning.ID = ""
+
+	var createdNode *nodes.Node
+
+	createCallback := func(node nodes.Node) {
+		createdNode = &node
+	}
+
+	ironic := testserver.NewIronic(t).WithDrivers().CreateNodes(createCallback).NoNode(host.Namespace + nameSeparator + host.Name).NoNode(host.Name)
+	ironic.AddDefaultResponse("/v1/nodes/node-0", "PATCH", http.StatusOK, "{}")
+	ironic.Start()
+	defer ironic.Stop()
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher, ironic.Endpoint(), auth)
+	if err != nil {
+		t.Fatalf("could not create provisioner: %s", err)
+	}
+
+	result, provID, err := prov.Register(t.Context(), provisioner.ManagementAccessData{
+		InspectionMode: metal3api.InspectionModeFast,
+	}, false, false)
+	if err != nil {
+		t.Fatalf("error from Register: %s", err)
+	}
+	assert.Empty(t, result.ErrorMessage)
+	assert.NotEmpty(t, createdNode.UUID)
+	assert.Equal(t, createdNode.UUID, provID)
+	assert.Equal(t, "redfish", createdNode.InspectInterface)
+}
+
+func TestRegisterFastInspectionUnsupported(t *testing.T) {
+	host := makeHost()
+	host.Spec.BootMACAddress = ""
+	host.Status.Provisioning.ID = ""
+
+	ironic := testserver.NewIronic(t).NoNode(host.Namespace + nameSeparator + host.Name).NoNode(host.Name)
+	ironic.Start()
+	defer ironic.Stop()
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nil, ironic.Endpoint(), auth)
+	if err != nil {
+		t.Fatalf("could not create provisioner: %s", err)
+	}
+
+	result, _, err := prov.Register(t.Context(), provisioner.ManagementAccessData{
+		InspectionMode: metal3api.InspectionModeFast,
+	}, false, false)
+	if err != nil {
+		t.Fatalf("error from Register: %s", err)
+	}
+	assert.Contains(t, result.ErrorMessage, "does not support fast (out-of-band) inspection")
+}
+
 func TestRegisterExistingNode(t *testing.T) {
 	// Create a host without a bootMACAddress and with a BMC that
 	// does not require one.

--- a/pkg/provisioner/ironic/servicing_test.go
+++ b/pkg/provisioner/ironic/servicing_test.go
@@ -31,6 +31,7 @@ func (r *BIOSTestBMC) ManagementInterface() string                   { return ""
 func (r *BIOSTestBMC) PowerInterface() string                        { return "" }
 func (r *BIOSTestBMC) RAIDInterface() string                         { return "" }
 func (r *BIOSTestBMC) VendorInterface() string                       { return "" }
+func (r *BIOSTestBMC) InspectInterface() string                      { return "" }
 func (r *BIOSTestBMC) SupportsSecureBoot() bool                      { return false }
 func (r *BIOSTestBMC) RequiresProvisioningNetwork() bool             { return true }
 func (r *BIOSTestBMC) BuildBIOSSettings(_ *bmc.FirmwareConfig) ([]map[string]string, error) {

--- a/pkg/provisioner/ironic/testbmc/testbmc.go
+++ b/pkg/provisioner/ironic/testbmc/testbmc.go
@@ -90,6 +90,10 @@ func (a *testAccessDetails) VendorInterface() string {
 	return ""
 }
 
+func (a *testAccessDetails) InspectInterface() string {
+	return ""
+}
+
 func (a *testAccessDetails) SupportsSecureBoot() bool {
 	return false
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -90,6 +90,7 @@ type ManagementAccessData struct {
 	CPUArchitecture            string
 	HardwareData               *metal3api.HardwareData
 	DisableInspection          bool
+	InspectionMode             metal3api.InspectionMode
 }
 
 type AdoptData struct {
@@ -99,6 +100,7 @@ type AdoptData struct {
 type InspectData struct {
 	BootMode        metal3api.BootMode
 	CPUArchitecture string
+	InspectionMode  metal3api.InspectionMode
 }
 
 // FirmwareConfig and FirmwareSettings are used for implementation of similar functionality

--- a/test/e2e/config/ironic.yaml
+++ b/test/e2e/config/ironic.yaml
@@ -72,7 +72,7 @@ intervals:
   default/wait-registering: [ "1m", "5s" ]
   inspection/wait-registration-error: [ "1m", "5s" ]
   external-inspection/wait-available: [ "1m", "1s" ]
-  default/wait-inspecting: [ "2m", "2s" ]
+  default/wait-inspecting: [ "2m", "1s" ]
   default/wait-available: [ "10m", "1s" ]
   default/wait-deployment: [ "10m", "1s" ]
   default/wait-namespace-deleted: [ "10m", "1s" ]

--- a/test/e2e/inspection_test.go
+++ b/test/e2e/inspection_test.go
@@ -104,6 +104,86 @@ var _ = Describe("Inspection", Label("required", "inspection", "ironic"), func()
 		}, e2eConfig.GetIntervals(specName, "wait-registration-error")...).Should(Succeed())
 	})
 
+	It("should inspect a BMH using fast (out-of-band) inspection", func() {
+		if bmc.AccessDetails.InspectInterface() == "" {
+			Skip("BMC driver does not support out-of-band inspection")
+		}
+
+		bmhName := specName + "-fast"
+		secretName := bmhName + "-bmc"
+
+		By("Creating a secret with BMH credentials")
+		bmcCredentialsData := map[string]string{
+			"username": bmc.User,
+			"password": bmc.Password,
+		}
+		secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+		toCleanup = append(toCleanup, secret)
+
+		By("creating a BMH with inspectionMode fast")
+		bmh := metal3api.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			},
+			Spec: metal3api.BareMetalHostSpec{
+				BMC: metal3api.BMCDetails{
+					Address:                        bmc.Address,
+					CredentialsName:                secretName,
+					DisableCertificateVerification: bmc.DisableCertificateVerification,
+				},
+				BootMode:       metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
+				InspectionMode: metal3api.InspectionModeFast,
+			},
+		}
+		if bmc.AccessDetails.NeedsMAC() {
+			bmh.Spec.BootMACAddress = bmc.BootMacAddress
+		}
+		err := clusterProxy.GetClient().Create(ctx, &bmh)
+		Expect(err).NotTo(HaveOccurred())
+		toCleanup = append(toCleanup, &bmh)
+
+		By("waiting for the BMH to be in inspecting state")
+		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.StateInspecting,
+		}, e2eConfig.GetIntervals(specName, "wait-inspecting")...)
+
+		By("waiting for the BMH to become available")
+		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.StateAvailable,
+		}, e2eConfig.GetIntervals(specName, "wait-available")...)
+
+		By("checking the hardware details were populated")
+		key := types.NamespacedName{Namespace: bmh.Namespace, Name: bmh.Name}
+		Expect(clusterProxy.GetClient().Get(ctx, key, &bmh)).To(Succeed())
+
+		Expect(bmh.Status.HardwareDetails).NotTo(BeNil())
+		Expect(bmh.Status.HardwareDetails.RAMMebibytes).To(BeNumerically(">", 0))
+		Expect(bmh.Status.HardwareDetails.CPU.Count).To(BeNumerically(">", 0))
+		Expect(bmh.Status.HardwareDetails.NIC).NotTo(BeEmpty())
+
+		By("checking that HardwareData resource was created")
+		hwData := &metal3api.HardwareData{}
+		Expect(clusterProxy.GetClient().Get(ctx, key, hwData)).To(Succeed())
+
+		Expect(hwData.Spec.HardwareDetails).NotTo(BeNil())
+		Expect(hwData.Spec.HardwareDetails.RAMMebibytes).To(BeNumerically(">", 0))
+		Expect(hwData.Spec.HardwareDetails.CPU.Count).To(BeNumerically(">", 0))
+		Expect(hwData.Spec.HardwareDetails.NIC).NotTo(BeEmpty())
+
+		if e2eConfig.GetBoolVariable("DEPLOY_IRONIC") {
+			By("checking that fast inspection did not populate a hostname or IP (no ramdisk was booted)")
+			Expect(bmh.Status.HardwareDetails.Hostname).To(BeEmpty())
+			Expect(bmh.Status.HardwareDetails.NIC[0].IP).To(BeEmpty())
+			Expect(hwData.Spec.HardwareDetails.Hostname).To(BeEmpty())
+			Expect(hwData.Spec.HardwareDetails.NIC[0].IP).To(BeEmpty())
+		}
+	})
+
 	It("should inspect a newly created BMH", func() {
 		By("Creating a secret with BMH credentials")
 


### PR DESCRIPTION
Allows inspection without booting ramdisk by contacting Redfish
endpoints of the machine.

See the design proposal for detailed motivation:
https://github.com/metal3-io/metal3-docs/blob/main/design/baremetal-operator/out-of-band-inspection.md

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>

P.S. (Rozzii) This feature has introduced breaking change in the AccessDetails interface of the pkg/hardwareutils/bmc/access.go. The break only happens for consumers who consume the hardwareutils package as a go library / dependency.