### PR TITLE
🐛 Redact image URL failure messages

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -835,7 +836,7 @@ func (p *ironicProvisioner) setUpForProvisioning(ctx context.Context, ironicNode
 		"deploy step", ironicNode.DeployStep,
 	)
 	p.publisher("ProvisioningStarted",
-		"Image provisioning started for "+data.Image.URL)
+		"Image provisioning started for "+redactSensitiveURL(data.Image.URL))
 	return result, nil
 }
 
@@ -1234,7 +1235,7 @@ func (p *ironicProvisioner) Provision(ctx context.Context, data provisioner.Prov
 			}
 			p.log.Info("found error", "msg", ironicNode.LastError)
 			checksum, _, _ := data.Image.GetChecksum()
-			imageInfo := "url: " + data.Image.URL
+			imageInfo := "url: " + redactSensitiveURL(data.Image.URL)
 			if checksum != "" {
 				imageInfo += ", checksum: " + checksum
 			}
@@ -1298,7 +1299,7 @@ func (p *ironicProvisioner) Provision(ctx context.Context, data provisioner.Prov
 	case nodes.Active:
 		// provisioning is done
 		p.publisher("ProvisioningComplete",
-			"Image provisioning completed for "+data.Image.URL)
+			"Image provisioning completed for "+redactSensitiveURL(data.Image.URL))
 		p.log.Info("finished provisioning")
 		return operationComplete()
 
@@ -1835,6 +1836,57 @@ func (p *ironicProvisioner) PowerOff(ctx context.Context, rebootMode metal3api.R
 
 func ironicNodeName(objMeta metav1.ObjectMeta) string {
 	return objMeta.Namespace + nameSeparator + objMeta.Name
+}
+
+// sensitiveURLQueryParams are query parameter names (compared
+// case-insensitively) whose values may carry credential or signed
+// access tokens and must not be leaked in the status/events/logs.
+var sensitiveURLQueryParams = map[string]struct{}{
+	"token":                {},
+	"access_token":         {},
+	"accesstoken":          {},
+	"signature":            {},
+	"sig":                  {},
+	"x-amz-signature":      {},
+	"x-amz-credential":     {},
+	"x-amz-security-token": {},
+	"x-goog-signature":     {}, // GCS V4 signed URL
+	"x-goog-credential":    {}, // GCS V4 signed URL
+	"temp_url_sig":         {}, // OpenStack Swift TempURL
+	"se":                   {}, // Azure SAS expiry/signature-related
+}
+
+func redactSensitiveURL(raw string) string {
+	if raw == "" {
+		return raw
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+
+	// Strip embedded credentials (user:pass@host).
+	if u.User != nil {
+		u.User = nil
+	}
+
+	// Redact sensitive query parameters.
+	if u.RawQuery != "" {
+		q := u.Query()
+		changed := false
+		for key := range q {
+			if _, ok := sensitiveURLQueryParams[strings.ToLower(key)]; ok {
+				q.Set(key, "REDACTED")
+				changed = true
+			}
+		}
+		if changed {
+			u.RawQuery = q.Encode()
+		}
+	}
+
+	return u.String()
 }
 
 func (p *ironicProvisioner) HasCapacity(ctx context.Context) (result bool, err error) {

--- a/pkg/provisioner/ironic/ironic_test.go
+++ b/pkg/provisioner/ironic/ironic_test.go
@@ -145,3 +145,83 @@ func TestNewNoBMCDetails(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, prov)
 }
+
+func TestRedactSensitiveURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty is unchanged",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "plain URL without secrets is unchanged",
+			in:   "https://example.com/images/image.qcow2",
+			want: "https://example.com/images/image.qcow2",
+		},
+		{
+			name: "benign query params are preserved as-is",
+			in:   "https://example.com/image.qcow2?version=2&format=qcow2",
+			want: "https://example.com/image.qcow2?version=2&format=qcow2",
+		},
+		{
+			name: "embedded userinfo credentials are removed",
+			in:   "https://user:pass@example.com/image.qcow2",
+			want: "https://example.com/image.qcow2",
+		},
+		{
+			name: "username-only userinfo is removed",
+			in:   "https://user@example.com/image.qcow2",
+			want: "https://example.com/image.qcow2",
+		},
+		{
+			name: "AWS signature query param is redacted",
+			in:   "https://example.com/image.qcow2?X-Amz-Signature=abc123&foo=bar",
+			want: "https://example.com/image.qcow2?X-Amz-Signature=REDACTED&foo=bar",
+		},
+		{
+			name: "token query param is redacted",
+			in:   "https://example.com/image.qcow2?token=supersecret",
+			want: "https://example.com/image.qcow2?token=REDACTED",
+		},
+		{
+			name: "access_token query param is redacted",
+			in:   "https://example.com/image.qcow2?access_token=supersecret",
+			want: "https://example.com/image.qcow2?access_token=REDACTED",
+		},
+		{
+			name: "redaction is case-insensitive on param name",
+			in:   "https://example.com/image.qcow2?Signature=abc",
+			want: "https://example.com/image.qcow2?Signature=REDACTED",
+		},
+		{
+			name: "both userinfo and signed params are handled",
+			in:   "https://user:pass@example.com/image.qcow2?sig=abc&keep=1",
+			want: "https://example.com/image.qcow2?keep=1&sig=REDACTED",
+		},
+		{
+			name: "GCS signed URL params are redacted",
+			in:   "https://storage.googleapis.com/bucket/image.qcow2?X-Goog-Signature=abc&X-Goog-Credential=def",
+			want: "https://storage.googleapis.com/bucket/image.qcow2?X-Goog-Credential=REDACTED&X-Goog-Signature=REDACTED",
+		},
+		{
+			name: "Swift temp_url_sig is redacted",
+			in:   "https://swift.example.com/v1/img.qcow2?temp_url_sig=abc&temp_url_expires=123",
+			want: "https://swift.example.com/v1/img.qcow2?temp_url_expires=123&temp_url_sig=REDACTED",
+		},
+		{
+			name: "unparseable input is returned unchanged",
+			in:   "://not a url",
+			want: "://not a url",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, redactSensitiveURL(tt.in))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:

This adds a `redactSensitiveURL` helper that:

- strips embedded userinfo (`user:pass@`)
- redacts the values of known-sensitive query parameters (case-insensitive) while keeping the parameter name
- falls back to the original string if the URL cannot be parsed, so normal URLs remain useful for debugging

The helper is applied to the provisioning failure message and to the `ProvisioningStarted` event.

**Why**:

Provisioning failure/status messages are surfaced in less-protected places (BMH status, events, logs, log aggregation) than Secrets. Pre-signed image URLs and URLs with embedded credentials should not be disclosed there.

**Changes**:

- Add `redactSensitiveURL` and `sensitiveURLQueryParams` in `pkg/provisioner/ironic/ìronic.go`.
- Use the redacted URL when building the `operationFailed` message and the `ProvisioningStarted` event.
- Add `TestRedactSensitiveURL` covering credentials, signed query params, case-insensitive matching, benign URLs, and unparsable input.

**NOTE**:

- Redaction uses denylist of parameters names, providers using an unusual sensitive param name would be caught.
- Only the failure message and ProvisioningStarted event are covered here, other raw-URL usages that are purely internal (e.g. image comparison) are intentionally left unchanged.

Fixes #3412

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
