### PR TITLE
:bug: Add AttributeType filtering to passwords in HostFirmwareSettings

### DIFF
--- a/internal/controller/metal3.io/hostfirmwaresettings_controller.go
+++ b/internal/controller/metal3.io/hostfirmwaresettings_controller.go
@@ -194,7 +194,20 @@ func (r *HostFirmwareSettingsReconciler) updateHostFirmwareSettings(ctx context.
 		return fmt.Errorf("could not get/create firmware schema: %w", err)
 	}
 
-	if err = r.updateStatus(ctx, info, currentSettings, firmwareSchema); err != nil {
+	// Filter out password-type settings before storing in Status.
+	// The schema has AttributeType metadata that the raw SettingsMap lacks.
+	filteredSettings := make(metal3api.SettingsMap, len(currentSettings))
+	for k, v := range currentSettings {
+		if strings.Contains(k, "Password") {
+			continue
+		}
+		if s, ok := schema[k]; ok && s.AttributeType == "Password" {
+			continue
+		}
+		filteredSettings[k] = v
+	}
+
+	if err = r.updateStatus(ctx, info, filteredSettings, firmwareSchema); err != nil {
 		return fmt.Errorf("could not update hostFirmwareSettings: %w", err)
 	}
 
@@ -421,6 +434,13 @@ func (r *HostFirmwareSettingsReconciler) validateHostFirmwareSettings(info *rInf
 		if strings.Contains(name, "Password") {
 			errs = append(errs, errors.New("cannot set Password field"))
 			continue
+		}
+		// Prohibit any settings whose schema AttributeType is Password
+		if schema != nil {
+			if s, ok := schema.Spec.Schema[name]; ok && s.AttributeType == "Password" {
+				errs = append(errs, errors.New("cannot set Password field"))
+				continue
+			}
 		}
 
 		// The setting must be in the Status

--- a/internal/controller/metal3.io/hostfirmwaresettings_controller.go
+++ b/internal/controller/metal3.io/hostfirmwaresettings_controller.go
@@ -52,6 +52,9 @@ const (
 	resourceNotAvailableRetryDelay       = time.Second * 30
 	reconcilerRequeueDelay               = time.Minute * 5
 	reconcilerRequeueDelayChangeDetected = time.Minute * 1
+
+	// attributeTypePassword is the Redfish BIOS attribute type for password fields.
+	attributeTypePassword = "Password"
 )
 
 // HostFirmwareSettingsReconciler reconciles a HostFirmwareSettings object.
@@ -198,10 +201,10 @@ func (r *HostFirmwareSettingsReconciler) updateHostFirmwareSettings(ctx context.
 	// The schema has AttributeType metadata that the raw SettingsMap lacks.
 	filteredSettings := make(metal3api.SettingsMap, len(currentSettings))
 	for k, v := range currentSettings {
-		if strings.Contains(k, "Password") {
+		if strings.Contains(k, attributeTypePassword) {
 			continue
 		}
-		if s, ok := schema[k]; ok && s.AttributeType == "Password" {
+		if s, ok := schema[k]; ok && s.AttributeType == attributeTypePassword {
 			continue
 		}
 		filteredSettings[k] = v
@@ -234,7 +237,7 @@ func (r *HostFirmwareSettingsReconciler) updateStatus(ctx context.Context, info 
 	// Update Status on changes
 	for k, v := range settings {
 		// Some vendors include encrypted password fields, don't add these
-		if strings.Contains(k, "Password") {
+		if strings.Contains(k, attributeTypePassword) {
 			continue
 		}
 
@@ -368,10 +371,10 @@ func (r *HostFirmwareSettingsReconciler) getOrCreateFirmwareSchema(ctx context.C
 	firmwareSchema.Spec.Schema = make(map[string]metal3api.SettingSchema)
 	for k, v := range schema {
 		// Don't store Password settings in Schema as these aren't stored in HostFirmwareSettings
-		if strings.Contains(k, "Password") {
+		if strings.Contains(k, attributeTypePassword) {
 			continue
 		}
-		if v.AttributeType == "Password" {
+		if v.AttributeType == attributeTypePassword {
 			continue
 		}
 
@@ -431,13 +434,13 @@ func (r *HostFirmwareSettingsReconciler) validateHostFirmwareSettings(info *rInf
 
 	for name, val := range info.hfs.Spec.Settings {
 		// Prohibit any Spec settings with "Password"
-		if strings.Contains(name, "Password") {
+		if strings.Contains(name, attributeTypePassword) {
 			errs = append(errs, errors.New("cannot set Password field"))
 			continue
 		}
 		// Prohibit any settings whose schema AttributeType is Password
 		if schema != nil {
-			if s, ok := schema.Spec.Schema[name]; ok && s.AttributeType == "Password" {
+			if s, ok := schema.Spec.Schema[name]; ok && s.AttributeType == attributeTypePassword {
 				errs = append(errs, errors.New("cannot set Password field"))
 				continue
 			}

--- a/internal/controller/metal3.io/hostfirmwaresettings_test.go
+++ b/internal/controller/metal3.io/hostfirmwaresettings_test.go
@@ -645,3 +645,159 @@ func TestValidateHostFirmwareSettings(t *testing.T) {
 		})
 	}
 }
+
+// Test that password-type settings are filtered by AttributeType, not just by name.
+func TestPasswordTypeFilteredByAttributeType(t *testing.T) {
+	// Settings from the provisioner include a password-type attribute
+	// whose name does NOT contain the substring "Password" (SetupPassphrase),
+	// one that does (SysPassword), and a normal setting that must survive.
+	settingsFromProvisioner := metal3api.SettingsMap{
+		"ProcVirtualization": "Disabled", // normal setting, must survive
+		"SetupPassphrase":    "s3cret!",  // Password-type by AttributeType, not by name
+		"SysPassword":        "pa$$word", // Not password-type, caught by the name filter
+	}
+
+	// Schema declares the password-type attributes
+	schemaFromProvisioner := map[string]metal3api.SettingSchema{
+		"ProcVirtualization": {
+			AttributeType:   "Enumeration",
+			AllowableValues: []string{"Enabled", "Disabled"},
+			ReadOnly:        &iFalse,
+		},
+		"SetupPassphrase": {
+			AttributeType: "Password",
+			MinLength:     &minLength,
+			MaxLength:     &maxLength,
+			ReadOnly:      &iFalse,
+		},
+		"SysPassword": {
+			AttributeType: "String",
+			MinLength:     &minLength,
+			MaxLength:     &maxLength,
+			ReadOnly:      &iFalse,
+		},
+	}
+
+	hfs := &metal3api.HostFirmwareSettings{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HostFirmwareSettings",
+			APIVersion: "metal3.io/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            hostName,
+			Namespace:       hostNamespace,
+			ResourceVersion: "1"},
+		Spec: metal3api.HostFirmwareSettingsSpec{
+			Settings: metal3api.DesiredSettingsMap{},
+		},
+		Status: metal3api.HostFirmwareSettingsStatus{},
+	}
+
+	r := getTestHFSReconciler(hfs)
+	bmh := createBaremetalHost()
+
+	info := &rInfo{
+		log: logf.Log.WithName("controllers").WithName("HostFirmwareSettings"),
+		hfs: hfs,
+		bmh: bmh,
+	}
+
+	ctx := t.Context()
+	err := r.updateHostFirmwareSettings(ctx, settingsFromProvisioner, schemaFromProvisioner, info)
+	require.NoError(t, err)
+
+	// Reload the HFS from the fake client
+	key := client.ObjectKey{Namespace: hostNamespace, Name: hostName}
+	actualHFS := &metal3api.HostFirmwareSettings{}
+	err = r.Client.Get(ctx, key, actualHFS)
+	require.NoError(t, err)
+
+	// Password-type settings must NOT appear in Status.Settings regardless of name
+	assert.NotContains(t, actualHFS.Status.Settings, "SetupPassphrase",
+		"Password-type setting 'SetupPassphrase' should be filtered from Status by AttributeType")
+	assert.NotContains(t, actualHFS.Status.Settings, "SysPassword",
+		"Password-type setting 'SysPassword' should be filtered from Status by name")
+
+	// Non-password settings must still be present
+	assert.Contains(t, actualHFS.Status.Settings, "ProcVirtualization")
+}
+
+// Test that validateHostFirmwareSettings rejects password-type settings by AttributeType.
+func TestValidateRejectsPasswordTypeByAttributeType(t *testing.T) {
+	testCases := []struct {
+		Scenario      string
+		SpecSettings  metal3api.HostFirmwareSettingsSpec
+		ExpectedError string
+	}{
+		{
+			Scenario: "password-type setting with non-Password name is rejected",
+			SpecSettings: metal3api.HostFirmwareSettingsSpec{
+				Settings: metal3api.DesiredSettingsMap{
+					"SetupPassphrase": intstr.FromString("newpassword"),
+				},
+			},
+			ExpectedError: "cannot set Password field",
+		},
+		{
+			Scenario: "password setting caught by name filter still works",
+			SpecSettings: metal3api.HostFirmwareSettingsSpec{
+				Settings: metal3api.DesiredSettingsMap{
+					"SysPassword": intstr.FromString("oldfilter"),
+				},
+			},
+			ExpectedError: "cannot set Password field",
+		},
+	}
+
+	// Schema declares SetupPassphrase as Password type
+	schema := &metal3api.FirmwareSchema{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      schemaName,
+			Namespace: hostNamespace,
+		},
+		Spec: metal3api.FirmwareSchemaSpec{
+			Schema: map[string]metal3api.SettingSchema{
+				"ProcVirtualization": {
+					AttributeType:   "Enumeration",
+					AllowableValues: []string{"Enabled", "Disabled"},
+					ReadOnly:        &iFalse,
+				},
+				"SetupPassphrase": {
+					AttributeType: "Password",
+					MinLength:     &minLength,
+					MaxLength:     &maxLength,
+					ReadOnly:      &iFalse,
+				},
+				"SysPassword": {
+					AttributeType: "String",
+					MinLength:     &minLength,
+					MaxLength:     &maxLength,
+					ReadOnly:      &iFalse,
+				},
+			},
+		},
+	}
+
+	status := &metal3api.HostFirmwareSettingsStatus{
+		Settings: metal3api.SettingsMap{
+			"ProcVirtualization": "Enabled",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			hfs := &metal3api.HostFirmwareSettings{}
+			hfs.Spec = tc.SpecSettings
+			hfs.Status = *status
+
+			r := getTestHFSReconciler(hfs)
+			info := &rInfo{
+				log: logf.Log.WithName("controllers").WithName("HostFirmwareSettings"),
+				hfs: hfs,
+			}
+
+			errors := r.validateHostFirmwareSettings(info, status, schema)
+			require.NotEmpty(t, errors, "expected validation error for password-type setting")
+			assert.Equal(t, tc.ExpectedError, errors[0].Error())
+		})
+	}
+}


### PR DESCRIPTION
Function `getOrCreateFirmwareSchema` already checks `v.AttributeType == "Password"`. Add this missing coverage in `internal/controller/metal3.io/hostfirmwaresettings_controller.go` to functions `updateStatus`  and `validateHostFirmwareSettings`. 

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
