### PR TITLE
🌱 Restore missing ironic entrypoint in run_local_ironic.sh

### DIFF
--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -222,6 +222,7 @@ sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name httpd \
 sudo "${CONTAINER_RUNTIME}" run -d --net host --privileged --name ironic \
      ${POD} ${CERTS_MOUNTS} ${BASIC_AUTH_MOUNTS} ${IRONIC_HTPASSWD_MOUNT} \
      --env-file "${IRONIC_DATA_DIR}/ironic-vars.env" \
+     --entrypoint /bin/runironic \
      -v "$IRONIC_DATA_DIR:/shared" "${IRONIC_IMAGE}"
 
 # Start ironic-endpoint-keepalived


### PR DESCRIPTION
PR #3478 removed the MariaDB password line, which also carried `--entrypoint /bin/runironic`. Without it the ironic container fell back to `/bin/bash` and exited. This restores the entrypoint.