### PR TITLE
🌱Bump go version to 1.25.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.25.12@sha256:d7912cedddfa15b2900a8dfb7187df0af5ec2cb424a371139b5b352fd3e6b740
+ARG BUILD_IMAGE=docker.io/golang:1.25.13@sha256:cbff9d1a9041b316010f2da6b701b6c0d597718cb90928c85eb597334a0d23d4
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GO_TEST_FLAGS = $(TEST_FLAGS)
 DEBUG = --debug
 COVER_PROFILE = cover.out
 GO := $(shell type -P go)
-GO_VERSION ?= 1.25.12
+GO_VERSION ?= 1.25.13
 
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 

--- a/hack/e2e/ensure_go.sh
+++ b/hack/e2e/ensure_go.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-MINIMUM_GO_VERSION=go1.25.12
+MINIMUM_GO_VERSION=go1.25.13
 
 # Verify mode turned off by default
 VERIFY_ONLY="${VERIFY_ONLY:-false}"


### PR DESCRIPTION
Bump go version to 1.25.13 to address the following CVEs
CVE-2026-56865
CVE-2026-56864 
CVE-2026-56859 
CVE-2026-56853 
CVE-2026-56860 
CVE-2026-46600
CVE-2026-56862 
CVE-2026-56858 
CVE-2026-39821
CVE-2026-33818