### PR TITLE
:seedling: Add items section for ironic-cacert secret in tls.yaml

### DIFF
--- a/ironic-deployment/components/tls/tls.yaml
+++ b/ironic-deployment/components/tls/tls.yaml
@@ -35,6 +35,9 @@ spec:
       - name: cert-ironic-ca
         secret:
           secretName: ironic-cacert
+          items:
+          - key: tls.crt
+            path: tls.crt
       - name: cert-ironic
         secret:
           secretName: ironic-cert


### PR DESCRIPTION
The `cert-ironic-ca` volume mounts the `ironic-cacert` Secret without an `items` section adding `tls.key` to both the `ironic` and `ironic-httpd` containers. These containers only need the CA certificate `tls.crt` for trust verification. Add items section to prevent unnecessary `tls.key` from being added to the containers. This is a small security hardening. 