### PR TITLE
:seedling: Improve IPv6 handling in vbmctl

### DIFF
--- a/test/e2e/config/vbmctl.yaml.tmpl
+++ b/test/e2e/config/vbmctl.yaml.tmpl
@@ -33,7 +33,7 @@ spec:
   - name: baremetal-e2e
     bridge: metal3
     address: 192.168.222.1
-    netmask: 255.255.255.0
+    netmask: 24
   vethPairs:
   - link1: metal3
     link2: kind-bridge

--- a/test/vbmctl/cmd/vbmctl/create.go
+++ b/test/vbmctl/cmd/vbmctl/create.go
@@ -282,7 +282,7 @@ func newCreateNetworkCmd() *cobra.Command {
 		name    string
 		bridge  string
 		address string
-		netmask string
+		netmask uint8
 	)
 
 	cmd := &cobra.Command{
@@ -329,7 +329,7 @@ func newCreateNetworkCmd() *cobra.Command {
 	cmd.Flags().StringVar(&name, "name", config.DefaultNetworkName, "name of the network")
 	cmd.Flags().StringVar(&bridge, "bridge", config.DefaultNetworkBridge, "name of the bridge interface")
 	cmd.Flags().StringVar(&address, "address", config.DefaultNetworkAddress, "address of bridge")
-	cmd.Flags().StringVar(&netmask, "netmask", config.DefaultNetworkNetmask, "netmask for network")
+	cmd.Flags().Uint8Var(&netmask, "netmask", config.DefaultNetworkNetmask, "netmask for network")
 
 	return cmd
 }

--- a/test/vbmctl/pkg/api/types.go
+++ b/test/vbmctl/pkg/api/types.go
@@ -123,11 +123,13 @@ type NetworkConfig struct {
 	// Bridge is the name of the bridge interface for the network.
 	Bridge string `json:"bridge,omitempty" yaml:"bridge,omitempty"`
 
-	// Address is the address of the bridge interface. Address is expected to be IPv4.
+	// Address is the address of the bridge interface. Address can
+	// be either v4 or v6.
 	Address string `json:"address,omitempty" yaml:"address,omitempty"`
 
-	// Netmask is the netmask for the network.
-	Netmask string `json:"netmask,omitempty" yaml:"netmask,omitempty"`
+	// Netmask is the netmask for the network. The netmask must be an integer
+	// which defines the significant bits of the network address.
+	Netmask uint8 `json:"netmask,omitempty" yaml:"netmask,omitempty"`
 }
 
 type VethPair struct {
@@ -265,8 +267,8 @@ func (c NetworkConfig) Defaults() NetworkConfig {
 	if cfg.Address == "" {
 		cfg.Address = "192.168.222.1"
 	}
-	if cfg.Netmask == "" {
-		cfg.Netmask = "255.255.255.0"
+	if cfg.Netmask == 0 {
+		cfg.Netmask = 24
 	}
 	return cfg
 }

--- a/test/vbmctl/pkg/config/config.go
+++ b/test/vbmctl/pkg/config/config.go
@@ -49,7 +49,7 @@ const (
 	DefaultNetworkAddress = "192.168.222.1"
 
 	// DefaultNetworkNetmask is the default netmask for the network.
-	DefaultNetworkNetmask = "255.255.255.0"
+	DefaultNetworkNetmask = 24
 
 	// dirPermissions is the default permission for directories.
 	dirPermissions = 0750
@@ -313,31 +313,38 @@ func (c *Config) Validate() error {
 			return errors.New("name is required for libvirt network")
 		}
 
-		if network.Bridge != "" {
-			if len(network.Bridge) > unix.IFNAMSIZ-1 {
-				return fmt.Errorf("too long bridgename for libvirt network %s", network.Name)
-			}
+		if network.Bridge == "" {
+			return errors.New("network bridge name is required")
+		}
+		if len(network.Bridge) > unix.IFNAMSIZ-1 {
+			return fmt.Errorf(
+				"too long bridgename for libvirt network %s, maximum length for name is %d",
+				network.Name,
+				unix.IFNAMSIZ,
+			)
 		}
 
-		if network.Address != "" {
-			addr, err := netip.ParseAddr(network.Address)
-			if err != nil {
-				return fmt.Errorf("malformed libvirt network address: %w", err)
-			}
-			if !addr.Is4() {
-				return fmt.Errorf("libvirt network address must be an IPv4 address: %s", network.Address)
-			}
+		if network.Address == "" {
+			return errors.New("network address is required")
 		}
 
-		if network.Netmask != "" {
-			ip := net.ParseIP(network.Netmask)
-			if ip == nil {
-				return fmt.Errorf("malformed libvirt netmask: %s", ip)
+		addr, err := netip.ParseAddr(network.Address)
+		if err != nil {
+			return fmt.Errorf("malformed libvirt network address: %w", err)
+		}
+
+		if network.Netmask == 0 {
+			return errors.New("netmask is required (cannot be 0)")
+		}
+		if addr.Is4() {
+			//nolint:mnd
+			if network.Netmask > 32 {
+				return errors.New("netmask must be integer between 1 and 32 with IPv4 address")
 			}
-			m := net.IPMask(ip.To4())
-			ones, zeros := m.Size()
-			if ones == 0 && zeros == 0 {
-				return fmt.Errorf("malformed libvirt netmask: %s", ip)
+		} else {
+			//nolint:mnd
+			if network.Netmask > 128 {
+				return errors.New("netmask must be integer between 1 and 128 with IPv6 address")
 			}
 		}
 	}

--- a/test/vbmctl/pkg/config/config_test.go
+++ b/test/vbmctl/pkg/config/config_test.go
@@ -60,7 +60,7 @@ spec:
   - name: "baremetal-e2e"
     bridge: "metal3"
     address: "192.168.222.1"
-    netmask: "255.255.255.0"
+    netmask: 24
   vethPairs:
   - link1: "metal3"
     link2: "kind-bridge"
@@ -168,8 +168,8 @@ spec:
 		t.Errorf("expected libvirt network address '192.168.222.1', got %s", cfg.Spec.Networks[0].Address)
 	}
 
-	if cfg.Spec.Networks[0].Netmask != "255.255.255.0" {
-		t.Errorf("expected libvirt network netmask '255.255.255.0', got %s", cfg.Spec.Networks[0].Netmask)
+	if cfg.Spec.Networks[0].Netmask != 24 {
+		t.Errorf("expected libvirt network netmask '24', got %d", cfg.Spec.Networks[0].Netmask)
 	}
 
 	// vethPairs tests
@@ -597,13 +597,26 @@ func TestValidate(t *testing.T) {
 		},
 
 		{
-			name: "valid libvirt network config",
+			name: "valid libvirt network config with v4 address",
 			modify: func(c *Config) {
 				c.Spec.Networks = []vbmctlapi.NetworkConfig{{
 					Name:    "baremetal-e2e",
 					Bridge:  "metal3",
 					Address: "192.168.222.1",
-					Netmask: "255.255.255.0",
+					Netmask: 24,
+				}}
+			},
+			wantErr: false,
+		},
+
+		{
+			name: "valid libvirt network config with v6 address",
+			modify: func(c *Config) {
+				c.Spec.Networks = []vbmctlapi.NetworkConfig{{
+					Name:    "baremetal-e2e",
+					Bridge:  "metal3",
+					Address: "2001:db8:a0b:12f0::8b6e",
+					Netmask: 112,
 				}}
 			},
 			wantErr: false,
@@ -620,10 +633,23 @@ func TestValidate(t *testing.T) {
 		},
 
 		{
-			name: "invalid libvirt network config - malformed netmask",
+			// The address defaults to v4 address
+			name: "invalid libvirt network config - too large netmask for v4 address",
 			modify: func(c *Config) {
 				c.Spec.Networks = []vbmctlapi.NetworkConfig{{
-					Netmask: "tsubadubaduu",
+					Address: "192.168.222.1",
+					Netmask: 64,
+				}}
+			},
+			wantErr: true,
+		},
+
+		{
+			name: "invalid libvirt network config - invalid netmask for v6 address",
+			modify: func(c *Config) {
+				c.Spec.Networks = []vbmctlapi.NetworkConfig{{
+					Address: "2001:db8:a0b:12f0::8b6e",
+					Netmask: 129,
 				}}
 			},
 			wantErr: true,

--- a/test/vbmctl/pkg/libvirt/templates.go
+++ b/test/vbmctl/pkg/libvirt/templates.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"embed"
 	"fmt"
+	"strings"
 	"text/template"
 
 	vbmctlapi "github.com/metal3-io/baremetal-operator/test/vbmctl/pkg/api"
@@ -99,7 +100,20 @@ func (r *TemplateRenderer) RenderVolume(cfg vbmctlapi.VolumeConfig) (string, err
 // RenderNetwork renders the network XML template with the given data.
 func (r *TemplateRenderer) RenderNetwork(cfg vbmctlapi.NetworkConfig) (string, error) {
 	cfg = cfg.Defaults()
-	return r.render("network.xml.tpl", cfg)
+	ipFamily := "ipv4"
+	// The address is validated before, it contains either v4 or v6 address
+	if strings.Contains(cfg.Address, ":") {
+		ipFamily = "ipv6"
+	}
+
+	data := struct {
+		vbmctlapi.NetworkConfig
+		IPFamily string
+	}{
+		NetworkConfig: cfg,
+		IPFamily:      ipFamily,
+	}
+	return r.render("network.xml.tpl", data)
 }
 
 // RenderDHCPHost renders XML for a DHCP host entry.

--- a/test/vbmctl/pkg/libvirt/templates/network.xml.tpl
+++ b/test/vbmctl/pkg/libvirt/templates/network.xml.tpl
@@ -6,5 +6,8 @@
     </nat>
   </forward>
   <bridge name='{{ .Bridge }}'/>
-  <ip address='{{ .Address }}' netmask='{{ .Netmask}}'/>
+  <ip family='{{ .IPFamily }}' address='{{ .Address }}' prefix='{{ .Netmask }}'/>
+  <!-- disabling dns disables libvirt dnsmasq server, so it does not -->
+  <!-- interfere with ironic dnsmasq server -->
+  <dns enable='no' />
 </network>


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

This PR adds support for IPv6 networking in vbmctl to pave the way for IPv6 support in e2e tests.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Related to issue #3578

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] E2E tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
