### PR TITLE
🐛 Delete detached hosts promptly before the operational status flips

### DIFF
--- a/internal/controller/metal3.io/host_state_machine.go
+++ b/internal/controller/metal3.io/host_state_machine.go
@@ -227,7 +227,14 @@ func (hsm *hostStateMachine) checkInitiateDelete(log logr.Logger) bool {
 		return false
 	}
 
-	if hsm.NextState != metal3api.StateDeleting && hsm.Host.OperationalStatus() == metal3api.OperationalStatusDetached {
+	// A host is treated as detached for deletion purposes as soon as the
+	// detached annotation is present, not only once the operational status has
+	// caught up. Otherwise a delete requested in the window before the status
+	// flips falls through to deprovisioning, which talks to the provisioner the
+	// detach was meant to avoid and stalls the delete behind the 10-minute
+	// detached slow poll (issue #3213).
+	if hsm.NextState != metal3api.StateDeleting &&
+		(hsm.Host.OperationalStatus() == metal3api.OperationalStatusDetached || hasDetachedAnnotation(hsm.Host)) {
 		if delayDeleteForDetachedHost(hsm.Host) {
 			log.Info("delaying detached host deletion")
 			deleteDelayedForDetached.Inc()

--- a/internal/controller/metal3.io/host_state_machine_test.go
+++ b/internal/controller/metal3.io/host_state_machine_test.go
@@ -1107,6 +1107,21 @@ func TestDeleteWaitsForDetach(t *testing.T) {
 			ExpectedState:             metal3api.StateDeprovisioning,
 			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
 		},
+		{
+			// Deletion requested while the detached annotation is set but the
+			// operational status has not been flipped to Detached yet. The host
+			// should go straight to Deleting like an already-detached host, not
+			// down the Deprovisioning path, which pokes the provisioner the
+			// detach was meant to avoid and drags the delete through the
+			// 10-minute detached slow poll (issue #3213).
+			Scenario: "detached-annotation-delete-before-status",
+			Host: host(metal3api.StateProvisioned).
+				setDeletion().
+				setDetached("{\"deleteAction\": \"delete\"}").
+				build(),
+			ExpectedState:             metal3api.StateDeleting,
+			ExpectedOperationalStatus: metal3api.OperationalStatusOK,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.Scenario, func(t *testing.T) {


### PR DESCRIPTION
### What this PR does / why we need it

If a delete comes in while a host is being detached, but before the operational status has actually flipped to `detached`, the delete falls through to the normal deprovisioning path instead of going straight to `deleting`. Two problems with that:

- it deprovisions through the provisioner that the detached annotation asked us to leave alone, and
- once detachment finishes the host lands in the 10 minute detached slow poll, so the delete sits there for up to ten minutes before it moves again.

`checkInitiateDelete` only took the fast detached-delete path when `OperationalStatus == detached`. This widens it to also trigger when the detached annotation is present, so it no longer depends on the status having caught up. The `delayDeleteForDetachedHost` / `deleteAction: delay` behaviour is unchanged.

Added a `TestDeleteWaitsForDetach` case for the window before the status update — it returns `deleting` now, `deprovisioning` before.

### Which issue(s) this PR fixes

Fixes #3213

/kind bug

```release-note
Fixed a delay of up to 10 minutes when deleting a BareMetalHost that had the detached annotation set but had not yet reached the detached operational status.
```
