### PR TITLE
📖 Add pinning of ironic-image to releasing process

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -160,6 +160,13 @@ BMO e2e is running as GitHub Actions. We need to add released branch and remove
 the non-maintained branches there, along with the suitable configurations with
 recently released Ironic-image releases as well in the fixtures.
 
+### Pin Ironic image in BMO e2e on the new release branch
+
+Pin the Ironic image version on the new release branch to the latest stable
+ironic-image release.
+
+[Prior art](https://github.com/metal3-io/baremetal-operator/pull/3464)
+
 ### Dependabot configuration
 
 In `main` branch, Dependabot configuration must be amended to allow updates


### PR DESCRIPTION
**What this PR does / why we need it**:

Add documentation for pinning Ironic on the new release branch as part of the release process.

Fixes #3178

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
