### PR TITLE
:bug: Build the manager and plugins with -trimpath

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       image-name: 'baremetal-operator'
       pushImage: true
+      image-build-args: MODULE_VERSION=${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
       generate-sbom: true
       sign-image: true
     secrets:

--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -7,9 +7,11 @@ on:
     - 'main'
     - 'release-*'
     paths:
+    - 'Dockerfile'
     - 'Dockerfile.plugin-test'
     - 'Makefile'
     - 'cmd/plugin-load-test/**'
+    - 'hack/plugin-build-flags.sh'
     - 'hack/plugin-test/**'
     - 'pkg/provisioner/**'
     - 'go.mod'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -155,6 +155,7 @@ jobs:
       image-name: 'baremetal-operator'
       pushImage: true
       ref: ${{ needs.push_release_tags.outputs.release_tag }}
+      image-build-args: MODULE_VERSION=${{ needs.push_release_tags.outputs.release_tag }}
       generate-sbom: true
       sign-image: true
     secrets:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,12 @@ ARG BASE_IMAGE=gcr.io/distroless/base-debian13:nonroot@sha256:a557d784ac275c287d
 # this image to guarantee toolchain and module-version parity with BMO.
 FROM $BUILD_IMAGE AS sdk
 
+# Record our own packages as module@version, the form a dependency gets, so an
+# out-of-tree plugin can be built from any directory. Must match the Makefile.
+# See docs/plugin-provisioners.md.
+ARG MODULE_VERSION=v0.0.0-dev
+ENV MODULE_VERSION=${MODULE_VERSION}
+
 WORKDIR /workspace
 
 COPY go.mod go.sum ./
@@ -26,14 +32,14 @@ FROM sdk AS builder
 ARG ARCH=amd64
 ARG LDFLAGS=-s -w
 RUN GOOS=linux GOARCH=${ARCH} \
-    go build -a -ldflags "${LDFLAGS}" -o baremetal-operator main.go
+    go build -a $(./hack/plugin-build-flags.sh /workspace "${MODULE_VERSION}") -ldflags "${LDFLAGS}" -o baremetal-operator main.go
 
 # Build the ironic provisioner plugin
 FROM sdk AS ironic-plugin-builder
 ARG ARCH=amd64
 ARG LDFLAGS=-s -w
 RUN GOOS=linux GOARCH=${ARCH} \
-    go build -buildmode=plugin -ldflags "${LDFLAGS}" \
+    go build -buildmode=plugin $(./hack/plugin-build-flags.sh /workspace "${MODULE_VERSION}") -ldflags "${LDFLAGS}" \
     -o ironic-provisioner.so ./pkg/provisioner/ironic/plugin/
 
 # Build the demo provisioner plugin
@@ -41,7 +47,7 @@ FROM sdk AS demo-plugin-builder
 ARG ARCH=amd64
 ARG LDFLAGS=-s -w
 RUN GOOS=linux GOARCH=${ARCH} \
-    go build -buildmode=plugin -ldflags "${LDFLAGS}" \
+    go build -buildmode=plugin $(./hack/plugin-build-flags.sh /workspace "${MODULE_VERSION}") -ldflags "${LDFLAGS}" \
     -o demo-provisioner.so ./pkg/provisioner/demo/plugin/
 
 # Runtime image. Uses distroless/base (not static) because Go plugins need glibc.

--- a/Dockerfile.plugin-test
+++ b/Dockerfile.plugin-test
@@ -11,9 +11,15 @@
 #                      reproduction of an external author depending on BMO)
 #   plugin-load-tester runs plugin-load-test against the .so, build fails on
 #                      any error
+#
+# The author stage keeps BMO at /bmo-src, not bmo-builder's /bmo, so this build
+# fails unless both sides record their BMO packages as module@version.
 ARG BUILD_IMAGE=docker.io/golang:1.26.6@sha256:640a234f4bea3e399c056b7b8f9c667c4939befae8db2f14e9785e16eccd4205
+ARG MODULE_VERSION=v0.0.0-dev
 
 FROM $BUILD_IMAGE AS bmo-builder
+ARG MODULE_VERSION
+ENV MODULE_VERSION=${MODULE_VERSION}
 WORKDIR /bmo
 COPY go.mod go.sum ./
 COPY apis/go.mod apis/go.sum apis/
@@ -26,11 +32,13 @@ ENV GO111MODULE=on
 ARG ARCH=amd64
 ARG LDFLAGS=-s -w
 RUN GOOS=linux GOARCH=${ARCH} \
-    go build -a -ldflags "${LDFLAGS}" -o /out/baremetal-operator main.go && \
+    go build -a $(/bmo/hack/plugin-build-flags.sh /bmo "${MODULE_VERSION}") -ldflags "${LDFLAGS}" -o /out/baremetal-operator main.go && \
     GOOS=linux GOARCH=${ARCH} \
-    go build -a -ldflags "${LDFLAGS}" -o /out/plugin-load-test ./cmd/plugin-load-test
+    go build -a $(/bmo/hack/plugin-build-flags.sh /bmo "${MODULE_VERSION}") -ldflags "${LDFLAGS}" -o /out/plugin-load-test ./cmd/plugin-load-test
 
 FROM $BUILD_IMAGE AS plugin-author
+ARG MODULE_VERSION
+ENV MODULE_VERSION=${MODULE_VERSION}
 ARG ARCH=amd64
 ARG LDFLAGS=-s -w
 ENV CGO_ENABLED=1
@@ -39,23 +47,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /
 # Bring in the BMO source so the replace directives below resolve to it. A
 # real consumer would `go get github.com/metal3-io/baremetal-operator@vX.Y.Z`
 # instead of carrying the source.
-COPY . /bmo
+COPY . /bmo-src
 WORKDIR /plugin
 RUN git init -q . && \
     git config user.email "test@example.com" && \
     git config user.name "plugin-author"
-RUN cp /bmo/pkg/provisioner/demo/plugin/main.go ./main.go
-# Rewrite GetHealth in /bmo's demo provisioner to use go.starlark.net,
+RUN cp /bmo-src/pkg/provisioner/demo/plugin/main.go ./main.go
+# Rewrite GetHealth in /bmo-src's demo provisioner to use go.starlark.net,
 # proving the plugin can pull in deps outside BMO's go.mod.
-RUN cd /bmo && go run -tags patcher ./hack/plugin-test/patcher ./pkg/provisioner/demo/demo.go
+RUN cd /bmo-src && go run -tags patcher ./hack/plugin-test/patcher ./pkg/provisioner/demo/demo.go
 RUN go mod init github.com/example/demo-provisioner-plugin && \
-    go mod edit -replace github.com/metal3-io/baremetal-operator=/bmo && \
-    go mod edit -replace github.com/metal3-io/baremetal-operator/apis=/bmo/apis && \
-    go mod edit -replace github.com/metal3-io/baremetal-operator/pkg/hardwareutils=/bmo/pkg/hardwareutils && \
+    go mod edit -replace github.com/metal3-io/baremetal-operator=/bmo-src && \
+    go mod edit -replace github.com/metal3-io/baremetal-operator/apis=/bmo-src/apis && \
+    go mod edit -replace github.com/metal3-io/baremetal-operator/pkg/hardwareutils=/bmo-src/pkg/hardwareutils && \
     go mod tidy && \
     git add -A && git commit -q -m "demo plugin with starlark"
 RUN GOOS=linux GOARCH=${ARCH} \
-    go build -buildmode=plugin -ldflags "${LDFLAGS}" \
+    go build -buildmode=plugin $(/bmo-src/hack/plugin-build-flags.sh /bmo-src "${MODULE_VERSION}") -ldflags "${LDFLAGS}" \
     -o /out/demo-provisioner.so .
 
 FROM $BUILD_IMAGE AS plugin-load-tester

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,11 @@ LDFLAGS = "-X $(VERSION_URI).Raw=${BUILD_VERSION} \
                 -X $(VERSION_URI).Commit=${SOURCE_GIT_COMMIT} \
                 -X $(VERSION_URI).BuildTime=$(shell date +%Y-%m-%dT%H:%M:%S%z)"
 
+# Lets a plugin be built from any directory. See hack/plugin-build-flags.sh
+# and docs/plugin-provisioners.md.
+MODULE_VERSION ?= $(BUILD_VERSION)
+PLUGIN_BUILD_FLAGS = $$($(ROOT_DIR)/hack/plugin-build-flags.sh $(ROOT_DIR) $(MODULE_VERSION))
+
 # Set some variables the operator expects to have in order to work
 # Those need to be the same as in config/default/ironic.env
 export OPERATOR_NAME=baremetal-operator
@@ -199,19 +204,19 @@ build: generate manifests manager tools build-e2e ## Build everything
 
 .PHONY: manager
 manager: generate lint ironic-plugin demo-plugin ## Build manager binary and bundled provisioner plugins
-	go build -ldflags $(LDFLAGS) -o bin/$(OPERATOR_NAME) main.go
+	go build $(PLUGIN_BUILD_FLAGS) -ldflags $(LDFLAGS) -o bin/$(OPERATOR_NAME) main.go
 
 .PHONY: run
 run: generate lint manifests ironic-plugin ## Run against the configured Kubernetes cluster in ~/.kube/config
-	PROVISIONER_PLUGIN_DIR=$(BIN_DIR) go run -ldflags $(LDFLAGS) ./main.go -namespace=$(RUN_NAMESPACE) -dev -provisioner=ironic -webhook-port=0 $(RUN_FLAGS)
+	PROVISIONER_PLUGIN_DIR=$(BIN_DIR) go run $(PLUGIN_BUILD_FLAGS) -ldflags $(LDFLAGS) ./main.go -namespace=$(RUN_NAMESPACE) -dev -provisioner=ironic -webhook-port=0 $(RUN_FLAGS)
 
 .PHONY: demo
 demo: generate lint manifests demo-plugin ## Run in demo mode
-	PROVISIONER_PLUGIN_DIR=$(BIN_DIR) go run -ldflags $(LDFLAGS) ./main.go -namespace=$(RUN_NAMESPACE) -dev -provisioner=demo -webhook-port=0 $(RUN_FLAGS)
+	PROVISIONER_PLUGIN_DIR=$(BIN_DIR) go run $(PLUGIN_BUILD_FLAGS) -ldflags $(LDFLAGS) ./main.go -namespace=$(RUN_NAMESPACE) -dev -provisioner=demo -webhook-port=0 $(RUN_FLAGS)
 
 .PHONY: run-test-mode
 run-test-mode: generate lint manifests ## Run against the configured Kubernetes cluster in ~/.kube/config
-	go run -ldflags $(LDFLAGS) ./main.go -namespace=$(RUN_NAMESPACE) -dev -provisioner=fixture -webhook-port=0 $(RUN_FLAGS)
+	go run $(PLUGIN_BUILD_FLAGS) -ldflags $(LDFLAGS) ./main.go -namespace=$(RUN_NAMESPACE) -dev -provisioner=fixture -webhook-port=0 $(RUN_FLAGS)
 
 .PHONY: install
 install: $(KUSTOMIZE) manifests ## Install CRDs into a cluster
@@ -305,6 +310,7 @@ docker: docker-build ## Alias for docker-build (for backwards compatibility)
 docker-build: generate manifests ## Build the docker image for controller-manager
 	$(CONTAINER_RUNTIME) build --platform=linux/$(ARCH) \
 	--build-arg ARCH=$(ARCH) \
+	--build-arg MODULE_VERSION=$(MODULE_VERSION) \
 	--build-arg http_proxy=$(http_proxy) \
 	--build-arg https_proxy=$(https_proxy) \
 	. -t ${IMG}-$(ARCH):${IMG_TAG}
@@ -317,6 +323,7 @@ docker-build: generate manifests ## Build the docker image for controller-manage
 docker-debug: generate manifests ## Build the docker image with debug info
 	$(CONTAINER_RUNTIME) build --platform=linux/$(ARCH) \
 	--build-arg ARCH=$(ARCH) \
+	--build-arg MODULE_VERSION= \
 	--build-arg http_proxy=$(http_proxy) \
 	--build-arg https_proxy=$(https_proxy) \
 	--build-arg LDFLAGS="" \
@@ -333,16 +340,17 @@ DEMO_PLUGIN_SO = bin/demo-provisioner.so
 
 .PHONY: ironic-plugin
 ironic-plugin: ## Build the ironic provisioner plugin .so locally
-	CGO_ENABLED=1 go build -buildmode=plugin -ldflags $(LDFLAGS) -o $(IRONIC_PLUGIN_SO) ./$(IRONIC_PLUGIN_DIR)/
+	CGO_ENABLED=1 go build -buildmode=plugin $(PLUGIN_BUILD_FLAGS) -ldflags $(LDFLAGS) -o $(IRONIC_PLUGIN_SO) ./$(IRONIC_PLUGIN_DIR)/
 
 .PHONY: demo-plugin
 demo-plugin: ## Build the demo provisioner plugin .so locally
-	CGO_ENABLED=1 go build -buildmode=plugin -ldflags $(LDFLAGS) -o $(DEMO_PLUGIN_SO) ./$(DEMO_PLUGIN_DIR)/
+	CGO_ENABLED=1 go build -buildmode=plugin $(PLUGIN_BUILD_FLAGS) -ldflags $(LDFLAGS) -o $(DEMO_PLUGIN_SO) ./$(DEMO_PLUGIN_DIR)/
 
 .PHONY: docker-build-sdk
 docker-build-sdk: ## Build the BMO SDK image for authoring custom provisioner plugins
 	$(CONTAINER_RUNTIME) build --platform=linux/$(ARCH) \
 	--build-arg ARCH=$(ARCH) \
+	--build-arg MODULE_VERSION=$(MODULE_VERSION) \
 	--build-arg http_proxy=$(http_proxy) \
 	--build-arg https_proxy=$(https_proxy) \
 	--target sdk \
@@ -352,6 +360,7 @@ docker-build-sdk: ## Build the BMO SDK image for authoring custom provisioner pl
 docker-build-plugin-test: ## Build the out-of-tree plugin compatibility test image
 	$(CONTAINER_RUNTIME) build --platform=linux/$(ARCH) \
 	--build-arg ARCH=$(ARCH) \
+	--build-arg MODULE_VERSION=$(MODULE_VERSION) \
 	--build-arg http_proxy=$(http_proxy) \
 	--build-arg https_proxy=$(https_proxy) \
 	-f Dockerfile.plugin-test \

--- a/docs/plugin-provisioners.md
+++ b/docs/plugin-provisioners.md
@@ -71,7 +71,8 @@ Build (output filename must follow the `<name>-provisioner.so` convention so
 the manager can resolve `-provisioner=<name>`):
 
 ```sh
-CGO_ENABLED=1 go build -buildmode=plugin -o foobar-provisioner.so ./path/to/plugin
+CGO_ENABLED=1 go build -buildmode=plugin -trimpath -o foobar-provisioner.so ./path/to/plugin
+# building against a BMO checkout instead of a release? see Source paths below
 ```
 
 ## Plugin configuration
@@ -158,9 +159,73 @@ For an out-of-tree plugin maintained in its own repo:
   Makefile):
 
   ```sh
-  CGO_ENABLED=1 go build -buildmode=plugin -o foobar-provisioner.so ./plugin
+  CGO_ENABLED=1 go build -buildmode=plugin -trimpath -o foobar-provisioner.so ./plugin
   ```
 
 - If `plugin.Open` reports a mismatch on a specific package, align it in
-  your `go.mod` (`replace` or `go get <pkg>@<ver>`) to the version used by
-  the BMO release, then rebuild.
+  your `go.mod` to the version the BMO release uses, then rebuild. Use
+  `go get <pkg>@<ver>`, or `exclude` the higher one: under `-trimpath` the
+  recorded path carries the module's selected version, so a
+  `replace <pkg> vX => <pkg> vY` does not align it.
+
+### Source paths
+
+Recorded source paths are part of a package's fingerprint too. `-trimpath`
+removes them, but it records a bare import path for the main module and
+`module@version` for a dependency, and BMO is the main module when the released
+binary is built while it is a dependency when your plugin is built. Released
+images therefore record BMO's own packages in the dependency form, using the
+release tag (see `hack/plugin-build-flags.sh`).
+
+So build with `-trimpath` and pin BMO at the release you target. Let BMO's
+`go.mod` decide the versions of `apis` and `pkg/hardwareutils` rather than
+requiring them yourself, since the release recorded whatever it resolves.
+
+```sh
+go get github.com/metal3-io/baremetal-operator@vX.Y.Z
+CGO_ENABLED=1 go build -buildmode=plugin -trimpath -o foobar-provisioner.so ./plugin
+```
+
+The directory you build in no longer matters, the version does. Only tagged
+releases carry one, so an image built from a branch records no version and
+takes plugins built the same way. A `replace` pointing at a local BMO checkout
+also records something else, and needs the same rewrite applied to your own
+build, which the next section spells out.
+
+### When the release requires older submodules
+
+The recipe above assumes the release requires `apis` and `pkg/hardwareutils` at
+its own version, so resolving them hands you the source that release was built
+from. Releases have shipped without that bump, so check what you resolved:
+
+```sh
+go list -m -f '{{.Version}}' github.com/metal3-io/baremetal-operator/apis
+```
+
+A version older than the release you pinned means the requirement was never
+bumped, and resolving it gives submodule source the release does not contain.
+Usually it will not compile against `pkg/provisioner` at all, and where it
+does, the package contents still differ from the manager's, so `plugin.Open`
+rejects the plugin.
+
+Build against a checkout of the release instead. The replaces supply the
+source the release actually contains, while the rewrite keeps recording the
+versions its `go.mod` names, which is what the manager recorded:
+
+```sh
+git clone --depth 1 --branch vX.Y.Z \
+    https://github.com/metal3-io/baremetal-operator /tmp/bmo
+go mod edit \
+    -replace github.com/metal3-io/baremetal-operator=/tmp/bmo \
+    -replace github.com/metal3-io/baremetal-operator/apis=/tmp/bmo/apis \
+    -replace github.com/metal3-io/baremetal-operator/pkg/hardwareutils=/tmp/bmo/pkg/hardwareutils
+go mod tidy
+CGO_ENABLED=1 go build -buildmode=plugin \
+    $(/tmp/bmo/hack/plugin-build-flags.sh /tmp/bmo vX.Y.Z) \
+    -o foobar-provisioner.so ./plugin
+```
+
+Leave the flags unquoted, they expand to two arguments. Pass the release tag
+rather than a version of your own, since that is what the image recorded.
+`Dockerfile.plugin-test` is a worked example, and CI builds it, so this path
+stays exercised rather than becoming folklore.

--- a/hack/plugin-build-flags.sh
+++ b/hack/plugin-build-flags.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Print the go build flags that let an out-of-tree plugin load from any
+# directory. Source paths in docs/plugin-provisioners.md says why.
+#
+# Usage plugin-build-flags.sh <bmo-source-dir> <module-version>
+# Run from the module the flags are for.
+
+set -o errexit -o nounset -o pipefail
+
+root="${1:?usage: plugin-build-flags.sh <bmo-source-dir> <module-version>}"
+version="${2-}"
+
+# Only a tagged build carries a version a plugin author can pin against.
+[[ -n "${version}" ]] || exit 0
+
+mod="github.com/metal3-io/baremetal-operator"
+
+# Read them, they are released on their own version line.
+apis="$(go list -m -f '{{.Version}}' "${mod}/apis")"
+hwutils="$(go list -m -f '{{.Version}}' "${mod}/pkg/hardwareutils")"
+
+# Most specific first, the compiler takes the first matching rule. The submodule
+# rules are needed because the module pattern would otherwise cover them.
+printf -- '-trimpath -gcflags=%s/...=-trimpath=%s/apis=>%s/apis@%s;%s/pkg/hardwareutils=>%s/pkg/hardwareutils@%s;%s=>%s@%s\n' \
+    "${mod}" \
+    "${root}" "${mod}" "${apis}" \
+    "${root}" "${mod}" "${hwutils}" \
+    "${root}" "${mod}" "${version}"


### PR DESCRIPTION
Source paths are part of the package fingerprint plugin.Open compares, so without -trimpath a plugin loads only when built from the same directory as the manager (/workspace for the release image), even when the toolchain and every shared module version already match.

Dockerfile.plugin-test now builds against BMO at /bmo-src rather than bmo-builder's /bmo, so it fails if -trimpath is dropped again.