### PR TITLE
🐛 Improve error handling on invalid inventory

### DIFF
--- a/pkg/provisioner/ironic/inspecthardware.go
+++ b/pkg/provisioner/ironic/inspecthardware.go
@@ -16,7 +16,7 @@ import (
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/hardwaredetails"
 )
 
-func (p *ironicProvisioner) abortInspection(ctx context.Context, ironicNode *nodes.Node) (result provisioner.Result, started bool, details *metal3api.HardwareDetails, err error) {
+func (p *ironicProvisioner) abortInspection(ctx context.Context, ironicNode *nodes.Node) (result provisioner.Result, started bool, err error) {
 	// Set started to let the controller know about the change
 	p.log.Info("aborting inspection to force reboot of preprovisioning image")
 	started, result, err = p.tryChangeNodeProvisionState(
@@ -101,7 +101,8 @@ func (p *ironicProvisioner) InspectHardware(ctx context.Context, data provisione
 		return result, started, details, err
 	case nodes.InspectWait:
 		if forceReboot {
-			return p.abortInspection(ctx, ironicNode)
+			result, started, err = p.abortInspection(ctx, ironicNode)
+			return result, started, details, err
 		}
 
 		fallthrough

--- a/pkg/provisioner/ironic/inspecthardware.go
+++ b/pkg/provisioner/ironic/inspecthardware.go
@@ -2,6 +2,8 @@ package ironic
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -135,24 +137,51 @@ func (p *ironicProvisioner) InspectHardware(ctx context.Context, data provisione
 		return result, started, details, err
 	}
 
-	p.log.Info("getting hardware details from inspection")
-	response := nodes.GetInventory(ctx, p.client, ironicNode.UUID)
-	introData, err := response.Extract()
-	if err != nil {
-		if gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
-			// The node has just been enrolled, inspection hasn't been started yet.
-			result, started, err = p.startInspection(ctx, data, ironicNode)
-			return result, started, details, err
-		}
-		result, err = transientError(fmt.Errorf("failed to retrieve hardware introspection data: %w", err))
+	inventoryData, result, err := p.getInventory(ctx, ironicNode)
+	if result.Dirty || result.ErrorMessage != "" || err != nil {
+		return result, started, details, err
+	} else if inventoryData == nil {
+		// The node has just been enrolled, inspection hasn't been started yet.
+		result, started, err = p.startInspection(ctx, data, ironicNode)
 		return result, started, details, err
 	}
 
-	// Introspection is done
-	p.log.Info("inspection finished successfully", "data", response.Body)
-
-	details = hardwaredetails.GetHardwareDetails(introData, ironicNode.Properties, p.log)
+	details = hardwaredetails.GetHardwareDetails(inventoryData, ironicNode.Properties, p.log)
 	p.publisher("InspectionComplete", "Hardware inspection completed")
 	result, err = operationComplete()
 	return result, started, details, err
+}
+
+// getInventory fetches inventory data from Ironic. It returns nil when data is
+// not present, a non-empty result on a permanent failure, and an error on a
+// transient error. Partial data may be returned even on failure.
+func (p *ironicProvisioner) getInventory(ctx context.Context, ironicNode *nodes.Node) (inventoryData *nodes.InventoryData, result provisioner.Result, err error) {
+	p.log.Info("getting hardware details from inspection")
+	response := nodes.GetInventory(ctx, p.client, ironicNode.UUID)
+	if response.Err != nil {
+		if gophercloud.ResponseCodeIs(response.Err, http.StatusNotFound) {
+			// Not a failure, the data is simply not there.
+			return nil, result, nil
+		}
+		result, err = transientError(fmt.Errorf("failed to retrieve hardware introspection data: %w", response.Err))
+		return nil, result, err
+	}
+
+	inventoryData = new(nodes.InventoryData)
+	err = response.ExtractInto(inventoryData)
+	unmarshalTypeError := &json.UnmarshalTypeError{}
+	if errors.As(err, &unmarshalTypeError) {
+		// TODO(dtantsur): at this point, introData may be partially constructed and contain useful information.
+		// We need to decide if that's good enough to declare success (and how to communicate the error).
+		p.log.Error(err, "unable to parse inventory JSON as InventoryData; it can be a bug in Ironic or GopherCloud")
+		result, err = operationFailed("Unable to parse inventory JSON, cannot finish inspection")
+		return inventoryData, result, err
+	} else if err != nil {
+		result, err = transientError(fmt.Errorf("failed to parse hardware introspection data: %w", err))
+		return nil, result, err
+	}
+
+	p.log.Info("inspection finished successfully", "data", response.Body)
+	result, err = operationComplete()
+	return inventoryData, result, err
 }

--- a/pkg/provisioner/ironic/inspecthardware.go
+++ b/pkg/provisioner/ironic/inspecthardware.go
@@ -164,6 +164,8 @@ func (p *ironicProvisioner) getInventory(ctx context.Context, ironicNode *nodes.
 			// Not a failure, the data is simply not there.
 			return nil, result, nil
 		}
+		// This branch captures not just networking problems but also conditions like SyntaxError from the JSON library,
+		// when Ironic returns something that cannot be interpreted as JSON at all (which is hopefully transient).
 		result, err = transientError(fmt.Errorf("failed to retrieve hardware introspection data: %w", response.Err))
 		return nil, result, err
 	}
@@ -172,8 +174,10 @@ func (p *ironicProvisioner) getInventory(ctx context.Context, ironicNode *nodes.
 	err = response.ExtractInto(inventoryData)
 	unmarshalTypeError := &json.UnmarshalTypeError{}
 	if errors.As(err, &unmarshalTypeError) {
-		// TODO(dtantsur): at this point, introData may be partially constructed and contain useful information.
-		// We need to decide if that's good enough to declare success (and how to communicate the error).
+		// TODO(dtantsur): at this point, inventoryData may be partially constructed and contain useful information
+		// (see https://pkg.go.dev/encoding/json#Unmarshal for details on this behavior).
+		// Until we decide if that's good enough to declare success (and how to communicate the error),
+		// report a fatal failure since it's not going to improve on retry.
 		p.log.Error(err, "unable to parse inventory JSON as InventoryData; it can be a bug in Ironic or GopherCloud")
 		result, err = operationFailed("Unable to parse inventory JSON, cannot finish inspection")
 		return inventoryData, result, err

--- a/pkg/provisioner/ironic/inspecthardware_test.go
+++ b/pkg/provisioner/ironic/inspecthardware_test.go
@@ -196,6 +196,8 @@ func TestInspectHardware(t *testing.T) {
 			expectedDetailsHost: "node-0",
 			expectedPublish:     "InspectionComplete Hardware inspection completed",
 		},
+		// Receiving complete gibberish from Ironic together with HTTP 200 is very unlikely
+		// This test differentiates it from the actually possible case of type mismatch in the inventory
 		{
 			name: "inspection-syntax-error-inventory",
 			ironic: testserver.NewIronic(t).Node(nodes.Node{
@@ -206,6 +208,7 @@ func TestInspectHardware(t *testing.T) {
 			// NOTE(dtantsur): not hardcoding the exact error since it comes from stdlib
 			expectedError: "failed to retrieve hardware introspection data: .*",
 		},
+		// If Ironic returns a valid JSON that we cannot interpret, it's useless to retry.
 		{
 			name: "inspection-type-error-inventory",
 			ironic: testserver.NewIronic(t).Node(nodes.Node{

--- a/pkg/provisioner/ironic/inspecthardware_test.go
+++ b/pkg/provisioner/ironic/inspecthardware_test.go
@@ -196,6 +196,31 @@ func TestInspectHardware(t *testing.T) {
 			expectedDetailsHost: "node-0",
 			expectedPublish:     "InspectionComplete Hardware inspection completed",
 		},
+		{
+			name: "inspection-syntax-error-inventory",
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
+				UUID:           nodeUUID,
+				ProvisionState: string(nodes.Manageable),
+			}).WithInventoryText(nodeUUID, "<html>"),
+
+			// NOTE(dtantsur): not hardcoding the exact error since it comes from stdlib
+			expectedError: "failed to retrieve hardware introspection data: .*",
+		},
+		{
+			name: "inspection-type-error-inventory",
+			ironic: testserver.NewIronic(t).Node(nodes.Node{
+				UUID:           nodeUUID,
+				ProvisionState: string(nodes.Manageable),
+			}).WithInventoryText(nodeUUID, `{
+			    "inventory": {
+				"cpu": {
+				    "count": "banana"
+				}
+			    }
+			}`),
+
+			expectedResultError: "Unable to parse inventory JSON, cannot finish inspection",
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/provisioner/ironic/testserver/ironic.go
+++ b/pkg/provisioner/ironic/testserver/ironic.go
@@ -517,7 +517,7 @@ func (m *IronicMock) WithInventoryFailed(nodeUUID string, errorCode int) *Ironic
 	return m
 }
 
-// WithInventory configures the server with an arbitrary response for /v1/nodes/<node>/inventory.
+// WithInventoryText configures the server with an arbitrary response for /v1/nodes/<node>/inventory.
 func (m *IronicMock) WithInventoryText(nodeUUID string, data string) *IronicMock {
 	m.ResponseWithCode(v1node+nodeUUID+"/inventory", data, http.StatusOK)
 	return m

--- a/pkg/provisioner/ironic/testserver/ironic.go
+++ b/pkg/provisioner/ironic/testserver/ironic.go
@@ -516,3 +516,9 @@ func (m *IronicMock) WithInventoryFailed(nodeUUID string, errorCode int) *Ironic
 	m.ErrorResponse(v1node+nodeUUID+"/inventory", errorCode)
 	return m
 }
+
+// WithInventory configures the server with an arbitrary response for /v1/nodes/<node>/inventory.
+func (m *IronicMock) WithInventoryText(nodeUUID string, data string) *IronicMock {
+	m.ResponseWithCode(v1node+nodeUUID+"/inventory", data, http.StatusOK)
+	return m
+}


### PR DESCRIPTION
When testing Redfish inspection, I hit a few cases where GopherCloud
could not parse the returned inventory. Currently, it ends up in an
infinite retry loop.

This patch excludes JSON parsing errors from retry, assuming that they
cannot be fixed by simply calling Ironic again.

I've left TODO for us to ponder if we can accept a partially parsed
HardwareData. No change here, just food for thought.

The PR includes a fix for an unrelated error that somehow only
appeared after my commit.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
