### PR TITLE
🌱 e2e: fix a typo in the expected state

### DIFF
--- a/test/e2e/externally_provisioned_test.go
+++ b/test/e2e/externally_provisioned_test.go
@@ -175,7 +175,7 @@ var _ = Describe("External Provisioning", Label("required", "provision", "deprov
 			WaitForBmhInProvisioningState(ctx, WaitForBmhInProvisioningStateInput{
 				Client: clusterProxy.GetClient(),
 				Bmh:    bmh,
-				State:  metal3api.StateExternallyProvisioned,
+				State:  metal3api.StateProvisioned,
 				// NOTE(dtantsur): using the smaller externally-provisioned interval on purpose since a real provisioning is not expected
 			}, e2eConfig.GetIntervals(specName, "wait-externally-provisioned")...)
 


### PR DESCRIPTION
When setting externallyProvisioned to false, the result should be
Provisioned, not ExternallyProvisioned. The test only passes because
BMO does not update the host quickly enough.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
