### PR TITLE
🌱 deploy.sh: pin BMO image to the checked-out git tag

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -102,6 +102,17 @@ export NAMEPREFIX=${NAMEPREFIX:-"baremetal-operator"}
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
+# Determine the BMO image tag to deploy.
+# Priority: BMO_IMAGE_TAG env var > exact git tag of HEAD > "latest"
+if [ -z "${BMO_IMAGE_TAG:-}" ]; then
+    BMO_IMAGE_TAG="$(git -C "${SCRIPTDIR}" describe --tags --exact-match 2>/dev/null || true)"
+    if [ -z "${BMO_IMAGE_TAG}" ]; then
+        echo "WARNING: HEAD is not on a git tag, defaulting BMO image tag to 'latest'." \
+            "Set BMO_IMAGE_TAG to override."
+        BMO_IMAGE_TAG="latest"
+    fi
+fi
+
 TEMP_BMO_OVERLAY="${SCRIPTDIR}/config/overlays/temp"
 TEMP_IRONIC_OVERLAY="${SCRIPTDIR}/ironic-deployment/overlays/temp"
 rm -rf "${TEMP_BMO_OVERLAY}"
@@ -211,6 +222,8 @@ if [[ "${DEPLOY_BMO}" == "true" ]]; then
     if [[ "${DEPLOY_TLS}" == "true" ]]; then
         ${KUSTOMIZE} edit add component ../../components/tls
     fi
+
+    ${KUSTOMIZE} edit set image quay.io/metal3-io/baremetal-operator=quay.io/metal3-io/baremetal-operator:"${BMO_IMAGE_TAG}"
     popd
 fi
 


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

**What this PR does / why we need it**:

`tools/deploy.sh` builds the BMO Deployment manifest straight from `config/base`,
whose `manager.yaml` sets no image tag, so the deployed image implicitly tracks
`:latest`. A user who clones a specific release tag (e.g.
`git clone --branch v0.12.1 ...`) and runs `deploy.sh -b` ends up running the
latest development image instead of the tagged release they checked out.

This PR makes `deploy.sh` pin the BMO image tag to the checked-out git tag by
default (overridable via `BMO_IMAGE_TAG`), applied via
`kustomize edit set image` in the BMO overlay section - the same mechanism
already used by `config/overlays/*/kustomization.yaml` release overlays to pin
images. Only the BMO overlay is touched; the Ironic overlay is unaffected and
out of scope for this report.

Fixes #2970

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

```release-note
tools/deploy.sh: pin BMO image to the checked-out git tag
```