### PR TITLE
🌱 Add E2E tests for dataimage finalizer removal

### DIFF
--- a/config/overlays/e2e/dataimage/kustomization.yaml
+++ b/config/overlays/e2e/dataimage/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../roles-rolebindings
+- namespace.yaml
+
+namespace: dataimage

--- a/config/overlays/e2e/dataimage/namespace.yaml
+++ b/config/overlays/e2e/dataimage/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dataimage

--- a/config/overlays/e2e/kustomization.yaml
+++ b/config/overlays/e2e/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - ./automated-cleaning
 - ./baremetalswitch
 - ./basic-ops
+- ./dataimage
 - ./external-inspection
 - ./externally-provisioned
 - ./firmware-components

--- a/config/overlays/e2e/namespaced-manager-patch.yaml
+++ b/config/overlays/e2e/namespaced-manager-patch.yaml
@@ -9,5 +9,5 @@ spec:
       containers:
       - env:
         - name: WATCH_NAMESPACE
-          value: basic-ops,external-inspection,externally-provisioned,firmware-settings,inspection,live-iso-ops,provisioning-ops,re-inspection,automated-cleaning,upgrade-bmo,upgrade-ironic,force-detach,network-data,baremetalswitch,firmware-components
+          value: basic-ops,external-inspection,externally-provisioned,firmware-settings,inspection,live-iso-ops,provisioning-ops,re-inspection,automated-cleaning,upgrade-bmo,upgrade-ironic,force-detach,network-data,baremetalswitch,firmware-components,dataimage
         name: manager

--- a/test/e2e/dataimage_test.go
+++ b/test/e2e/dataimage_test.go
@@ -1,0 +1,317 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"path"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("DataImage Finalizer", Label("required", "dataimage"), func() {
+	const dataImageURL = "http://example.com/ubuntu.iso"
+
+	var (
+		specName      = "dataimage"
+		namespace     *corev1.Namespace
+		cancelWatches context.CancelFunc
+		toCleanup     []client.Object
+	)
+
+	BeforeEach(func() {
+		toCleanup = nil
+
+		namespace, cancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
+			Creator:             clusterProxy.GetClient(),
+			ClientSet:           clusterProxy.GetClientSet(),
+			Name:                specName,
+			LogFolder:           artifactFolder,
+			IgnoreAlreadyExists: true,
+		})
+	})
+
+	It("should add a finalizer to a new DataImage when a BMH exists", func() {
+		bmhName := specName + "-add-finalizer"
+		secretName := bmhName + "-bmc-creds"
+
+		By("Creating a secret with BMH credentials")
+		bmcCredentialsData := map[string]string{
+			"username": bmc.User,
+			"password": bmc.Password,
+		}
+		secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+		toCleanup = append(toCleanup, secret)
+
+		By("Creating a BMH with inspection disabled")
+		bmh := metal3api.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			},
+			Spec: metal3api.BareMetalHostSpec{
+				Online: true,
+				BMC: metal3api.BMCDetails{
+					Address:                        bmc.Address,
+					CredentialsName:                secretName,
+					DisableCertificateVerification: bmc.DisableCertificateVerification,
+				},
+				BootMode:              metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
+				BootMACAddress:        bmc.BootMacAddress,
+				AutomatedCleaningMode: metal3api.CleaningModeDisabled,
+				InspectionMode:        metal3api.InspectionModeDisabled,
+			},
+		}
+		err := clusterProxy.GetClient().Create(ctx, &bmh)
+		Expect(err).NotTo(HaveOccurred())
+		toCleanup = append(toCleanup, &bmh)
+
+		By("Creating a DataImage with the same name as the BMH")
+		di := &metal3api.DataImage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			},
+			Spec: metal3api.DataImageSpec{
+				URL: dataImageURL,
+			},
+		}
+		err = clusterProxy.GetClient().Create(ctx, di)
+		Expect(err).NotTo(HaveOccurred())
+		toCleanup = append(toCleanup, di)
+
+		By("Waiting for the finalizer to be added to the DataImage")
+		Eventually(func(g Gomega) {
+			updatedDI := &metal3api.DataImage{}
+			g.Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			}, updatedDI)).To(Succeed())
+			g.Expect(updatedDI.Finalizers).To(ContainElement(metal3api.DataImageFinalizer))
+		}, e2eConfig.GetIntervals(specName, "wait-available")...).Should(Succeed())
+	})
+
+	It("should remove the finalizer when DataImage is deleted and no BMH exists", func() {
+		diName := specName + "-no-bmh"
+
+		By("Creating a DataImage without a corresponding BMH")
+		di := &metal3api.DataImage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       diName,
+				Namespace:  namespace.Name,
+				Finalizers: []string{metal3api.DataImageFinalizer},
+			},
+			Spec: metal3api.DataImageSpec{
+				URL: dataImageURL,
+			},
+		}
+		err := clusterProxy.GetClient().Create(ctx, di)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the controller to remove the finalizer (no BMH exists)")
+		Eventually(func(g Gomega) {
+			updatedDI := &metal3api.DataImage{}
+			g.Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      diName,
+				Namespace: namespace.Name,
+			}, updatedDI)).To(Succeed())
+			g.Expect(updatedDI.Finalizers).NotTo(ContainElement(metal3api.DataImageFinalizer))
+		}, e2eConfig.GetIntervals(specName, "wait-available")...).Should(Succeed())
+
+		By("Deleting the DataImage")
+		err = clusterProxy.GetClient().Delete(ctx, di)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the DataImage to be fully removed")
+		Eventually(func() bool {
+			err := clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      diName,
+				Namespace: namespace.Name,
+			}, &metal3api.DataImage{})
+			return k8serrors.IsNotFound(err)
+		}, e2eConfig.GetIntervals(specName, "wait-available")...).Should(BeTrue())
+	})
+
+	It("should remove the finalizer when BMH is detached and DataImage is deleted", func() {
+		bmhName := specName + "-detached"
+		secretName := bmhName + "-bmc-creds"
+
+		By("Creating a secret with BMH credentials")
+		bmcCredentialsData := map[string]string{
+			"username": bmc.User,
+			"password": bmc.Password,
+		}
+		secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+		toCleanup = append(toCleanup, secret)
+
+		By("Creating a BMH with inspection disabled")
+		bmh := metal3api.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			},
+			Spec: metal3api.BareMetalHostSpec{
+				Online: true,
+				BMC: metal3api.BMCDetails{
+					Address:                        bmc.Address,
+					CredentialsName:                secretName,
+					DisableCertificateVerification: bmc.DisableCertificateVerification,
+				},
+				BootMode:              metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
+				BootMACAddress:        bmc.BootMacAddress,
+				AutomatedCleaningMode: metal3api.CleaningModeDisabled,
+				InspectionMode:        metal3api.InspectionModeDisabled,
+			},
+		}
+		err := clusterProxy.GetClient().Create(ctx, &bmh)
+		Expect(err).NotTo(HaveOccurred())
+		toCleanup = append(toCleanup, &bmh)
+
+		By("Creating a DataImage with the same name")
+		di := &metal3api.DataImage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			},
+			Spec: metal3api.DataImageSpec{
+				URL: dataImageURL,
+			},
+		}
+		err = clusterProxy.GetClient().Create(ctx, di)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the finalizer to be added")
+		Eventually(func(g Gomega) {
+			updatedDI := &metal3api.DataImage{}
+			g.Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			}, updatedDI)).To(Succeed())
+			g.Expect(updatedDI.Finalizers).To(ContainElement(metal3api.DataImageFinalizer))
+		}, e2eConfig.GetIntervals(specName, "wait-available")...).Should(Succeed())
+
+		By("Adding the detached annotation to the BMH")
+		detachedValue := "{}"
+		AnnotateBmh(ctx, clusterProxy.GetClient(), bmh, metal3api.DetachedAnnotation, &detachedValue)
+
+		By("Waiting for the BMH to be in detached operational status")
+		WaitForBmhInOperationalStatus(ctx, WaitForBmhInOperationalStatusInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.OperationalStatusDetached,
+		}, e2eConfig.GetIntervals(specName, "wait-available")...)
+
+		By("Deleting the DataImage")
+		err = clusterProxy.GetClient().Delete(ctx, di)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the DataImage to be fully removed (finalizer removed in detached state)")
+		Eventually(func() bool {
+			err := clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			}, &metal3api.DataImage{})
+			return k8serrors.IsNotFound(err)
+		}, e2eConfig.GetIntervals(specName, "wait-available")...).Should(BeTrue())
+	})
+
+	It("should remove the finalizer when image is not attached and DataImage is deleted", func() {
+		if e2eConfig.GetBoolVariable("DEPLOY_IRONIC") {
+			Skip("With Ironic deployed, the image gets attached and detach is not triggered by deletion alone")
+		}
+
+		bmhName := specName + "-image-detached"
+		secretName := bmhName + "-bmc-creds"
+
+		By("Creating a secret with BMH credentials")
+		bmcCredentialsData := map[string]string{
+			"username": bmc.User,
+			"password": bmc.Password,
+		}
+		secret := CreateSecret(ctx, clusterProxy.GetClient(), namespace.Name, secretName, bmcCredentialsData)
+		toCleanup = append(toCleanup, secret)
+
+		By("Creating a BMH with inspection disabled")
+		bmh := metal3api.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			},
+			Spec: metal3api.BareMetalHostSpec{
+				Online: true,
+				BMC: metal3api.BMCDetails{
+					Address:                        bmc.Address,
+					CredentialsName:                secretName,
+					DisableCertificateVerification: bmc.DisableCertificateVerification,
+				},
+				BootMode:              metal3api.BootMode(e2eConfig.GetVariable("BOOT_MODE")),
+				BootMACAddress:        bmc.BootMacAddress,
+				AutomatedCleaningMode: metal3api.CleaningModeDisabled,
+				InspectionMode:        metal3api.InspectionModeDisabled,
+			},
+		}
+		err := clusterProxy.GetClient().Create(ctx, &bmh)
+		Expect(err).NotTo(HaveOccurred())
+		toCleanup = append(toCleanup, &bmh)
+
+		By("Waiting for the BMH to become available")
+		WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
+			Client: clusterProxy.GetClient(),
+			Bmh:    bmh,
+			State:  metal3api.StateAvailable,
+		}, e2eConfig.GetIntervals(specName, "wait-available")...)
+
+		By("Creating a DataImage with the same name")
+		di := &metal3api.DataImage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			},
+			Spec: metal3api.DataImageSpec{
+				URL: dataImageURL,
+			},
+		}
+		err = clusterProxy.GetClient().Create(ctx, di)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the finalizer to be added")
+		Eventually(func(g Gomega) {
+			updatedDI := &metal3api.DataImage{}
+			g.Expect(clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			}, updatedDI)).To(Succeed())
+			g.Expect(updatedDI.Finalizers).To(ContainElement(metal3api.DataImageFinalizer))
+		}, e2eConfig.GetIntervals(specName, "wait-available")...).Should(Succeed())
+
+		By("Deleting the DataImage")
+		err = clusterProxy.GetClient().Delete(ctx, di)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the DataImage to be fully removed (image not attached, finalizer removed)")
+		Eventually(func() bool {
+			err := clusterProxy.GetClient().Get(ctx, types.NamespacedName{
+				Name:      bmhName,
+				Namespace: namespace.Name,
+			}, &metal3api.DataImage{})
+			return k8serrors.IsNotFound(err)
+		}, "20m", "10s").Should(BeTrue())
+	})
+
+	AfterEach(func() {
+		CollectSerialLogs(bmc.Name, path.Join(artifactFolder, specName))
+		DumpResources(ctx, e2eConfig, clusterProxy, path.Join(artifactFolder, specName))
+		if !skipCleanup {
+			Cleanup(ctx, clusterProxy, namespace, cancelWatches, e2eConfig, toCleanup)
+		}
+	})
+})


### PR DESCRIPTION
| # | Test | Scenario | Expected outcome |
|---|------|----------|-----------------|
| 1 | Add a finalizer to a new DataImage when a BMH exists | BMH + DataImage created together | Finalizer appears on DataImage |
 | 2 | Remove the finalizer when DataImage is deleted and no BMH exists | DataImage created alone, no BMH | DataImage deletes without getting stuck | 
| 3 | Remove the finalizer when BMH is detached and DataImage is deleted | BMH detached, then DataImage deleted | DataImage deletes without Ironic check | 
| 4 | Remove the finalizer when image is not attached and DataImage is deleted | BMH available, image not attached | DataImage deletes after provisioner confirms |

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**: 

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes https://github.com/metal3-io/baremetal-operator/issues/2053

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [X] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
