### PR TITLE
🐛 Avoid returning RequeueAfter=0

### DIFF
--- a/internal/controller/metal3.io/action_result.go
+++ b/internal/controller/metal3.io/action_result.go
@@ -18,6 +18,8 @@ const (
 	defaultBackoff  = 0.5
 )
 
+var tinyDelay = 10 * time.Millisecond
+
 // actionResult is an interface that encapsulates the result of a Reconcile
 // call, as returned by the action corresponding to the current state.
 type actionResult interface {
@@ -33,9 +35,11 @@ type actionContinue struct {
 }
 
 func (r actionContinue) Result() (result reconcile.Result, err error) {
-	result.RequeueAfter = r.delay
-	// Set Requeue true as well as RequeueAfter in case the delay is 0.
-	result.Requeue = true
+	if r.delay == 0 {
+		result.RequeueAfter = tinyDelay
+	} else {
+		result.RequeueAfter = r.delay
+	}
 	return
 }
 
@@ -62,7 +66,6 @@ type actionDelayed struct {
 
 func (r actionDelayed) Result() (result reconcile.Result, err error) {
 	result.RequeueAfter = calculateBackoff(1)
-	result.Requeue = true
 	return
 }
 
@@ -72,7 +75,7 @@ type actionComplete struct {
 }
 
 func (r actionComplete) Result() (result reconcile.Result, err error) {
-	result.Requeue = true
+	result.RequeueAfter = tinyDelay
 	return
 }
 

--- a/internal/controller/metal3.io/action_result.go
+++ b/internal/controller/metal3.io/action_result.go
@@ -20,6 +20,12 @@ const (
 
 var tinyDelay = 10 * time.Millisecond
 
+func simpleRequeue() reconcile.Result {
+	return reconcile.Result{
+		RequeueAfter: tinyDelay,
+	}
+}
+
 // actionResult is an interface that encapsulates the result of a Reconcile
 // call, as returned by the action corresponding to the current state.
 type actionResult interface {
@@ -75,8 +81,7 @@ type actionComplete struct {
 }
 
 func (r actionComplete) Result() (result reconcile.Result, err error) {
-	result.RequeueAfter = tinyDelay
-	return
+	return simpleRequeue(), nil
 }
 
 func (r actionComplete) Dirty() bool {

--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -149,7 +149,7 @@ func (r *BareMetalHostReconciler) Reconcile(ctx context.Context, request ctrl.Re
 	if annotations != nil {
 		if _, ok := annotations[metal3api.PausedAnnotation]; ok {
 			reqLogger.Info("host is paused, no work to do")
-			return ctrl.Result{Requeue: false}, nil
+			return ctrl.Result{}, nil
 		}
 	}
 
@@ -157,7 +157,7 @@ func (r *BareMetalHostReconciler) Reconcile(ctx context.Context, request ctrl.Re
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("could not reconcile host data: %w", err)
 	} else if hostData.Requeue {
-		return ctrl.Result{Requeue: true}, nil
+		return simpleRequeue(), nil
 	}
 
 	// Consume hardwaredetails from annotation if present
@@ -165,7 +165,7 @@ func (r *BareMetalHostReconciler) Reconcile(ctx context.Context, request ctrl.Re
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("could not update hardware details: %w", err)
 	} else if hwdUpdated {
-		return ctrl.Result{Requeue: true}, nil
+		return simpleRequeue(), nil
 	}
 
 	// NOTE(dhellmann): Handle a few steps outside of the phase
@@ -186,7 +186,7 @@ func (r *BareMetalHostReconciler) Reconcile(ctx context.Context, request ctrl.Re
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return simpleRequeue(), nil
 	}
 
 	// Retrieve the BMC details from the host spec and validate host
@@ -402,11 +402,11 @@ func (r *BareMetalHostReconciler) credentialsErrorResult(ctx context.Context, er
 		credentialsMissing.Inc()
 		saveErr := r.setErrorCondition(ctx, request, host, metal3api.RegistrationError, err.Error())
 		if saveErr != nil {
-			return ctrl.Result{Requeue: true}, saveErr
+			return simpleRequeue(), saveErr
 		}
 		r.publishEvent(ctx, request, host.NewEvent("BMCCredentialError", err.Error()))
 
-		return ctrl.Result{Requeue: true, RequeueAfter: hostErrorRetryDelay}, nil
+		return ctrl.Result{RequeueAfter: hostErrorRetryDelay}, nil
 	}
 
 	// If a managed Host is missing a BMC address or secret, or
@@ -420,7 +420,7 @@ func (r *BareMetalHostReconciler) credentialsErrorResult(ctx context.Context, er
 		credentialsInvalid.Inc()
 		saveErr := r.setErrorCondition(ctx, request, host, metal3api.RegistrationError, err.Error())
 		if saveErr != nil {
-			return ctrl.Result{Requeue: true}, saveErr
+			return simpleRequeue(), saveErr
 		}
 		// Only publish the event if we do not have an error
 		// after saving so that we only publish one time.
@@ -2744,7 +2744,7 @@ func (r *BareMetalHostReconciler) reconcileHostData(ctx context.Context, host *m
 			if errStatus != nil {
 				return ctrl.Result{}, hardwareData, fmt.Errorf("could not restore status from annotation: %w", errStatus)
 			}
-			return ctrl.Result{Requeue: true}, hardwareData, nil
+			return simpleRequeue(), hardwareData, nil
 		}
 		reqLogger.V(VerbosityLevelDebug).Info("no status cache found")
 	}
@@ -2758,7 +2758,7 @@ func (r *BareMetalHostReconciler) reconcileHostData(ctx context.Context, host *m
 			return ctrl.Result{}, hardwareData, fmt.Errorf("could not delete status annotation: %w", errStatus)
 		}
 		reqLogger.V(VerbosityLevelDebug).Info("deleted status annotation")
-		return ctrl.Result{Requeue: true}, hardwareData, nil
+		return simpleRequeue(), hardwareData, nil
 	}
 
 	if host.Spec.Architecture == "" && hardwareData != nil && hardwareData.Spec.HardwareDetails != nil && hardwareData.Spec.HardwareDetails.CPU.Arch != "" {
@@ -2769,7 +2769,7 @@ func (r *BareMetalHostReconciler) reconcileHostData(ctx context.Context, host *m
 		if err := r.Client.Update(ctx, host); err != nil {
 			return ctrl.Result{}, hardwareData, fmt.Errorf("failed to update architecture: %w", err)
 		}
-		return ctrl.Result{Requeue: true}, hardwareData, nil
+		return simpleRequeue(), hardwareData, nil
 	}
 	return ctrl.Result{}, hardwareData, nil
 }

--- a/internal/controller/metal3.io/dataimage_controller.go
+++ b/internal/controller/metal3.io/dataimage_controller.go
@@ -106,7 +106,7 @@ func (r *DataImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		return ctrl.Result{Requeue: true, RequeueAfter: dataImageRetryDelay}, fmt.Errorf("could not load dataImage, %w", err)
+		return ctrl.Result{RequeueAfter: dataImageRetryDelay}, fmt.Errorf("could not load dataImage, %w", err)
 	}
 
 	// If a corresponding BareMetalHost is missing, keep retrying
@@ -117,7 +117,7 @@ func (r *DataImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			reqLogger.Info("bareMetalHost not found for the dataImage, remove finalizer if it exists")
 			if controllerutil.RemoveFinalizer(di, metal3api.DataImageFinalizer) {
 				if err = r.Update(ctx, di); err != nil {
-					return ctrl.Result{Requeue: true, RequeueAfter: dataImageRetryDelay}, fmt.Errorf("failed to update resource after remove finalizer, %w", err)
+					return ctrl.Result{RequeueAfter: dataImageRetryDelay}, fmt.Errorf("failed to update resource after remove finalizer, %w", err)
 				}
 			} else {
 				reqLogger.Info("finalizer already removed, no update needed")
@@ -126,7 +126,7 @@ func (r *DataImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 
 		// Error reading the object - requeue the request.
-		return ctrl.Result{Requeue: true, RequeueAfter: dataImageRetryDelay}, fmt.Errorf("could not load baremetalhost, %w", err)
+		return ctrl.Result{RequeueAfter: dataImageRetryDelay}, fmt.Errorf("could not load baremetalhost, %w", err)
 	}
 
 	info := &rdiInfo{log: reqLogger, request: req, di: di, bmh: bmh}
@@ -135,19 +135,19 @@ func (r *DataImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	annotations := bmh.GetAnnotations()
 	if _, ok := annotations[metal3api.PausedAnnotation]; ok {
 		reqLogger.Info("host associated with dataImage is paused, no work to do")
-		return ctrl.Result{Requeue: false}, nil
+		return ctrl.Result{}, nil
 	}
 
 	// If DataImage exists, add its ownerReference
 	if !ownerReferenceExists(bmh, di) {
 		if err := controllerutil.SetOwnerReference(bmh, di, r.Scheme()); err != nil {
-			return ctrl.Result{Requeue: true, RequeueAfter: dataImageRetryDelay}, fmt.Errorf("could not set bmh as controller, %w", err)
+			return ctrl.Result{RequeueAfter: dataImageRetryDelay}, fmt.Errorf("could not set bmh as controller, %w", err)
 		}
 		if err := r.Update(ctx, di); err != nil {
-			return ctrl.Result{Requeue: true, RequeueAfter: dataImageRetryDelay}, fmt.Errorf("failure updating dataImage status, %w", err)
+			return ctrl.Result{RequeueAfter: dataImageRetryDelay}, fmt.Errorf("failure updating dataImage status, %w", err)
 		}
 
-		return ctrl.Result{Requeue: true}, nil
+		return simpleRequeue(), nil
 	}
 
 	// Add finalizer for newly created DataImage
@@ -160,7 +160,7 @@ func (r *DataImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if err != nil {
 			return ctrl.Result{RequeueAfter: dataImageUpdateDelay}, fmt.Errorf("failed to update resource after add finalizer, %w", err)
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return simpleRequeue(), nil
 	}
 
 	if hasDetachedAnnotation(bmh) {
@@ -170,7 +170,7 @@ func (r *DataImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			reqLogger.Info("dataImage deletion requested in detached state, removing finalizer")
 			if controllerutil.RemoveFinalizer(di, metal3api.DataImageFinalizer) {
 				if err := r.Update(ctx, di); err != nil {
-					return ctrl.Result{Requeue: true, RequeueAfter: dataImageRetryDelay}, fmt.Errorf("failed to update resource after remove finalizer, %w", err)
+					return ctrl.Result{RequeueAfter: dataImageRetryDelay}, fmt.Errorf("failed to update resource after remove finalizer, %w", err)
 				}
 			}
 			return ctrl.Result{}, nil
@@ -178,7 +178,7 @@ func (r *DataImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		// If the associated BMH is detached, keep requeuing till the annotation is removed
 		reqLogger.Info("the host is detached, not running reconciler")
-		return ctrl.Result{Requeue: true, RequeueAfter: dataImageUnmanagedRetryDelay}, nil
+		return ctrl.Result{RequeueAfter: dataImageUnmanagedRetryDelay}, nil
 	}
 
 	// Create a provisioner that can access Ironic API
@@ -205,11 +205,11 @@ func (r *DataImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 			// Update dataImage status and requeue
 			if err := r.updateStatus(ctx, info); err != nil {
-				return ctrl.Result{Requeue: true, RequeueAfter: dataImageRetryDelay}, fmt.Errorf("failed to update resource status, %w", err)
+				return ctrl.Result{RequeueAfter: dataImageRetryDelay}, fmt.Errorf("failed to update resource status, %w", err)
 			}
 		}
 
-		return ctrl.Result{Requeue: true, RequeueAfter: dataImageUpdateDelay}, nil
+		return ctrl.Result{RequeueAfter: dataImageUpdateDelay}, nil
 	}
 	di.Status.Error.Message = ""
 	di.Status.Error.Count = 0
@@ -221,12 +221,12 @@ func (r *DataImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		if isImageAttached {
 			reqLogger.Info("Wait for DataImage to detach before removing finalizer, requeueing")
-			return ctrl.Result{Requeue: true, RequeueAfter: dataImageRetryDelay}, nil
+			return ctrl.Result{RequeueAfter: dataImageRetryDelay}, nil
 		}
 
 		if controllerutil.RemoveFinalizer(di, metal3api.DataImageFinalizer) {
 			if err := r.Update(ctx, di); err != nil {
-				return ctrl.Result{Requeue: true, RequeueAfter: dataImageRetryDelay}, fmt.Errorf("failed to update resource after remove finalizer, %w", err)
+				return ctrl.Result{RequeueAfter: dataImageRetryDelay}, fmt.Errorf("failed to update resource after remove finalizer, %w", err)
 			}
 		}
 		return ctrl.Result{}, nil
@@ -234,7 +234,7 @@ func (r *DataImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Update the latest status fetched from the Node
 	if err := r.updateStatus(ctx, info); err != nil {
-		return ctrl.Result{Requeue: true, RequeueAfter: dataImageRetryDelay}, fmt.Errorf("failed to update resource statu, %w", err)
+		return ctrl.Result{RequeueAfter: dataImageRetryDelay}, fmt.Errorf("failed to update resource statu, %w", err)
 	}
 
 	for _, e := range info.events {

--- a/internal/controller/metal3.io/hostclaim_controller.go
+++ b/internal/controller/metal3.io/hostclaim_controller.go
@@ -196,7 +196,7 @@ func checkHostClaimError(err error, errMessage string) (ctrl.Result, error) {
 		return ctrl.Result{}, nil
 	}
 	if ok, delay := hostclaimManager.IsRequeueAfterError(err); ok {
-		return ctrl.Result{Requeue: true, RequeueAfter: delay}, nil
+		return ctrl.Result{RequeueAfter: delay}, nil
 	}
 	return ctrl.Result{}, fmt.Errorf("%s: %w", errMessage, err)
 }

--- a/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
+++ b/internal/controller/metal3.io/hostfirmwarecomponents_controller.go
@@ -107,12 +107,12 @@ func (r *HostFirmwareComponentsReconciler) Reconcile(ctx context.Context, req ct
 			return ctrl.Result{}, nil
 		}
 		reqLogger.Error(err, "could not get baremetal host, not running hostfirmwarecomponents reconciler")
-		return ctrl.Result{Requeue: true, RequeueAfter: resourceNotAvailableRetryDelay}, err
+		return ctrl.Result{RequeueAfter: resourceNotAvailableRetryDelay}, err
 	}
 
 	if skipReconcileSubresource(bmh, reqLogger) {
 		// We'll get notified on BMH changes, no need to reconcile soon
-		return ctrl.Result{Requeue: true, RequeueAfter: unmanagedRetryDelay}, nil
+		return ctrl.Result{RequeueAfter: unmanagedRetryDelay}, nil
 	}
 
 	// Fetch the HostFirmwareComponents
@@ -149,7 +149,7 @@ func (r *HostFirmwareComponentsReconciler) Reconcile(ctx context.Context, req ct
 		reqLogger.Info("provisioner returns error",
 			LogFieldError, err.Error(),
 			LogFieldRequeueAfter, provisionerRetryDelay)
-		return ctrl.Result{Requeue: true, RequeueAfter: provisionerRetryDelay}, nil
+		return ctrl.Result{RequeueAfter: provisionerRetryDelay}, nil
 	}
 
 	if err = r.updateHostFirmware(ctx, info, components); err != nil {
@@ -163,9 +163,9 @@ func (r *HostFirmwareComponentsReconciler) Reconcile(ctx context.Context, req ct
 	}
 
 	if meta.IsStatusConditionTrue(info.hfc.Status.Conditions, string(metal3api.HostFirmwareComponentsChangeDetected)) {
-		return ctrl.Result{Requeue: true, RequeueAfter: reconcilerRequeueDelayChangeDetected}, nil
+		return ctrl.Result{RequeueAfter: reconcilerRequeueDelayChangeDetected}, nil
 	}
-	return ctrl.Result{Requeue: true, RequeueAfter: reconcilerRequeueDelay}, nil
+	return ctrl.Result{RequeueAfter: reconcilerRequeueDelay}, nil
 }
 
 // Update the HostFirmwareComponents resource using the components from provisioner.

--- a/internal/controller/metal3.io/hostfirmwaresettings_controller.go
+++ b/internal/controller/metal3.io/hostfirmwaresettings_controller.go
@@ -125,12 +125,12 @@ func (r *HostFirmwareSettingsReconciler) Reconcile(ctx context.Context, req ctrl
 		if k8serrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{Requeue: true, RequeueAfter: resourceNotAvailableRetryDelay}, nil
+		return ctrl.Result{RequeueAfter: resourceNotAvailableRetryDelay}, nil
 	}
 
 	if skipReconcileSubresource(bmh, reqLogger) {
 		// We'll get notified on BMH changes, no need to reconcile soon
-		return ctrl.Result{Requeue: true, RequeueAfter: unmanagedRetryDelay}, nil
+		return ctrl.Result{RequeueAfter: unmanagedRetryDelay}, nil
 	}
 
 	// Fetch the HostFirmwareSettings
@@ -140,7 +140,7 @@ func (r *HostFirmwareSettingsReconciler) Reconcile(ctx context.Context, req ctrl
 		// The HFS resource may have been deleted
 		if k8serrors.IsNotFound(err) {
 			reqLogger.V(VerbosityLevelDebug).Info("hostFirmwareSettings not found")
-			return ctrl.Result{Requeue: true, RequeueAfter: resourceNotAvailableRetryDelay}, nil
+			return ctrl.Result{RequeueAfter: resourceNotAvailableRetryDelay}, nil
 		}
 		// Error reading the object - requeue the request.
 		return ctrl.Result{}, fmt.Errorf("could not load hostFirmwareSettings: %w", err)
@@ -167,7 +167,7 @@ func (r *HostFirmwareSettingsReconciler) Reconcile(ctx context.Context, req ctrl
 		reqLogger.Info("provisioner returns error",
 			LogFieldError, err.Error(),
 			LogFieldRequeueAfter, provisionerRetryDelay)
-		return ctrl.Result{Requeue: true, RequeueAfter: provisionerRetryDelay}, nil
+		return ctrl.Result{RequeueAfter: provisionerRetryDelay}, nil
 	}
 
 	if err = r.updateHostFirmwareSettings(ctx, currentSettings, schema, info); err != nil {
@@ -181,9 +181,9 @@ func (r *HostFirmwareSettingsReconciler) Reconcile(ctx context.Context, req ctrl
 	// requeue to run again after delay
 	if meta.IsStatusConditionTrue(info.hfs.Status.Conditions, string(metal3api.FirmwareSettingsChangeDetected)) {
 		// If there is a difference between Spec and Status shorten the query from Ironic so that the Status is updated when cleaning completes
-		return ctrl.Result{Requeue: true, RequeueAfter: reconcilerRequeueDelayChangeDetected}, nil
+		return ctrl.Result{RequeueAfter: reconcilerRequeueDelayChangeDetected}, nil
 	}
-	return ctrl.Result{Requeue: true, RequeueAfter: reconcilerRequeueDelay}, nil
+	return ctrl.Result{RequeueAfter: reconcilerRequeueDelay}, nil
 }
 
 // Get the firmware settings from the provisioner and update hostFirmwareSettings.

--- a/pkg/provisioner/ironic/delete_test.go
+++ b/pkg/provisioner/ironic/delete_test.go
@@ -192,8 +192,6 @@ func deleteTest(t *testing.T, detach bool) {
 					Maintenance:    true,
 				},
 			).DeleteError(nodeUUID, http.StatusNotFound),
-			expectedDirty:        true,
-			expectedRequestAfter: 0,
 		},
 		{
 			name: "delete-ok",
@@ -204,8 +202,6 @@ func deleteTest(t *testing.T, detach bool) {
 					Maintenance:    true,
 				},
 			).Delete(nodeUUID),
-			expectedDirty:        true,
-			expectedRequestAfter: 0,
 		},
 		{
 			name: "host-not-found",
@@ -228,8 +224,6 @@ func deleteTest(t *testing.T, detach bool) {
 					Maintenance:    false,
 				},
 			).Delete(nodeUUID),
-			expectedDirty:        true,
-			expectedRequestAfter: 0,
 		},
 		{
 			name: "stale-instance-uuid-update",
@@ -242,8 +236,6 @@ func deleteTest(t *testing.T, detach bool) {
 			).NodeUpdate(nodes.Node{
 				UUID: nodeUUID,
 			}).Delete(nodeUUID),
-			expectedDirty:        true,
-			expectedRequestAfter: 0,
 			expectedUpdate: &nodes.UpdateOperation{
 				Op:   nodes.RemoveOp,
 				Path: "/instance_uuid",
@@ -310,9 +302,6 @@ func deleteTest(t *testing.T, detach bool) {
 					Maintenance:    false,
 				},
 			).Delete(nodeUUID),
-			// Should delete directly without setting maintenance mode
-			expectedDirty:        true,
-			expectedRequestAfter: 0,
 		},
 	}
 

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1340,6 +1340,8 @@ func (p *ironicProvisioner) setMaintenanceFlag(ctx context.Context, ironicNode *
 	}
 
 	if err == nil {
+		// FIXME(dtantsur): this should be operationComplete because changing the maintenance flag is synchronous.
+		// However, a lot of callers rely on it returning a Dirty result.
 		result, err = operationContinuing(0)
 		p.cachedNode = nil
 	} else if gophercloud.ResponseCodeIs(err, http.StatusConflict) {
@@ -1354,12 +1356,12 @@ func (p *ironicProvisioner) setMaintenanceFlag(ctx context.Context, ironicNode *
 
 // syncAutomatedClean updates the Ironic node's automated_clean field if it doesn't match the desired state.
 // Returns true if an update was needed and applied.
-func (p *ironicProvisioner) syncAutomatedClean(ctx context.Context, ironicNode *nodes.Node, automatedCleaningMode metal3api.AutomatedCleaningMode) (updated bool, err error) {
+func (p *ironicProvisioner) syncAutomatedClean(ctx context.Context, ironicNode *nodes.Node, automatedCleaningMode metal3api.AutomatedCleaningMode) error {
 	desiredAutomatedClean := automatedCleaningMode != metal3api.CleaningModeDisabled
 
 	// Check if update is needed
 	if ironicNode.AutomatedClean != nil && *ironicNode.AutomatedClean == desiredAutomatedClean {
-		return false, nil
+		return nil
 	}
 
 	p.log.Info("synchronizing automatedClean before deprovisioning",
@@ -1371,11 +1373,11 @@ func (p *ironicProvisioner) syncAutomatedClean(ctx context.Context, ironicNode *
 
 	updatedNode, err := nodes.Update(ctx, p.client, ironicNode.UUID, updater.Updates).Extract()
 	if err != nil {
-		return false, fmt.Errorf("failed to update automatedClean: %w", err)
+		return fmt.Errorf("failed to update automatedClean: %w", err)
 	}
 
 	p.cachedNode = updatedNode
-	return true, nil
+	return nil
 }
 
 // Deprovision removes the host from the image. It may be called
@@ -1468,12 +1470,9 @@ func (p *ironicProvisioner) Deprovision(ctx context.Context, restartOnFailure bo
 		// Before starting deprovisioning, ensure Ironic's automated_clean matches the BMH spec.
 		// This prevents the PPI deletion race where the spec is changed right before deletion
 		// but Ironic hasn't been updated yet.
-		updated, err := p.syncAutomatedClean(ctx, ironicNode, automatedCleaningMode)
+		err := p.syncAutomatedClean(ctx, ironicNode, automatedCleaningMode)
 		if err != nil {
 			return transientError(err)
-		}
-		if updated {
-			return operationContinuing(0)
 		}
 
 		p.log.Info("starting deprovisioning", "automatedClean", ironicNode.AutomatedClean)
@@ -1601,7 +1600,8 @@ func (p *ironicProvisioner) realDelete(ctx context.Context, ironicNode *nodes.No
 		return transientError(fmt.Errorf("failed to remove host: %w", err))
 	}
 
-	return operationContinuing(0)
+	// Deletion is synchronous, proceed immediately
+	return operationComplete()
 }
 
 // Detach removes the host from the provisioning system.
@@ -1671,7 +1671,7 @@ func (p *ironicProvisioner) changePower(ctx context.Context, ironicNode *nodes.N
 		powerStateOpts)
 
 	if changeResult.Err == nil {
-		p.log.Info("power change OK")
+		p.log.Info("power change requested successfully", "target", powerStateOpts.Target)
 		event := map[nodes.TargetPowerState]struct{ Event, Reason string }{
 			nodes.PowerOn:      {Event: "PowerOn", Reason: "Host powered on"},
 			nodes.PowerOff:     {Event: "PowerOff", Reason: "Host powered off"},
@@ -1679,6 +1679,7 @@ func (p *ironicProvisioner) changePower(ctx context.Context, ironicNode *nodes.N
 		}[target]
 		p.publisher(event.Event, event.Reason)
 		p.cachedNode = nil
+		// FIXME(dtantsur): this should be a short delay instead, power actions are not immediate
 		return operationContinuing(0)
 	} else if gophercloud.ResponseCodeIs(changeResult.Err, http.StatusConflict) {
 		p.log.Info("host is locked, trying again after delay", "delay", shortRetryDelay)

--- a/pkg/provisioner/ironic/provision_test.go
+++ b/pkg/provisioner/ironic/provision_test.go
@@ -277,7 +277,7 @@ func TestDeprovision(t *testing.T) {
 				ProvisionState: string(nodes.Active),
 				UUID:           nodeUUID,
 			}),
-			expectedRequestAfter: 0,
+			expectedRequestAfter: 3,
 			expectedDirty:        true,
 		},
 		{
@@ -286,7 +286,7 @@ func TestDeprovision(t *testing.T) {
 				ProvisionState: string(nodes.DeployFail),
 				UUID:           nodeUUID,
 			}),
-			expectedRequestAfter: 0,
+			expectedRequestAfter: 3,
 			expectedDirty:        true,
 		},
 		{
@@ -388,39 +388,34 @@ func TestDeprovisionSyncAutomatedClean(t *testing.T) {
 	automatedCleanFalse := false
 
 	cases := []struct {
-		name                     string
-		automatedCleaningMode    metal3api.AutomatedCleaningMode
-		nodeAutomatedClean       *bool
-		expectSync               bool
-		expectProvisionStateCall bool
+		name                  string
+		automatedCleaningMode metal3api.AutomatedCleaningMode
+		nodeAutomatedClean    *bool
+		expectSync            bool
 	}{
 		{
-			name:                     "sync needed - disable cleaning",
-			automatedCleaningMode:    metal3api.CleaningModeDisabled,
-			nodeAutomatedClean:       &automatedCleanTrue,
-			expectSync:               true,
-			expectProvisionStateCall: false, // Should requeue before sending TargetDeleted
+			name:                  "sync needed - disable cleaning",
+			automatedCleaningMode: metal3api.CleaningModeDisabled,
+			nodeAutomatedClean:    &automatedCleanTrue,
+			expectSync:            true,
 		},
 		{
-			name:                     "sync needed - enable cleaning",
-			automatedCleaningMode:    metal3api.CleaningModeMetadata,
-			nodeAutomatedClean:       &automatedCleanFalse,
-			expectSync:               true,
-			expectProvisionStateCall: false, // Should requeue before sending TargetDeleted
+			name:                  "sync needed - enable cleaning",
+			automatedCleaningMode: metal3api.CleaningModeMetadata,
+			nodeAutomatedClean:    &automatedCleanFalse,
+			expectSync:            true,
 		},
 		{
-			name:                     "already synced - cleaning disabled",
-			automatedCleaningMode:    metal3api.CleaningModeDisabled,
-			nodeAutomatedClean:       &automatedCleanFalse,
-			expectSync:               false,
-			expectProvisionStateCall: true, // Should proceed with TargetDeleted
+			name:                  "already synced - cleaning disabled",
+			automatedCleaningMode: metal3api.CleaningModeDisabled,
+			nodeAutomatedClean:    &automatedCleanFalse,
+			expectSync:            false,
 		},
 		{
-			name:                     "already synced - cleaning enabled",
-			automatedCleaningMode:    metal3api.CleaningModeMetadata,
-			nodeAutomatedClean:       &automatedCleanTrue,
-			expectSync:               false,
-			expectProvisionStateCall: true, // Should proceed with TargetDeleted
+			name:                  "already synced - cleaning enabled",
+			automatedCleaningMode: metal3api.CleaningModeMetadata,
+			nodeAutomatedClean:    &automatedCleanTrue,
+			expectSync:            false,
 		},
 	}
 
@@ -447,9 +442,7 @@ func TestDeprovisionSyncAutomatedClean(t *testing.T) {
 			// Check if automated_clean was updated
 			updates := ironic.GetLastNodeUpdateRequestFor(nodeUUID)
 			if tc.expectSync {
-				// Should have updated automated_clean and requeued
-				assert.True(t, result.Dirty, "should be dirty to requeue after sync")
-				assert.Equal(t, time.Duration(0), result.RequeueAfter)
+				// Should have updated automated_clean
 				require.NotNil(t, updates, "should have called Update API")
 				// Verify the automated_clean field was updated
 				found := false
@@ -469,13 +462,10 @@ func TestDeprovisionSyncAutomatedClean(t *testing.T) {
 
 			// Check if provision state change was called
 			stateUpdate := ironic.GetLastNodeStatesProvisionUpdateRequestFor(nodeUUID)
-			if tc.expectProvisionStateCall {
-				assert.NotEmpty(t, stateUpdate.Target, "should have called provision state API")
-				assert.Equal(t, nodes.TargetDeleted, stateUpdate.Target)
-			} else if tc.expectSync {
-				// If sync was needed, should not have called provision state yet
-				assert.Empty(t, stateUpdate.Target, "should not call provision state if sync was needed")
-			}
+			assert.True(t, result.Dirty, "should be dirty to requeue")
+			assert.Equal(t, time.Second*3, result.RequeueAfter)
+			assert.NotEmpty(t, stateUpdate.Target, "should have called provision state API")
+			assert.Equal(t, nodes.TargetDeleted, stateUpdate.Target)
 		})
 	}
 }


### PR DESCRIPTION
Apparently, the deprecated Requeue flag does not do anything any more,
so returning RequeueAfter 0 means no requeue. This can block deletion,
for example.

This commit:
- changes Result in the controller to never return requeue delay of 0 if
  requeue is expected and drops the deprecated Requeue flag
- changes deletion in the Ironic backend to not requeue (deletions are
  synchronous)
- changes automated clean sync to not requeue (patching nodes is
  synchronous too)

I've left TODOs for revisiting power and maintenance actions since
changing them requires modifying a lot of caller places and tests.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
