### PR TITLE
🌱 Remove zizmor inline ignore

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
     if: github.repository == 'metal3-io/baremetal-operator'
     steps:
     - name: Checkout code
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 # zizmor: ignore[artipacked]
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
     - name: Get changed files

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -7,3 +7,8 @@ rules:
   dependabot-cooldown:
     config:
       days: 3
+
+  # persist-credentials needed later in the workflow
+  artipacked:
+    ignore:
+    - release.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

Removed the `# zizmor: ignore[artipacked]` inline suppression comment from `.github/workflows/release.yaml`. The `artipacked` warning is now handled via a targeted ignore rule in `.zizmor.yml` at the repo root instead, since `persist-credentials: false` cannot be used here as credentials are needed later in the workflow.

This inline comment was also confusing dependabot when trying to bump the checkout action version.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
