### PR TITLE
🐛 Set image_type in Ironic to avoid an unnecessary HEAD call

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -34,6 +34,8 @@ var (
 	longRetryDelay = time.Second * 10
 
 	softPowerOffTimeout = time.Second * 180
+
+	imageTypeWholeDisk = "whole-disk"
 )
 
 const (
@@ -576,6 +578,7 @@ func (p *ironicProvisioner) setLiveIsoUpdateOptsForNode(ironicNode *nodes.Node, 
 
 		// remove any image_source or checksum options
 		"image_source":        nil,
+		"image_type":          nil,
 		"image_os_hash_value": nil,
 		"image_os_hash_algo":  nil,
 		"image_checksum":      nil,
@@ -604,7 +607,11 @@ func (p *ironicProvisioner) setDirectDeployUpdateOptsForNode(ironicNode *nodes.N
 		// Remove any boot_iso field
 		"boot_iso":          nil,
 		"image_source":      imageData.URL,
+		"image_type":        nil,
 		"image_disk_format": imageData.DiskFormat,
+	}
+	if !imageData.IsOCI() {
+		optValues["image_type"] = imageTypeWholeDisk
 	}
 
 	// Set or clear image pull secret (clear removes a previously-set secret on reprovision)
@@ -656,6 +663,7 @@ func (p *ironicProvisioner) setCustomDeployUpdateOptsForNode(ironicNode *nodes.N
 				"boot_iso":            nil,
 				"image_checksum":      nil,
 				"image_source":        imageData.URL,
+				"image_type":          nil,
 				"image_os_hash_algo":  checksumType,
 				"image_os_hash_value": checksum,
 				"image_disk_format":   imageData.DiskFormat,
@@ -665,10 +673,14 @@ func (p *ironicProvisioner) setCustomDeployUpdateOptsForNode(ironicNode *nodes.N
 				"boot_iso":            nil,
 				"image_checksum":      nil,
 				"image_source":        imageData.URL,
+				"image_type":          nil,
 				"image_os_hash_algo":  nil,
 				"image_os_hash_value": nil,
 				"image_disk_format":   imageData.DiskFormat,
 			}
+		}
+		if !imageData.IsOCI() {
+			optValues["image_type"] = imageTypeWholeDisk
 		}
 		// Set or clear image pull secret (clear removes a previously-set secret on reprovision)
 		if imagePullSecret != "" {
@@ -682,6 +694,7 @@ func (p *ironicProvisioner) setCustomDeployUpdateOptsForNode(ironicNode *nodes.N
 			"boot_iso":            nil,
 			"image_checksum":      nil,
 			"image_source":        nil,
+			"image_type":          nil,
 			"image_os_hash_algo":  nil,
 			"image_os_hash_value": nil,
 			"image_disk_format":   nil,

--- a/pkg/provisioner/ironic/provision_test.go
+++ b/pkg/provisioner/ironic/provision_test.go
@@ -863,6 +863,10 @@ func TestGetUpdateOptsForNodeVirtual(t *testing.T) {
 			Value: "not-empty",
 		},
 		{
+			Path:  "/instance_info/image_type",
+			Value: "whole-disk",
+		},
+		{
 			Path:  "/instance_info/image_os_hash_algo",
 			Value: "md5",
 		},
@@ -1072,6 +1076,7 @@ func TestGetUpdateOptsForNodeImageToLiveIso(t *testing.T) {
 	ironicNode := &nodes.Node{
 		InstanceInfo: map[string]any{
 			"image_source":        "oldimage",
+			"image_type":          "whole-disk",
 			"image_os_hash_value": "thechecksum",
 			"image_os_hash_algo":  "md5",
 		},
@@ -1103,6 +1108,10 @@ func TestGetUpdateOptsForNodeImageToLiveIso(t *testing.T) {
 		},
 		{
 			Path: "/instance_info/image_source",
+			Op:   nodes.RemoveOp,
+		},
+		{
+			Path: "/instance_info/image_type",
 			Op:   nodes.RemoveOp,
 		},
 		{
@@ -1182,6 +1191,11 @@ func TestGetUpdateOptsForNodeLiveIsoToImage(t *testing.T) {
 		{
 			Path:  "/instance_info/image_source",
 			Value: "newimage",
+			Op:    nodes.AddOp,
+		},
+		{
+			Path:  "/instance_info/image_type",
+			Value: "whole-disk",
 			Op:    nodes.AddOp,
 		},
 		{
@@ -1537,6 +1551,10 @@ func TestGetUpdateOptsForNodeOCIWithPullSecret(t *testing.T) {
 			Path:  "/instance_info/image_pull_secret",
 			Value: "user:pass",
 		},
+		{
+			Path:  "/instance_info/image_type",
+			Value: nil,
+		},
 	}
 
 	for _, e := range expected {
@@ -1550,10 +1568,11 @@ func TestGetUpdateOptsForNodeOCIWithPullSecret(t *testing.T) {
 					break
 				}
 			}
-			if update.Path != e.Path {
-				t.Errorf("did not find %q in updates", e.Path)
+			if e.Value == nil {
+				assert.Emptyf(t, update.Path, "found an update for %q when none is expected", e.Path)
 				return
 			}
+			require.Equalf(t, e.Path, update.Path, "did not find %q in updates", e.Path)
 			assert.Equal(t, e.Value, update.Value, "%s does not match", e.Path)
 		})
 	}


### PR DESCRIPTION
When image_type is not set, the validation API ends up doing a HEAD call
to the image. This is not necessary in the Metal3 case since we don't
support partition images. Set image_type to "whole-disk" to disable this
path.

See https://bugs.launchpad.net/ironic/+bug/2164916

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
