### PR TITLE
:seedling: Enhance  CRD comment for HostClaim namespaces

### DIFF
--- a/apis/metal3.io/v1alpha1/hostdeploypolicy_types.go
+++ b/apis/metal3.io/v1alpha1/hostdeploypolicy_types.go
@@ -30,8 +30,11 @@ type HostDeployPolicySpec struct {
 type HostClaimNamespaces struct {
 	// Namespaces is a list of namespace names where the hostClaim is authorized to reside in.
 	Names []string `json:"names,omitempty"`
-	// NameMatches is a string interpreted as a regular expression that must be matched by the
-	// namespace of the HostClaim.
+	// NameMatches is a regular expression that is matched against
+	// the entire namespace name of the HostClaim. NOTE:
+	// "prod" matches "prod", "production", "not-prod" and "reproduce".
+	// Use "^prod$" to match exactly "prod", "^prod.*" to match namespaces
+	// starting with "prod" etc.
 	NameMatches string `json:"nameMatches,omitempty"`
 	// HasLabels is a list of label names and their associated value.
 	// The namespace should have all of those labels. If the value

--- a/config/base/crds/bases/metal3.io_hostdeploypolicies.yaml
+++ b/config/base/crds/bases/metal3.io_hostdeploypolicies.yaml
@@ -63,8 +63,11 @@ spec:
                     type: array
                   nameMatches:
                     description: |-
-                      NameMatches is a string interpreted as a regular expression that must be matched by the
-                      namespace of the HostClaim.
+                      NameMatches is a regular expression that is matched against
+                      the entire namespace name of the HostClaim. NOTE:
+                      "prod" matches "prod", "production", "not-prod" and "reproduce".
+                      Use "^prod$" to match exactly "prod", "^prod.*" to match namespaces
+                      starting with "prod" etc.
                     type: string
                   names:
                     description: Namespaces is a list of namespace names where the

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -2619,8 +2619,11 @@ spec:
                     type: array
                   nameMatches:
                     description: |-
-                      NameMatches is a string interpreted as a regular expression that must be matched by the
-                      namespace of the HostClaim.
+                      NameMatches is a regular expression that is matched against
+                      the entire namespace name of the HostClaim. NOTE:
+                      "prod" matches "prod", "production", "not-prod" and "reproduce".
+                      Use "^prod$" to match exactly "prod", "^prod.*" to match namespaces
+                      starting with "prod" etc.
                     type: string
                   names:
                     description: Namespaces is a list of namespace names where the

--- a/internal/testutil/common.go
+++ b/internal/testutil/common.go
@@ -227,6 +227,11 @@ func NewHostclaim(name string) *HostClaimBuilder {
 	}
 }
 
+func (hb *HostClaimBuilder) InNamespace(ns string) *HostClaimBuilder {
+	hb.hostClaim.Namespace = ns
+	return hb
+}
+
 func (hb *HostClaimBuilder) Build() *metal3api.HostClaim {
 	return &hb.hostClaim
 }

--- a/pkg/hostclaim/hostclaim_manager_test.go
+++ b/pkg/hostclaim/hostclaim_manager_test.go
@@ -258,6 +258,62 @@ var _ = Describe("HostClaim manager", func() {
 			ExpectedBmhName: "",
 			ExpectFail:      true,
 		}),
+		Entry("with regexp matching exact namespace", testCaseChooseBMH{
+			HostClaim:  NewHostclaim(HostclaimName).InNamespace("prod").Build(),
+			Namespaces: []*corev1.Namespace{NewNamespace("prod").Build(), ns1},
+			HostDeployPolicies: []*metal3api.HostDeployPolicy{
+				NewHostdeploypolicy("hdp", "ns1").AcceptRegexp("prod").Build()},
+			BareMetalHosts:  []*metal3api.BareMetalHost{bmhns1},
+			ExpectedBmhName: "bmh1",
+		}),
+		Entry("with regexp should not match namespace with extra prefix", testCaseChooseBMH{
+			HostClaim:  NewHostclaim(HostclaimName).InNamespace("not-prod").Build(),
+			Namespaces: []*corev1.Namespace{NewNamespace("not-prod").Build(), ns1},
+			HostDeployPolicies: []*metal3api.HostDeployPolicy{
+				NewHostdeploypolicy("hdp", "ns1").AcceptRegexp("prod").Build()},
+			BareMetalHosts:  []*metal3api.BareMetalHost{bmhns1},
+			ExpectedBmhName: "bmh1",
+		}),
+		Entry("with regexp should not match namespace with extra suffix", testCaseChooseBMH{
+			HostClaim:  NewHostclaim(HostclaimName).InNamespace("production").Build(),
+			Namespaces: []*corev1.Namespace{NewNamespace("production").Build(), ns1},
+			HostDeployPolicies: []*metal3api.HostDeployPolicy{
+				NewHostdeploypolicy("hdp", "ns1").AcceptRegexp("prod").Build()},
+			BareMetalHosts:  []*metal3api.BareMetalHost{bmhns1},
+			ExpectedBmhName: "bmh1",
+		}),
+		Entry("with regexp should not match unrelated namespace containing substring", testCaseChooseBMH{
+			HostClaim:  NewHostclaim(HostclaimName).InNamespace("reproduce").Build(),
+			Namespaces: []*corev1.Namespace{NewNamespace("reproduce").Build(), ns1},
+			HostDeployPolicies: []*metal3api.HostDeployPolicy{
+				NewHostdeploypolicy("hdp", "ns1").AcceptRegexp("prod").Build()},
+			BareMetalHosts:  []*metal3api.BareMetalHost{bmhns1},
+			ExpectedBmhName: "bmh1",
+		}),
+		Entry("with regexp anchored full match", testCaseChooseBMH{
+			HostClaim:  NewHostclaim(HostclaimName).InNamespace("prod").Build(),
+			Namespaces: []*corev1.Namespace{NewNamespace("prod").Build(), ns1},
+			HostDeployPolicies: []*metal3api.HostDeployPolicy{
+				NewHostdeploypolicy("hdp", "ns1").AcceptRegexp("^prod$").Build()},
+			BareMetalHosts:  []*metal3api.BareMetalHost{bmhns1},
+			ExpectedBmhName: "bmh1",
+		}),
+		Entry("with regexp anchored partial match (positive)", testCaseChooseBMH{
+			HostClaim:  NewHostclaim(HostclaimName).InNamespace("production").Build(),
+			Namespaces: []*corev1.Namespace{NewNamespace("production").Build(), ns1},
+			HostDeployPolicies: []*metal3api.HostDeployPolicy{
+				NewHostdeploypolicy("hdp", "ns1").AcceptRegexp("^prod.*$").Build()},
+			BareMetalHosts:  []*metal3api.BareMetalHost{bmhns1},
+			ExpectedBmhName: "bmh1",
+		}),
+		Entry("with regexp anchored partial match should not match different prefix", testCaseChooseBMH{
+			HostClaim:  NewHostclaim(HostclaimName).InNamespace("reproduce").Build(),
+			Namespaces: []*corev1.Namespace{NewNamespace("reproduce").Build(), ns1},
+			HostDeployPolicies: []*metal3api.HostDeployPolicy{
+				NewHostdeploypolicy("hdp", "ns1").AcceptRegexp("^prod.*$").Build()},
+			BareMetalHosts:  []*metal3api.BareMetalHost{bmhns1},
+			ExpectedBmhName: "",
+		}),
 		Entry("with Failure Domain (available bmh)", testCaseChooseBMH{
 			HostClaim: NewHostclaim(HostclaimName).
 				SetLabelSelector(map[string]string{"default-selector": "default-value"}).


### PR DESCRIPTION
The only documentation for NameMatches is the API type comment and the CRD description: "NameMatches is a string interpreted as a regular expression that must be matched by the namespace of the HostClaim."

The phrasing "must be matched by" is ambiguous. It could mean either "the namespace must contain a match" or "the namespace must be a match". There are no additional docs that clarify whether substring or full-string matching was intended.

No documentation exists that tells users "remember to anchor your patterns with ^...$." I'm adding this documentation to the CRD comment. I think it was too easy to misinterpret the comment and use the field in a wrong way.

I think it would be more logical to assume simple namespace names are not expanded but used as is. For now I'm hardening the `nameMatches` by documenting better. I think it would be good future work to change this so that simple strings are taken as is instead of having to anchor them. 

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
