### PR TITLE
:sparkles: Require the released apis and hardwareutils versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,7 @@ lint: $(GOLANGCI_LINT)
 	cd pkg/hardwareutils; $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) ./... --timeout=10m
 	cd hack/tools; $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) ./... --timeout=10m
 	./hack/check-e2e.sh
+	./hack/check-submodule-versions.sh
 
 .PHONY: lint-fix
 lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -69,6 +69,30 @@ by using following command `git remote -v`.
 - Fetch the remote (`metal3-io`): `git fetch upstream`
 This makes sure that all the tags are accessible.
 
+### Bumping the submodule requirements
+
+The root `go.mod` and `test/go.mod` require `apis` and `pkg/hardwareutils` at
+a version that their `replace` directives hide, so only consumers ever resolve
+it. Release tagging creates `v0.x.y`, `apis/v0.x.y`, `test/v0.x.y` and
+`pkg/hardwareutils/v0.x.y` from one commit, so both files have to require
+`v0.x.y` before the release notes are merged. Otherwise the released root
+module points consumers at submodule code that no released submodule version
+contains, and an out of tree plugin built against it hits a package
+fingerprint mismatch. See [plugin provisioners](plugin-provisioners.md).
+
+- Bump the two requirements in `go.mod` and `test/go.mod` to the version you
+   are about to release, in a pull request of its own, and merge it first. The
+   release notes commit has to contain the notes file and nothing else, so the
+   bump cannot ride along with it.
+
+- Until those tags exist, `hack/check-submodule-versions.sh` reports the
+   version as not tagged yet and skips its build check, so `make lint` stays
+   green on that pull request.
+
+- `hack/verify-release.sh` fails when the two files ask for anything other
+   than the version being released, so run it before tagging to catch a
+   forgotten bump while it can still be fixed.
+
 ### Creating Release Notes
 
 - Switch to the main branch: `git checkout main`

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/google/safetext v0.0.0-20230106111101-7156a760e523
 	github.com/google/uuid v1.6.0
 	github.com/gophercloud/gophercloud/v2 v2.14.0
-	github.com/metal3-io/baremetal-operator/apis v0.5.1
-	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.5.1
+	github.com/metal3-io/baremetal-operator/apis v0.14.0
+	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.14.0
 	github.com/metal3-io/ironic-standalone-operator/api v0.11.0
 	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.43.0

--- a/hack/check-submodule-versions.sh
+++ b/hack/check-submodule-versions.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# Consumers get no replace directives, so they resolve whatever versions of
+# apis and pkg/hardwareutils go.mod requires, and a stale one breaks them.
+# Build pkg/provisioner the way they resolve it, from the repository root.
+
+set -o errexit -o nounset -o pipefail
+
+mod="github.com/metal3-io/baremetal-operator"
+check="go.submodule-check.mod"
+checksum="go.submodule-check.sum"
+
+submodules=("${mod}/apis" "${mod}/pkg/hardwareutils")
+
+cleanup() {
+    rm -f "${check}" "${checksum}"
+}
+trap cleanup EXIT
+
+cp go.mod "${check}"
+cp go.sum "${checksum}"
+
+go mod edit -modfile="${check}" \
+    -dropreplace "${mod}/apis" \
+    -dropreplace "${mod}/pkg/hardwareutils"
+
+# -e so a version with no tag yet is reported instead of failing the graph.
+required() {
+    go list -modfile="${check}" -m -e -f '{{.Version}}' "$1"
+}
+
+# A release tags the root and the submodules at once, so a requirement naming
+# that release resolves only once the tags are pushed.
+pending=""
+report=""
+
+for submodule in "${submodules[@]}"; do
+    version="$(required "${submodule}")"
+    report+="    ${submodule} ${version}"$'\n'
+    test_version="$(cd test && go list -m -e -f '{{.Version}}' "${submodule}")"
+
+    if [[ "${version}" != "${test_version}" ]]; then
+        cat >&2 <<EOF
+error: go.mod and test/go.mod require different versions of ${submodule}
+
+    go.mod      ${version}
+    test/go.mod ${test_version}
+
+Only consumers see this, so bump the two files together.
+EOF
+        exit 1
+    fi
+
+    if ! query="$(GOFLAGS=-mod=mod go list -modfile="${check}" -m "${submodule}@${version}" 2>&1)"; then
+        case "${query}" in
+        *"unknown revision"* | *"invalid version"*)
+            pending="${submodule} ${version}"
+            ;;
+        *)
+            echo "${query}" >&2
+            exit 1
+            ;;
+        esac
+    fi
+done
+
+if [[ -n "${pending}" ]]; then
+    echo "${pending} is not tagged yet, skipping the build check"
+    exit 0
+fi
+
+# Only the package a plugin imports, ./... would drag in the plugin main
+# packages. -mod=mod to record checksums for the unreplaced modules.
+if ! GOFLAGS=-mod=mod go build -modfile="${check}" ./pkg/provisioner 2>&1; then
+    cat >&2 <<EOF
+error: pkg/provisioner does not build against the versions go.mod requires
+
+${report}
+Consumers resolve exactly these. Bump go.mod and test/go.mod to the
+released versions of the current line.
+EOF
+    exit 1
+fi
+
+echo "pkg/provisioner builds against the required submodule versions"

--- a/hack/verify-release.sh
+++ b/hack/verify-release.sh
@@ -79,6 +79,19 @@ declare -a git_nonexisting_tags=(
     "hack/tools/v${VERSION}"
 )
 
+# modules released from this repository, which the root and test modules have
+# to require at the release version. See docs/releasing.md
+declare -a submodule_requirements=(
+    "github.com/metal3-io/baremetal-operator/apis"
+    "github.com/metal3-io/baremetal-operator/pkg/hardwareutils"
+)
+
+# go.mod files that carry those requirements
+declare -a submodule_requirement_files=(
+    "go.mod"
+    "test/go.mod"
+)
+
 # release notes should have these strings
 declare -a release_note_strings=(
     ":recycle:"
@@ -511,6 +524,16 @@ _module_get_version()
         | grep -v "//\s*indirect" | head -1 | awk '{print $2;}'
 }
 
+_submodule_get_required_version()
+{
+    # get the required version of a submodule from one go.mod, matching the
+    # require block only so the module line and the replaces stay out of it
+    local file="$1"
+    local module="$2"
+
+    grep -hE "^[[:space:]]+${module} v" "${file}" | head -1 | awk '{print $2;}'
+}
+
 _module_get_latest_patch_release()
 {
     # get latest patch release from given version
@@ -620,6 +643,32 @@ verify_module_releases()
     echo -e "Done\n"
 }
 
+verify_submodule_requirements()
+{
+    # the release tags the root module and the submodules from one commit, so
+    # requiring this version is what makes a consumer resolve the tagged source
+    local file module version
+
+    echo "Verify apis and pkg/hardwareutils are required at the release version ..."
+
+    for file in "${submodule_requirement_files[@]}"; do
+        for module in "${submodule_requirements[@]}"; do
+            # shellcheck disable=SC2311
+            version="$(_submodule_get_required_version "${file}" "${module}")"
+
+            if [[ -z "${version}" ]]; then
+                echo "ERROR: ${file} does not require ${module}"
+            elif [[ "${version}" != "v${VERSION}" ]]; then
+                echo "ERROR: ${file} requires ${module} ${version}, expected v${VERSION}"
+                echo "       bump it before tagging, otherwise the release points"
+                echo "       consumers at submodule source it does not contain"
+            fi
+        done
+    done
+
+    echo -e "Done\n"
+}
+
 verify_vulnerabilities()
 {
     # run osv-scanner to verify if we have open vulnerabilities in deps
@@ -669,4 +718,5 @@ verify_container_base_image
 verify_module_versions
 verify_module_group_versions
 verify_module_releases
+verify_submodule_requirements
 verify_vulnerabilities

--- a/test/go.mod
+++ b/test/go.mod
@@ -5,8 +5,8 @@ go 1.26.0
 require (
 	github.com/cert-manager/cert-manager v1.20.3
 	github.com/gophercloud/gophercloud/v2 v2.14.0
-	github.com/metal3-io/baremetal-operator/apis v0.5.1
-	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.5.1
+	github.com/metal3-io/baremetal-operator/apis v0.14.0
+	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.14.0
 	github.com/metal3-io/ironic-standalone-operator/api v0.11.0
 	github.com/moby/moby/api v1.56.0
 	github.com/moby/moby/client v0.6.0


### PR DESCRIPTION
The root `go.mod` and `test/go.mod` require `apis` and `pkg/hardwareutils` at
v0.5.1, hidden by the local `replace` directives. Consumers get no replace, so
they resolve v0.5.1 and `pkg/provisioner` does not compile against it.

Both files move to v0.14.0. Lint builds `pkg/provisioner` the way a consumer
resolves it, and `verify-release.sh` fails unless both files name the version
being tagged.