### PR TITLE
🐛 get-hardware-details: allow auth via files, not just URL

### DIFF
--- a/cmd/get-hardware-details/main.go
+++ b/cmd/get-hardware-details/main.go
@@ -87,6 +87,25 @@ func getOptions() (o options) {
 	if err != nil {
 		log.Fatalf("Error: %s\n", err)
 	}
+
+	o.AuthConfig, err = resolveAuthConfig(o.AuthConfig)
+	if err != nil {
+		log.Fatalf("Error: %s\n", err)
+	}
+
 	o.NodeID = os.Args[2]
 	return
+}
+
+// resolveAuthConfig returns urlAuth unchanged if it already carries
+// credentials parsed from the endpoint URL. Embedding credentials in the
+// URL exposes them in the process list, so when none were supplied that
+// way, this falls back to the auth files read by LoadAuth (see
+// docs/ironic-authentication.md) so credentials can be passed without
+// appearing on the command line.
+func resolveAuthConfig(urlAuth clients.AuthConfig) (clients.AuthConfig, error) {
+	if urlAuth.Type != clients.NoAuth {
+		return urlAuth, nil
+	}
+	return clients.LoadAuth()
 }

--- a/cmd/get-hardware-details/main_test.go
+++ b/cmd/get-hardware-details/main_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/clients"
+)
+
+func TestResolveAuthConfig(t *testing.T) {
+	t.Run("URL credentials take precedence", func(t *testing.T) {
+		urlAuth := clients.AuthConfig{
+			Type:     clients.HTTPBasicAuth,
+			Username: "urluser",
+			Password: "urlpass",
+		}
+
+		auth, err := resolveAuthConfig(urlAuth)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if auth != urlAuth {
+			t.Fatalf("expected URL auth to be returned unchanged, got %+v", auth)
+		}
+	})
+
+	t.Run("falls back to LoadAuth when URL has no credentials", func(t *testing.T) {
+		authRoot := filepath.Join(t.TempDir(), "auth")
+		t.Setenv("METAL3_AUTH_ROOT_DIR", authRoot)
+
+		authPath := path.Join(authRoot, "ironic")
+		if err := os.MkdirAll(authPath, 0750); err != nil {
+			t.Fatalf("failed to set up auth dir: %v", err)
+		}
+		if err := os.WriteFile(path.Join(authPath, "username"), []byte("fileuser"), 0600); err != nil {
+			t.Fatalf("failed to write username file: %v", err)
+		}
+		if err := os.WriteFile(path.Join(authPath, "password"), []byte("filepass"), 0600); err != nil {
+			t.Fatalf("failed to write password file: %v", err)
+		}
+
+		auth, err := resolveAuthConfig(clients.AuthConfig{Type: clients.NoAuth})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if auth.Type != clients.HTTPBasicAuth || auth.Username != "fileuser" || auth.Password != "filepass" {
+			t.Fatalf("expected credentials loaded from auth files, got %+v", auth)
+		}
+	})
+
+	t.Run("no credentials anywhere yields NoAuth", func(t *testing.T) {
+		t.Setenv("METAL3_AUTH_ROOT_DIR", filepath.Join(t.TempDir(), "missing"))
+
+		auth, err := resolveAuthConfig(clients.AuthConfig{Type: clients.NoAuth})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if auth.Type != clients.NoAuth {
+			t.Fatalf("expected NoAuth, got %+v", auth)
+		}
+	})
+}

--- a/cmd/get-hardware-details/main_test.go
+++ b/cmd/get-hardware-details/main_test.go
@@ -11,6 +11,20 @@ import (
 
 func TestResolveAuthConfig(t *testing.T) {
 	t.Run("URL credentials take precedence", func(t *testing.T) {
+		authRoot := filepath.Join(t.TempDir(), "auth")
+		t.Setenv("METAL3_AUTH_ROOT_DIR", authRoot)
+
+		authPath := path.Join(authRoot, "ironic")
+		if err := os.MkdirAll(authPath, 0750); err != nil {
+			t.Fatalf("failed to set up auth dir: %v", err)
+		}
+		if err := os.WriteFile(path.Join(authPath, "username"), []byte("fileuser"), 0600); err != nil {
+			t.Fatalf("failed to write username file: %v", err)
+		}
+		if err := os.WriteFile(path.Join(authPath, "password"), []byte("filepass"), 0600); err != nil {
+			t.Fatalf("failed to write password file: %v", err)
+		}
+
 		urlAuth := clients.AuthConfig{
 			Type:     clients.HTTPBasicAuth,
 			Username: "urluser",


### PR DESCRIPTION
🐛 get-hardware-details: allow auth via files, not just URL

**What this PR does / why we need it**:

The `get-hardware-details` CLI tool requires Ironic credentials to be embedded
in the endpoint URL argument (parsed by `clients.ConfigFromEndpointURL`).
Command-line arguments are visible in the process listing (e.g. `ps aux`) on
multi-user systems, which is not a great way to pass secrets.

The operator already loads Ironic Basic Auth credentials from files under
`$METAL3_AUTH_ROOT_DIR/ironic/{username,password}` via `clients.LoadAuth()`
(see `pkg/provisioner/ironic/factory.go` and `docs/ironic-authentication.md`).
This PR wires the same, already-documented mechanism into
`get-hardware-details`: if the endpoint URL does not carry embedded
credentials, the tool now falls back to `clients.LoadAuth()` instead of
running unauthenticated. Credentials embedded in the URL still take
precedence, so existing invocations are unaffected.

Note: `main` CI is currently green (checked via
`gh run list --repo metal3-io/baremetal-operator --branch main --limit 5`),
so no known unrelated red checks are expected on this PR.

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

Fixes #3545

```release-note
get-hardware-details: allow auth via files, not just URL
```