### PR TITLE
:sparkles: e2e: support and use IrSO 0.11, support Ironic 38.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gophercloud/gophercloud/v2 v2.13.0
 	github.com/metal3-io/baremetal-operator/apis v0.5.1
 	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.5.1
-	github.com/metal3-io/ironic-standalone-operator/api v0.10.0
+	github.com/metal3-io/ironic-standalone-operator/api v0.11.0
 	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.42.1
 	github.com/prometheus/client_golang v1.24.1

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
 github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
-github.com/metal3-io/ironic-standalone-operator/api v0.10.0 h1:6bWAQ5PwYuuKzvMlBH+lu8jIMjYArRjCfDVcacGOQcQ=
-github.com/metal3-io/ironic-standalone-operator/api v0.10.0/go.mod h1:eVVRnDV8Hue5vkUZPUcfrFaAJn1oV7WBU0JykbIdXzA=
+github.com/metal3-io/ironic-standalone-operator/api v0.11.0 h1:Qyd12pjVs0IrTfQHzNvl+6ygwxdC969w8tIM6i6NI4o=
+github.com/metal3-io/ironic-standalone-operator/api v0.11.0/go.mod h1:7MJ9f1HJZFcBDJdXSr3BwOBFidhRMtIwnQ7k53GNfwE=
 github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3vE=
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/test/e2e/config/ironic.yaml
+++ b/test/e2e/config/ironic.yaml
@@ -25,6 +25,8 @@ images:
   loadBehavior: tryLoad
 - name: quay.io/metal3-io/ironic-standalone-operator:v0.10.0
   loadBehavior: tryLoad
+- name: quay.io/metal3-io/ironic-standalone-operator:v0.11.0
+  loadBehavior: tryLoad
 - name: quay.io/metal3-io/ironic-ipa-downloader:main
   loadBehavior: tryLoad
 
@@ -34,7 +36,7 @@ variables:
   DEPLOY_IRONIC: "true"
   DEPLOY_BMO: "true"
   DEPLOY_CERT_MANAGER: "true"
-  IRSO_KUSTOMIZATION: "data/ironic-standalone-operator/operator/irso-v0.10"
+  IRSO_KUSTOMIZATION: "data/ironic-standalone-operator/operator/irso-v0.11"
   BMO_KUSTOMIZATION: "../../config/overlays/e2e"
   IRONIC_KUSTOMIZATION: "data/ironic-standalone-operator/ironic/overlays/e2e"
 

--- a/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e-release-38.0/kustomization.yaml
+++ b/test/e2e/data/ironic-standalone-operator/ironic/overlays/e2e-release-38.0/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: baremetal-operator-system
+
+resources:
+- ../../base
+
+components:
+- ../../../components/tls
+- ../../../components/basic-auth
+- ../../../components/upgrade-ip
+
+patches:
+- target:
+    kind: Ironic
+    name: ironic
+  patch: |-
+    - op: replace
+      path: /spec/version
+      value: "38.0"

--- a/test/e2e/data/ironic-standalone-operator/operator/irso-v0.11/kustomization.yaml
+++ b/test/e2e/data/ironic-standalone-operator/operator/irso-v0.11/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ironic-standalone-operator-system
+
+resources:
+- https://github.com/metal3-io/ironic-standalone-operator/releases/download/v0.11.0/install.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+- name: ironic-operator-config
+  literals:
+  - IPA_BASEURI=http://192.168.222.1
+
+patches:
+- target:
+    kind: Deployment
+    name: ironic-standalone-operator-controller-manager
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: ironic-standalone-operator
+    spec:
+      template:
+        spec:
+          containers:
+            - name: manager
+              envFrom:
+                - configMapRef:
+                    name: ironic-operator-config

--- a/test/go.mod
+++ b/test/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gophercloud/gophercloud/v2 v2.13.0
 	github.com/metal3-io/baremetal-operator/apis v0.5.1
 	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.5.1
-	github.com/metal3-io/ironic-standalone-operator/api v0.10.0
+	github.com/metal3-io/ironic-standalone-operator/api v0.11.0
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.1
 	github.com/onsi/ginkgo/v2 v2.32.1

--- a/test/go.sum
+++ b/test/go.sum
@@ -161,8 +161,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
-github.com/metal3-io/ironic-standalone-operator/api v0.10.0 h1:6bWAQ5PwYuuKzvMlBH+lu8jIMjYArRjCfDVcacGOQcQ=
-github.com/metal3-io/ironic-standalone-operator/api v0.10.0/go.mod h1:eVVRnDV8Hue5vkUZPUcfrFaAJn1oV7WBU0JykbIdXzA=
+github.com/metal3-io/ironic-standalone-operator/api v0.11.0 h1:Qyd12pjVs0IrTfQHzNvl+6ygwxdC969w8tIM6i6NI4o=
+github.com/metal3-io/ironic-standalone-operator/api v0.11.0/go.mod h1:7MJ9f1HJZFcBDJdXSr3BwOBFidhRMtIwnQ7k53GNfwE=
 github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3vE=
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=


### PR DESCRIPTION
Bump ironic-standalone-operator/api to v0.11.0 so e2e can deploy Ironic 38.0.


