### PR TITLE
🌱 Add Alloy log collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ config/overlays/temp
 
 # ai stuff
 .claude
+
+# Alloy runtime files (created by run-alloy.sh / stop-alloy.sh)
+/hack/alloy/alloy-data/
+/hack/alloy/alloy.pid

--- a/hack/alloy/README.md
+++ b/hack/alloy/README.md
@@ -1,0 +1,86 @@
+# BMO e2e log collection (Alloy → Loki)
+
+Streams the logs produced during the BMO e2e suite to the Metal³ CI log
+collector (Grafana Loki), so they are searchable in Grafana alongside the
+Jenkins console output instead of only living inside the `artifacts-*.tar.gz`
+archive.
+
+## How it works
+
+The CAPI test framework already streams the deployment logs to files *live*
+during the run (`WatchDeploymentLogs` in `test/e2e/e2e_suite_test.go`), and
+libvirt writes the BMH serial consoles live under `/var/log/libvirt/qemu/`.
+Grafana Alloy simply tails those files as they grow and pushes each line to
+Loki. Because the files are written live, this is real-time streaming - logs
+arrive as they happen and survive a mid-run crash - without Alloy needing any
+Kubernetes API access or pod discovery.
+
+```text
+CAPI framework ─┐                         ┌─ loki.process (labels + metadata)
+libvirt        ─┴─▶ *.log files ─▶ Alloy ─┤
+                                          └─ loki.write ─▶ Loki (push API)
+```
+
+`hack/ci-e2e.sh` starts Alloy before `make test-e2e` and stops it afterwards:
+
+```text
+run-alloy.sh   # installs Alloy on demand, starts it in the background
+make test-e2e  # logs are tailed and shipped while the suite runs
+verify.sh      # asserts Alloy actually shipped entries (reads its metrics)
+stop-alloy.sh  # flushes and stops Alloy
+```
+
+All of this is opt-in: if the push endpoint/credential is not configured, or
+Alloy cannot be installed, the scripts print a message and exit 0, leaving the
+e2e run unchanged.
+
+## Files
+
+| File                     | Purpose                                                        |
+|--------------------------|----------------------------------------------------------------|
+| `config.alloy`           | Alloy pipeline: tail log files, label them, push to Loki.      |
+| `run-alloy.sh`           | Start Alloy in the background (installs it on demand).          |
+| `verify.sh`              | Confirm Alloy shipped entries, via its local metrics endpoint.  |
+| `stop-alloy.sh`          | Flush and stop the background Alloy process.                    |
+| `../e2e/ensure_alloy.sh` | Install the Alloy binary if it is not already on `PATH`.        |
+
+## Configuration (environment variables)
+
+Set by the Jenkins pipeline; the `ALLOY_*` / `BMO_ARTIFACTS_DIR` values fall
+back to sensible defaults for local runs. The variable names match the CAPM3
+Alloy config so a single pipeline wiring feeds both jobs.
+
+| Variable             | Required | Meaning                                                    |
+|----------------------|----------|------------------------------------------------------------|
+| `LOKI_URL`           | yes      | Loki push endpoint, e.g. `.../store/api/v1/push`.          |
+| `LOKI_USERNAME`      | yes      | Read/write push username.                                  |
+| `LOKI_PASSWORD`      | yes      | Read/write push password.                                  |
+| `ALLOY_JOB`          | no       | `job` label (default `metal3ci`).                          |
+| `ALLOY_PIPELINE_ID`  | no       | `pipeline_id` label (default `metal3-bmo-e2e`).            |
+| `ALLOY_BUILD_NUMBER` | no       | `build_number` label (default `0`).                        |
+| `BMO_ARTIFACTS_DIR`  | no       | Path to `_artifacts` (default `test/e2e/_artifacts`).      |
+| `ALLOY_VERSION`      | no       | Alloy release to install (default `v1.18.1`).               |
+
+## Labels and metadata
+
+Streams carry a small set of low-cardinality **labels** for dashboard
+drill-down, and richer per-line **structured metadata** derived from the file
+path:
+
+- Labels: `job`, `pipeline_id`, `build_number`, `source="artifact"` (set in
+  `loki.write.external_labels`), plus `collector` (`container` or `serial`).
+- Structured metadata: `component`, `pod`, `container` for container logs;
+  `machine` for serial consoles.
+
+To appear in the same dashboard context as a build's Jenkins output,
+`pipeline_id` and `build_number` must match the values that build reports.
+
+Only `*.log` files are shipped. Manifests, resource dumps and `*-log-metadata`
+files are left in the artifact archive, not pushed to Loki.
+
+## CI wiring
+
+The push credential and `ALLOY_*` values are supplied to `ci-e2e.sh` by the BMO
+e2e Jenkins job via the `metal3-ci-log-collector-push` credential; that pipeline
+wiring lives in `project-infra`. Without it the log-collection steps no-op and
+the e2e run is unaffected.

--- a/hack/alloy/config.alloy
+++ b/hack/alloy/config.alloy
@@ -1,0 +1,156 @@
+// -----------------------------------------------------------------------------
+// Description: Ships BMO e2e logs to the CI log collector (Loki) by tailing the
+//              log files as they are written during the test run. The CAPI test
+//              framework streams deployment logs to files live
+//              (WatchDeploymentLogs), and libvirt writes BMH serial consoles
+//              live, so tailing those files yields real-time streaming without
+//              any Kubernetes API or pod discovery.
+//              Started by hack/ci-e2e.sh alongside `make test-e2e`.
+//              Endpoint, credentials and correlation labels are supplied via
+//              environment variables so nothing instance-specific or secret is
+//              committed. The env-var interface matches the CAPM3 Alloy config
+//              so a single pipeline wiring feeds both jobs.
+// Usage:       Inputs (set by the Jenkins pipeline; see hack/alloy/run-alloy.sh
+//              for local defaults):
+//                LOKI_URL             Loki push endpoint (.../store/api/v1/push)
+//                LOKI_USERNAME        RW push username
+//                LOKI_PASSWORD        RW push password
+//                ALLOY_JOB            stream label 'job' (e.g. metal3ci)
+//                ALLOY_PIPELINE_ID    stream label 'pipeline_id' (^metal3[-_]...)
+//                ALLOY_BUILD_NUMBER   stream label 'build_number'
+//                BMO_ARTIFACTS_DIR    absolute path to test/e2e/_artifacts
+//              alloy run hack/alloy/config.alloy
+// -----------------------------------------------------------------------------
+
+logging {
+  level  = "info"
+  format = "logfmt"
+}
+
+// --- Sources -----------------------------------------------------------------
+
+// Container logs, streamed live to files by the framework. Two layouts exist;
+// the ** glob covers both:
+//   _artifacts/logs/<ns>/<deployment>/<pod>/<container>.log      (main suite)
+//   _artifacts/<spec>/logs/<deployment>/<pod>/<container>.log    (upgrade specs)
+// Serial consoles live under a qemu/ dir; they are handled by the serial source
+// below, so exclude them here to avoid double-collection.
+local.file_match "container" {
+  path_targets = [{
+    __path__         = sys.env("BMO_ARTIFACTS_DIR") + "/**/logs/**/*.log",
+    __path_exclude__ = sys.env("BMO_ARTIFACTS_DIR") + "/**/qemu/**",
+  }]
+  sync_period = "5s"
+}
+
+// BMH serial consoles, written live by libvirt.
+local.file_match "serial" {
+  path_targets = [{
+    __path__ = "/var/log/libvirt/qemu/*.log",
+  }]
+  sync_period = "5s"
+}
+
+loki.source.file "container" {
+  targets    = local.file_match.container.targets
+  forward_to = [loki.process.container.receiver]
+}
+
+loki.source.file "serial" {
+  targets    = local.file_match.serial.targets
+  forward_to = [loki.process.serial.receiver]
+}
+
+// --- Processing --------------------------------------------------------------
+// Correlation labels (job/pipeline_id/build_number/source) are applied centrally
+// in loki.write via external_labels. Here we only tag which collector produced
+// the line (a low-cardinality label) and derive per-line detail from the file
+// path as structured metadata. Structured controller logs carry a JSON "ts"
+// that we parse into the entry timestamp; other lines use their read time, which
+// approximates the event time when tailing files as they are written.
+
+loki.process "container" {
+  stage.static_labels {
+    values = {
+      collector = "container",
+    }
+  }
+
+  // Structured logs carry their own timestamp; parse it into the entry
+  // timestamp for accurate per-line times. JSON controller logs use a fractional
+  // Unix "ts"; some controllers log an RFC3339 prefix instead. action_on_failure
+  // = "skip" means lines with neither (shell traces, plain output) are left at
+  // their read time rather than being altered.
+  stage.json {
+    expressions = {
+      ts = "ts",
+    }
+  }
+  stage.timestamp {
+    source            = "ts"
+    format            = "Unix"
+    action_on_failure = "skip"
+  }
+  stage.regex {
+    expression = "^(?P<rfc3339_ts>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)"
+  }
+  stage.timestamp {
+    source            = "rfc3339_ts"
+    format            = "RFC3339"
+    action_on_failure = "skip"
+  }
+
+  // .../<component>/<pod>/<container>.log
+  stage.regex {
+    expression = "/(?P<component>[^/]+)/(?P<pod>[^/]+)/(?P<container>[^/]+)\\.log$"
+    source     = "filename"
+  }
+  stage.structured_metadata {
+    values = {
+      component = "component",
+      pod       = "pod",
+      container = "container",
+    }
+  }
+
+  forward_to = [loki.write.default.receiver]
+}
+
+loki.process "serial" {
+  stage.static_labels {
+    values = {
+      collector = "serial",
+    }
+  }
+
+  // .../<machine>-serial0.log
+  stage.regex {
+    expression = "/(?P<machine>[^/]+)-serial\\d*\\.log$"
+    source     = "filename"
+  }
+  stage.structured_metadata {
+    values = {
+      machine = "machine",
+    }
+  }
+
+  forward_to = [loki.write.default.receiver]
+}
+
+// --- Sink --------------------------------------------------------------------
+
+loki.write "default" {
+  endpoint {
+    url = sys.env("LOKI_URL")
+    basic_auth {
+      username = sys.env("LOKI_USERNAME")
+      password = sys.env("LOKI_PASSWORD")
+    }
+  }
+  external_labels = {
+    job          = sys.env("ALLOY_JOB"),
+    pipeline_id  = sys.env("ALLOY_PIPELINE_ID"),
+    build_number = sys.env("ALLOY_BUILD_NUMBER"),
+    source       = "artifact",
+  }
+}

--- a/hack/alloy/run-alloy.sh
+++ b/hack/alloy/run-alloy.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Description: Starts Grafana Alloy in the background to stream BMO e2e logs to
+#              the CI log collector (Loki) while the test suite runs. Tails the
+#              log files the CAPI framework writes live, plus libvirt serial
+#              consoles. No-op (exits 0) if the push credential is not set, so
+#              local/dev runs and unconfigured jobs are unaffected.
+# Usage:       Called by hack/ci-e2e.sh before `make test-e2e`. The pipeline
+#              only needs to provide the push credential; everything else has a
+#              working default:
+#                LOKI_USERNAME        RW push username (required, from credential)
+#                LOKI_PASSWORD        RW push password (required, from credential)
+#                LOKI_URL             push endpoint (default: staging collector)
+#                ALLOY_JOB            'job' label       (default metal3ci)
+#                ALLOY_PIPELINE_ID    'pipeline_id'     (default metal3-bmo-e2e[-<protocol>])
+#                ALLOY_BUILD_NUMBER   'build_number'    (default $BUILD_NUMBER or 0)
+#                BMO_ARTIFACTS_DIR    path to _artifacts (default test/e2e/_artifacts)
+# -----------------------------------------------------------------------------
+set -eu
+
+REPO_ROOT=$(realpath "$(dirname "${BASH_SOURCE[0]}")/../..")
+ALLOY_DIR="${REPO_ROOT}/hack/alloy"
+
+# Streaming is gated on the push credential, which the pipeline provides via
+# withCredentials. Without it, no-op so local/dev runs are unaffected.
+if [[ -z "${LOKI_USERNAME:-}" || -z "${LOKI_PASSWORD:-}" ]]; then
+  echo "log-collection: push credential not set; skipping streaming"
+  exit 0
+fi
+
+# Install Alloy on demand when the credential is present but the binary is not.
+if ! command -v alloy >/dev/null 2>&1; then
+  "${REPO_ROOT}/hack/e2e/ensure_alloy.sh" || true
+fi
+if ! command -v alloy >/dev/null 2>&1; then
+  echo "log-collection: alloy unavailable after install attempt; skipping streaming"
+  exit 0
+fi
+
+# Endpoint defaults to the staging collector; override via env for test/live.
+export LOKI_URL="${LOKI_URL:-https://log.apps.staging.metal3.io/store/api/v1/push}"
+
+# Labels default to Jenkins built-ins so no extra pipeline plumbing is required:
+# BMC_PROTOCOL is set by the e2e matrix, BUILD_NUMBER by Jenkins.
+export ALLOY_JOB="${ALLOY_JOB:-metal3ci}"
+export ALLOY_PIPELINE_ID="${ALLOY_PIPELINE_ID:-metal3-bmo-e2e${BMC_PROTOCOL:+-${BMC_PROTOCOL}}}"
+export ALLOY_BUILD_NUMBER="${ALLOY_BUILD_NUMBER:-${BUILD_NUMBER:-0}}"
+export BMO_ARTIFACTS_DIR="${BMO_ARTIFACTS_DIR:-${REPO_ROOT}/test/e2e/_artifacts}"
+
+# The framework creates this later; make sure it exists so Alloy can watch it.
+mkdir -p "${BMO_ARTIFACTS_DIR}"
+
+# Don't start a second instance if one is already running.
+if [[ -f "${ALLOY_DIR}/alloy.pid" ]] && kill -0 "$(cat "${ALLOY_DIR}/alloy.pid")" 2>/dev/null; then
+  echo "log-collection: alloy already running (pid $(cat "${ALLOY_DIR}/alloy.pid")); skipping start"
+  exit 0
+fi
+
+alloy run "${ALLOY_DIR}/config.alloy" \
+  --storage.path="${ALLOY_DIR}/alloy-data" \
+  --server.http.listen-addr=127.0.0.1:12345 \
+  > "${BMO_ARTIFACTS_DIR}/alloy.log" 2>&1 &
+
+echo $! > "${ALLOY_DIR}/alloy.pid"
+echo "log-collection: alloy started (pid $(cat "${ALLOY_DIR}/alloy.pid")), pipeline_id=${ALLOY_PIPELINE_ID}"

--- a/hack/alloy/stop-alloy.sh
+++ b/hack/alloy/stop-alloy.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Description: Stops the background Alloy process started by run-alloy.sh, after
+#              a short grace period so the final log lines are flushed to the
+#              collector. No-op if Alloy was never started.
+#
+#
+# Usage:       Called by hack/ci-e2e.sh after the tests (and verify.sh).
+# -----------------------------------------------------------------------------
+set -u
+
+REPO_ROOT=$(realpath "$(dirname "${BASH_SOURCE[0]}")/../..")
+PIDFILE="${REPO_ROOT}/hack/alloy/alloy.pid"
+
+if [[ ! -f "${PIDFILE}" ]]; then
+  echo "log-collection: no alloy pidfile; nothing to stop"
+  exit 0
+fi
+
+PID=$(cat "${PIDFILE}")
+# Only signal the PID if it is alive and actually an Alloy process, to avoid
+# killing an unrelated process that may have reused a stale PID.
+if kill -0 "${PID}" 2>/dev/null && [[ "$(ps -p "${PID}" -o comm= 2>/dev/null)" == *alloy* ]]; then
+    # Give Alloy time to tail and push the final lines before we stop it.
+    sleep 10
+    kill "${PID}" 2>/dev/null || true
+    echo "log-collection: alloy stopped (pid ${PID})"
+else
+    echo "log-collection: no running alloy for pid ${PID}; nothing to stop"
+fi
+rm -f "${PIDFILE}"

--- a/hack/alloy/verify.sh
+++ b/hack/alloy/verify.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Description: Sanity check that Alloy shipped log entries to the collector, by
+#              reading its metrics endpoint. Must run while Alloy is still up
+#              (i.e. before stop-alloy.sh). Prints the sent/dropped counts and
+#              succeeds only if at least one entry was sent. Never fails the
+#              build on its own (callers invoke it with `|| true`).
+#
+# Usage:       Called by hack/ci-e2e.sh after `make test-e2e`.
+# -----------------------------------------------------------------------------
+set -u
+
+METRICS="$(curl -s --connect-timeout 2 --max-time 5 http://127.0.0.1:12345/metrics 2>/dev/null || true)"
+if [[ -z "${METRICS}" ]]; then
+  echo "log-collection: alloy metrics unavailable (not running?)"
+  exit 0
+fi
+
+sent=$(awk '/^loki_write_sent_entries_total/{s+=$NF} END{print s+0}' <<<"${METRICS}")
+dropped=$(awk '/^loki_write_dropped_entries_total/{s+=$NF} END{print s+0}' <<<"${METRICS}")
+echo "log-collection: sent_entries=${sent} dropped_entries=${dropped}"
+
+[[ "${sent}" -gt 0 ]]

--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -265,9 +265,16 @@ SSH_PUB_KEY_CONTENT="${pub_ssh_key}" envsubst '${SSH_PUB_KEY_CONTENT}' < \
 # We need to gather artifacts/logs before exiting also if there are errors
 set +e
 
+# Start streaming e2e logs to the CI log collector (no-op if not configured).
+"${REPO_ROOT}/hack/alloy/run-alloy.sh" || true
+
 # Run the e2e tests
 make test-e2e
 test_status="$?"
+
+# Confirm logs were shipped, then stop streaming (flushes remaining lines).
+"${REPO_ROOT}/hack/alloy/verify.sh" || true
+"${REPO_ROOT}/hack/alloy/stop-alloy.sh" || true
 
 LOGS_DIR="${REPO_ROOT}/test/e2e/_artifacts/logs"
 mkdir -p "${LOGS_DIR}/qemu"

--- a/hack/e2e/ensure_alloy.sh
+++ b/hack/e2e/ensure_alloy.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -eu
+
+USR_LOCAL_BIN="/usr/local/bin"
+# Pin a release by exporting ALLOY_VERSION=vX.Y.Z; defaults to v1.18.1.
+ALLOY_VERSION="${ALLOY_VERSION:-v1.18.1}"
+ALLOY_RELEASES_URL="https://github.com/grafana/alloy/releases"
+
+# Verify mode turned off by default
+VERIFY_ONLY="${VERIFY_ONLY:-false}"
+
+# Check if the alloy tool is installed and install it if not
+verify_alloy()
+{
+    ALLOY="$(command -v alloy || true)"
+    if ! [[ -x "${ALLOY}" ]]; then
+        if [[ "${VERIFY_ONLY}" != "false" ]]; then
+            echo "alloy is not in PATH"
+            return 0
+        fi
+        if [[ "${OSTYPE}" == "linux-gnu" ]]; then
+            echo "alloy not found, installing"
+            # Alloy ships the binary as a zip; make sure we can extract it.
+            if ! command -v unzip >/dev/null 2>&1; then
+                sudo apt-get update && sudo apt-get install -y unzip
+            fi
+            ALLOY_ZIP="alloy-linux-amd64.zip"
+            if [[ "${ALLOY_VERSION}" == "latest" ]]; then
+                ALLOY_BASE_URL="${ALLOY_RELEASES_URL}/latest/download"
+            else
+                ALLOY_BASE_URL="${ALLOY_RELEASES_URL}/download/${ALLOY_VERSION}"
+            fi
+            set -x
+            curl -LO --create-dirs --output-dir "/tmp" "${ALLOY_BASE_URL}/${ALLOY_ZIP}"
+            curl -LO --create-dirs --output-dir "/tmp" "${ALLOY_BASE_URL}/SHA256SUMS"
+            # Verify the archive against the release checksums before installing.
+            (cd "/tmp" && sha256sum --ignore-missing -c SHA256SUMS)
+            unzip -o "/tmp/${ALLOY_ZIP}" -d "/tmp"
+            sudo install "/tmp/alloy-linux-amd64" "${USR_LOCAL_BIN}/alloy"
+            set +x
+        else
+            echo "ERROR: Missing required binary in path: alloy"
+            return 2
+        fi
+    else
+        echo "$(alloy --version | head -n1) is installed at ${ALLOY}"
+    fi
+}
+
+verify_alloy


### PR DESCRIPTION
Add log streaming from the BMO e2e suite to the Metal3 CI log collector (Grafana Loki), using Grafana Alloy.

**How it works**:

The CAPI test framework already streams deployment logs to files live (`WatchDeploymentLogs`), and libvirt writes BMH serial consoles live. Alloy tails those files and pushes each line to Loki real-time, with no Kubernetes API or pod discovery. `ci-e2e.sh` starts Alloy before `make test-e2e` and stops it after.

- Labels: `job`, `pipeline_id`, `build_number`, `source=artifact`, `collector`
- Structured metadata: `component`/`pod`/`container`(containers), `machine` (serial)
- Only `*.logs` files are chipped; manifest/JSON stay in the archive
- Structure controller logs get their real timestamp (JSON `ts` / RFC3339)

**Testing**:

- Ran Alloy locally agaiest an extracted `artifacts-*.tar.gz`, pushing to the staging collector; confirmed lines appaear in Grafana under a test `pipeline_id`, with correct labels/metadata and parsed timestamps for the structured logs.

**Dependency**: (not in this PR)

Logs only ship once the BMO e2e Jenkins job provides the push credential (`metal3-ci-log-collector-push`) and `ALLOY_*``values to `ci-e2e.sh`, that wiring lives in[ project-infra](https://github.com/metal3-io/project-infra/tree/main/jenkins). Until then these steps no-op and the e2e run is unaffected.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
