### PR TITLE
🐛 Run BMO with a read-only root filesystem

### DIFF
--- a/config/base/manager.yaml
+++ b/config/base/manager.yaml
@@ -74,8 +74,8 @@ spec:
           successThreshold: 1
           failureThreshold: 10
       volumes:
-      - emptyDir: {}
-        name: tmp
+      - name: tmp
+        emptyDir: {}
       terminationGracePeriodSeconds: 10
       securityContext:
         runAsNonRoot: true

--- a/config/base/manager.yaml
+++ b/config/base/manager.yaml
@@ -49,8 +49,12 @@ spec:
             drop:
             - ALL
           privileged: false
+          readOnlyRootFilesystem: true
           runAsUser: 65532
           runAsGroup: 65532
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
         livenessProbe:
           httpGet:
             path: /healthz
@@ -69,6 +73,9 @@ spec:
           timeoutSeconds: 2
           successThreshold: 1
           failureThreshold: 10
+      volumes:
+      - emptyDir: {}
+        name: tmp
       terminationGracePeriodSeconds: 10
       securityContext:
         runAsNonRoot: true

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -3637,12 +3637,15 @@ spec:
             drop:
             - ALL
           privileged: false
+          readOnlyRootFilesystem: true
           runAsGroup: 65532
           runAsUser: 65532
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -3654,6 +3657,8 @@ spec:
         secret:
           defaultMode: 420
           secretName: bmo-webhook-server-cert
+      - emptyDir: {}
+        name: tmp
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate


### PR DESCRIPTION
**What this PR does / why we need it**:

Configure the BMO manager container to run with a read-only root filesystem. Mount a writable `emptyDir` at `/tmp` for temporary Ironic CA certificate files.

The existing webhook certificate Secret remains mounted read-only at `/tmp/k8s-webhook-server/serving-certs`.

Regenerate the rendered CAPM3 manifest with the updated manager configuration.

Fixes #3492

**Testing:**

- `make test`
- `make generate-check-local`
- `CONTAINER_RUNTIME=docker make manifest-lint`
- `GINKGO_NODES=1 GINKGO_FOCUS=External.Inspection GINKGO_NOCOLOR=true GINKGO_TIMEOUT=30m make test-e2e` (2 focused specs passed)

**Checklist:**

- [x] Documentation has been updated, if necessary. (Not needed; there are no user-facing API or configuration changes.)
- [x] Unit tests have been added, if necessary. (Not needed for this manifest-only change.)
- [x] E2E tests have been added, if necessary. (Existing E2E coverage was run.)
- [x] Integration tests have been added, if necessary. (Not needed for this manifest-only change.)