### PR TITLE
:seedling: Build release-branch tagged image when a new release branch is created

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_tag: ${{ steps.release-version.outputs.release_version }}
+      release_branch: ${{ steps.release-branch.outputs.release_branch }}
     if: github.repository == 'metal3-io/baremetal-operator'
     steps:
     - name: Checkout code
@@ -48,14 +49,17 @@ jobs:
           fi
         done
     - name: Determine the release branch to use
+      id: release-branch
       run: |
         if [[ ${RELEASE_VERSION} =~ beta ]] || [[ ${RELEASE_VERSION} =~ alpha ]]; then
           export RELEASE_BRANCH=main
           echo "RELEASE_BRANCH=${RELEASE_BRANCH}" >> ${GITHUB_ENV}
+          echo "release_branch=${RELEASE_BRANCH}" >> ${GITHUB_OUTPUT}
           echo "This is a beta or alpha release, will use release branch ${RELEASE_BRANCH}"
         else
           export RELEASE_BRANCH=release-$(echo ${RELEASE_VERSION} | sed -E 's/^v([0-9]+)\.([0-9]+)\..*$/\1.\2/')
           echo "RELEASE_BRANCH=${RELEASE_BRANCH}" >> ${GITHUB_ENV}
+          echo "release_branch=${RELEASE_BRANCH}" >> ${GITHUB_OUTPUT}
           echo "This is not a beta or alpha release, will use release branch ${RELEASE_BRANCH}"
         fi
     - name: Create or checkout release branch
@@ -151,6 +155,29 @@ jobs:
       image-name: 'baremetal-operator'
       pushImage: true
       ref: ${{ needs.push_release_tags.outputs.release_tag }}
+      generate-sbom: true
+      sign-image: true
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  # The "Create or checkout release branch" step above pushes the release branch using the
+  # workflow's own GITHUB_TOKEN, which GitHub does not allow to trigger other workflows
+  # (including the branches:[release-*] push trigger in build-images-action.yml). Build the
+  # branch-tagged image explicitly here so a new release branch always has an initial
+  # release-x.y image.
+  build_bmo_release_branch:
+    permissions:
+      contents: read
+      id-token: write
+    needs: push_release_tags
+    name: Build BMO container image for release branch
+    if: github.repository == 'metal3-io/baremetal-operator' && needs.push_release_tags.outputs.release_branch != 'main'
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main # zizmor: ignore[unpinned-uses]
+    with:
+      image-name: 'baremetal-operator'
+      pushImage: true
+      ref: ${{ needs.push_release_tags.outputs.release_branch }}
       generate-sbom: true
       sign-image: true
     secrets:


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

**What this PR does / why we need it**:

When a minor/RC release creates a new release branch (e.g. `release-1.10`),
no container image is ever built and tagged `release-1.10` — the floating
tag used by test suites to track the branch head. This PR adds a job that
explicitly builds and pushes that branch-tagged image as part of the
release workflow.

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

Fixes #2449

```release-note
Build release-branch tagged image when a new release branch is created
```