### PR TITLE
:seedling: Feature gate for HostClaims

### DIFF
--- a/config/base/manager.yaml
+++ b/config/base/manager.yaml
@@ -23,7 +23,6 @@ spec:
         - /baremetal-operator
         args:
         - --enable-leader-election
-        - --hostclaims
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/config/overlays/e2e/features.env
+++ b/config/overlays/e2e/features.env
@@ -1,1 +1,1 @@
-FEATURE_GATES=
+FEATURE_GATES=HostClaims=true

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -3651,7 +3651,6 @@ spec:
       containers:
       - args:
         - --enable-leader-election
-        - --hostclaims
         command:
         - /baremetal-operator
         env:

--- a/internal/webhooks/metal3.io/v1alpha1/hostclaim_webhook.go
+++ b/internal/webhooks/metal3.io/v1alpha1/hostclaim_webhook.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/features"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -44,6 +45,10 @@ var _ admission.Validator[*metal3api.HostClaim] = &HostClaimWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (webhook *HostClaimWebhook) ValidateCreate(_ context.Context, hc *metal3api.HostClaim) (admission.Warnings, error) {
+	if !features.CurrentFeatureGate.Enabled(features.FeatureHostClaims) {
+		return nil, errors.New("HostClaims are an experimental feature and feature gate 'HostClaims' is not enabled")
+	}
+
 	if hc == nil {
 		hostclaimlog.Error(errors.New("object is nil"), "validate create error")
 		return nil, nil
@@ -55,6 +60,10 @@ func (webhook *HostClaimWebhook) ValidateCreate(_ context.Context, hc *metal3api
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (webhook *HostClaimWebhook) ValidateUpdate(_ context.Context, _, newHc *metal3api.HostClaim) (admission.Warnings, error) {
+	if !features.CurrentFeatureGate.Enabled(features.FeatureHostClaims) {
+		return nil, errors.New("HostClaims are an experimental feature and feature gate 'HostClaims' is not enabled")
+	}
+
 	if newHc == nil {
 		hostclaimlog.Error(errors.New("object is nil"), "validate update error")
 		return nil, nil

--- a/internal/webhooks/metal3.io/v1alpha1/hostclaim_webhook_test.go
+++ b/internal/webhooks/metal3.io/v1alpha1/hostclaim_webhook_test.go
@@ -20,14 +20,17 @@ import (
 	"testing"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/features"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 )
 
 func TestHostClaimCreate(t *testing.T) {
 	tests := []struct {
-		name      string
-		hostclaim *metal3api.HostClaim
-		wantedErr string
+		name               string
+		hostclaim          *metal3api.HostClaim
+		featureGateEnabled bool
+		wantedErr          string
 	}{
 		{
 			name: "valid",
@@ -38,7 +41,8 @@ func TestHostClaimCreate(t *testing.T) {
 				Name:      "test",
 				Namespace: "test-namespace",
 			}, Spec: metal3api.HostClaimSpec{}},
-			wantedErr: "",
+			featureGateEnabled: true,
+			wantedErr:          "",
 		},
 		{
 			name: "invalid-bad-label-selector",
@@ -53,7 +57,20 @@ func TestHostClaimCreate(t *testing.T) {
 					MatchLabels: map[string]string{"-bad-key-": "v"},
 				},
 			}},
-			wantedErr: "-bad-key-=v: name part must consist",
+			featureGateEnabled: true,
+			wantedErr:          "-bad-key-=v: name part must consist",
+		},
+		{
+			name: "feature gate disabled",
+			hostclaim: &metal3api.HostClaim{TypeMeta: metav1.TypeMeta{
+				Kind:       "HostClaim",
+				APIVersion: "metal3.io/v1alpha1",
+			}, ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test-namespace",
+			}, Spec: metal3api.HostClaimSpec{}},
+			featureGateEnabled: false,
+			wantedErr:          "HostClaims are an experimental feature",
 		},
 	}
 
@@ -61,6 +78,7 @@ func TestHostClaimCreate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			webhook := &HostClaimWebhook{}
 			ctx := t.Context()
+			featuregatetesting.SetFeatureGateDuringTest(t, features.CurrentFeatureGate, features.FeatureHostClaims, tt.featureGateEnabled)
 			if _, err := webhook.ValidateCreate(ctx, tt.hostclaim); !errorContains(err, tt.wantedErr) {
 				t.Errorf("HostClaim.ValidateCreate() error = %v, wantErr %v", err, tt.wantedErr)
 			}
@@ -70,9 +88,10 @@ func TestHostClaimCreate(t *testing.T) {
 
 func TestHostClaimUpdate(t *testing.T) {
 	tests := []struct {
-		name      string
-		hostclaim *metal3api.HostClaim
-		wantedErr string
+		name               string
+		hostclaim          *metal3api.HostClaim
+		featureGateEnabled bool
+		wantedErr          string
 	}{
 		{
 			name: "valid",
@@ -83,7 +102,20 @@ func TestHostClaimUpdate(t *testing.T) {
 				Name:      "test",
 				Namespace: "test-namespace",
 			}, Spec: metal3api.HostClaimSpec{}},
-			wantedErr: "",
+			featureGateEnabled: true,
+			wantedErr:          "",
+		},
+		{
+			name: "feature gate not enabled",
+			hostclaim: &metal3api.HostClaim{TypeMeta: metav1.TypeMeta{
+				Kind:       "HostClaim",
+				APIVersion: "metal3.io/v1alpha1",
+			}, ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test-namespace",
+			}, Spec: metal3api.HostClaimSpec{}},
+			featureGateEnabled: false,
+			wantedErr:          "HostClaims are an experimental feature",
 		},
 	}
 
@@ -91,6 +123,7 @@ func TestHostClaimUpdate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			webhook := &HostClaimWebhook{}
 			ctx := t.Context()
+			featuregatetesting.SetFeatureGateDuringTest(t, features.CurrentFeatureGate, features.FeatureHostClaims, tt.featureGateEnabled)
 			// We do not really test on oldObj as it is ignored
 			if _, err := webhook.ValidateUpdate(ctx, nil, tt.hostclaim); !errorContains(err, tt.wantedErr) {
 				t.Errorf("HostClaim.ValidateUpdate() error = %v, wantErr %v", err, tt.wantedErr)

--- a/main.go
+++ b/main.go
@@ -207,7 +207,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&preprovImgEnable, "build-preprov-image", false, "enable integration with the PreprovisioningImage API")
-	flag.BoolVar(&hostClaimsEnable, "hostclaims", false, "enable HostClaims controller")
+	flag.BoolVar(&hostClaimsEnable, "hostclaims", true, "enable HostClaims controller (feature gate 'HostClaims' must be enabled)")
 	flag.BoolVar(&devLogging, "dev", false, "enable developer logging")
 	flag.StringVar(&provisionerName, "provisioner", defaultProvisionerName,
 		"Name of the provisioner plugin to load. Resolves to "+
@@ -480,7 +480,9 @@ func main() {
 		}
 	}
 
-	if hostClaimsEnable {
+	// No reason to run hostClaim controller unless the feature gate is enabled.
+	// If the feature gate is enabled then the default is to run the controller.
+	if hostClaimsEnable && features.CurrentFeatureGate.Enabled(features.FeatureHostClaims) {
 		if err = (&metal3iocontroller.HostClaimReconciler{
 			Client:              mgr.GetClient(),
 			Log:                 ctrl.Log.WithName("controllers").WithName("HostClaim"),

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -20,8 +20,14 @@ import (
 	"k8s.io/component-base/featuregate"
 )
 
+const (
+	FeatureHostClaims featuregate.Feature = "HostClaims"
+)
+
 var (
-	availableFeatures = map[featuregate.Feature]featuregate.FeatureSpec{}
+	availableFeatures = map[featuregate.Feature]featuregate.FeatureSpec{
+		FeatureHostClaims: {Default: false, PreRelease: featuregate.Alpha},
+	}
 
 	CurrentFeatureGate = featuregate.NewFeatureGate()
 )


### PR DESCRIPTION

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

Hide Hostclaims implementation behind a feature gate:

* disabled by default (alpha)
* HostClaim controller disabled unless the feature is enabled. In that case, it can still be disabled with --hostclaims=false (which can be useful if only the part in bmh controller or the webhooks are wanted).
