### PR TITLE
🌱 Build vbmctl as a release artifact

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,6 +111,10 @@ jobs:
       with:
         go-version: ${{ env.go_version }}
         cache: false
+    - name: Install libvirt build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libvirt-dev
     - name: generate release artifacts
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -240,12 +240,17 @@ deploy-cli:
 build-e2e:
 	cd test; go build --tags=e2e ./...
 
+# output path and ldflags for vbmctl binary. Overridable so the release
+# build can retarget the output (see release-vbmctl)
+VBMCTL_OUT ?= $(abspath $(BIN_DIR)/vbmctl)
+VBMCTL_LDFLAGS ?= "-X github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/config.Version=${BUILD_VERSION}"
+
 .PHONY: build-vbmctl
 build-vbmctl:
-	cd test; go build --tags=e2e,vbmctl -ldflags $(LDFLAGS) -o $(abspath $(BIN_DIR)/vbmctl) ./vbmctl/cmd/vbmctl
+	cd test; CGO_ENABLED=1 go build --tags=e2e,vbmctl -ldflags $(VBMCTL_LDFLAGS) -o $(VBMCTL_OUT) ./vbmctl/cmd/vbmctl
 
 .PHONY: unit-vbmctl
-unit-vbmctl: ## Run vbmctl unit tests
+unit-vbmctl: # Run unit tests for vbmctl
 	cd test && go test --tags=e2e,vbmctl $(GO_TEST_FLAGS) ./vbmctl/...
 
 .PHONY: manifests
@@ -467,6 +472,10 @@ release-notes: $(RELEASE_NOTES_DIR) $(RELEASE_NOTES)
 release-manifests: $(KUSTOMIZE) $(RELEASE_DIR) ## Builds the manifests to publish with a release
 	$(KUSTOMIZE) build config > $(RELEASE_DIR)/baremetal-operator.yaml
 
+.PHONY: release-vbmctl
+release-vbmctl: $(RELEASE_DIR) ## Build vbmctl for the release into out/
+	$(MAKE) build-vbmctl VBMCTL_OUT=$(abspath $(RELEASE_DIR))/vbmctl-$(shell go env GOOS)-$(shell go env GOARCH)
+
 .PHONY: release
 release:
 	@if [ -z "${RELEASE_TAG}" ]; then echo "RELEASE_TAG is not set"; exit 1; fi
@@ -475,6 +484,7 @@ release:
 	MANIFEST_IMG=$(IMG) MANIFEST_TAG=$(RELEASE_TAG) $(MAKE) set-manifest-image-bmo
 	PULL_POLICY=IfNotPresent $(MAKE) set-manifest-pull-policy
 	$(MAKE) release-manifests
+	$(MAKE) release-vbmctl BUILD_VERSION=${RELEASE_TAG}
 	$(MAKE) release-notes
 
 go-version: ## Print the go version we use to compile our binaries and images

--- a/test/vbmctl/pkg/config/config.go
+++ b/test/vbmctl/pkg/config/config.go
@@ -14,10 +14,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const (
-	// Version is set at build time.
-	Version = "dev"
+// Version is set at build time via -ldflags -X.
+var Version = "dev"
 
+const (
 	// DefaultConfigFileName is the default name for the config file.
 	DefaultConfigFileName = "vbmctl.yaml"
 


### PR DESCRIPTION
Build vbmctl as part of the release and publish it as a release artifact. vbmctl is already used in the e2e tests and is handy for local development and demos, but right now everyone has to build it themselves.

This adds a release-vbmctl Make target that builds the binary into out/ and stamps it with the release version. Since vbmctl links against libvirt, the release job also needs the libvirt dev headers to build it.

Follow-up to #2751.

**Key changes**:

- Add release-vbmctl Make target that builds vbmctl into out/ as vbmctl-<os>-<arch>
- Wire release-vbmctl into the release target
- Add VBMCTL_LDFLAGS so the binary reports its real version
- Change config.Version from a const to a var so it can be set at built time
- Install libvirt-dev in the release workflow job